### PR TITLE
Support defining a unique family id in the config

### DIFF
--- a/scout/adapter/client.py
+++ b/scout/adapter/client.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_connection(host='localhost', port=27017, username=None, password=None,
-                   uri=None, mongodb=None, timeout=20):
+                   uri=None, mongodb=None, authdb=None, timeout=20):
     """Get a client to the mongo database
 
         host(str): Host of database
@@ -29,13 +29,15 @@ def get_connection(host='localhost', port=27017, username=None, password=None,
         username(str)
         password(str)
         uri(str)
+        authdb (str): database to use for authentication
         timeout(int): How long should the client try to connect
 
     """
+    authdb = authdb or mongodb
     if uri is None:
         if username and password:
             uri = ("mongodb://{}:{}@{}:{}/{}"
-                   .format(quote_plus(username), quote_plus(password), host, port, mongodb))
+                   .format(quote_plus(username), quote_plus(password), host, port, authdb))
         else:
             uri = "mongodb://%s:%s" % (host, port)
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -234,6 +234,15 @@ class CaseHandler(object):
             except (IntegrityError, ValueError, ConfigError, KeyError) as error:
                 logger.warning(error)
 
+        # Check if case exists with old case id
+        old_caseid = '-'.join([case_obj['owner'], case_obj['display_name']])
+        old_case = self.case(old_caseid)
+        if old_case:
+            if update:
+                self.update_caseid(old_case, case_obj['_id'])
+            else:
+                raise IntegrityError("Case %s exists with old id", old_caseid)
+
         # Check if case exists in database
         existing_case = self.case(case_obj['_id'])
         if existing_case:
@@ -255,7 +264,7 @@ class CaseHandler(object):
             Args:
                 case_obj(Case)
         """
-        if self.case(case_obj['case_id']):
+        if self.case(case_obj['_id']):
             raise IntegrityError("Case %s already exists in database" % case_obj['_id'])
 
         return self.case_collection.insert_one(case_obj)

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -364,7 +364,7 @@ class CaseHandler(object):
             )
 
         # insert the updated case
-        self.case_collection.insert(new_case)
+        self.case_collection.insert_one(new_case)
         # delete the old case
         self.case_collection.find_one_and_delete({'_id': case_obj['_id']})
         return new_case

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -249,8 +249,7 @@ class CaseHandler(object):
             if update:
                 self.update_case(case_obj)
             else:
-                raise IntegrityError("Case {0} already exists in database".format(
-                                     case_obj['case_id']))
+                raise IntegrityError("Case {0} already exists in database".format(case_obj['_id']))
         else:
             logger.info('Loading case %s into database', case_obj['display_name'])
             self._add_case(case_obj)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -482,7 +482,7 @@ class VariantHandler(object):
 
         try:
             for nr_variants, variant in enumerate(vcf_obj(region)):
-                rank_score = parse_rank_score(variant.INFO.get('RankScore'), case_obj['case_id'])
+                rank_score = parse_rank_score(variant.INFO.get('RankScore'), case_obj['_id'])
                 if (rank_score is None) or (rank_score > rank_threshold):
                     # Parse the vcf variant
                     parsed_variant = parse_variant(

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -169,9 +169,10 @@ class VariantHandler(object):
             sorting = [('rank_score', pymongo.DESCENDING)]
 
         result = self.variant_collection.find(
-                        mongo_query,
-                        skip=skip,
-                        limit=nr_of_variants).sort(sorting)
+            mongo_query,
+            skip=skip,
+            limit=nr_of_variants
+        ).sort(sorting)
 
         return result
 
@@ -410,12 +411,7 @@ class VariantHandler(object):
             nr_inserted(int)
         """
         institute_obj = self.institute(institute_id=case_obj['owner'])
-
-        if not institute_obj:
-            raise IntegrityError("Institute {0} does not exist in"
-                                 " database.".format(case_obj['owner']))
         gene_to_panels = self.gene_to_panels()
-
         hgncid_to_gene = self.hgncid_to_gene()
 
         variant_file = None
@@ -486,10 +482,7 @@ class VariantHandler(object):
 
         try:
             for nr_variants, variant in enumerate(vcf_obj(region)):
-                rank_score = parse_rank_score(
-                    variant.INFO.get('RankScore'),
-                    case_obj['display_name'],
-                )
+                rank_score = parse_rank_score(variant.INFO.get('RankScore'), case_obj['case_id'])
                 if (rank_score is None) or (rank_score > rank_threshold):
                     # Parse the vcf variant
                     parsed_variant = parse_variant(
@@ -517,13 +510,13 @@ class VariantHandler(object):
                         pass
 
                     if (nr_variants != 0 and nr_variants % 5000 == 0):
-                        logger.info("%s variants parsed" % str(nr_variants))
-                        logger.info("Time to parse variants: {} ".format(
-                                    datetime.now() - start_five_thousand))
+                        logger.info("%s variants parsed", str(nr_variants))
+                        logger.info("Time to parse variants: %s",
+                                    (datetime.now() - start_five_thousand))
                         start_five_thousand = datetime.now()
 
                     if (nr_inserted != 0 and (nr_inserted * inserted) % (1000 * inserted) == 0):
-                        logger.info("%s variants inserted" % nr_inserted)
+                        logger.info("%s variants inserted", nr_inserted)
                         inserted += 1
 
         except Exception as error:
@@ -573,14 +566,15 @@ class VariantHandler(object):
                         region_end = gene_end
 
         query = self.build_query(
-            case_id = variant_obj['case_id'],
-            query = {
+            case_id=variant_obj['case_id'],
+            query={
                 'variant_type': variant_obj['variant_type'],
                 'chrom': chromosome,
                 'start': region_start,
                 'end': region_end,
-                },
-            category=category)
+            },
+            category=category
+        )
 
         sort_key = [('rank_score', pymongo.DESCENDING)]
         variants = self.variant_collection.find(query).sort(sort_key)

--- a/scout/adapter/utils.py
+++ b/scout/adapter/utils.py
@@ -6,30 +6,29 @@ from pymongo.errors import (ServerSelectionTimeoutError)
 log = logging.getLogger(__name__)
 
 
-def check_connection(host='localhost', port=27017, username=None, password=None, 
-                     max_delay=1):
+def check_connection(host='localhost', port=27017, username=None, password=None,
+                     authdb=None, max_delay=1):
     """Check if a connection could be made to the mongo process specified
-    
+
     Args:
         host(str)
         port(int)
         username(str)
         password(str)
+        authdb (str): database to to for authentication
         max_delay(int): Number of milliseconds to wait for connection
-    
+
     Returns:
         bool: If connection could be established
     """
     #uri looks like:
     #mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
     uri = "mongodb://"
