### PR TITLE
Query overlapping variants by matching genes instead of coordinates

### DIFF
--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -340,8 +340,8 @@ class VariantHandler(VariantLoader):
     def overlapping(self, variant_obj):
         """Return overlapping variants.
 
-        Look at the genes that a variant overlaps to, to get coordinates.
-        Then return all variants that overlap these coordinates.
+        Look at the genes that a variant overlaps to.
+        Then return all variants that overlap these genes.
 
         If variant_obj is sv it will return the overlapping snvs and oposite
         There is a problem when SVs are huge since there are to many overlapping variants.

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -875,7 +875,7 @@
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}s
+              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}
             {% endif %}
           </td>
           {% if variant.cytoband_start and variant.cytoband_end %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -871,15 +871,13 @@
         <tr>
           <td><span class="badge badge-warning pull-left">{{variant.sub_category|upper}}</span></td>
           <td>{{ variant.length }}</td>
-          {% if variant.end_chrom %} <!-- end_chrom key is also in database-->
-            {% if variant.chromosome == variant.end_chrom %} <!--but it's still not a rearrangement involving different chromosomes-->
-              <td>chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}</td>
+          <td>
+            {% if variant.chromosome == variant.end_chrom %}
+              chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              <td>chr{{variant.chromosome}}:{{variant.position}}-{{'chr'+variant.end_chrom}}:{{variant.end}}</td> <!--variant ends on another chromosome-->
+              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}s
             {% endif %}
-          {% else %} <!--sometimes there are just "chrom", "position" and "end" keys for SVs-->
-            <td>chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}</td>
-          {% endif %}
+          </td>
           {% if variant.cytoband_start and variant.cytoband_end %}
             <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
           {% else %}

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -31,7 +31,7 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
     skip_count = per_page * max(page - 1, 0)
     more_variants = True if variant_count > (skip_count + per_page) else False
     variant_res = variants_query.skip(skip_count).limit(per_page)
-    
+
     genome_build = case_obj.get('genome_build', '37')
     if genome_build not in ['37','38']:
         genome_build = '37'
@@ -40,7 +40,7 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
     for variant_obj in variant_res:
         overlapping_svs = [sv for sv in store.overlapping(variant_obj)]
         variant_obj['overlapping'] = overlapping_svs or None
-        variants.append(parse_variant(store, institute_obj, case_obj, variant_obj, 
+        variants.append(parse_variant(store, institute_obj, case_obj, variant_obj,
                         update=True, genome_build=genome_build))
 
     return {
@@ -183,6 +183,9 @@ def sv_variant(store, institute_id, case_name, variant_id=None, variant_obj=None
     if variant_id in case_clinvars:
         variant_obj['clinvar_clinsig'] = case_clinvars.get(variant_id)['clinsig']
 
+    if not 'end_chrom' in variant_obj:
+        variant_obj['end_chrom'] = variant_obj['chromosome']
+
     return {
         'institute': institute_obj,
         'case': case_obj,
@@ -193,7 +196,7 @@ def sv_variant(store, institute_id, case_name, variant_id=None, variant_obj=None
     }
 
 
-def parse_variant(store, institute_obj, case_obj, variant_obj, update=False, genome_build='37', 
+def parse_variant(store, institute_obj, case_obj, variant_obj, update=False, genome_build='37',
                   get_compounds = True):
     """Parse information about variants.
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -119,18 +119,7 @@
         <li class="list-group-item">
           Position
           <div class="pull-right">
-            {{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}
-            {% if variant.chromosome == "MT" and case.mt_bams %}
-              - Alignment:
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">Pileup viewer</a><br>
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">IGV viewer (BETA)</a>
-            {% elif case.bam_files %}
-              - Alignment:
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.end + 50)) }}" target="_blank">IGV (BETA)</a>
-            {% else %}
-              - BAM file(s) missing
-            {% endif %}
+            {{ variant.chromosome }}:{{ variant.position }} {{ "-" if variant.end_chrom == variant.chromosome else " / "+variant.end_chrom+":" }}{{ variant.end }}
           </div>
         </li>
         <li class="list-group-item">
@@ -153,15 +142,15 @@
         <li class="list-group-item">
           Breakpoint 2
           <div class="pull-right">
