### PR TITLE
Refactor: case.parse_individual(sample) <parse>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Causatives in alphabetical order, display ACMG classification and filter by gene.
 - Added 'external' to the list of analysis type options
 - Adds functionality to display "Tissue type". Passed via load config.
+- Update to IGV 2.
 
 ### Fixed
 - Fixed 3 bugs affecting SV pages visualization
 - Reintroduced the --version cli option
 - Fixed variants query by panel (hpo panel + gene panel).
 - Downloaded MT report contains excel files with individuals' display name
+- Refactored code in parsing of config files.
 
 ## [4.5.1]
 

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -221,48 +221,27 @@ def parse_individual(sample):
     ind_info['confirmed_sex'] = sample.get('confirmed_sex')
     ind_info['predicted_ancestry'] = sample.get('predicted_ancestry')
 
-    bam_file = sample.get('bam_path')
-    if bam_file:
-        ind_info['bam_file'] = bam_file
+    ind_info['bam_file'] = sample.get('bam_path')
+        
+    ind_info['mt_bam'] = sample.get('mt_bam')
+    ind_info['analysis_type'] = sample.get('analysis_type')
 
-    mt_bam = sample.get('mt_bam')
-    if mt_bam:
-        ind_info['mt_bam'] = mt_bam
-
-    analysis_type = sample.get('analysis_type')
-    if analysis_type:
-        ind_info['analysis_type'] = analysis_type
+    # Path to downloadable vcf2cytosure file
+    ind_info['vcf2cytosure'] = sample.get('vcf2cytosure')
 
     ind_info['capture_kits'] = ([sample.get('capture_kit')]
                                 if 'capture_kit' in sample else [])
-
-    # Path to downloadable vcf2cytosure file
-    vcf2cytosure = sample.get('vcf2cytosure')
-    if vcf2cytosure:
-        ind_info['vcf2cytosure'] = vcf2cytosure
-
+    
     # Cancer specific values
-    tumor_type = sample.get('tumor_type')
-    if tumor_type:
-        ind_info['tumor_type'] = tumor_type
+    ind_info['tumor_type'] = sample.get('tumor_type')
+    # tumor_mutational_burden
+    ind_info['tmb'] = sample.get('tmb')
+    ind_info['msi'] = sample.get('msi')
+    ind_info['tumor_purity'] = sample.get('tumor_purity')
+    ind_info['tissue_type'] = sample.get('tissue_type')
 
-    tumor_mutational_burden = sample.get('tmb')
-    if tumor_mutational_burden:
-        ind_info['tmb'] = tumor_mutational_burden
-
-    msi = sample.get('msi')
-    if msi:
-        ind_info['msi'] = msi
-
-    tumor_purity = sample.get('tumor_purity')
-    if tumor_purity:
-        ind_info['tumor_purity'] = tumor_purity
-
-    tissue_type = sample.get('tissue_type')
-    if tissue_type:
-        ind_info['tissue_type'] = tissue_type
-
-    return ind_info
+    # Remove key-value pairs from ind_info where key==None and return
+    return removeNoneValues(ind_info)
 
 
 def parse_individuals(samples):
@@ -389,3 +368,21 @@ def parse_ped(ped_stream, family_type='ped'):
     } for ind_id, individual in family.individuals.items()]
 
     return family_id, samples
+
+
+
+
+def removeNoneValues(dict):
+    """ If value = None in key/value pair, the pair is removed.
+        Python >3
+    Args:
+        dict: dictionary
+
+    Returns:
+        dictionary
+
+    """
+    
+    return {k:v for k,v in dict.items() if v is not None}
+
+

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -267,15 +267,17 @@ def test_wrong_relations():
 
 
 def test_removeNoneValues():
+    # WHEN a dict *not* containing a value which is None
     d = {"a":"1", "b":2, "c":3}
 
+    # THEN calling removeNoneValues(dict) will not change dict
     assert d == removeNoneValues(d)
 
 
 def test_removeNoneValues():
+    # WHEN a dict containing a value which is None
     d = {"a":"1", "b":2, "c":None}
-
-    d_ = {"a":"1", "b":2}
     
-    assert d_ == removeNoneValues(d)
-
+    # THEN calling removeNoneValues(dict) will remove key-value pair
+    # where value=None
+    assert {"a":"1", "b":2} == removeNoneValues(d)

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -2,7 +2,8 @@ import pytest
 
 from pprint import pprint as pp
 from scout.parse.case import (parse_case, parse_ped, parse_individuals,
-                              parse_individual, parse_case_data)
+                              parse_individual, parse_case_data,
+                              removeNoneValues)
 from scout.exceptions import PedigreeError
 from scout.constants import REV_SEX_MAP
 
@@ -261,3 +262,20 @@ def test_wrong_relations():
     # THEN a PedigreeError should be raised
     with pytest.raises(PedigreeError):
         parse_individuals(samples)
+
+
+
+
+def test_removeNoneValues():
+    d = {"a":"1", "b":2, "c":3}
+
+    assert d == removeNoneValues(d)
+
+
+def test_removeNoneValues():
+    d = {"a":"1", "b":2, "c":None}
+
+    d_ = {"a":"1", "b":2}
+    
+    assert d_ == removeNoneValues(d)
+


### PR DESCRIPTION
Remove if-clauses when building ind_info dict. Make sure no None
value is added by callin removeNoneValues(ind_info) in Return.

This PR is refactoring. And preparation for later bigger commits.


**How to test**:
1. how to install it
`git checkout feature_igv-tracks_190626`


1. how to test it, possibly with real cases/data
`pytest tests/parse/test_parse_case.py`


**Expected outcome**:
Tests should pass.


**Review:**
- [x] code approved by @moonso 
- [ ] tests executed by
- [ ] "merge and deploy" approved by