-    if (username and password):
-        uri += "{0}:{1}@".format(
-            username,
-            password,
-            
-        )
+    if username and password:
+        uri += "{0}:{1}@".format(username, password)
     uri += "{0}:{1}".format(host, port)
+    if authdb:
+        uri = "{}/{}".format(uri, authdb)
 
     client = MongoClient(uri, serverSelectionTimeoutMS=max_delay)
 
@@ -37,7 +36,5 @@ def check_connection(host='localhost', port=27017, username=None, password=None,
         client.server_info()
     except ServerSelectionTimeoutError as err:
         return False
-    
+
     return True
-    
-    

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -94,14 +94,11 @@ def build_case(case_data, adapter):
 
     )
     """
-    try:
-        log.info("build case with id: {0}".format(case_data['case_id']))
-        case_obj = {'_id': case_data['case_id']}
-        case_obj['case_id'] = case_data['case_id']
-    except KeyError as err:
-        raise PedigreeError("Case has to have a case id")
-
-    case_obj['display_name'] = case_data.get('display_name', case_obj['case_id'])
+    log.info("build case with id: {0}".format(case_data['case_id']))
+    case_obj = {
+        '_id': case_data['case_id'],
+        'display_name': case_data['display_name'],
+    }
 
     # Check if institute exists in database
     try:

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -8,7 +8,7 @@ import yaml
 # Adapter stuff
 from scout.adapter.mongo import MongoAdapter
 from scout.adapter.client import get_connection
-from pymongo.errors import (ConnectionFailure, ServerSelectionTimeoutError)
+from pymongo.errors import ConnectionFailure
 
 # General, logging
 from scout import __version__
@@ -33,83 +33,76 @@ log = logging.getLogger(__name__)
 
 
 @click.group()
-@click.option('-l', '--logfile',
-    type=click.Path(exists=False),
-    help="Path to log file. If none logging is printed to stderr.",
-)
-@click.option('--loglevel',
-    default='INFO',
-    type=click.Choice(LOG_LEVELS),
-    help="Set the level of log output.",
-    show_default=True,
-)
-@click.option('-db', '--mongodb', help='Name of mongo database')
+@click.option('--loglevel', default='INFO', type=click.Choice(LOG_LEVELS),
+              help="Set the level of log output.", show_default=True)
+@click.option('-db', '--mongodb', help='Name of mongo database [scout]')
 @click.option('-u', '--username')
 @click.option('-p', '--password')
+@click.option('-a', '--authdb', help='database to use for authentication')
 @click.option('-port', '--port', help="Specify on what port to listen for the mongod")
 @click.option('-h', '--host', help="Specify the host for the mongo database.")
-@click.option('-c', '--config',
-    type=click.Path(exists=True),
-    help="Specify the path to a config file with database info.",
-)
+@click.option('-c', '--config', type=click.Path(exists=True),
+              help="Specify the path to a config file with database info.")
 @click.option('--demo', is_flag=True, help="If the demo database should be used")
 @click.version_option(__version__)
 @click.pass_context
-def cli(context, mongodb, username, password, host, port, logfile, loglevel,
-        config, demo):
+def cli(context, mongodb, username, password, authdb, host, port, loglevel, config, demo):
     """scout: manage interactions with a scout instance."""
     coloredlogs.install(level=loglevel)
     log.info("Running scout version %s", __version__)
     log.debug("Debug logging enabled.")
 
-    mongo_configs = {}
-    configs = {}
+    mongo_config = {}
     if config:
-        log.debug("Use config file {0}".format(config))
+        log.debug("Use config file %s", config)
         with open(config, 'r') as in_handle:
-            configs = yaml.load(in_handle)
+            cli_config = yaml.load(in_handle)
+    else:
+        cli_config = {}
 
-    mongo_configs['mongodb'] = (mongodb or configs.get('mongodb') or 'scout')
+    mongo_config['mongodb'] = (mongodb or cli_config.get('mongodb') or 'scout')
     if demo:
-        mongo_configs['mongodb'] = 'scout-demo'
+        mongo_config['mongodb'] = 'scout-demo'
 
-    mongo_configs['host'] = (host or configs.get('host') or 'localhost')
-    mongo_configs['port'] = (port or configs.get('port') or 27017)
-    mongo_configs['username'] = username or configs.get('username')
-    mongo_configs['password'] = password or configs.get('password')
+    mongo_config['host'] = (host or cli_config.get('host') or 'localhost')
+    mongo_config['port'] = (port or cli_config.get('port') or 27017)
+    mongo_config['username'] = username or cli_config.get('username')
+    mongo_config['password'] = password or cli_config.get('password')
+    mongo_config['authdb'] = authdb or cli_config.get('authdb') or mongo_config['mongodb']
     # mongo uri looks like:
     # mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
 
     if context.invoked_subcommand in ('setup', 'serve'):
-        mongo_configs['adapter'] = None
+        mongo_config['adapter'] = None
     else:
-        log.info("Setting database name to %s", mongo_configs['mongodb'])
-        log.debug("Setting host to {0}".format(mongo_configs['host']))
-        log.debug("Setting port to {0}".format(mongo_configs['port']))
-        
+        log.info("Setting database name to %s", mongo_config['mongodb'])
+        log.debug("Setting host to %s", mongo_config['host'])
+        log.debug("Setting port to %s", mongo_config['port'])
+
         valid_connection = check_connection(
-            host=mongo_configs['host'], 
-            port=mongo_configs['port'], 
-            username=mongo_configs['username'], 
-            password=mongo_configs['password'], )
-    
+            host=mongo_config['host'],
+            port=mongo_config['port'],
+            username=mongo_config['username'],
+            password=mongo_config['password'],
+            authdb=mongo_config['authdb'],
+        )
+
         log.info("Test if mongod is running")
         if not valid_connection:
             log.warning("Connection could not be established")
             context.abort()
 
         try:
-            client = get_connection(**mongo_configs)
+            client = get_connection(**mongo_config)
         except ConnectionFailure:
             context.abort()
 
-        database = client[mongo_configs['mongodb']]
+        database = client[mongo_config['mongodb']]
 
         log.info("Setting up a mongo adapter")
-        mongo_adapter = MongoAdapter(database)
-        mongo_configs['adapter'] = mongo_adapter
+        mongo_config['adapter'] = MongoAdapter(database)
 
-    context.obj = mongo_configs
+    context.obj = mongo_config
 
 
 cli.add_command(load_command)

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -44,8 +44,8 @@ def research(context, case_id, institute, force):
         if force or case_obj['research_requested']:
             # Test to upload research snvs
             if case_obj['vcf_files'].get('vcf_snv_research'):
-                adapter.delete_variants(case_id=case_obj['_id'], 
-                                        variant_type='research', 
+                adapter.delete_variants(case_id=case_obj['_id'],
+                                        variant_type='research',
                                         category='snv')
 
                 log.info("Load research SNV for: %s", case_obj['case_id'])
@@ -55,11 +55,11 @@ def research(context, case_id, institute, force):
                     category='snv',
                     rank_threshold=default_threshold,
                     )
-            
+
             # Test to upload research svs
             if case_obj['vcf_files'].get('vcf_sv_research'):
-                adapter.delete_variants(case_id=case_obj['_id'], 
-                                        variant_type='research', 
+                adapter.delete_variants(case_id=case_obj['_id'],
+                                        variant_type='research',
                                         category='sv')
                 log.info("Load research SV for: %s", case_obj['case_id'])
                 adapter. load_variants(
@@ -71,11 +71,11 @@ def research(context, case_id, institute, force):
 
             # Test to upload research cancer variants
             if case_obj['vcf_files'].get('vcf_sv_research'):
-                adapter.delete_variants(case_id=case_obj['_id'], 
-                                        variant_type='research', 
+                adapter.delete_variants(case_id=case_obj['_id'],
+                                        variant_type='research',
                                         category='cancer')
-                
-                log.info("Load research cancer for: %s", case_obj['case_id'])
+
+                log.info("Load research cancer for: %s", case_obj['_id'])
                 adapter. load_variants(
                     case_obj=case_obj,
                     variant_type='research',

--- a/scout/commands/view/view_command.py
+++ b/scout/commands/view/view_command.py
@@ -17,12 +17,12 @@ def index(context, collection_name):
     """Show all indexes in the database"""
     log.info("Running scout view index")
     adapter = context.obj['adapter']
-    
+
     i = 0
     for index in adapter.indexes(collection_name):
         click.echo(index)
         i += 1
-    
+
     if i == 0:
         log.info("No indexes found")
 
@@ -33,16 +33,16 @@ def panels(context):
     """Show all gene panels in the database"""
     log.info("Running scout view panels")
     adapter = context.obj['adapter']
-    
+
     panel_objs = adapter.gene_panels()
     if panel_objs.count() == 0:
         log.info("No panels found")
         context.abort()
     click.echo("#panel_name\tversion\tnr_genes")
-        
+
     for panel_obj in panel_objs:
         click.echo("{0}\t{1}\t{2}".format(
-            panel_obj['panel_name'], 
+            panel_obj['panel_name'],
             str(panel_obj['version']),
             len(panel_obj['genes'])
         ))
@@ -53,12 +53,12 @@ def users(context):
     """Show all users in the database"""
     log.info("Running scout view users")
     adapter = context.obj['adapter']
-    
+
     user_objs = adapter.users()
     if user_objs.count() == 0:
         log.info("No users found")
         context.abort()
-    
+
     click.echo("#name\temail\troles\tinstitutes")
     for user_obj in user_objs:
         click.echo("{0}\t{1}\t{2}\t{3}\t".format(
@@ -84,7 +84,7 @@ def individuals(context, institute, causatives, case_id):
     log.info("Running scout view individuals")
     adapter = context.obj['adapter']
     individuals = []
-    
+
     if case_id:
         case = adapter.case(case_id=case_id)
         if case:
@@ -93,9 +93,9 @@ def individuals(context, institute, causatives, case_id):
             log.info("Could not find case %s", case_id)
             return
     else:
-        cases = [case_obj for case_obj in 
+        cases = [case_obj for case_obj in
                  adapter.cases(
-                     collaborator=institute, 
+                     collaborator=institute,
                      has_causatives=causatives)]
         if len(cases) == 0:
             log.info("Could not find cases that match criteria")
@@ -103,11 +103,11 @@ def individuals(context, institute, causatives, case_id):
         individuals = (ind_obj for case_obj in cases for ind_obj in case_obj['individuals'])
 
     click.echo("#case_id\tind_id\tdisplay_name\tsex\tphenotype\tmother\tfather")
-    
+
     for case in cases:
         for ind_obj in case['individuals']:
             ind_info = [
-                case['case_id'], ind_obj['individual_id'], 
+                case['_id'], ind_obj['individual_id'],
                 ind_obj['display_name'], SEX_MAP[int(ind_obj['sex'])],
                 PHENOTYPE_MAP[ind_obj['phenotype']], ind_obj['mother'],
                 ind_obj['father']
@@ -132,7 +132,7 @@ def whitelist(context):
     """Show all objects in the whitelist collection"""
     log.info("Running scout view users")
     adapter = context.obj['adapter']
-    
+
     ## TODO add a User interface to the adapter
     for whitelist_obj in adapter.whitelist_collection.find():
         click.echo(whitelist_obj['_id'])
@@ -144,12 +144,12 @@ def institutes(context):
     """Show all institutes in the database"""
     log.info("Running scout view institutes")
     adapter = context.obj['adapter']
-    
+
     institute_objs = adapter.institutes()
     if institute_objs.count() == 0:
         click.echo("No institutes found")
         context.abort()
-    
+
     click.echo("#institute_id\tdisplay_name")
     for institute_obj in institute_objs:
         click.echo("{0}\t{1}".format(
@@ -164,7 +164,7 @@ def aliases(context, build):
     """Show all alias symbols and how they map to ids"""
     log.info("Running scout view aliases")
     adapter = context.obj['adapter']
-    
+
     alias_genes = adapter.genes_by_alias(build=build)
     click.echo("#hgnc_symbol\ttrue_id\thgnc_ids")
     for alias_symbol in alias_genes:
@@ -176,7 +176,7 @@ def aliases(context, build):
             ', '.join([str(gene_id) for gene_id in alias_genes[alias_symbol]['ids']])
             )
         )
-        
+
 
 @click.command('genes', short_help='Display genes')
 @click.option('-b', '--build', default='37', type=click.Choice(['37','38']))
@@ -185,7 +185,7 @@ def genes(context, build):
     """Show all genes in the database"""
     log.info("Running scout view genes")
     adapter = context.obj['adapter']
-    
+
     click.echo("Chromosom\tstart\tend\thgnc_id\thgnc_symbol")
     for gene_obj in adapter.all_genes(build=build):
         click.echo("{0}\t{1}\t{2}\t{3}\t{4}".format(
@@ -202,13 +202,13 @@ def diseases(context):
     """Show all diseases in the database"""
     log.info("Running scout view diseases")
     adapter = context.obj['adapter']
-    
+
     disease_objs = adapter.disease_terms()
-    
+
     nr_diseases = disease_objs.count()
     if nr_diseases == 0:
        click.echo("No diseases found")
-    else: 
+    else:
         click.echo("Disease")
         for disease_obj in adapter.disease_terms():
             click.echo("{0}".format(disease_obj['_id']))
@@ -220,7 +220,7 @@ def hpo(context):
     """Show all hpo terms in the database"""
     log.info("Running scout view hpo")
     adapter = context.obj['adapter']
-    
+
     click.echo("hpo_id\tdescription")
     for hpo_obj in adapter.hpo_terms():
         click.echo("{0}\t{1}".format(

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -3,6 +3,7 @@
 owner: cust000
 
 family: '643594'
+family_name: '643594'
 samples:
   - analysis_type: wes
     sample_id: ADM1059A2

--- a/scout/load/case.py
+++ b/scout/load/case.py
@@ -30,8 +30,7 @@ def load_case(adapter, case_obj, update=False):
         if update:
             adapter.update_case(case_obj)
         else:
-            raise IntegrityError("Case {0} already exists in database".format(
-                                 case_obj['case_id']))
+            raise IntegrityError("Case {0} already exists in database".format(case_obj['_id']))
     else:
         adapter.add_case(case_obj)
     return case_obj

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -260,8 +260,8 @@ def parse_case(config):
     case_data = {
         'owner': config['owner'],
         'collaborators': [config['owner']],
-        'case_id': '-'.join([config['owner'], config['family']]),
-        'display_name': config['family'],
+        'case_id': config['family'],
+        'display_name': config.get('family_name', config['family']),
         'genome_build': config.get('human_genome_build'),
         'rank_model_version': config.get('rank_model_version'),
         'rank_score_threshold': config.get('rank_score_threshold', 0),

--- a/scout/parse/variant/compound.py
+++ b/scout/parse/variant/compound.py
@@ -4,12 +4,12 @@ from scout.utils.md5 import generate_md5_key
 
 logger = logging.getLogger(__name__)
 
-def parse_compounds(compound_info, case, variant_type):
+def parse_compounds(compound_info, case_id, variant_type):
     """Get a list with compounds objects for this variant.
 
         Arguments:
             compound_info(str): A Variant dictionary