-            {{ variant.chromosome }}:{{ variant.end }}
-            {% if variant.chromosome == "MT" and case.mt_bams %}
+            {{ variant.end_chrom }}:{{ variant.end }}
+            {% if variant.end_chrom == "MT" and case.mt_bams %}
               - Alignment:
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">Pileup viewer</a><br>
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV viewer (BETA)</a>
+              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.mt_bams, bai=case.mt_bais, vcf=case.region_vcf_file, sample=case.sample_names, contig=variant.end_chrom, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">Pileup viewer</a><br>
+              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.mt_bams, bai=case.mt_bais, contig=variant.end_chrom, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV viewer (BETA)</a>
             {% elif case.bam_files %}
               - Alignment:
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
-              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.chromosome, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV (BETA)</a>
+              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.pileup', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, contig=variant.end_chrom, start=(variant.end - 500), stop=(variant.end + 500), vcf=case.vcf_files.vcf_sv) }}" target="_blank">Pileup</a>
+              <a class="btn btn-default btn-sm" href="{{ url_for('alignviewers.igv', bam=case.bam_files, bai=case.bai_files, sample=case.sample_names, build=case.genome_build, contig=variant.end_chrom, start=(variant.end - 500), stop=(variant.end + 500)) }}" target="_blank">IGV (BETA)</a>
             {% else %}
               - BAM file(s) missing
             {% endif %}
@@ -169,7 +158,7 @@
         </li>
 	      <li class="list-group-item">
 	        Cytoband
-          <div class="pull-right">
+          <div class="pull-right">    
             {% if variant.chromosome == variant.end_chrom and variant.cytoband_start == variant.cytoband_end %}
               {{ variant.chromosome }}{{ variant.cytoband_start }}
             {% elif variant.chromosome == variant.end_chrom %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -60,11 +60,11 @@
                                  institute_id=institute._id,
                                  case_name=case.display_name,
                                  variant_id=sv._id) }}'>
-                {{ sv.chromosome }}{{ sv.cytoband_start }} 
+                {{ sv.chromosome }}{{ sv.cytoband_start }}
               </a>
           </td>
           <td class='text-right'>{{ sv.sub_category }}</td>
-          <td class='text-right'>{{ sv.length }}</td>
+          <td class='text-right'>{{ sv.length if sv.length < 100000000000 else "-" }}</td>
           <td class='text-right'>{{ sv.rank_score }}</td>
         </tr>
       {% endfor %}

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -1,12 +1,12 @@
 
 def test_build_query(adapter):
     case_id = 'cust000'
-    
+
     # GIVEN a empty database
-    
+
     # WHEN building a query
     query = adapter.build_query(case_id)
-    
+
     # THEN the query should be on the right format
     assert query['case_id'] == case_id
     assert query['category'] == 'snv'
@@ -16,12 +16,12 @@ def test_build_gnomad_query(adapter):
     case_id = 'cust000'
     freq = 0.01
     query = {'gnomad_frequency': freq}
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
+
     assert mongo_query['case_id'] == case_id
     assert mongo_query['category'] == 'snv'
