### PR TITLE
Bugfix: load panel, hgnc_id not in database

### DIFF
--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -45,7 +45,7 @@ def build_gene(gene_info, adapter):
     
     hgnc_gene = adapter.hgnc_gene(hgnc_id)
     if hgnc_gene is None:
-        raise IntegrityError
+        raise IntegrityError("hgnc_id {0} is not in the gene database!".format(hgnc_id))
     
     gene_obj['symbol'] = hgnc_gene['hgnc_symbol']
 

--- a/scout/commands/load/panel.py
+++ b/scout/commands/load/panel.py
@@ -74,5 +74,5 @@ def panel(context, date, name, version, panel_type, panel_id, path, institute):
     try:
         adapter.load_panel(info)
     except IntegrityError as e:
-        logger.warning(e)
+        log.warning(e)
         context.abort()


### PR DESCRIPTION
Fixes bug when trying to add gene panel with an hgnc_id which is not in the database. Also adds an error message.