-            case(dict)
+            case_id (str): unique family id
             variant_type(str): 'research' or 'clinical'
 
         Returns:
@@ -17,25 +17,17 @@ def parse_compounds(compound_info, case, variant_type):
     """
     # We need the case to construct the correct id
     compounds = []
-    
     if compound_info:
-        case_id = case['_id']
-        case_name = case['display_name']
-        parsed_compounds = {}
         for family_info in compound_info.split(','):
             splitted_entry = family_info.split(':')
             # This is the family id
-            if splitted_entry[0] == case_name:
+            if splitted_entry[0] == case_id:
                 for compound in splitted_entry[1].split('|'):
                     splitted_compound = compound.split('>')
                     compound_obj = {}
                     compound_name = splitted_compound[0]
-                    
-                    compound_obj['variant'] = generate_md5_key(
-                                               compound_name.split('_') +
-                                               [variant_type] +
-                                               case_id.split('_')
-                                              )
+                    compound_obj['variant'] = generate_md5_key(compound_name.split('_') +
+                                                               [variant_type, case_id])
 
                     try:
                         compound_score = float(splitted_compound[1])
@@ -44,8 +36,8 @@ def parse_compounds(compound_info, case, variant_type):
 
                     compound_obj['score'] = compound_score
                     compound_obj['display_name'] = compound_name
-                    
+
                     compounds.append(compound_obj)
-                    
+
     return compounds
 

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -1,14 +1,14 @@
 # encoding: utf-8
 """
