### PR TITLE
adding jinja2 'do' extension

### DIFF
--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -31,6 +31,7 @@ def create_app(config_file=None, config=None):
     """Flask app factory function."""
     app = Flask(__name__)
     app.config.from_pyfile('config.py')
+    app.jinja_env.add_extension('jinja2.ext.do')
     if config:
         app.config.update(config)
     if config_file:


### PR DESCRIPTION
The idea is to fix #917.
It is weird that jinja2 extensions are found in scout stage but not in scout production..!