### PR TITLE
added links for clinvar submitted variants under cases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ $scout update hpo
 - Added an analysis report page (html and PDF format) containing phenotype, gene panels and variants that are relevant to solve a case.
 
 ### Fixed
-
+- Links to clinvar submitted variants at the cases level
 - Adapts clinvar parsing to new format
 - Fixed problem in `scout update user` when the user object had no roles
 - Makes pileup.js use online genome resources when viewing alignments. Now any instance of Scout can make use of this functionality.

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -26,7 +26,7 @@ def cases(store, case_query, limit=100):
                                  case_obj.get('assignees', [])]
         case_groups[case_obj['status']].append(case_obj)
         case_obj['is_rerun'] = len(case_obj.get('analyses', [])) > 0
-        case_obj['clinvar_id'] = store.clinvars(case_id=case_obj['display_name'])
+        case_obj['clinvar_submissions'] = store.clinvars(case_id=case_obj['display_name'])
 
     data = {
         'cases': [(status, case_groups[status]) for status in CASE_STATUSES],
@@ -128,14 +128,14 @@ def case_report_content(store, institute_obj, case_obj):
                                                            'acmg_classification', case_obj, institute_obj)
 
     # get complete info for tagged variants
-    data['tagged_detailed'] = variants_filter_by_field(store, evaluated_variants, 
+    data['tagged_detailed'] = variants_filter_by_field(store, evaluated_variants,
                                                        'manual_rank', case_obj, institute_obj)
 
     # get complete info for dismissed variants
-    data['dismissed_detailed'] = variants_filter_by_field(store, evaluated_variants, 
+    data['dismissed_detailed'] = variants_filter_by_field(store, evaluated_variants,
                                                         'dismiss_variant', case_obj, institute_obj)
 
-    data['commented_detailed'] = variants_filter_by_field(store, evaluated_variants, 
+    data['commented_detailed'] = variants_filter_by_field(store, evaluated_variants,
                                                         'is_commented', case_obj, institute_obj)
 
     return data

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -155,9 +155,15 @@
       {% endfor %}
     </td>
     <td>
-      {% if case.clinvar_id %}
-      <span class="label label-info">created</span>
-      {%endif%}
+      {% if case.clinvar_submissions %}
+        {% for subm in case.clinvar_submissions %}
+          {% if subm.variant_type == 'snv'%}
+            <span class="label label-success" title="{{ subm.Gene_symbol if subm.Gene_symbol else 'chr'+subm.Chromosome+'_'+subm.Start }}"><a href="{{ url_for('variants.variant', institute_id=case.owner, case_name=case.display_name, variant_id=subm._id ) }}">snv</a></span>
+          {% else %}
+            <span class="label label-warning" title="{{'chr'+subm.Chromosome+'_'+subm.Variant_type}}"><a href="{{ url_for('variants.sv_variant', institute_id=case.owner, case_name=case.display_name, variant_id=subm._id ) }}">sv</a></span>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
     </td>
   </tr>
 {% endmacro %}


### PR DESCRIPTION
Now you see a small green or yellow label under the clinvar submission column for each snv/sv submitted for a case