### PR TITLE
gene name or number in validation email subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 Add new stuff here
 
 
+## [4.2.1]
+
+### Fixed
+- Re-introduced gene name(s) in verification email subject
+
+
 ## [4.2.0]
 
 ### Added


### PR DESCRIPTION
Fix #1048.

Now I remember: when I updated the code I removed the gene name from the email subject on purpose to make it more general (when you validate a big SV that would be many gene names to clog the message). This fix re-introduces the gene name if the variant contains <= 3 gene, otherwise the email subject contains the gene number.

Example for variant containing 1 gene: 
**SCOUT: validation of SNV variant 14_76548781_GTGGACC_G_clinical, (IFT43)**

Example for variant containing 5 genes:
**SCOUT: validation of SV variant 9:67890445_DEL, (5 genes)**