### PR TITLE
Mark primary transcript in verification email

### DIFF
--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -946,7 +946,7 @@ def variant_verification(store, mail, institute_obj, case_obj, user_obj, variant
                         transcript_line.append(urllib.parse.unquote(tx_obj['protein_sequence_name']))
                     else:
                         transcript_line.append('')
-                    if refseq_id in gene_obj['common']['primary_transcripts']:
+                    if refseq_id in gene_obj.get('common',{}).get('primary_transcripts',{}):
                         transcript_line.append('<b>primary</b>')
                     else:
                         transcript_line.append('')

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -946,6 +946,10 @@ def variant_verification(store, mail, institute_obj, case_obj, user_obj, variant
                         transcript_line.append(urllib.parse.unquote(tx_obj['protein_sequence_name']))
                     else:
                         transcript_line.append('')
+                    if refseq_id in gene_obj['common']['primary_transcripts']:
+                        transcript_line.append('<b>primary</b>')
+                    else:
+                        transcript_line.append('')
 
                     tx_changes.append("<li>{}</li>".format(':'.join(transcript_line)))
 


### PR DESCRIPTION
Simply adds the the word "primary" to the refseq primary transcript in the verification email.