-parse_genotypes will try to collect and merge information from vcf with 
-genotypes called by multiple variant callers. This is a complex problem, 
-especially for Structural Variants. I will try to explain some of the specific 
+parse_genotypes will try to collect and merge information from vcf with
+genotypes called by multiple variant callers. This is a complex problem,
+especially for Structural Variants. I will try to explain some of the specific
 problems here.
 
 ## cnvnator
-Calls copy number events such as deletions and duplications. Genotype calls 
+Calls copy number events such as deletions and duplications. Genotype calls
 are simple and not that informative. It includes 'GT' and 'CN' wich estimates
-the number of copies of an event. We will not use 'CN' since it is a bit 
+the number of copies of an event. We will not use 'CN' since it is a bit
 unclear at the moment.
 
 ## tiddit
@@ -20,58 +20,55 @@ Uses 'DV' to describe number of paired ends that supports the event and
 
 GENOTYPE_MAP = {0: '0', 1: '1', -1:'.'}
 
-def parse_genotypes(variant, case, individual_positions):
+def parse_genotypes(variant, individuals, individual_positions):
     """Parse the genotype calls for a variant
-    
+
         Args:
             variant(cyvcf2.Variant)
-            case(dict)
+            individuals: List[dict]
             individual_positions(dict)
         Returns:
             genotypes(list(dict)): A list of genotypes
     """
     genotypes = []
-    individuals = case['individuals']
-    if individuals:
-        for ind in individuals:
-            pos = individual_positions[ind['individual_id']]
-            genotypes.append(parse_genotype(variant, ind, pos))
-
+    for ind in individuals:
+        pos = individual_positions[ind['individual_id']]
+        genotypes.append(parse_genotype(variant, ind, pos))
     return genotypes
 
 def parse_genotype(variant, ind, pos):
     """Get the genotype information in the proper format
-    
+
     Sv specific format fields:
-    
+
     ##FORMAT=<ID=DV,Number=1,Type=Integer,
     Description="Number of paired-ends that support the event">
-    
+
     ##FORMAT=<ID=PE,Number=1,Type=Integer,
     Description="Number of paired-ends that support the event">
-    
+
     ##FORMAT=<ID=PR,Number=.,Type=Integer,
-    Description="Spanning paired-read support for the ref and alt alleles 
+    Description="Spanning paired-read support for the ref and alt alleles
                 in the order listed">
-    
+
     ##FORMAT=<ID=RC,Number=1,Type=Integer,
     Description="Raw high-quality read counts for the SV">
-    
+
     ##FORMAT=<ID=RCL,Number=1,Type=Integer,
     Description="Raw high-quality read counts for the left control region">
-    
+
     ##FORMAT=<ID=RCR,Number=1,Type=Integer,
     Description="Raw high-quality read counts for the right control region">
-    
+
     ##FORMAT=<ID=RR,Number=1,Type=Integer,
     Description="# high-quality reference junction reads">
-    
+
     ##FORMAT=<ID=RV,Number=1,Type=Integer,
     Description="# high-quality variant junction reads">
-    
+
     ##FORMAT=<ID=SR,Number=1,Type=Integer,
     Description="Number of split reads that support the event">
-    
+
     Args:
         variant(cyvcf2.Variant)
         ind_id(dict): A dictionary with individual information
@@ -83,19 +80,19 @@ def parse_genotype(variant, ind, pos):
     """
     gt_call = {}
     ind_id = ind['individual_id']
