### PR TITLE
reintroduces --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds functionality to display "Tissue type". Passed via load config.
 
 ### Fixed
-- reintroduced the --version cli option
+- Reintroduced the --version cli option
 - Fixed variants query by panel (hpo panel + gene panel).
 - Downloaded MT report contains excel files with individuals' display name
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds functionality to display "Tissue type". Passed via load config.
 
 ### Fixed
+- reintroduced the --version cli option
 - Fixed variants query by panel (hpo panel + gene panel).
 - Downloaded MT report contains excel files with individuals' display name
 

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -35,16 +35,10 @@ def loglevel(ctx):
     log_format = None
     coloredlogs.install(level=loglevel, fmt=log_format)
     LOG.info("Running scout version %s", __version__)
-
-    if ctx.find_root().params["scout_version"]:
-        # display version and exit
-        return
-
     LOG.debug("Debug logging enabled.")
 
 
 @click.pass_context
-@click.version_option(__version__)
 def get_app(ctx):
     """Create an app with the correct config or with default app params"""
 
@@ -70,13 +64,13 @@ def get_app(ctx):
     return app
 
 
+@click.version_option(__version__)
 @click.group(cls=FlaskGroup, create_app=get_app, invoke_without_command=True, add_default_commands=False)
 @click.option('-c', '--config', type=click.Path(exists=True),
               help="Specify the path to a config file with database info.")
 @click.option('--loglevel', default='DEBUG', type=click.Choice(LOG_LEVELS),
               help="Set the level of log output.", show_default=True)
 @click.option('--demo', is_flag=True, help="If the demo database should be used")
-@click.option('-v', 'scout_version', is_flag=True, help="Display version of Scout")
 @click.option('-db', '--mongodb', help='Name of mongo database [scout]')
 @click.option('-u', '--username')
 @click.option('-p', '--password')

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -24,9 +24,9 @@ def test_base_cmd():
     assert 'Debug logging enabled.' not in result.output
 
     # test the cli with -v (version) option
-    result =  runner.invoke(cli, ['-v'])
+    result =  runner.invoke(cli, ['--version'])
     assert result.exit_code == 0
-    assert 'INFO Running scout version {}'.format( __version__) in result.output
+    assert __version__ in result.output
 
     # test the cli with --demo option
     result =  runner.invoke(cli, ['--demo'])


### PR DESCRIPTION
This PR reintroduces the --version option required for deployment on clinical-db. fix #1259

**How to test**:
1. ssh to clinical-db server
1. become hiseq.clinical user
1. go to $HOME/servers/resources/clinical-db
1. run:
 ```
 bash update-scout-stage.sh fix_cli_version
 ```

**Expected outcome**:
1. Installation process should have no errors
1. activate stage environment with the 'us' command
1. run:
```
scout --version
```
and make sure that it displays: **scout, 4.5.1**

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @northwestwitch 
