### PR TITLE
re-introduced breakpoint alignments for SVs

### DIFF
--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -117,13 +117,47 @@
           <div class="pull-right">
             {{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}
             {% if variant.chromosome == "MT" and case.mt_bams %}
-              - Alignments:
+              - Alignment:
               <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">Pileup viewer</a><br>
               <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">IGV viewer (BETA)</a>
             {% elif case.bam_files %}
-              - Alignments:
+              - Alignment:
               <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
               <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">IGV (BETA)</a>
+            {% else %}
+              - BAM file(s) missing
+            {% endif %}
+          </div>
+        </li>
+        <li class="list-group-item">
+          Left breakpoint
+          <div class="pull-right">
+            {{ variant.chromosome }}:{{ variant.position }}
+            {% if variant.chromosome == "MT" and case.mt_bams %}
+              - Alignment:
+              <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 500), stop=(variant.position + 500)) }}" target="_blank">Pileup viewer</a><br>
+              <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.chromosome, start=(variant.position - 500), stop=(variant.position + 500)) }}" target="_blank">IGV viewer (BETA)</a>
+            {% elif case.bam_files %}
+              - Alignment:
+              <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 500), stop=(variant.position + 500), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
+              <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.chromosome, start=(variant.position - 500), stop=(variant.position + 500)) }}" target="_blank">IGV (BETA)</a>
+            {% else %}
+              - BAM file(s) missing
+            {% endif %}
+          </div>
+        </li>
+        <li class="list-group-item">
+          Right breakpoint
+          <div class="pull-right">
+            {{ variant.chromosome }}:{{ variant.end }}
+            {% if variant.chromosome == "MT" and case.mt_bams %}
+              - Alignment:
+              <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">Pileup viewer</a><br>
+              <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV viewer (BETA)</a>
+            {% elif case.bam_files %}
+              - Alignment:
+              <a class="btn btn-default btn-sm" href="{{ url_for('pileup.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
+              <a class="btn btn-default btn-sm" href="{{ url_for('igv.viewer', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV (BETA)</a>
             {% else %}
               - BAM file(s) missing
             {% endif %}


### PR DESCRIPTION
I removed the alignments view for the breakpoints by mistake when I introduced the IGV viewer! Fix #910 

Since the line was a bit busy I've introduced a left and right breakpoint line. Or should I name them breakpoint 1 and breakpoint 2 instead?

![image](https://user-images.githubusercontent.com/28093618/44021534-5e1a1f40-9ee5-11e8-81e0-e55949d1fb3c.png)
