### PR TITLE
List cases with missing HPO terms, pheno groups and blank synopsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Displaying more info on the Causatives page and hiding those not causative at the case level
 - Add a comment text field to Sanger order request form, allowing a message to be included in the email
 - MatchMaker Exchange integration
-- List cases with missing HPO terms or missing phenotype groups (HP:, PG:)
+- List cases with empty synopsis, missing HPO terms and phenotype groups.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Displaying more info on the Causatives page and hiding those not causative at the case level
 - Add a comment text field to Sanger order request form, allowing a message to be included in the email
 - MatchMaker Exchange integration
+- List cases with missing HPO terms or missing phenotype groups (HP:, PG:)
 
 ### Fixed
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -96,7 +96,6 @@ class CaseHandler(object):
             query['cohorts'] = {'$exists': True, '$ne': []}
 
         if name_query:
-            LOG.info('name_query is:{}'.format(name_query))
             name_value = name_query.split(':')[-1] # capture ant value provided after query descriptor
             users = self.user_collection.find({'name': {'$regex': name_query, '$options': 'i'}})
             if users.count() > 0:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -96,7 +96,6 @@ class CaseHandler(object):
             query['cohorts'] = {'$exists': True, '$ne': []}
 
         if name_query:
-            LOG.info('name-query:{}'.format(name_query))
             name_value = name_query.split(':')[-1] # capture ant value provided after query descriptor
             users = self.user_collection.find({'name': {'$regex': name_query, '$options': 'i'}})
             if users.count() > 0:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -96,25 +96,29 @@ class CaseHandler(object):
             query['cohorts'] = {'$exists': True, '$ne': []}
 
         if name_query:
+            name_value = name_query.split(':')[-1] # capture ant value provided after query descriptor
             users = self.user_collection.find({'name': {'$regex': name_query, '$options': 'i'}})
             if users.count() > 0:
                 query['assignees'] = {'$in': [user['email'] for user in users]}
             elif name_query.startswith('HP:'):
                 LOG.debug("HPO case query")
-                query['phenotype_terms.phenotype_id'] = name_query
+                if name_value:
+                    query['phenotype_terms.phenotype_id'] = name_query
+                else: # query for cases with no HPO terms
+                    query['phenotype_terms'] = {'$size' : 0}
             elif name_query.startswith('PG:'):
                 LOG.debug("PG case query")
-                phenotype_group_query = name_query.replace('PG:', 'HP:')
-                query['phenotype_groups.phenotype_id'] = phenotype_group_query
+                if name_value:
+                    phenotype_group_query = name_query.replace('PG:', 'HP:')
+                    query['phenotype_groups.phenotype_id'] = phenotype_group_query
+                else: # query for cases with no phenotype groups
+                    query['phenotype_groups'] = {'$size' : 0}
             elif name_query.startswith('synopsis:'):
-                synopsis_query=name_query.replace('synopsis:','')
-                query['$text']={'$search':synopsis_query}
+                query['$text']={'$search':name_value}
             elif name_query.startswith('cohort:'):
-                cohort_query = name_query.replace('cohort:','')
-                query['cohorts'] = cohort_query
+                query['cohorts'] = name_value
             elif name_query.startswith('panel:'):
