### PR TITLE
fix #747

### DIFF
--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -66,6 +66,7 @@ def logout():
 @login_bp.route('/authorized')
 @public_endpoint
 def authorized():
+    oauth_response = None
     try:
         oauth_response = google.authorized_response()
     except OAuthException as error:


### PR DESCRIPTION
The oauth_response was indeed referenced before being instantiated. This should fix the problem, but to be sure we should test the situation when the error occurs. Does it happen when the session expires and you click on pages that require login?