### PR TITLE
add link to 1000G page with detailed freq information (#107)

### DIFF
--- a/scout/core/templates/variant.html
+++ b/scout/core/templates/variant.html
@@ -320,19 +320,41 @@
       <div id="frequency" class="md-card is-main">
         <div class="md-card-header">Frequency</div>
         <div class="md-card-body-list">
-          <div class="variant-list-item">
-            <div>ThousandG</div>
+          <div class="variant-row-item">
             <div>
-              {{ variant.thousand_genomes_frequency|human_decimal }}
+              {% if variant.db_snp_ids %}
+                <a href="{{ variant.thousandg_link }}" target="_blank">1000G</a>
+              {% else %}
+                1000G
+              {% endif %}
+            </div>
+
+            <div class="variant-row-item-sublist">
+              {% if variant.max_thousand_genomes_frequency %}
+                <div class="variant-row-item-sublist-item">
+                  {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small>
+                </div>
+              {% endif %}
+
+              <div class="variant-row-item-sublist-item">
+                {{ variant.thousand_genomes_frequency|human_decimal }}
+              </div>
             </div>
           </div>
 
-          <div class="variant-list-item">
-            <div title="Exome Aggregation Consortium">ExAC</div>
+          <div class="variant-row-item">
             <div>
-              <a target="_blank" href="{{ variant.exac_link }}">
-                {{ variant.exac_frequency|human_decimal }}
-              </a>
+              <a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a>
+            </div>
+            <div class="variant-row-item-sublist">
+                {% if variant.exac_frequency %}
+                  <div class="variant-row-item-sublist-item">
+                    {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small>
+                  </div>
+                {% endif %}
+                <div class="variant-row-item-sublist-item">
+                  {{ variant.exac_frequency|human_decimal }}
+                </div>
             </div>
           </div>
         </div>

--- a/scout/ext/backend/utils/get_mongo_variant.py
+++ b/scout/ext/backend/utils/get_mongo_variant.py
@@ -195,12 +195,26 @@ def get_mongo_variant(variant, variant_type, individuals, case, institute,
             variant['variant_id'], value))
         mongo_variant['thousand_genomes_frequency'] = float(value)
 
+    thousand_g_max = variant['info_dict'].get('1000G_MAX_AF')
+    if thousand_g_max:
+        value = thousand_g_max[0]
+        logger.debug("Updating 1000G max freq for variant {0} to {1}".format(
+            variant['variant_id'], value))
+        mongo_variant['max_thousand_genomes_frequency'] = float(value)
+
     exac = variant['info_dict'].get('EXACAF')
     if exac:
         value = exac[0]
         logger.debug("Updating EXAC freq for variant {0} to {1}".format(
             variant['variant_id'], value))
         mongo_variant['exac_frequency'] = float(value)
+
+    max_exac = variant['info_dict'].get('ExAC_MAX_AF')
+    if exac:
+        value = max_exac[0]
+        logger.debug("Updating EXAC max freq for variant {0} to {1}".format(
+            variant['variant_id'], value))
+        mongo_variant['max_exac_frequency'] = float(value)
 
     # Add the severity predictions
     cadd = variant['info_dict'].get('CADD')

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -301,6 +301,14 @@ class Variant(Document):
         return url_template.format(this=self)
 
     @property
+    def thousandg_link(self):
+        """Compose link to 1000G page for detailed information."""
+        if self.db_snp_ids:
+            url_template = ("http://browser.1000genomes.org/Homo_sapiens/"
+                            "Variation/Population?db=core;source=dbSNP;v={}")
+            return url_template.format(self.db_snp_ids[0])
+
+    @property
     def ucsc_link(self):
         url_template = ("http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&"\
                         "position=chr{this.chromosome}:{this.position}"\

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -76,6 +76,8 @@ class Variant(Document):
     # Frequencies:
     thousand_genomes_frequency = FloatField()
     exac_frequency = FloatField()
+    max_thousand_genomes_frequency = FloatField()
+    max_exac_frequency = FloatField()
     local_frequency = FloatField()
     # Predicted deleteriousness:
     cadd_score = FloatField()


### PR DESCRIPTION
I've added the link and will display the max freq when the variant model is updated, relates to #107

@moonso: I named the fields as "max_" followed by the normal AF frequency name