### PR TITLE
Fixes broken load delivery_report command

### DIFF
--- a/scout/commands/load/report.py
+++ b/scout/commands/load/report.py
@@ -6,12 +6,12 @@ from scout.load.report import load_delivery_report
 LOG = logging.getLogger(__name__)
 
 
-@click.command()
+@click.command('delivery-report')
 @click.argument('case_id')
 @click.argument('report_path', type=click.Path(exists=True))
 @click.argument('update', required=False)
 @click.pass_context
-def delivery_report(context, case_id, analysis_date, report_path,
+def delivery_report(context, case_id, report_path,
                     update):
     """Add delivery report to an existing case."""
 

--- a/scout/commands/load/report.py
+++ b/scout/commands/load/report.py
@@ -8,7 +8,6 @@ LOG = logging.getLogger(__name__)
 
 @click.command()
 @click.argument('case_id')
-@click.argument('analysis_date')
 @click.argument('report_path', type=click.Path(exists=True))
 @click.argument('update', required=False)
 @click.pass_context
@@ -19,8 +18,8 @@ def delivery_report(context, case_id, analysis_date, report_path,
     adapter = context.obj['adapter']
 
     try:
-        load_delivery_report(adapter, case_id, analysis_date,
-                             report_path, update)
+        load_delivery_report(adapter=adapter, case_id=case_id,
+                             report_path=report_path, update=update)
         LOG.info("saved report to case!")
     except Exception as e:
         LOG.error(e)


### PR DESCRIPTION
This PR fixes the broken load delivery_report command (by removing unused extranous parameter)

How to test:
1. install on scout stage
1. us
1. scout load delivery-report [CASE-ID] [REPORT-PATH]

Expected outcome: 
Message about upload successful or already uploaded