### PR TITLE
Speed up query for creating case report, fix #984 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ $scout update hpo
 - Added an analysis report page (html and PDF format) containing phenotype, gene panels and variants that are relevant to solve a case.
 
 ### Fixed
+- Optimized evaluated variants to speed up creation of case report
 - Moved igv and pileup viewer under a common folder
 - Fixed MT alignment view pileup.js
 - Fixed coordinates for SVs with start chromosome different from end chromosome

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -157,7 +157,7 @@ class VariantHandler(VariantLoader):
             result(Iterable[Variant])
         """
         LOG.debug("Fetching variants from {0}".format(case_id))
-        
+
         if variant_ids:
             nr_of_variants = len(variant_ids)
 
@@ -206,7 +206,7 @@ class VariantHandler(VariantLoader):
         else:
             # search with a unique id
             query['_id'] = document_id
-        
+
         variant_obj = self.variant_collection.find_one(query)
         if variant_obj:
             variant_obj = self.add_gene_info(variant_obj, gene_panels)
@@ -342,13 +342,13 @@ class VariantHandler(VariantLoader):
 
             gene_start = gene_obj['start']
             gene_end = gene_obj['end']
-            
+
             #Get the coordinates for a region
             if not region_start:
                 region_start = gene_start
             if gene_start < region_start:
                 region_start = gene_start
-            
+
             if not region_end:
                 region_end = gene_end
             if gene_end > region_end:
@@ -386,13 +386,18 @@ class VariantHandler(VariantLoader):
         """
         # Get all variants that have been evaluated in some way for a case
         query = {
-            'case_id': case_id,
-            '$or': [
-                {'acmg_classification': {'$exists': True}},
-                {'manual_rank': {'$exists': True}},
-                {'dismiss_variant': {'$exists': True}},
+            '$and': [
+                {'case_id': case_id},
+                {
+                    '$or': [
+                        {'acmg_classification': {'$exists': True}},
+                        {'manual_rank': {'$exists': True}},
+                        {'dismiss_variant': {'$exists': True}},
+                    ]
+                }
             ],
         }
+
         # Collect all relevant variant_ids in a list
         variants = {}
         for var in self.variant_collection.find(query):
@@ -404,10 +409,10 @@ class VariantHandler(VariantLoader):
             'category': 'variant',
             'verb': 'comment',
         }
-        
+
         # Get all variantids for commented variants
         comment_variants = {event['variant_id'] for event in self.event_collection.find(event_query)}
-        
+
         # Get the variant objects for commented variants, if they exist
         for var_id in comment_variants:
             # Skip if we already added the variant
@@ -415,7 +420,7 @@ class VariantHandler(VariantLoader):
                 continue
             # Get the variant with variant_id (not _id!)
             variant_obj = self.variant(var_id, case_id=case_id)
-            
+
             # There could be cases with comments that refers to non existing variants
             # if a case has been reanalysed
             if not variant_obj:


### PR DESCRIPTION
Found a query which was not optimized and fixed it. Instead of returning just the variants for a case that were either ACMG-classified, Manual ranked or dismissed, it returned them all. Later in the code there was a control loop that was potentially quite slow. 
This way the report page should be faster to load