### PR TITLE
Show end_chrom in sv_variant and sv_variants when different from start_chrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ $scout update hpo
 - Added an analysis report page (html and PDF format) containing phenotype, gene panels and variants that are relevant to solve a case.
 
 ### Fixed
+- Fixed coordinates for SVs with start chromosome different from end chromosome
 - Links to clinvar submitted variants at the cases level
 - Adapts clinvar parsing to new format
 - Fixed problem in `scout update user` when the user object had no roles

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -870,8 +870,14 @@
         <tr>
           <td><span class="badge badge-warning pull-left">{{variant.sub_category|upper}}</span></td>
           <td>{{ variant.length }}</td>
-          <td>chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}</td>
-          <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
+          <td>chr{{variant.chromosome}}:{{variant.position}}-{{ 'chr'+variant.end_chrom if not variant.chromosome == variant.end_chrom }}:{{variant.end}}</td>
+          {% if variant.chromosome == variant.end_chrom %}
+            <td>chr{{variant.chromosome}}:{{variant.position}}-{{ 'chr'+variant.end_chrom if not variant.chromosome == variant.end_chrom }}:{{variant.end}}</td>
+            <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
+          {% else %}
+            <td>chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}</td>
+            <td>{{variant.chromosome}}{{variant.cytoband_start}}-{{variant.end_chrom}}{{variant.cytoband_end}}</td>
+          {% endif %}
           <td>
             {% for panel_id in variant.panels %}
               <a href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank">{{ panel_id }}</a><br>

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -100,10 +100,12 @@
 	      <li class="list-group-item">
 	        Cytoband
           <div class="pull-right">
-            {% if variant.cytoband_start == variant.cytoband_end %}
-            {{ variant.chromosome }}{{ variant.cytoband_start }}
+            {% if variant.chromosome == variant.end_chrom and variant.cytoband_start == variant.cytoband_end %}
+              {{ variant.chromosome }}{{ variant.cytoband_start }}
+            {% elif variant.chromosome == variant.end_chrom %}
+              {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end }}
             {% else %}
-            {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end }}
+              {{ variant.chromosome }}{{ variant.cytoband_start }}-{{variant.end_chrom}}{{ variant.cytoband_end }}
             {% endif %}
           </div>
 	      </li>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -247,7 +247,7 @@
     </td>
     <td>{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
-    <td>{{ variant.chromosome }}</td>
+    <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
     <td>{{ variant.position }}</td>
     <td>{{ 'inf' if variant.end == 100000000000 else variant.end }}</td>
     <td>{{ variant.length }}</td>


### PR DESCRIPTION
This way whenever end chromosome is different from start chromosome, end chr is shown in sv_variant and sv_variants pages.

In sv_variant: cytoband becomes [startchr][cytobandstart]-[endchr][cytobandend]
in sv_variants: startchr becomes [startchr]-[endchr]