### PR TITLE
Export causative variants from a case, with '--case-id' option

### DIFF
--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -257,6 +257,24 @@ class VariantHandler(VariantLoader):
         ])
         return [item['_id'] for item in query]
 
+    def get_case_causatives(self, case_id):
+        """
+            Return all causatives for a case
+
+            Args:
+                case_id(str)
+
+            Returns:
+                list: list of variant _id
+        """
+
+        case_obj = self.case_collection.find_one(
+                {"display_name": case_id}
+            )
+
+        return [causative for causative in case_obj['causatives']]
+
+
     def check_causatives(self, case_obj=None, institute_obj=None):
         """Check if there are any variants that are previously marked causative
 

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -46,40 +46,20 @@ def variants(context, collaborator, document_id, case_id, json):
     #and genotypes
     if case_id:
         vcf_header[1] = vcf_header[1] + "\tFORMAT"
-
         case_obj = adapter.case(case_id=case_id)
         for individual in case_obj['individuals']:
             vcf_header[1] = vcf_header[1] + "\t" + individual['individual_id']
 
-        #print header
-        for line in vcf_header:
-            click.echo(line)
+    #print header
+    for line in vcf_header:
+        click.echo(line)
 
-        for variant_obj in variants:
-            variant_string = get_vcf_entry(variant_obj)
-            click.echo(variant_string)
+    for variant_obj in variants:
+        variant_string = get_vcf_entry(variant_obj, case_id=case_id)
+        click.echo(variant_string)
 
-    else:
 
-        for line in vcf_header:
-            click.echo(line)
-
-        #put variants in a dict to get unique ones
-        variant_string = ("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}")
-
-        for variant_obj in variants:
-            click.echo(variant_string.format(
-                variant_obj['chromosome'],
-                variant_obj['position'],
-                variant_obj['dbsnp_id'],
-                variant_obj['reference'],
-                variant_obj['alternative'],
-                variant_obj['quality'],
-                ';'.join(variant_obj['filters']),
-                '.'
-            ))
-
-def get_vcf_entry(variant_obj):
+def get_vcf_entry(variant_obj, case_id=None):
     """
         Get vcf entry from variant object
 
@@ -100,7 +80,7 @@ def get_vcf_entry(variant_obj):
             ]
         )
 
-    variant_string = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}\t{8}".format(
+    variant_string = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}".format(
         variant_obj['chromosome'],
         variant_obj['position'],
         variant_obj['dbsnp_id'],
@@ -108,10 +88,12 @@ def get_vcf_entry(variant_obj):
         variant_obj['alternative'],
         variant_obj['quality'],
         ';'.join(variant_obj['filters']),
-        info_field,
-        'GT'
+        info_field
     )
-    for sample in variant_obj['samples']:
-        variant_string += "\t" + sample['genotype_call']
+
+    if case_id:
+        variant_string += "\tGT"
+        for sample in variant_obj['samples']:
+            variant_string += "\t" + sample['genotype_call']
 
     return variant_string

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -15,39 +15,103 @@ LOG = logging.getLogger(__name__)
 @click.option('-d', '--document-id',
         help="Search for a specific variant",
 )
+@click.option('--case-id',
+        help="Find causative variants for case",
+)
 @json_option
 @click.pass_context
-def variants(context, collaborator, document_id, json):
+def variants(context, collaborator, document_id, case_id, json):
     """Export causatives for a collaborator in .vcf format"""
     LOG.info("Running scout export variants")
     adapter = context.obj['adapter']
     collaborator = collaborator or 'cust000'
-    
-    variants = export_variants(adapter, collaborator, document_id=document_id)
-    
+
+    variants = export_variants(
+        adapter,
+        collaborator,
+        document_id=document_id,
+        case_id=case_id
+    )
+
     if json:
         click.echo(dumps([var for var in variants]))
         return
-    
+
     vcf_header = [
         "##fileformat=VCFv4.2",
         "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
     ]
 
-    for line in vcf_header:
-        click.echo(line)
+    #If case_id is given, print more complete vcf entries, with INFO,
+    #and genotypes
+    if case_id:
+        vcf_header[1] = vcf_header[1] + "\tFORMAT"
 
-    #put variants in a dict to get unique ones
-    variant_string = ("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}")
+        case_obj = adapter.case(case_id=case_id)
+        for individual in case_obj['individuals']:
+            vcf_header[1] = vcf_header[1] + "\t" + individual['individual_id']
 
