### PR TITLE
Fixes problems with case sensitivity of email address returned by gooogle oauth

### DIFF
--- a/scout/commands/load/user.py
+++ b/scout/commands/load/user.py
@@ -40,7 +40,7 @@ def user(context, institute_id, user_name, user_mail, admin):
         LOG.info("User is admin")
         roles.append('admin')
 
-    user_info = dict(email=user_mail, name=user_name, roles=roles, institutes=institutes)
+    user_info = dict(email=user_mail.lower(), name=user_name, roles=roles, institutes=institutes)
 
     user_obj = build_user(user_info)
 

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -89,8 +89,13 @@ def authorized():
     google_data = google_user.data
 
     user_obj = store.user(google_data['email'])
+
+    # Try again with lower-cased email address if no match
     if user_obj is None:
-        flash('your email is not whitelisted, contact admin.', 'warning')
+        user_obj = store.user(google_data['email'].lower())
+        
+    if user_obj is None:
+        flash("email not whitelisted: {}".format(google_data['email']), 'warning')
         return redirect(url_for('public.index'))
 
     user_obj['name'] = google_data['name']


### PR DESCRIPTION
**Feel free to reject this pull request or suggest a different solution. It fixes a pretty esoteric problem which I've spent way too much time analysing........**

We noticed that when a user registers a google account with a non-google email address, and enters that email with capital letters (ex User.Name@skane.se), the OAuth API will return the email **with** that capitalization. It appears impossible to change this in the settings at google.

This caused a pretty difficult-to-find authorization problem for us, since we added the user to scout ("scout load user") with the email address lower-cased. Of course we could just delete the user and add them again with the capitalized email, but that's pretty inconvenient.

I thought there would be an obvious way to fix this, but this is the best solution I could think of that doesn't break anything. First I've changed commands/load/user.py to lowercase the email to make sure that no capitalized email addresses are added using "scout load user" (this also prevents two users with the same email capitalized differently from existing in the database). Then in the authorized()-function I've added a second query using the lower-cased email returned by the OAuth API, if nothing was returned using the as-given version. The double query is necessary for backwards compatitility in case you've previously added users with capitalized emails.

(I know that theoretically, according to the specs, email addresses are case senstive, but I choose not to care...)

(I also know that it is possible to do case-insenstive queries using collation in MongoDB, but this requires 3.4 or later, and I don't know what version you require.)