### PR TITLE
pin flask-pymongo 0.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 Flask>=0.10
 Flask-DebugToolbar
-Flask-PyMongo>=0.5.1
+Flask-PyMongo==0.5.2
 Flask-Bootstrap
 path.py
 Flask-OAuthlib


### PR DESCRIPTION
In about the next month, Flask-PyMongo 2.0 is going to be released, which is not (necessarily) compatible with 0.x versions. This change will prevent accidental updates, but I'd also be happy to work with you on upgrading safely to 2.0, which will be the base version going forward that will receive compatibility and bug fix improvements, etc.

In particular, it looks like you are configuring with MONGO_HOST, MONGO_DBNAME, etc. To use Flask-PyMongo 2.0, you should convert to using MONGO_URI. It should be pretty straight forward, and I'll be happy to lend a hand if it helps.