### PR TITLE
Fix sanger snvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.1.2b]
+- Fixed sanger validation popup, now unevaluated by user and institute
 
 ### Added
 
-- Logs uri without pwd when connecting 
+- Logs uri without pwd when connecting
 - Disease-causing transcripts in case report
 - Thicker lines in case report
 - Supports HPO search for cases, both terms or if described in synopsis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.1.2b]
-- Fixed sanger validation popup, now unevaluated by user and institute
+
 
 ### Added
 
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 - Use db name instead of **auth** as default for authentification
 - Fixes so that reports can be generated even with many variants
+- Fixed sanger validation popup to show individual variants queried by user and institute.
 
 ## [4.1.1]
 - Fix problem with institute authentication flash message in utils

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -185,27 +185,30 @@ class VariantEventHandler(object):
         )
         return updated_variant
 
-    def sanger_ordered_by_institute_user(self, institute_id, user_id):
-        """Get all variants for an institute with Sanger validations ever ordered.
-            This is used in the cases list page to highlight cases which can be potentially
-            solved by Sanger sequencing validations.
+    def sanger_ordered(self, institute_id=None, user_id=None):
+        """Get all variants where Sanger validations ever ordered.
 
         Args:
             institute_id(str) : The id of an institute
+            user_id(str) : The id of an user
 
         Returns:
             sanger_ordered(list) : a list of dictionaries, each with "case_id" as keys and list of variant ids as values
         """
-
-        # Get all sanger ordered variants grouped by case_id
-        results = self.event_collection.aggregate([
-            {'$match': {
+        query = {'$match': {
                 '$and': [
                     {'verb': 'sanger'},
-                    {'user_id': user_id},
-                    {'institute': institute_id}
                 ],
-            }},
+            }}
+
+        if institute_id:
+            query['$match']['$and'].append({'institute': institute_id})
+        if user_id:
+            query['$match']['$and'].append({'user_id': user_id})
+        
+        # Get all sanger ordered variants grouped by case_id
+        results = self.event_collection.aggregate([
+            query,
             {'$group': {
                 '_id': "$case",
                 'vars': {'$addToSet' : '$variant_id'}

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -185,7 +185,7 @@ class VariantEventHandler(object):
         )
         return updated_variant
 
-    def sanger_ordered_by_institute(self, institute_id):
+    def sanger_ordered_by_institute_user(self, institute_id, user_id):
         """Get all variants for an institute with Sanger validations ever ordered.
             This is used in the cases list page to highlight cases which can be potentially
             solved by Sanger sequencing validations.
@@ -201,7 +201,8 @@ class VariantEventHandler(object):
         results = self.event_collection.aggregate([
             {'$match': {
                 '$and': [
-                    {'verb': 'sanger' },
+                    {'verb': 'sanger'},
+                    {'user_id': user_id},
                     {'institute': institute_id}
                 ],
             }},

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -255,7 +255,7 @@ def multiqc(store, institute_id, case_name):
     )
 
 
-def get_sanger_unevaluated(store, institute_id):
+def get_sanger_unevaluated(store, institute_id, user_id):
     """Get all variants for an institute having Sanger validations ordered but still not evaluated
 
         Args:
@@ -270,7 +270,7 @@ def get_sanger_unevaluated(store, institute_id):
 
     # Retrieve a list of ids for variants with Sanger ordered grouped by case from the 'event' collection
     # This way is much faster than querying over all variants in all cases of an institute
-    sanger_ordered_by_case = store.sanger_ordered_by_institute(institute_id)
+    sanger_ordered_by_case = store.sanger_ordered_by_institute_user(institute_id,user_id)
     unevaluated = []
 
     # for each object where key==case and value==[variant_id with Sanger ordered]
@@ -295,7 +295,7 @@ def get_sanger_unevaluated(store, institute_id):
             variant_obj = store.variant(document_id=var_id, case_id=case_id)
 
             # Double check that Sanger was ordered (and not canceled) for the variant
-            if variant_obj is None or variant_obj.get('sanger_ordered') is None:
+            if variant_obj is None or variant_obj.get('sanger_ordered') is None or variant_obj.get('sanger_ordered') is False:
                 continue
 
             validation = variant_obj.get('validation', 'not_evaluated')

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -345,7 +345,7 @@ def get_sanger_unevaluated(store, institute_id, user_id):
 
     # Retrieve a list of ids for variants with Sanger ordered grouped by case from the 'event' collection
     # This way is much faster than querying over all variants in all cases of an institute
-    sanger_ordered_by_case = store.sanger_ordered_by_institute_user(institute_id,user_id)
+    sanger_ordered_by_case = store.sanger_ordered(institute_id, user_id)
     unevaluated = []
 
     # for each object where key==case and value==[variant_id with Sanger ordered]

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -58,7 +58,12 @@
                 {% for uneval_obj in sanger_unevaluated %}
                 {% for case, var_list in uneval_obj.items() %}
                 <li>
-                  Case <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case) }}" target="_blank">{{case}}</strong></a> ---> <strong>{{var_list|length}}</strong> variants.
+                  Case <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case) }}" target="_blank">{{case}}</strong></a> ---> <strong>{{var_list|length}}</strong> variants:
+                  <ul>
+                    {% for var in var_list %}
+                      <li><a href="{{ url_for('variants.variant', institute_id=institute._id, case_name=case, variant_id=var) }}" target="_blank">{{var}}</a></li>
+                    {% endfor %}
+                  </ul>
                 </li>
                 {% endfor %}
                 {% endfor %}

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -48,7 +48,7 @@ def cases(institute_id):
     all_cases = store.cases(institute_id, name_query=query, skip_assigned=skip_assigned)
     data = controllers.cases(store, all_cases, limit)
 
-    sanger_unevaluated = controllers.get_sanger_unevaluated(store, institute_id)
+    sanger_unevaluated = controllers.get_sanger_unevaluated(store, institute_id, current_user.email)
     if len(sanger_unevaluated)> 0:
         data['sanger_unevaluated'] = sanger_unevaluated
 

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -67,7 +67,7 @@ def test_get_sanger_unevaluated(real_populated_database, variant_objs, institute
 
     # Test that the Sanger ordered but not validated for the institute are 2
     # sanger_unevaluated should look like this: [{ 'case_id': [var1, var2] }]
-    sanger_unevaluated = get_sanger_unevaluated(adapter, institute['_id'])
+    sanger_unevaluated = get_sanger_unevaluated(adapter, institute['_id'], user_obj['email'])
     assert len(sanger_unevaluated[0][case_obj['display_name']]) == 2
 
     # Set one of the two variants as validated
@@ -78,6 +78,6 @@ def test_get_sanger_unevaluated(real_populated_database, variant_objs, institute
 
     # Test that now the Sanger ordered but not validated is only one
     # sanger_unevaluated should look like this: [{ 'case_id': [var2] }]
-    sanger_unevaluated = get_sanger_unevaluated(adapter, institute['_id'])
+    sanger_unevaluated = get_sanger_unevaluated(adapter, institute['_id'], user_obj['email'])
     pp(sanger_unevaluated)
     assert len(sanger_unevaluated[0][case_obj['display_name']]) == 1


### PR DESCRIPTION
Fixes #998, namely:

- Variants with Sanger to be evaluated are queried by institute and user.
- Fixed a bug that suggested to be evaluated variants with sanger canceled.
- Showing in popup "Sanger validations to evaluate" both link to cases and all their sanger-ordered variants. 
