### PR TITLE
added instructions to install cairo and pango separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 Add new stuff here
 
+### Added
+- Instructions to install cairo and pango libs from WeasyPrint page
+
 ### Fixed
 - Visualization of PDF-exported gene panels
 - Force number validation in SV filter by size

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ cd scout
 pip install --requirement requirements.txt --editable .
 ```
 
+Scout PDF reports are created using [Flask-WeasyPrintWeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
+
 You also need to have an instance of MongoDB running. I've found that it's easiest to do using the official Docker image:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd scout
 pip install --requirement requirements.txt --editable .
 ```
 
-Scout PDF reports are created using [Flask-WeasyPrintWeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
+Scout PDF reports are created using [Flask-WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
 
 You also need to have an instance of MongoDB running. I've found that it's easiest to do using the official Docker image:
 


### PR DESCRIPTION
I'm referring to the page of the library we use. Otherwise it's messy because installation of the external libraries is platform-specific..