### PR TITLE
Allows multiple alleles in VEP's MAF-fields, separated by ampersands

### DIFF
--- a/scout/parse/variant/transcript.py
+++ b/scout/parse/variant/transcript.py
@@ -122,16 +122,21 @@ def parse_transcripts(raw_transcripts, allele=None):
         thousandg_frequencies = []
         for key in entry:
             if key.endswith('MAF'):
-                # If the frequency starts with 'ExAC' we know it is a exac freq
-                splitted_entry = entry[key].split(':')
-                if splitted_entry[0] == allele:
-                    value = float(splitted_entry[1])
-                    if value > 0:
-                        if key.startswith('ExAC'):
-                            exac_frequencies.append(value)
-                # Otherwise we know it is a 1000G frequency
-                        else:
-                            thousandg_frequencies.append(value)
+
+                maf_allele_entries = entry[key].split('&')
+
+                for maf_allele in maf_allele_entries:
+                    
+                    # If the frequency starts with 'ExAC' we know it is a exac freq
+                    splitted_entry = maf_allele.split(':')
+                    if splitted_entry[0] == allele:
+                        value = float(splitted_entry[1])
+                        if value > 0:
+                            if key.startswith('ExAC'):
+                                exac_frequencies.append(value)
+                                # Otherwise we know it is a 1000G frequency
+                            else:
+                                thousandg_frequencies.append(value)
 
         if exac_frequencies:
             transcript['exac_maf'] = sum(exac_frequencies)/len(exac_frequencies)


### PR DESCRIPTION
Our VEP-annotated VCFs sometimes contain allele frequencies for multiple alleles like this "A:0.00483&T:0.0001725", which causes "scout load  case" to crash. This should fix that.