### PR TITLE
Removed reference to other panels in gene panel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fixed gene panel create/modify from CSV file utf-8 decoding error
 - Updating genes in gene panels now supports edit comments and entry version
+- Gene panel export timeout error
 
 
 ## [4.2.1]

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -144,27 +144,4 @@ def panel_export(store, panel_obj):
     full_name = "{}({})".format(panel_obj['display_name'], panel_obj['version'])
     panel_obj['name_and_version'] = full_name
 
-    panel_explained = {} # a disctionary with display_name(version) as key and an increasing index as value
-    panel_index = 0
-
-    # Add gene_to_panels - related info
-    for gene in panel_obj['genes']:
-        associated_panels = [] # list of gene panels associated to this gene
-        gene_associated_gene_panels = list(store.hgnc_to_panels(gene['hgnc_id'])) # a list of gene panels objects containing that gene
-        for panel in gene_associated_gene_panels:
-            # include in export document only the associated panels that are not archived
-            if 'is_archived' in panel:
-                continue
-            associated_panel = "{}({})".format(panel['display_name'], panel['version'])
-            if associated_panel in panel_explained:
-                associated_panels.append(panel_explained[associated_panel])
-            else:
-                panel_index =  panel_index + 1
-                panel_explained[associated_panel] =  panel_index
-                associated_panels.append(panel_index)
-        gene['associated_panels'] = associated_panels
-
-    export_footer = sorted( panel_explained.items(), key=operator.itemgetter(1) )
-    panel_obj['export_footer'] = export_footer
-
     return dict(panel=panel_obj)

--- a/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
+++ b/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
@@ -56,13 +56,11 @@
         <td></td>
         <td>HGNC id</td>
         <td>Gene name</td>
-
         <td>Disease associated transcripts</td>
         <td>Reduced penetrance</td>
         <td>Mosaicism</td>
         <td>Entry version</td>
         <td>Inheritance</td>
-        <td>Panels*</td>
       </tr>
       {% for gene in panel.genes|sort(attribute='symbol') %}
         <tr>
@@ -76,21 +74,9 @@
           <td>{{ 'Mosaicism' if gene.mosaicism}}</td>
           <td><span class="badge badge-secondary">{{ gene.database_entry_version }}</span></td>
           <td>{{ gene.inheritance_models|join(', ') }}</td>
-          <td>
-            {% for batch_panels in gene.associated_panels|sort|batch(10) -%}
-              {{ batch_panels|join(',') }}
-              {%- if not loop.last -%},<br>{%- endif %}
-            {%- endfor %}
-          </td>
-
         </tr>
       {% endfor %}
     </table>
   </div>
 </div>
-<h6>*Gene panel explanation:</h6>
-{% for panel_index in panel.export_footer%}
-  {{panel_index[1]}}:&nbsp;{{panel_index[0]}}<br>
-{% endfor %}
-<br>
 {% endmacro %}


### PR DESCRIPTION
It takes too much time to check in which other panels each gene of a panel is. I'm removing this option for preventing bug #1067 . 
What we could do instead is improving the gene view, listing there all gene panels the gene belongs to.