### PR TITLE
Case names on mt report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed variants query by panel (hpo panel + gene panel).
+- Downloaded MT report contains excel files with individuals' display name
 
 ## [4.5.1]
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -352,10 +352,11 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
     written_files = 0
     for sample in samples:
         sample_id = sample['individual_id']
+        display_name = sample['display_name']
         sample_lines = export_mt_variants(variants=mt_variants, sample_id=sample_id)
 
         # set up document name
-        document_name = '.'.join([case_obj['display_name'], sample_id, today]) + '.xlsx'
+        document_name = '.'.join([case_obj['display_name'], display_name, today]) + '.xlsx'
         workbook = Workbook(os.path.join(temp_excel_dir,document_name))
         Report_Sheet = workbook.add_worksheet()
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -455,7 +455,8 @@ def mt_report(institute_id, case_name):
             data,
             mimetype='application/zip',
             as_attachment=True,
-            attachment_filename='_'.join(['scout', case_name, 'MT_report', today])+'.zip'
+            attachment_filename='_'.join(['scout', case_name, 'MT_report', today])+'.zip',
+            cache_timeout=0
         )
     else:
         flash('No MT report excel file could be exported for this sample', 'warning')

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -561,7 +561,8 @@ def download_verified():
             data,
             mimetype='application/zip',
             as_attachment=True,
-            attachment_filename='_'.join(['scout', 'verified_variants', today])+'.zip'
+            attachment_filename='_'.join(['scout', 'verified_variants', today])+'.zip',
+            cache_timeout=0
         )
     else:
         flash("No verified variants could be exported for user's institutes", 'warning')

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -120,9 +120,9 @@ def test_mt_report(app, user_obj, institute_obj, case_obj):
                                   institute_id=institute_obj['internal_id'],
                                   case_name=case_obj['display_name']),
                                   )
-        # THEN it should return a page
+        # a successful response should be returned
         assert resp.status_code == 200
-        # This file should be a zipped file and not a web page
+        # and it should contain a zipped file, not HTML code
         assert resp.mimetype == 'application/zip'
 
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask import url_for, current_app
+
 from scout.server.extensions import store
 
 def test_cases(app, user_obj, institute_obj):
@@ -103,6 +104,26 @@ def test_causatives(app, user_obj, institute_obj):
 
             # THEN it should return a page
             assert resp.status_code == 200
+
+
+def test_mt_report(app, user_obj, institute_obj, case_obj):
+    # GIVEN an initialized app
+    # GIVEN a valid user and institute
+
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for('auto_login'))
+        assert resp.status_code == 200
+
+        # When clicking on 'mtDNA report' on case page
+        resp = client.get(url_for('cases.mt_report',
+                                  institute_id=institute_obj['internal_id'],
+                                  case_name=case_obj['display_name']),
+                                  )
+        # THEN it should return a page
+        assert resp.status_code == 200
+        # This file should be a zipped file and not a web page
+        assert resp.mimetype == 'application/zip'
 
 
 def test_matchmaker_add(app, institute_obj, case_obj):


### PR DESCRIPTION
fix #1236.

Mitochondial reports downloaded from case page contain an excel file per case individual. 
Each file was named like this:  **caseDisplayName_individualID_date**.

This fix renames the files to: **caseDisplayName_individualDisplayName_date**

- [x] review by @moonso 
- [x] verified by @northwestwitch 