-    assert mongo_query['variant_type'] == 'clinical'    
+    assert mongo_query['variant_type'] == 'clinical'
     assert mongo_query['$and'] == [
         {
             '$or':[
@@ -35,9 +35,9 @@ def test_build_non_existing_gnomad(adapter):
     case_id = 'cust000'
     freq = '-1'
     query = {'gnomad_frequency': freq}
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
+
     assert mongo_query['gnomad_frequency'] == {'$exists': False}
 
 def test_build_cadd_exclusive(adapter):
@@ -76,9 +76,9 @@ def test_build_gnomad_and_cadd(adapter):
     freq = 0.01
     cadd = 10.0
     query = {'gnomad_frequency': freq, 'cadd_score': cadd}
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
+
     assert mongo_query['$and'] == [
         {
             '$or':[
@@ -95,7 +95,7 @@ def test_build_clinsig(adapter):
     case_id = 'cust000'
     clinsig_items = [ 3, 4, 5 ]
     query = {'clinsig': clinsig_items}
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
 
     assert mongo_query['clnsig.value'] == {
@@ -106,19 +106,19 @@ def test_build_clinsig_filter(adapter):
     case_id = 'cust000'
     clinsig_items = [ 4, 5 ]
     region_annotation = ['exonic', 'splicing']
-    
-    query = {'region_annotations': region_annotation, 
+
+    query = {'region_annotations': region_annotation,
                  'clinsig': clinsig_items }
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
+
     assert mongo_query['$and'] == [
         { 'genes.region_annotation':
               {'$in': region_annotation }
           },
         { 'clnsig.value':
               { '$in': clinsig_items }
-          } 
+          }
         ]
 
 def test_build_clinsig_always(adapter):
@@ -127,8 +127,8 @@ def test_build_clinsig_always(adapter):
     clinsig_items = [ 4, 5 ]
     region_annotation = ['exonic', 'splicing']
     freq=0.01
-    
-    query = {'region_annotations': region_annotation, 
+
+    query = {'region_annotations': region_annotation,
              'clinsig': clinsig_items,
              'clinsig_confident_always_returned': clinsig_confident_always_returned,
              'gnomad_frequency': freq
@@ -137,7 +137,7 @@ def test_build_clinsig_always(adapter):
     mongo_query = adapter.build_query(case_id, query=query)
 
     assert mongo_query['$or'] == [
-        { '$and': 
+        { '$and':
           [ {
               '$or':[
                 {'gnomad_frequency': {'$lt': freq}},
@@ -153,10 +153,10 @@ def test_build_clinsig_always(adapter):
                 '$elemMatch': { 'value':
                                     { '$in' : clinsig_items },
                                 'revstat':
-                                    { '$in' : ['mult', 
-                                               'single', 
-                                               'exp', 
-                                               'guideline'] 
+                                    { '$in' : ['mult',
+                                               'single',
+                                               'exp',
+                                               'guideline']
                                       }
                                 }
                 }
@@ -168,22 +168,22 @@ def test_build_spidex_not_reported(adapter):
     spidex_human = ['not_reported']
 
     query = { 'spidex_human': spidex_human }
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
-    assert mongo_query['$and'] == [{'$or': [{'spidex': {'$exists': False}}] }] 
+
+    assert mongo_query['$and'] == [{'$or': [{'spidex': {'$exists': False}}] }]
 
 def test_build_spidex_high(adapter):
     case_id = 'cust000'
     spidex_human = ['high']
 
     query = { 'spidex_human': spidex_human }
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
-    
+
     assert mongo_query['$and'] == [{'$or': [{'$or': [
                     {'$and': [
-                            {'spidex': {'$gt': -2}}, {'spidex': {'$lt': -float('inf')}}]}, 
+                            {'spidex': {'$gt': -2}}, {'spidex': {'$lt': -float('inf')}}]},
                     {'$and': [
                             {'spidex': {'$gt': 2}}, {'spidex': {'$lt': float('inf')}}]}
                     ]}]}]
@@ -203,10 +203,10 @@ def test_build_clinsig_always_only(adapter):
         '$elemMatch': { 'value':
                             { '$in' : clinsig_items },
                         'revstat':
-                            { '$in' : ['mult', 
-                                       'single', 
-                                       'exp', 
-                                       'guideline'] 
+                            { '$in' : ['mult',
+                                       'single',
+                                       'exp',
+                                       'guideline']
                               }
                         }
         }
@@ -225,7 +225,7 @@ def test_build_ngi_sv(adapter):
     case_id = 'cust000'
     count = 1
     query = {'clingen_ngi': count}
-    
+
     mongo_query = adapter.build_query(case_id, query=query)
     assert  mongo_query['$and'] == [
         {
@@ -251,17 +251,17 @@ def test_build_range(adapter):
 
 def test_get_overlapping_variant(populated_database, parsed_case):
     """Add a couple of overlapping variants"""
-    
+
     ## GIVEN a database with some basic information but no variants
-    
+
     case_id = parsed_case['case_id']
 
     assert populated_database.variants(case_id, category='snv').count() == 0
-    
+
     assert populated_database.variants(case_id, category='sv').count() == 0
 
     ## WHEN inserting a couple of variants
-    
+
     institute_id = parsed_case['owner']
     institute_obj = populated_database.institute(institute_id)
     snv_one = dict(
@@ -278,13 +278,11 @@ def test_get_overlapping_variant(populated_database, parsed_case):
         position=235824342,
         end=235824342,
         length=1,
-        reference='A',
-        alternative='T',
         rank_score=10,
         variant_rank=1,
         institute=institute_obj,
         hgnc_symbols=['LYST'],
-        hgnc_ids=[1968]
+        hgnc_ids=[1968],
     )
     populated_database.load_variant(snv_one)
 
@@ -299,20 +297,18 @@ def test_get_overlapping_variant(populated_database, parsed_case):
         sub_category='snv',
         case_id=case_id,
         chromosome='1',
-        position=235824350,
-        end=235824350,
+        position=235710920,
+        end=235710920,
         length=1,
-        reference='G',
-        alternative='T',
         rank_score=9,
         variant_rank=2,
         institute=institute_obj,
-        hgnc_symbols=['LYST'],
-        hgnc_ids=[1968]
+        hgnc_symbols=['GNG4'],
+        hgnc_ids=[4407]
     )
-    
     populated_database.load_variant(snv_two)
 
+    # create a SV that overlaps just with snv_one
     sv_one = dict(
         _id='first_sv',
         document_id='first_sv',
@@ -327,8 +323,6 @@ def test_get_overlapping_variant(populated_database, parsed_case):
         position=235824350,
         end=235824355,
         length=5,
-        reference='A',
-        alternative='ATTTTTT',
         rank_score=10,
         variant_rank=1,
         institute=institute_obj,
@@ -336,51 +330,45 @@ def test_get_overlapping_variant(populated_database, parsed_case):
         hgnc_ids=[1968]
     )
     populated_database.load_variant(sv_one)
+
+    # create a SV that overlaps with both variants
+    sv_two = dict(
+        _id='second_sv',
+        document_id='second_sv',
+        variant_id='second_sv',
+        display_name='second_sv',
+        simple_id='second_sv',
+        variant_type='clinical',
+        category='sv',
+        sub_category='del',
+        case_id=case_id,
+        chromosome='1',
+        position=235710900,
+        end=235824450,
+        length=113550,
+        rank_score=15,
+        variant_rank=1,
+        institute=institute_obj,
+        hgnc_symbols=['LYST', 'GNG4'],
+        hgnc_ids=[1968, 4407]
+    )
+    populated_database.load_variant(sv_two)
+
     ## THEN make sure that the variants where inserted
     result = populated_database.variants(case_id, category='snv')
     # Thow snvs where loaded
     assert result.count() == 2
 
-    #One SV was added
+    #Two SV where added
     result = populated_database.variants(case_id, category='sv')
-    assert result.count() == 1
-        
-    #Try to match only snv_one
-    query = {'chrom': '1', 'start': 235824342, 'end':235824342}
-    result = populated_database.variants(case_id, category='snv', query=query)
-    assert result.count() == 1
-
-    #Try to match both snvs
-    query = {'chrom': '1', 'start': 235824341, 'end':235824352}
-    result = populated_database.variants(case_id, category='snv', query=query)
     assert result.count() == 2
 
-    #Try interval larger than sv
-    query = {'chrom': '1', 'start': 235824342, 'end':235824360}
-    result = populated_database.variants(case_id, category='sv', query=query)
-    assert result.count() == 1
-
-    #Try interval lower overlap sv
-    query = {'chrom': '1', 'start': 235824332, 'end':235824352}
-    result = populated_database.variants(case_id, category='sv', query=query)
-    assert result.count() == 1
-
-    #Try interval outside sv
-    query = {'chrom': '1', 'start': 5, 'end':7}
-    result = populated_database.variants(case_id, category='sv', query=query)
-    assert result.count() == 0
-
-    #Try minimal interval sv
-    query = {'chrom': '1', 'start': 235824352, 'end':235824352}
-    result = populated_database.variants(case_id, category='sv', query=query)
-    assert result.count() == 1
-
-    # test function
+    # test functions to collect all overlapping variants
     result = populated_database.overlapping(snv_one)
     index = 0
     for variant in result:
         index += 1
-    assert index == 1
+    assert index == 2
 
     # test function
     result = populated_database.overlapping(snv_two)
@@ -391,6 +379,13 @@ def test_get_overlapping_variant(populated_database, parsed_case):
 
     # test function
     result = populated_database.overlapping(sv_one)
+    index = 0
+    for variant in result:
+        index += 1
+    assert index == 1
+
+    # test function
+    result = populated_database.overlapping(sv_two)
     index = 0
     for variant in result:
         index += 1


### PR DESCRIPTION
Fix #1046

I don't know if I'm naive and missing something here, but I was reasoning that instead of looping through the genes of the query variant to establish the largest genomic interval (given by the start of the first gene and the end of the last), you could simply get all variants that occur in the same genes as the query one (it's basically the same, isn't it?). This way the query should be faster and you also skip the passage where you have to create a gene object for each gene in the query variant.

It fixes the BND issue because BNDs that don't have that gene are not collected.

I also realized that BNDs still had visualizing issues in the sv_variant page and in the report. I've fixed them now!

Fixed also the template so it doesn't print the length of the variant if it's a huge rearrangement.