### PR TITLE
Sv length shorter

### DIFF
--- a/docs/user-guide/variants.md
+++ b/docs/user-guide/variants.md
@@ -68,6 +68,8 @@ A variant with Pass status passed all the filters from its variant callers, wher
 #### SVs
 
 SVs are structural variants, balanced or unbalanced chromosomal abberrations.
+Size filtering can be done either to show only variants longer than the given size, or shorter if the "Length shorter than" checkbox is activated.
+When the checkbox is ticked, queries are also inclusive of non-existing annotations e.g. SV events without size. Note that some BNDs, like interchromosomal translocations are given with a very large (larger than chromosome) size instead.
 
 Scout supports viewing general SVs as encoded in the VCF format specification.
 Some sample callers that we have worked with include:

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -29,6 +29,8 @@ class QueryHandler(object):
                 'start': int,
                 'end': int,
                 'svtype': list,
+                'size': int,
+                'size_shorter': boolean,
                 'gene_panels': list(str),
                 'mvl_tag": boolean,
                 'decipher": boolean,
@@ -205,14 +207,13 @@ class QueryHandler(object):
             size_query = {'length': {'$gt': int(size)}}
             logger.debug("Adding length: %s to query" % size)
 
-            if query.get('size_inclusive') == 'yes':
+            if query.get('size_shorter'):
                 size_query = {
                     '$or': [
-                        size_query,
+                        {'length': {'$lt': int(size)}},
                         {'length': {'$exists': False}}
-
                     ]}
-                logger.debug("Adding size inclusive to query.")
+                logger.debug("Adding size less than, undef inclusive to query.")
 
             mongo_query_minor.append(size_query)
 
@@ -292,13 +293,13 @@ class QueryHandler(object):
 
         if mongo_query_minor and mongo_query_major:
             if gene_query:
-                mongo_query['$and'] = [ 
-                    {'$or': gene_query}, 
+                mongo_query['$and'] = [
+                    {'$or': gene_query},
                     {
                         '$or': [
                             {'$and': mongo_query_minor}, mongo_query_major
                         ]
-                    } 
+                    }
                 ]
             else:
                 mongo_query['$or'] = [ {'$and': mongo_query_minor},

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -91,7 +91,7 @@ class StrFiltersForm(FlaskForm):
 class SvFiltersForm(FiltersForm):
     """Extends FiltersForm for structural variants"""
     size = TextField('Length')
-    size_inclusive = BooleanField('Length inclusive')
+    size_shorter = BooleanField('Length shorter than')
     svtype = SelectMultipleField('SVType', choices=SV_TYPE_CHOICES)
     decipher = BooleanField('Decipher')
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -135,8 +135,8 @@
           {{ form.size(class="form-control") }}
         </div>
         <div class="col-xs-2">
-          {{ form.size_inclusive.label(class="control-label") }}
-          <div>{{ form.size_inclusive() }}</div>
+          {{ form.size_shorter.label(class="control-label") }}
+          <div>{{ form.size_shorter() }}</div>
         </div>
         <div class="col-xs-2">
           {{ form.decipher.label(class="control-label") }}


### PR DESCRIPTION
Fix #1073. Replaces length inclusive option with a "shorter than" boolean, that is also inclusive to non-existing lengths. This extends the interface with the sought function, while preserving the old to all practical purposes.