-    
+
     gt_call['individual_id'] = ind_id
     gt_call['display_name'] = ind['display_name']
-    
+
     # Fill the object with the relevant information:
     genotype = variant.genotypes[pos]
-    
+
     ref_call = genotype[0]
     alt_call = genotype[1]
-    
-    gt_call['genotype_call'] = '/'.join([GENOTYPE_MAP[ref_call], 
+
+    gt_call['genotype_call'] = '/'.join([GENOTYPE_MAP[ref_call],
                                          GENOTYPE_MAP[alt_call]])
-    
+
     paired_end_alt = None
     paired_end_ref = None
     split_read_alt = None
@@ -110,7 +107,7 @@ def parse_genotype(variant, ind, pos):
                 paired_end_alt = value
         except ValueError as e:
             pass
-    
+
     # Check if PR is annotated
     # Number of paired end reads that supports ref and alt
     if 'PR' in variant.FORMAT:
@@ -124,7 +121,7 @@ def parse_genotype(variant, ind, pos):
                 paired_end_ref = ref_value
         except ValueError as r:
             pass
-    
+
     # Check if 'SR' is annotated
     if 'SR' in variant.FORMAT:
         values = variant.format('SR')[pos]
@@ -139,7 +136,7 @@ def parse_genotype(variant, ind, pos):
             split_read_alt = alt_value
         if not ref_value < 0:
             split_read_ref = ref_value
-    
+
     # Number of paired ends that supports the event
     if 'DV' in variant.FORMAT:
         values = variant.format('DV')[pos]
@@ -160,29 +157,29 @@ def parse_genotype(variant, ind, pos):
         alt_value = int(values[0])
         if not alt_value < 0:
             split_read_alt = alt_value
-    
+
     # Number of split reads that supports the reference
     if 'RR' in variant.FORMAT:
         values = variant.format('RR')[pos]
         ref_value = int(values[0])
         if not ref_value < 0:
             split_read_ref = ref_value
-    
-    
+
+
     alt_depth = int(variant.gt_alt_depths[pos])
     if alt_depth == -1:
         if 'VD' in variant.FORMAT:
             alt_depth = int(variant.format('VD')[pos][0])
-        
+
         if (paired_end_alt != None or split_read_alt != None):
             alt_depth = 0
             if paired_end_alt:
                 alt_depth += paired_end_alt
             if split_read_alt:
                 alt_depth += split_read_alt
-             
+
     gt_call['alt_depth'] = alt_depth
-    
+
     ref_depth = int(variant.gt_ref_depths[pos])
     if ref_depth == -1:
         if (paired_end_ref != None or split_read_ref != None):
@@ -193,7 +190,7 @@ def parse_genotype(variant, ind, pos):
                 ref_depth += split_read_ref
 
     gt_call['ref_depth'] = ref_depth
-    
+
     alt_frequency = float(variant.gt_alt_depths[pos])
     if alt_frequency == -1:
         if 'AF' in variant.FORMAT:

--- a/scout/parse/variant/ids.py
+++ b/scout/parse/variant/ids.py
@@ -26,8 +26,8 @@ def parse_ids(chrom, pos, ref, alt, case_id, variant_type):
 
 def parse_simple_id(chrom, pos, ref, alt):
     """Parse the simple id for a variant
-    
-    Simple id is used as a human readable reference for a position, it is 
+
+    Simple id is used as a human readable reference for a position, it is
     in no way unique.
 
     Args:
@@ -43,8 +43,8 @@ def parse_simple_id(chrom, pos, ref, alt):
 
 def parse_variant_id(chrom, pos, ref, alt, variant_type):
     """Parse the variant id for a variant
-    
-    variant_id is used to identify variants within a certain type of 
+
+    variant_id is used to identify variants within a certain type of
     analysis. It is not human readable since it is a md5 key.
 
     Args:
@@ -61,7 +61,7 @@ def parse_variant_id(chrom, pos, ref, alt, variant_type):
 
 def parse_display_name(chrom, pos, ref, alt, variant_type):
     """Parse the variant id for a variant
-    
+
     This is used to display the variant in scout.
 
     Args:
@@ -78,7 +78,7 @@ def parse_display_name(chrom, pos, ref, alt, variant_type):
 
 def parse_document_id(chrom, pos, ref, alt, variant_type, case_id):
     """Parse the unique document id for a variant.
-    
+
     This will allways bu unique in the database.
 
     Args:
@@ -87,10 +87,10 @@ def parse_document_id(chrom, pos, ref, alt, variant_type, case_id):
         ref(str)
         alt(str)
         variant_type(str): 'clinical' or 'research'
-        case_id(str): format is institute_familyid
+        case_id(str): unqiue family id
 
     Returns:
         document_id(str): The unique document id in an md5 string
     """
-    return generate_md5_key([chrom, pos, ref, alt, variant_type] + case_id.split('_'))
+    return generate_md5_key([chrom, pos, ref, alt, variant_type, case_id])
 

--- a/scout/parse/variant/models.py
+++ b/scout/parse/variant/models.py
@@ -1,20 +1,20 @@
 
-def parse_genetic_models(models_info, case_name):
+def parse_genetic_models(models_info, case_id):
     """Parse the genetic models entry of a vcf
-    
+
     Args:
         models_info(str): The raw vcf information
-        case_name(str)
-    
+        case_id(str)
+
     Returns:
         genetic_models(list)
-    
+
     """
     genetic_models = []
     if models_info:
         for family_info in models_info.split(','):
             splitted_info = family_info.split(':')
-            if splitted_info[0] == case_name:
+            if splitted_info[0] == case_id:
                 genetic_models = splitted_info[1].split('|')
-    
+
     return genetic_models

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -51,7 +51,6 @@ def parse_variant(variant, case, variant_type='clinical',
     # Create the ID for the variant
     case_id = case['_id']
     case_name = case['display_name']
-
     chrom = variant.CHROM
     if (chrom.startswith('chr') or chrom.startswith('CHR')):
         chrom = chrom[3:]
@@ -143,21 +142,16 @@ def parse_variant(variant, case, variant_type='clinical',
     parsed_variant['rank_score'] = rank_score or 0
 
     ################# Add gt calls #################
-    samples = {}
-    if individual_positions:
-        samples = parse_genotypes(
-                            variant,
-                            case,
-                            individual_positions
-                        )
-    parsed_variant['samples'] = samples
+    if individual_positions and case['individuals']:
+        parsed_variant['samples'] = parse_genotypes(variant, case['individuals'],
+                                                    individual_positions)
+    else:
+        parsed_variant['samples'] = []
 
     ################# Add the compound information #################
-    compounds = parse_compounds(
-                                compound_info=variant.INFO.get('Compounds'),
-                                case=case,
-                                variant_type=variant_type
-                                )
+    compounds = parse_compounds(compound_info=variant.INFO.get('Compounds'),
+                                case_id=case_id,
+                                variant_type=variant_type)
     if compounds:
         parsed_variant['compounds'] = compounds
 

--- a/tests/adapter/conftest.py
+++ b/tests/adapter/conftest.py
@@ -1,0 +1,51 @@
+from copy import deepcopy
+import pytest
+
+
+@pytest.yield_fixture
+def real_oldcase_database(real_panel_database, scout_config):
+    # add case with old case id construct
+    config_data = deepcopy(scout_config)
+    config_data['family'] = '-'.join([config_data['owner'], config_data['family_name']])
+    case_obj = real_panel_database.load_case(config_data)
+    # add suspect and causative!
+    institute_obj = real_panel_database.institute(case_obj['owner'])
+    user_obj = real_panel_database.users()[0]
+    variant_obj = real_panel_database.variants(case_obj['_id'])[0]
+    real_panel_database.pin_variant(
+        institute=institute_obj,
+        case=case_obj,
+        user=user_obj,
+        link='',
+        variant=variant_obj,
+    )
+    real_panel_database.mark_causative(
+        institute=institute_obj,
+        case=case_obj,
+        user=user_obj,
+        link='',
+        variant=variant_obj,
+    )
+    # add ACMG evaluation
+    real_panel_database.submit_evaluation(
+        variant_obj=variant_obj,
+        user_obj=user_obj,
+        institute_obj=institute_obj,
+        case_obj=case_obj,
+        link='',
+        criteria=[{'term': 'PS1'}, {'term': 'PM1'}],
+    )
+    # add comment on a variant
+    real_panel_database.comment(
+        institute=institute_obj,
+        case=case_obj,
+        user=user_obj,
+        link='',
+        variant=variant_obj,
+        comment_level='specific',
+    )
+    yield {
+        'adapter': real_panel_database,
+        'variant': variant_obj,
+        'case': real_panel_database.case(case_obj['_id']),
+    }

--- a/tests/adapter/test_adapter_variant_caseid.py
+++ b/tests/adapter/test_adapter_variant_caseid.py
@@ -1,0 +1,47 @@
+
+
+def test_update_caseid(real_oldcase_database, scout_config):
+    # GIVEN a case with a "old-style" case id
+    adapter = real_oldcase_database['adapter']
+    old_case = real_oldcase_database['case']
+    old_caseid = old_case['_id']
+    assert old_caseid == '-'.join([old_case['owner'], old_case['display_name']])
+    assert isinstance(adapter.case(old_caseid), dict)
+    assert adapter.case(scout_config['family']) is None
+
+    case_lists = {'suspects': None, 'causatives': None}
+    for case_variants in case_lists:
+        case_lists[case_variants] = old_case[case_variants][0]
+        assert isinstance(adapter.variant(case_lists[case_variants]), dict)
+
+    old_variant = real_oldcase_database['variant']
+    old_evaluation = adapter.get_evaluations(old_variant)[0]
+    assert old_evaluation['case_id'] == old_caseid
+    assert old_evaluation['variant_specific'] == old_variant['_id']
+
+    institute_obj = adapter.institute(old_case['owner'])
+    events = adapter.events(institute_obj, case=old_case)
+    for event_obj in events:
+        assert event_obj['case'] == old_caseid
+
+    # WHEN updating the case it as part of a upload
+    adapter.load_case(scout_config, update=True)
+
+    # THEN it should replace the case in the database
+    assert adapter.case(old_caseid) is None
+    new_case = adapter.case(scout_config['family'])
+    assert isinstance(new_case, dict)
+    # AND the suspect/causative variant should have an updated id
+    for case_variants, old_variantid in case_lists.items():
+        assert new_case[case_variants][0] != old_variantid
+        assert isinstance(adapter.variant(new_case[case_variants][0]), dict)
+    # AND the ACMG classification should have new case + variant ids
+    new_variant = adapter.variants(new_case['_id'])[0]
+    new_evaluation = adapter.get_evaluations(new_variant)[0]
+    assert new_evaluation['case_id'] == new_case['_id']
+    assert new_evaluation['variant_specific'] == new_variant['_id']
+    # AND update ids for events
+    assert adapter.events(institute_obj, case=old_case).count() == 0
+    new_events = adapter.events(institute_obj, case=new_case)
+    for event_obj in new_events:
+        assert event_obj['case'] == new_case['_id']

--- a/tests/adapter/test_variant_handling.py
+++ b/tests/adapter/test_variant_handling.py
@@ -10,25 +10,25 @@ log = logging.getLogger(__name__)
 def test_load_variants(real_populated_database, variant_objs, case_obj):
     """Test to load variants into a mongo database"""
     adapter = real_populated_database
-    case_id = case_obj['case_id']
+    case_id = case_obj['_id']
     # Make sure that there are no variants in the database
     # GIVEN a populated database without any variants
     assert adapter.variants(case_id=case_id, nr_of_variants=-1).count() == 0
-    
+
     # WHEN adding a number of variants
     for index, variant_obj in enumerate(variant_objs):
         # print(variant_obj)
         adapter.load_variant(variant_obj)
-    
+
     # THEN the same number of variants should have been loaded
     result = adapter.variants(case_id=case_id, nr_of_variants=-1)
     log.info("Number of variants loaded:%s", result.count())
-    assert result.count() == index+1
+    assert result.count() == index + 1
 
 # def test_manual_rank(real_populated_database, variant_objs, case_obj):
 #     """Check that the manual rank is added"""
 #     adapter = real_populated_database
-#     case_id = case_obj['case_id']
+#     case_id = case_obj['_id']
 #     # Make sure that there are no variants in the database
 #     # GIVEN a populated database without any variants
 #     assert adapter.variants(case_id=case_id, nr_of_variants=-1).count() == 0
@@ -48,7 +48,7 @@ def test_load_variants(real_populated_database, variant_objs, case_obj):
 
 def test_load_sv_variants(populated_database, sv_variant_objs, case_obj):
     """Test to load variants into a mongo database"""
-    case_id = case_obj['case_id']
+    case_id = case_obj['_id']
 
     # GIVEN a populated database without any sv variants
     assert populated_database.variants(case_id=case_id, nr_of_variants=-1).count() == 0
@@ -59,33 +59,33 @@ def test_load_sv_variants(populated_database, sv_variant_objs, case_obj):
 
     # THEN the same number of SV variants should have been loaded
     result = populated_database.variants(case_id=case_id, nr_of_variants=-1, category='sv')
-    assert result.count() == index+1
+    assert result.count() == index + 1
 
 def test_load_all_variants(populated_database, variant_objs, case_obj):
     adapter = populated_database
-    case_id = case_obj['case_id']
-    
+    case_id = case_obj['_id']
+
     ## GIVEN a populated database without any variants
     assert adapter.variants(case_id=case_id, nr_of_variants=-1).count() == 0
 
     ## WHEN loading all variants into the database
-    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical', 
-                          category='snv', rank_threshold=None, chrom=None, 
+    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical',
+                          category='snv', rank_threshold=None, chrom=None,
                           start=None, end=None, gene_obj=None)
 
     # THEN the same number of SV variants should have been loaded
     result = populated_database.variants(case_id=case_id, nr_of_variants=-1, category='snv')
-    
+
     assert nr_loaded == result.count()
 
 def test_load_whole_gene(populated_database, variant_objs, case_obj):
     adapter = populated_database
-    case_id = case_obj['case_id']
-    
+    case_id = case_obj['_id']
+
     assert adapter.variants(case_id=case_id, nr_of_variants=-1).count() == 0
 
-    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical', 
-                          category='snv', rank_threshold=None, chrom=None, 
+    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical',
+                          category='snv', rank_threshold=None, chrom=None,
                           start=None, end=None, gene_obj=None)
 
     ## GIVEN a populated database with variants in a certain gene
@@ -93,24 +93,24 @@ def test_load_whole_gene(populated_database, variant_objs, case_obj):
     gene_obj = adapter.hgnc_gene(hgnc_id)
     assert gene_obj
     nr_variants_in_gene = adapter.variant_collection.find({'hgnc_ids': hgnc_id}).count()
-    
+
     ## WHEN loading all variants for that gene
-    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical', 
-                          category='snv', rank_threshold=None, chrom=None, 
+    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical',
+                          category='snv', rank_threshold=None, chrom=None,
                           start=None, end=None, gene_obj=gene_obj)
     new_nr_variants_in_gene = adapter.variant_collection.find({'hgnc_ids': hgnc_id}).count()
-    
+
     ## Then assert that the other variants where loaded
     assert new_nr_variants_in_gene > nr_variants_in_gene
 
 def test_load_coordinates(populated_database, variant_objs, case_obj):
     adapter = populated_database
-    case_id = case_obj['case_id']
-    
+    case_id = case_obj['_id']
+
     assert adapter.variants(case_id=case_id, nr_of_variants=-1).count() == 0
 
-    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical', 
-                          category='snv', rank_threshold=None, chrom=None, 
+    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical',
+                          category='snv', rank_threshold=None, chrom=None,
                           start=None, end=None, gene_obj=None)
 
     ## GIVEN a populated database with variants in a certain gene
@@ -118,14 +118,14 @@ def test_load_coordinates(populated_database, variant_objs, case_obj):
     gene_obj = adapter.hgnc_gene(hgnc_id)
     assert gene_obj
     nr_variants_in_gene = adapter.variant_collection.find({'hgnc_ids': hgnc_id}).count()
-    
+
     ## WHEN loading all variants for that gene
-    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical', 
-                          category='snv', rank_threshold=None, chrom=gene_obj['chromosome'], 
+    nr_loaded = adapter.load_variants(case_obj=case_obj, variant_type='clinical',
+                          category='snv', rank_threshold=None, chrom=gene_obj['chromosome'],
                           start=gene_obj['start'], end=gene_obj['end'], gene_obj=None)
 
     new_nr_variants_in_gene = adapter.variant_collection.find({'hgnc_ids': hgnc_id}).count()
-    
+
     ## Then assert that the other variants where loaded
     assert new_nr_variants_in_gene > nr_variants_in_gene
 
@@ -134,10 +134,10 @@ def test_load_coordinates(populated_database, variant_objs, case_obj):
 def test_get_region_vcf(populated_database, case_obj):
     print('Travis', TRAVIS, type(TRAVIS))
     adapter = populated_database
-    case_id = case_obj['case_id']
-    
-    file_name = adapter.get_region_vcf(case_obj, chrom=None, start=None, end=None, 
-                       gene_obj=None, variant_type='clinical', category='snv', 
+    case_id = case_obj['_id']
+
+    file_name = adapter.get_region_vcf(case_obj, chrom=None, start=None, end=None,
+                       gene_obj=None, variant_type='clinical', category='snv',
                        rank_threshold=None)
     ## GIVEN a populated database with variants in a certain gene
     nr_variants = 0
@@ -145,7 +145,7 @@ def test_get_region_vcf(populated_database, case_obj):
         for line in f:
             if not line.startswith('#'):
                 nr_variants += 1
-    
+
     os.remove(file_name)
-    
+
     assert nr_variants > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,10 +29,10 @@ from scout.load import (load_hgnc_genes)
 from scout.load.hpo import load_hpo
 
 # These are the reduced data files
-from scout.demo.resources import (hgnc_reduced_path, transcripts37_reduced_path, 
-exac_reduced_path, hpogenes_reduced_path, hpoterms_reduced_path, 
+from scout.demo.resources import (hgnc_reduced_path, transcripts37_reduced_path,
+exac_reduced_path, hpogenes_reduced_path, hpoterms_reduced_path,
 hpo_phenotype_to_terms_reduced_path, mim2gene_reduced_path, genemap2_reduced_path)
-from scout.demo import (research_snv_path, research_sv_path, clinical_snv_path, 
+from scout.demo import (research_snv_path, research_sv_path, clinical_snv_path,
                         clinical_sv_path, ped_path, load_path, panel_path)
 
 DATABASE = 'testdb'
@@ -696,9 +696,9 @@ def parsed_variants(request, variants, case_obj):
     individual_positions = {}
     for i,ind in enumerate(variants.samples):
         individual_positions[ind] = i
-    
-    return (parse_variant(variant, case_obj, 
-            individual_positions=individual_positions) 
+
+    return (parse_variant(variant, case_obj,
+            individual_positions=individual_positions)
             for variant in variants)
 
 @pytest.fixture(scope='function')
@@ -709,8 +709,8 @@ def parsed_sv_variants(request, sv_variants, case_obj):
     for i,ind in enumerate(sv_variants.samples):
         individual_positions[ind] = i
 
-    return (parse_variant(variant, case_obj, 
-            individual_positions=individual_positions) 
+    return (parse_variant(variant, case_obj,
+            individual_positions=individual_positions)
             for variant in sv_variants)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,18 +416,14 @@ def case_database(request, institute_database, case_obj):
 def populated_database(request, panel_database, institute_obj, parsed_user, case_obj):
     "Returns an adapter to a database populated with user, institute case, genes, panels"
     adapter = panel_database
-
     adapter._add_case(case_obj)
-
     return adapter
 
 @pytest.fixture(scope='function')
 def real_populated_database(request, real_panel_database, institute_obj, parsed_user, case_obj):
     "Returns an adapter to a database populated with user, institute case, genes, panels"
     adapter = real_panel_database
-
     adapter._add_case(case_obj)
-
     return adapter
 
 @pytest.fixture(scope='function')

--- a/tests/load/test_load_case.py
+++ b/tests/load/test_load_case.py
@@ -12,10 +12,10 @@ def test_load_case(case_obj, panel_database):
     # THEN assert that the case have been loaded with correct info
     assert adapter.cases().count() == 1
     loaded_case = adapter.case(case_obj['_id'])
-    
-    assert loaded_case['case_id'] == case_obj['case_id']
+
+    assert loaded_case['_id'] == case_obj['_id']
 
     assert len(loaded_case['panels']) > 0
-    
+
     for panel in loaded_case['panels']:
         assert panel['display_name']

--- a/tests/parse/test_ids.py
+++ b/tests/parse/test_ids.py
@@ -56,7 +56,7 @@ def test_parse_document_id():
     # WHEN parsing the document id
     variant_id = parse_document_id(chrom, pos, ref, alt, variant_type, case_id)
     # THEN we should get a correct md5 string back
-    assert variant_id == generate_md5_key([chrom, pos, ref, alt, variant_type] + case_id.split('_'))
+    assert variant_id == generate_md5_key([chrom, pos, ref, alt, variant_type, case_id])
 
 
 def test_parse_ids():

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -15,7 +15,7 @@ def test_parse_case(scout_config):
     # WHEN case is parsed
     case_data = parse_case(scout_config)
     # THEN the case a correct case id
-    assert case_data['case_id'] == '{0}-{1}'.format(scout_config['owner'], scout_config['family'])
+    assert case_data['case_id'] == scout_config['family']
 
 def test_parse_case_madeline(scout_config):
     # GIVEN you load sample information from a scout config

--- a/tests/parse/test_parse_compounds.py
+++ b/tests/parse/test_parse_compounds.py
@@ -7,7 +7,7 @@ def test_parse_simple_compound(case_obj):
     compound_string = "643594:7_117175579_AT_A>32"
 
     ## When parsing the compounds
-    compounds = parse_compounds(compound_string, case=case_obj, variant_type='clinical')
+    compounds = parse_compounds(compound_string, case_id=case_obj['_id'], variant_type='clinical')
     compound = compounds[0]
 
     ## THEN assert that the correct info is returned
@@ -19,7 +19,7 @@ def test_parse_compound_no_score(case_obj):
     compound_string = "643594:7_117175579_AT_A"
 
     ## When parsing the compounds
-    compounds = parse_compounds(compound_string, case=case_obj, variant_type='clinical')
+    compounds = parse_compounds(compound_string, case_id=case_obj['_id'], variant_type='clinical')
     compound = compounds[0]
 
     ## THEN assert that the correct info is returned
@@ -31,9 +31,9 @@ def test_parse_compound_no_compound(case_obj):
     compound_string = None
 
     ## When parsing the compounds
-    compounds = parse_compounds(compound_string, case=case_obj, variant_type='clinical')
+    compounds = parse_compounds(compound_string, case_id=case_obj['_id'], variant_type='clinical')
 
-    ## THEN assert that the correct info is returned    
+    ## THEN assert that the correct info is returned
     assert compounds == []
 
 def test_parse_multiple_compound(case_obj):
@@ -41,8 +41,8 @@ def test_parse_multiple_compound(case_obj):
     compound_string = "643594:7_117175579_AT_A>32|7_117175580_T_G>28"
 
     ## When parsing the compounds
-    compounds = parse_compounds(compound_string, case=case_obj, variant_type='clinical')
-    
+    compounds = parse_compounds(compound_string, case_id=case_obj['_id'], variant_type='clinical')
+
     ## THEN assert that the correct info is returned
     assert len(compounds) == 2
 

--- a/tests/parse/test_parse_genotype.py
+++ b/tests/parse/test_parse_genotype.py
@@ -15,26 +15,26 @@ def test_parse_genotype(variants):
             'individual_id': ind,
             'display_name': ind
         }
-        
+
     ## WHEN parsing the variants genotypes
     for variant in variants:
         for ind_id in ind_ids:
             pos = ind_positions[ind_id]
             genotype = parse_genotype(
-                            variant=variant, 
+                            variant=variant,
                             ind=individuals[ind_id],
                             pos=pos
                         )
     ## THEN assert genotypes are parsed correct
             vcf_genotype = variant.genotypes[pos]
             gt_call = "{0}/{1}".format(
-                GENOTYPE_MAP[vcf_genotype[0]], 
+                GENOTYPE_MAP[vcf_genotype[0]],
                 GENOTYPE_MAP[vcf_genotype[1]]
                 )
-            
+
             vcf_read_depth = int(variant.gt_depths[pos])
             vcf_quality = float(variant.gt_quals[pos])
-            
+
             if vcf_read_depth != -1:
                 assert genotype['genotype_call'] == gt_call
                 assert genotype['read_depth'] == vcf_read_depth
@@ -55,10 +55,10 @@ def test_parse_genotypes(variants):
     case['individuals'] = [individuals[ind_id] for ind_id in individuals]
     ## WHEN parsing the variants genotypes
     for variant in variants:
-    
+
     ## THEN assert genotypes are parsed correct
-        
-        genotypes = parse_genotypes(variant, case, ind_positions)
+
+        genotypes = parse_genotypes(variant, case['individuals'], ind_positions)
         assert len(genotypes) == len(variant.genotypes)
 
 def test_parse_cnvnator():
@@ -66,4 +66,3 @@ def test_parse_cnvnator():
     vcf_obj = VCF(one_cnvnator)
     for variant in vcf_obj:
         assert variant
-    


### PR DESCRIPTION
I've added a method that can migrate a case using the `CUSTOMER-FAMILY` syntax over to using a unique family id.

I'm not updating variant documents since I think we should only run this function when we re-upload a case and then all the variants will be deleted either way!