-    for variant_obj in variants:
-        click.echo(variant_string.format(
-            variant_obj['chromosome'],
-            variant_obj['position'],
-            variant_obj['dbsnp_id'],
-            variant_obj['reference'],
-            variant_obj['alternative'],
-            variant_obj['quality'],
-            ';'.join(variant_obj['filters']),
-            '.'
-        ))
+        #print header
+        for line in vcf_header:
+            click.echo(line)
+
+        for variant_obj in variants:
+            variant_string = get_vcf_entry(variant_obj)
+            click.echo(variant_string)
+
+    else:
+
+        for line in vcf_header:
+            click.echo(line)
+
+        #put variants in a dict to get unique ones
+        variant_string = ("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}")
+
+        for variant_obj in variants:
+            click.echo(variant_string.format(
+                variant_obj['chromosome'],
+                variant_obj['position'],
+                variant_obj['dbsnp_id'],
+                variant_obj['reference'],
+                variant_obj['alternative'],
+                variant_obj['quality'],
+                ';'.join(variant_obj['filters']),
+                '.'
+            ))
+
+def get_vcf_entry(variant_obj):
+    """
+        Get vcf entry from variant object
+
+        Args:
+            variant_obj(dict)
+        Returns:
+            variant_string(str): string representing variant in vcf format
+    """
+    if variant_obj['category'] == 'snv':
+        var_type = 'TYPE'
+    else:
+        var_type = 'SVTYPE'
+
+    info_field = ';'.join(
+            [
+                'END='+str(variant_obj['end']),
+                var_type+'='+variant_obj['sub_category'].upper()
+            ]
+        )
+
+    variant_string = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}\t{8}".format(
+        variant_obj['chromosome'],
+        variant_obj['position'],
+        variant_obj['dbsnp_id'],
+        variant_obj['reference'],
+        variant_obj['alternative'],
+        variant_obj['quality'],
+        ';'.join(variant_obj['filters']),
+        info_field,
+        'GT'
+    )
+    for sample in variant_obj['samples']:
+        variant_string += "\t" + sample['genotype_call']
+
+    return variant_string

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -21,12 +21,10 @@ def export_variants(adapter, collaborator, document_id=None, case_id=None):
         yield adapter.variant(document_id)
         return
 
-    if case_id:
-        variant_ids = adapter.get_case_causatives(case_id=case_id)
-
-    else:
-        variant_ids = adapter.get_causatives(institute_id=collaborator)
-
+    variant_ids = adapter.get_causatives(
+        institute_id=collaborator,
+        case_id=case_id
+        )
     ##TODO add check so that same variant is not included more than once
     for document_id in variant_ids:
 

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -2,42 +2,48 @@ from pprint import pprint as pp
 
 from scout.constants import (CHROMOSOMES, CHROMOSOME_INTEGERS)
 
-def export_variants(adapter, collaborator, document_id=None):
+def export_variants(adapter, collaborator, document_id=None, case_id=None):
     """Export causative variants for a collaborator
-    
+
     Args:
         adapter(MongoAdapter)
         collaborator(str)
         document_id(str): Search for a specific variant
-    
+        case_id(str): Search causative variants for a case
+
     Yields:
-        variant_obj(scout.Models.Variant): Variants marked as causative ordered by position. 
+        variant_obj(scout.Models.Variant): Variants marked as causative ordered by position.
     """
-    
+
     # Store the variants in a list for sorting
     variants = []
     if document_id:
         yield adapter.variant(document_id)
         return
-    
+
+    if case_id:
+        variant_ids = adapter.get_case_causatives(case_id=case_id)
+
+    else:
+        variant_ids = adapter.get_causatives(institute_id=collaborator)
+
     ##TODO add check so that same variant is not included more than once
-    for document_id in adapter.get_causatives(institute_id=collaborator):
+    for document_id in variant_ids:
+
         variant_obj = adapter.variant(document_id)
-        
         chrom = variant_obj['chromosome']
         # Convert chromosome to integer for sorting
         chrom_int = CHROMOSOME_INTEGERS.get(chrom)
         if not chrom_int:
             LOG.info("Unknown chromosome %s", chrom)
             continue
-        
+
         # Add chromosome and position to prepare for sorting
         variants.append((chrom_int, variant_obj['position'], variant_obj))
-    
+
     # Sort varants based on position
     variants.sort(key=lambda x: (x[0], x[1]))
-    
+
     for variant in variants:
         variant_obj = variant[2]
         yield variant_obj
-    


### PR DESCRIPTION
If a case-id is given, i.e. 'scout export variants --case-id ...' this will print more complete vcf entries.