### PR TITLE
Fix panel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 Add new stuff here
 
+### Fixed
+- Visualization of PDF-exported gene panels
+
 ## [4.3.0]
 
 ### Added

--- a/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
+++ b/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
@@ -16,34 +16,29 @@
     Panel: <a href="{{ url_for('panels.panel', panel_id=panel._id) }}">{{panel.name_and_version}}</a>
   </div>
   <div class="card-body">
-    <div class="row">
-      <ul class="list-group">
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          Date
-          <span class="badge badge-secondary badge-pill">{{ panel.date.strftime('%Y-%m-%d') }}</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          Number of genes
-          <span class="badge badge-secondary badge-pill">{{ panel.genes|length }}</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          Institute
-          <span class="badge badge-secondary badge-pill">{{ panel.institute.display_name }}</span>
-        </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          Panel archived
+    <table class="table table-sm">
+      <tr>
+        <td>Date:<span class="badge badge-secondary badge-pill">{{ panel.date.strftime('%Y-%m-%d') }}</span></td>
+      </tr>
+      <tr>
+        <td>Number of genes:<span class="badge badge-secondary badge-pill">{{ panel.genes|length }}</span></td>
+      </tr>
+      <tr>
+        <td>Institute: <span class="badge badge-secondary badge-pill">{{ panel.institute.display_name }}</span></td>
+      </tr>
+      <tr>
+        <td>Panel archived:
           {% if panel.is_archived %}
             <span class="badge badge-danger badge-pill">True</span>
           {% else %}
             <span class="badge badge-secondary badge-pill">False</span>
           {% endif %}
-        </li>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-          Panel database id
-          <span class="badge badge-secondary badge-pill">{{ panel._id }}</span>
-        </li>
-      </ul>
-    </div>
+        </td>
+      </tr>
+      <tr>
+        <td>Panel database ID: <span class="badge badge-secondary badge-pill">{{ panel._id }}</span></td>
+      </tr>
+    </table>
   </div>
 </div>
   <br>

--- a/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
+++ b/scout/server/blueprints/panels/templates/panels/panel_pdf_simple.html
@@ -15,8 +15,8 @@
   <div class="card-header">
     Panel: <a href="{{ url_for('panels.panel', panel_id=panel._id) }}">{{panel.name_and_version}}</a>
   </div>
-  <div class="row">
-    <div class="col-sm-6">
+  <div class="card-body">
+    <div class="row">
       <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between align-items-center">
           Date
@@ -30,10 +30,6 @@
           Institute
           <span class="badge badge-secondary badge-pill">{{ panel.institute.display_name }}</span>
         </li>
-      </ul>
-    </div>
-    <div class="col-sm-6">
-      <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between align-items-center">
           Panel archived
           {% if panel.is_archived %}
@@ -49,6 +45,7 @@
       </ul>
     </div>
   </div>
+</div>
   <br>
   <div>
     <table class="table table-sm">


### PR DESCRIPTION
Fix #1110. The problem is that the library we use to export web pages to PDF doesn't like much bootstrap components for page layout. I've made that part into a HTML table instead and it looks better.

You could try in on scout stage!