### PR TITLE
show gene HGNC id in gene, genes, and gene panels pages

### DIFF
--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -22,7 +22,7 @@
       <typeahead url="/api/v1/genes" v-on:send="visitGene" bootstrap="yes"></typeahead>
     </div>
   </div>
-  
+
   <h1>
     {{ symbol }} <small>{{ ensembl_id }}</small>
   </h1>
@@ -50,6 +50,10 @@
     <li class="list-group-item">
       Aliases
       <span class="pull-right">{{ gene.aliases|join(', ') }}</span>
+    </li>
+    <li class="list-group-item">
+      HGNC ID
+      <span class="pull-right">{{ gene.hgnc_id }}</span>
     </li>
     <li class="list-group-item">
       Chromosome

--- a/scout/server/blueprints/genes/templates/genes/genes.html
+++ b/scout/server/blueprints/genes/templates/genes/genes.html
@@ -29,6 +29,7 @@
               <td>{{ gene.hgnc_id }}</td>
             </tr>
           {% endfor %}
+          </tbody>
         </table>
       </div>
     </div>

--- a/scout/server/blueprints/genes/templates/genes/genes.html
+++ b/scout/server/blueprints/genes/templates/genes/genes.html
@@ -17,15 +17,19 @@
     <div class="col-md-12">
       <div class="panel panel-default">
         <div class="panel-heading">Genes</div>
-        <ul class="list-group">
+        <table class="table table-bordered">
+          <thead>
+            <th>Gene symbol</th>
+            <th>HGNC ID</th>
+          </thead>
+          <tbody>
           {% for gene in genes %}
-            <li class="list-group-item">
-              <a href="{{ url_for('genes.gene', hgnc_symbol=gene.hgnc_id) }}">
-                {{ gene.hgnc_symbol }}
-              </a>
-            </li>
+            <tr>
+              <td><a href="{{ url_for('genes.gene', hgnc_symbol=gene.hgnc_id) }}">{{ gene.hgnc_symbol }}</a></td>
+              <td>{{ gene.hgnc_id }}</td>
+            </tr>
           {% endfor %}
-        </ul>
+        </table>
       </div>
     </div>
   </div>

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -85,6 +85,7 @@
         <thead>
           <tr>
             <th>Gene</th>
+            <th>HGNC ID</th>
             <th>Transcripts</th>
             <th>Reduced penetrance</th>
             <th>Mosaicism</th>
@@ -102,6 +103,7 @@
                   {{ gene.symbol }}
                 </a>
               </td>
+              <td>{{ gene.hgnc_id }}</td>
               <td>{{ gene.disease_associated_transcripts|join(', ') }}</td>
               <td>{{ 'Yes' if gene.reduced_penetrance }}</td>
               <td>{{ 'Yes' if gene.mosaicism }}</td>


### PR DESCRIPTION
Mostly useful when, from a case view, you want to check the coverage for a certain gene of a panel. It can be used as a reference for the customized search on the coverage report. Addresses issue #865