-                panel_name_query = name_query.replace('panel:','')
-                query['panels'] = {'$elemMatch': {'panel_name': panel_name_query,
+                query['panels'] = {'$elemMatch': {'panel_name': name_value,
                                     'is_default': True }}
             else:
                 query['$or'] = [
@@ -496,7 +500,7 @@ class CaseHandler(object):
         # delete the old case
         self.case_collection.find_one_and_delete({'_id': case_obj['_id']})
         return new_case
-        
+
 
 def get_variantid(variant_obj, family_id):
     """Create a new variant id.

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -114,7 +114,10 @@ class CaseHandler(object):
                 else: # query for cases with no phenotype groups
                     query['$or'] = [ {'phenotype_groups' : {'$size' : 0}}, {'phenotype_groups' : {'$exists' : False}} ]
             elif name_query.startswith('synopsis:'):
-                query['$text']={'$search':name_value}
+                if name_value:
+                    query['$text']={'$search':name_value}
+                else: # query for cases with missing synopsis
+                    query['synopsis'] = ''
             elif name_query.startswith('cohort:'):
                 query['cohorts'] = name_value
             elif name_query.startswith('panel:'):

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -96,6 +96,7 @@ class CaseHandler(object):
             query['cohorts'] = {'$exists': True, '$ne': []}
 
         if name_query:
+            LOG.info('name_query is:{}'.format(name_query))
             name_value = name_query.split(':')[-1] # capture ant value provided after query descriptor
             users = self.user_collection.find({'name': {'$regex': name_query, '$options': 'i'}})
             if users.count() > 0:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -96,6 +96,7 @@ class CaseHandler(object):
             query['cohorts'] = {'$exists': True, '$ne': []}
 
         if name_query:
+            LOG.info('name-query:{}'.format(name_query))
             name_value = name_query.split(':')[-1] # capture ant value provided after query descriptor
             users = self.user_collection.find({'name': {'$regex': name_query, '$options': 'i'}})
             if users.count() > 0:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -105,14 +105,14 @@ class CaseHandler(object):
                 if name_value:
                     query['phenotype_terms.phenotype_id'] = name_query
                 else: # query for cases with no HPO terms
-                    query['phenotype_terms'] = {'$size' : 0}
+                    query['$or'] = [ {'phenotype_terms' : {'$size' : 0}}, {'phenotype_terms' : {'$exists' : False}} ]
             elif name_query.startswith('PG:'):
                 LOG.debug("PG case query")
                 if name_value:
                     phenotype_group_query = name_query.replace('PG:', 'HP:')
                     query['phenotype_groups.phenotype_id'] = phenotype_group_query
                 else: # query for cases with no phenotype groups
-                    query['phenotype_groups'] = {'$size' : 0}
+                    query['$or'] = [ {'phenotype_groups' : {'$size' : 0}}, {'phenotype_groups' : {'$exists' : False}} ]
             elif name_query.startswith('synopsis:'):
                 query['$text']={'$search':name_value}
             elif name_query.startswith('cohort:'):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -375,7 +375,7 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
 def update_synopsis(store, institute_obj, case_obj, user_obj, new_synopsis):
     """Update synopsis."""
     # create event only if synopsis was actually changed
-    if new_synopsis and case_obj['synopsis'] != new_synopsis:
+    if case_obj['synopsis'] != new_synopsis:
         link = url_for('cases.case', institute_id=institute_obj['_id'],
                        case_name=case_obj['display_name'])
         store.update_synopsis(institute_obj, case_obj, user_obj, link,

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -119,7 +119,8 @@
       </div>
     </div>
     <div class="bottom-align-text">
-      <br>Examples: case_id=<strong>18201</strong>, HPO-term=<strong>HP:0001166</strong>, synopsis=<strong>synopsis:epilepsy</strong>, panel=<strong>panel:NMD</strong>, phenotype group=<strong>PG:0100022</strong>, cohort=<strong>cohort:pedhep</strong>.
+      <br>Examples: case_id=<strong>18201</strong>, HPO-term=<strong>HP:0001166</strong>, synopsis=<strong>synopsis:epilepsy</strong>, panel=<strong>panel:NMD</strong>, phenotype group=<strong>PG:0100022</strong>, cohort=<strong>cohort:pedhep</strong>.<br>
+      Leave blank values after key to search for cases with missing info (<strong>HP:</strong>,<strong>PG:</strong>,<strong>synopsis:</strong>).
     </div>
   </form>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -120,7 +120,7 @@
     </div>
     <div class="bottom-align-text">
       <br>Examples: case_id=<strong>18201</strong>, HPO-term=<strong>HP:0001166</strong>, synopsis=<strong>synopsis:epilepsy</strong>, panel=<strong>panel:NMD</strong>, phenotype group=<strong>PG:0100022</strong>, cohort=<strong>cohort:pedhep</strong>.<br>
-      Leave blank values after key to search for cases with missing info (<strong>HP:</strong>,<strong>PG:</strong>,<strong>synopsis:</strong>).
+      Use key without value to search for cases with missing info (<strong>HP:</strong>,<strong>PG:</strong>,<strong>synopsis:</strong>).
     </div>
   </form>
 {% endmacro %}

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -61,10 +61,10 @@ def test_get_cases(adapter, case_obj):
 def test_get_cases_no_synopsis(real_adapter, case_obj, institute_obj, user_obj):
 
     adapter = real_adapter
-    # GIVEN an empty database (no cases)
+    # GIVEN a real database with no cases
     assert real_adapter.cases().count() == 0
 
-    # Insert a case, an instutute and a user
+    # Insert a case
     adapter.case_collection.insert_one(case_obj)
     assert adapter.case_collection.find().count() == 1
 


### PR DESCRIPTION
In cases page, write 'synopsis:', 'HP:' or 'PG:' to get all cases with missing info for these fields