### PR TITLE
Update to IGV.js 2.2.11

### DIFF
--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -28,7 +28,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-    <script type="text/javascript" src="https://igv.org/web/release/1.0.9/igv-1.0.9.js"></script>
+     <script type="text/javascript" src="https://igv.org/web/release/2.2.11/dist/igv.min.js"></script>    
 </head>
 <body>
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>


### PR DESCRIPTION
Update igv javascrit from 1.0.9 to 2.2.11. Addresses issue #1199.

This PR to update igv javascript from 1.0.9 to 2.2.11. Tests below are for 

Contact: @mikaell

### How to test
(Running Scout in demo)
1. open corresponding <filename>.config.yaml (e.i. scout/demo/643594.config.yaml)
2. edit samples:bam_path to point to a bam-file (can be found at ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase1/data)
3. load the config
`$ scout --demo load case scout/demo/<filename>.config.yaml -u`
4. start scout and login
5. click the igv-button in the "Clinical Structural Variants" or in "Clinical SNV and Indels".

### Expected outcome
a. the igv view will load in a separate browser window (or tab).
b. inspect page source HTML header, where igv 2 now is called
`<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/igv@2.2.11/dist/igv.min.js"></script>`


### Review
- [x] code approaved by @northwestwitch 
- [x] tests executed by


