### PR TITLE
Stop ignoring 'build' dir when running Pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
   phenogroups and cohorts.
 
 ### Fixed
+- Fixes of and induced by build tests
 - Fixed bug affecting variant observations in other cases
 - Fixed a bug that showed wrong gene coverage in general panel PDF export
 - MT report only shows variants occurring in the specific individual of the excel sheet

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 addopts = -v -x
+norecursedirs = '.*' 'dist' 'CVS' '_darcs' '{arch}' '*.egg' 'venv'

--- a/scout/build/variant/gene.py
+++ b/scout/build/variant/gene.py
@@ -8,21 +8,21 @@ LOG = logging.getLogger(__name__)
 
 def build_gene(gene, hgncid_to_gene=None):
     """Build a gene object
-        
+
         Has to build the transcripts for the genes to
-    
+
     Args:
         gene(dict): Parsed information from the VCF
-        hgncid_to_gene(dict): A map from hgnc_id  -> hgnc_gene objects 
+        hgncid_to_gene(dict): A map from hgnc_id  -> hgnc_gene objects
 
     Returns:
         gene_obj(dict)
-    
+
     gene = dict(
         # The hgnc gene id
         hgnc_id = int, # required
-        hgnc_symbol = str, 
-        ensembl_gene_id = str, 
+        hgnc_symbol = str,
+        ensembl_gene_id = str,
         # A list of Transcript objects
         transcripts = list, # list of <transcript>
         # This is the worst functional impact of all transcripts
@@ -34,11 +34,11 @@ def build_gene(gene, hgncid_to_gene=None):
         # This is most severe polyphen prediction of all transcripts
         polyphen_prediction = str, # choices=CONSEQUENCE
     )
-    
+
     """
     hgncid_to_gene = hgncid_to_gene or {}
     gene_obj = dict()
- 
+
     # This id is collected from the VCF
     # Typically annotated by VEP or snpEFF
     hgnc_id = int(gene['hgnc_id'])
@@ -46,7 +46,7 @@ def build_gene(gene, hgncid_to_gene=None):
 
     # Get the gene information from database
     hgnc_gene = hgncid_to_gene.get(hgnc_id)
-    
+
     inheritance = set()
     hgnc_transcripts = []
     if hgnc_gene:
@@ -57,7 +57,7 @@ def build_gene(gene, hgncid_to_gene=None):
 
         if hgnc_gene.get('inheritance_models'):
             gene_obj['inheritance'] = hgnc_gene['inheritance_models']
-    
+
     transcripts = []
     for transcript in gene['transcripts']:
         transcript_obj = build_transcript(transcript)
@@ -70,14 +70,14 @@ def build_gene(gene, hgncid_to_gene=None):
             LOG.warning("Invalid functional annotation %s", functional_annotation)
         else:
             gene_obj['functional_annotation'] = functional_annotation
-    
+
     region_annotation = gene.get('region_annotation')
     if region_annotation:
         if not region_annotation in FEATURE_TYPES:
             LOG.warning("Invalid region annotation %s", region_annotation)
         else:
             gene_obj['region_annotation'] = region_annotation
- 
+
     sift_prediction = gene.get('most_severe_sift')
     if sift_prediction:
         if not sift_prediction in CONSEQUENCE:
@@ -91,9 +91,9 @@ def build_gene(gene, hgncid_to_gene=None):
             LOG.warning("Invalid polyphen prediction %s", polyphen_prediction)
         else:
             gene_obj['polyphen_prediction'] = polyphen_prediction
-    
-    gene_obj['hgvs_identifier'] = gene['hgvs_identifier']
-    gene_obj['canonical_transcript'] = gene['canonical_transcript']
-    gene_obj['exon'] = gene['exon']
-    
+
+    gene_obj['hgvs_identifier'] = gene.get('hgvs_identifier')
+    gene_obj['canonical_transcript'] = gene.get('canonical_transcript')
+    gene_obj['exon'] = gene.get('exon')
+
     return gene_obj

--- a/scout/parse/variant/gene.py
+++ b/scout/parse/variant/gene.py
@@ -16,7 +16,13 @@ from scout.constants import SO_TERMS
 def parse_genes(transcripts):
     """Parse transcript information and get the gene information from there.
 
-    Use hgnc_id as identifier for genes and ensembl transcript id to identify transcripts
+    Use hgnc_id as identifier for genes and ensembl transcript id to identify transcripts.
+    
+    First group all transcripts on gene. Choose to group by hgnc id when available, otherwise 
+    hgnc symbol. If no gene identifier we skip the transcript.
+    
+    Then go through all transcript for every gene and find out which one that has the most severe 
+    consequence.
 
     Args:
         transcripts(iterable(dict))
@@ -25,36 +31,25 @@ def parse_genes(transcripts):
       genes (list(dict)): A list with dictionaries that represents genes
 
     """
-    # Dictionary to group the transcripts by hgnc_id
     genes_to_transcripts = {}
+    for transcript in transcripts:
+        hgnc_id = transcript['hgnc_id']
+        hgnc_symbol = transcript['hgnc_symbol']
 
-    # List with all genes and there transcripts
+        gene_identifier = hgnc_id or hgnc_symbol
+        if not gene_identifier:
+            continue
+        
+        if gene_identifier not in genes_to_transcripts:
+            genes_to_transcripts[gene_identifier] = []
+        genes_to_transcripts[gene_identifier].append(transcript)
+
+    # List with all genes and their transcripts
     genes = []
 
     hgvs_identifier = None
     canonical_transcript = None
     exon = None
-    # Group all transcripts by gene
-    for transcript in transcripts:
-        # Check what hgnc_id a transcript belongs to
-        hgnc_id = transcript['hgnc_id']
-        hgnc_symbol = transcript['hgnc_symbol']
-
-        # If there is a identifier we group the transcripts under gene
-        if hgnc_id:
-            if hgnc_id in genes_to_transcripts:
-                genes_to_transcripts[hgnc_id].append(transcript)
-            else:
-                genes_to_transcripts[hgnc_id] = [transcript]
-        else:
-            if hgnc_symbol:
-                if hgnc_symbol in genes_to_transcripts:
-                    genes_to_transcripts[hgnc_symbol].append(transcript)
-                else:
-                    genes_to_transcripts[hgnc_symbol] = [transcript]
-
-    # We need to find out the most severe consequence in all transcripts
-    # and save in what transcript we found it
 
     # Loop over all genes
     for gene_id in genes_to_transcripts:
@@ -80,6 +75,12 @@ def parse_genes(transcripts):
         for transcript in gene_transcripts:
             hgnc_id = transcript['hgnc_id']
             hgnc_symbol = transcript['hgnc_symbol']
+            if not hgvs_identifier:
+                hgvs_identifier = transcript.get('coding_sequence_name')
+            if not canonical_transcript:
+                canonical_transcript = transcript['transcript_id']
+            if not exon:
+                exon = transcript['exon']
 
             # Loop over the consequences for a transcript
             for consequence in transcript['functional_annotations']:
@@ -87,24 +88,20 @@ def parse_genes(transcripts):
                 # Lower rank is worse
                 new_rank = SO_TERMS[consequence]['rank']
 
-                if new_rank < most_severe_rank:
-                    # If a worse consequence is found, update the parameters
-                    most_severe_rank = new_rank
-                    most_severe_consequence = consequence
-                    most_severe_transcript = transcript
-                    most_severe_sift = transcript['sift_prediction']
-                    most_severe_polyphen = transcript['polyphen_prediction']
-                    most_severe_region = SO_TERMS[consequence]['region']
+                if new_rank > most_severe_rank:
+                    continue
+                # If a worse consequence is found, update the parameters
+                most_severe_rank = new_rank
+                most_severe_consequence = consequence
+                most_severe_transcript = transcript
+                most_severe_sift = transcript['sift_prediction']
+                most_severe_polyphen = transcript['polyphen_prediction']
+                most_severe_region = SO_TERMS[consequence]['region']
 
             if (transcript['is_canonical'] and transcript.get('coding_sequence_name')):
                 hgvs_identifier = transcript.get('coding_sequence_name')
                 canonical_transcript = transcript['transcript_id']
                 exon = transcript['exon']
-
-        if hgvs_identifier == None:
-            hgvs_identifier = transcript.get('coding_sequence_name')
-            canonical_transcript = transcript['transcript_id']
-            exon = transcript['exon']
 
         gene = {
             'transcripts': gene_transcripts,

--- a/tests/build/test_build_gene.py
+++ b/tests/build/test_build_gene.py
@@ -7,9 +7,7 @@ Tests for genes that are built on the variants
 from scout.build.variant.gene import build_gene
 
 def test_build_gene():
-    ## GIVEN information about a gene and a transcripts
-
-    ## WHEN adding gene and transcript information and building variant
+    ## GIVEN information about a gene and a transcript
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
         'transcript_id': 'ENST00000249504',
@@ -28,15 +26,17 @@ def test_build_gene():
         'canonical_transcript': 'ENST00000249504'
     }
 
+    ## WHEN building the gene object
+
     gene_obj = build_gene(gene_info)
 
+    ## THEN assert that the hgnc id was added correct
     assert gene_obj['hgnc_id'] == gene_info['hgnc_id']
+    ## Then assert no hgnc symbol was found
     assert 'hgnc_symbol' not in gene_obj
 
 def test_build_gene_hgnc_info():
     ## GIVEN information about a gene and some hgnc information
-
-    ## WHEN adding gene and transcript information and building variant
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
         'transcript_id': 'ENST00000249504',
@@ -102,7 +102,13 @@ def test_build_gene_hgnc_info():
 
     hgncid_to_gene = {5134: hgnc_gene}
 
-    gene_obj = build_gene(gene_info, hgncid_to_gene=hgncid_to_gene)
+    ## WHEN adding gene and transcript information and building variant
 
+    gene_obj = build_gene(gene_info, hgncid_to_gene=hgncid_to_gene)
+    
+    ## THEN assert that the hgnc id was added correct
+    assert gene_obj['hgnc_id'] == gene_info['hgnc_id']
+    ## THEN assert that the hgnc symbol was added from the hgnc gene information
     assert gene_obj['hgnc_symbol'] == hgnc_gene['hgnc_symbol']
-    assert gene_obj['inheritance'] == ['AD']
+    ## THEN assert that the gene inheritance models was added correct
+    assert gene_obj['inheritance'] == hgnc_gene['inheritance_models']

--- a/tests/build/test_build_gene.py
+++ b/tests/build/test_build_gene.py
@@ -8,7 +8,7 @@ from scout.build.variant.gene import build_gene
 
 def test_build_gene():
     ## GIVEN information about a gene and a transcripts
-    
+
     ## WHEN adding gene and transcript information and building variant
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
@@ -24,16 +24,18 @@ def test_build_gene():
         'most_severe_polyphen': None,
         'hgnc_id': 5134,
         'region_annotation': 'exonic',
+        'coding_sequence_name': 'c.95T>C',
+        'canonical_transcript': 'ENST00000249504'
     }
-    
+
     gene_obj = build_gene(gene_info)
-    
+
     assert gene_obj['hgnc_id'] == gene_info['hgnc_id']
     assert 'hgnc_symbol' not in gene_obj
 
 def test_build_gene_hgnc_info():
     ## GIVEN information about a gene and some hgnc information
-    
+
     ## WHEN adding gene and transcript information and building variant
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
@@ -48,7 +50,7 @@ def test_build_gene_hgnc_info():
         'most_severe_sift': 'deleterious',
         'most_severe_polyphen': None,
         'hgnc_id': 5134,
-        'region_annotation': 'exonic',
+        'region_annotation': 'exonic'
     }
 
     transcript_1 = {
@@ -64,13 +66,14 @@ def test_build_gene_hgnc_info():
             'refseq_id': 'NM_021192',
             'start': 176972014,
             'end': 176974722,
+            'is_canonical': True
         }
 
     hgnc_transcripts = [
         transcript_1,
         transcript_2
     ]
-    
+
     hgnc_gene = {
         'hgnc_id': 5134,
         'hgnc_symbol': 'HOXD11',
@@ -90,21 +93,16 @@ def test_build_gene_hgnc_info():
         'vega_id': 'OTTHUMG00000132510',
         'transcripts': hgnc_transcripts,
         'incomplete_penetrance': False,
-        'ad': True,
-        'ar': False,
-        'xd': False,
-        'xr': False,
-        'x': False,
-        'y': False,
+        'inheritance_models': ['AD'],
         'transcripts_dict': {
             'ENST00000498438': transcript_1,
             'ENST00000249504': transcript_2,
         }
     }
-    
+
     hgncid_to_gene = {5134: hgnc_gene}
-    
+
     gene_obj = build_gene(gene_info, hgncid_to_gene=hgncid_to_gene)
-    
+
     assert gene_obj['hgnc_symbol'] == hgnc_gene['hgnc_symbol']
     assert gene_obj['inheritance'] == ['AD']

--- a/tests/build/test_build_individual.py
+++ b/tests/build/test_build_individual.py
@@ -12,10 +12,10 @@ def test_build_individual():
         'display_name': '1-1',
         'sex': 'male',
         'phenotype': 'affected',
-        'bam_file': 'a.bam',
+        'bam_file': 'scout/demo/reduced_mt.bam',
         'capture_kits': ['Agilent']
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 
@@ -26,7 +26,7 @@ def test_build_individual():
     assert ind_obj['mother'] == ind_info['mother']
     assert ind_obj['sex'] == '1'
     assert ind_obj['phenotype'] == 2
-    assert ind_obj['bam_file'] == ind_info['bam_file']
+    assert ind_obj['bam_file'].endswith(ind_info['bam_file'])
     assert ind_obj['analysis_type'] == 'unknown'
 
 def test_build_individual_no_individual_id():
@@ -170,7 +170,7 @@ def test_build_individual_tmb():
         'capture_kits': ['Agilent'],
         'tmb': '0.1',
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 
@@ -191,7 +191,7 @@ def test_build_individual_msi():
         'tmb': '0.1',
         'msi': '13',
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 
@@ -213,7 +213,7 @@ def test_build_individual_tumor_purity():
         'msi': '13',
         'tumor_purity': '0.013',
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 
@@ -235,7 +235,7 @@ def test_build_individual_tumor_type():
         'msi': '13',
         'tumor_type': 'melanoma',
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 
@@ -258,7 +258,7 @@ def test_build_individual_tissue_type():
         'msi': '13',
         'tissue_type': 'blood',
     }
-    
+
     ## WHEN parsing the information
     ind_obj = build_individual(ind_info)
 

--- a/tests/build/test_build_variant.py
+++ b/tests/build/test_build_variant.py
@@ -10,7 +10,7 @@ INSTITUTE_ID = 'test'
 def test_build_empty():
     ## GIVEN a variant with no information
     variant = {}
-    
+
     ## WHEN building a variant_obj
     ## THEN a Key Error should be raised since mandatory fields are missing
     with pytest.raises(KeyError):
@@ -30,9 +30,9 @@ def test_build_minimal(case_obj):
             self.QUAL = None
             self.var_type = 'snp'
             self.INFO = {}
-    
+
     variant = Cyvcf2Variant()
-    
+
     parsed_variant = parse_variant(variant, case_obj)
     assert 'ids' in parsed_variant
     variant_obj = build_variant(parsed_variant, INSTITUTE_ID)
@@ -40,7 +40,7 @@ def test_build_minimal(case_obj):
 
 def test_build_with_gene_info(parsed_variant):
     ## GIVEN information about a variant
-    
+
     ## WHEN adding gene and transcript information and building variant
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
@@ -57,18 +57,18 @@ def test_build_with_gene_info(parsed_variant):
         'hgnc_id': 5134,
         'region_annotation': 'exonic',
     }
-    
+
     parsed_variant['genes'].append(gene_info)
 
     variant_obj = build_variant(parsed_variant, INSTITUTE_ID)
-    
+
     ## THEN assert the information is added
     assert variant_obj['institute'] == INSTITUTE_ID
     assert len(variant_obj['genes']) == 1
 
 def test_build_with_hgnc_info(parsed_variant):
     ## GIVEN information about a variant
-    
+
     ## WHEN adding gene and transcript information and building variant
     transcript_info = {
         'functional_annotations': ['transcript_ablation'],
@@ -85,16 +85,16 @@ def test_build_with_hgnc_info(parsed_variant):
         'hgnc_id': 5134,
         'region_annotation': 'exonic',
     }
-    
+
     parsed_variant['genes'].append(gene_info)
-    
+
     transcript_1 = {
             'ensembl_transcript_id': 'ENST00000498438',
             'is_primary': False,
             'start': 176968944,
             'end': 176974482
         }
-    
+
     transcript_2 = {
             'ensembl_transcript_id': 'ENST00000249504',
             'is_primary': True,
@@ -104,12 +104,12 @@ def test_build_with_hgnc_info(parsed_variant):
         }
 
 
-    
+
     hgnc_transcripts = [
         transcript_1,
         transcript_2
     ]
-    
+
     hgnc_gene = {
         'hgnc_id': 5134,
         'hgnc_symbol': 'HOXD11',
@@ -129,22 +129,17 @@ def test_build_with_hgnc_info(parsed_variant):
         'vega_id': 'OTTHUMG00000132510',
         'transcripts': hgnc_transcripts,
         'incomplete_penetrance': False,
-        'ad': True,
-        'ar': False,
-        'xd': False,
-        'xr': False,
-        'x': False,
-        'y': False,
+        'inheritance_models': ['AD'],
         'transcripts_dict': {
             'ENST00000498438': transcript_1,
             'ENST00000249504': transcript_2,
             }
     }
-    
+
     hgncid_to_gene = {5134: hgnc_gene}
 
     variant_obj = build_variant(parsed_variant, INSTITUTE_ID, hgncid_to_gene=hgncid_to_gene)
-    
+
     ## THEN assert the information is added
     assert variant_obj['institute'] == INSTITUTE_ID
     assert variant_obj['genes'][0]['hgnc_id'] == 5134
@@ -154,7 +149,7 @@ def test_build_with_hgnc_info(parsed_variant):
 
 def test_build_variant(parsed_variant):
     variant_obj = build_variant(parsed_variant, INSTITUTE_ID)
-        
+
     assert variant_obj['chromosome'] == parsed_variant['chromosome']
     assert variant_obj['category'] == 'snv'
     assert variant_obj['institute'] == INSTITUTE_ID
@@ -168,7 +163,7 @@ def test_build_variants(parsed_variants, institute_obj):
 
 def test_build_sv_variant(parsed_sv_variant, institute_obj):
     variant_obj = build_variant(parsed_sv_variant, institute_obj)
-        
+
     assert variant_obj['chromosome'] == parsed_sv_variant['chromosome']
     assert variant_obj['category'] == 'sv'
 
@@ -183,8 +178,7 @@ def test_build_cadd_score(parsed_variants, institute_obj):
     for index,variant in enumerate(parsed_variants):
         if variant.get('cadd_score'):
             variant_obj = build_variant(variant, institute_obj)
-            
-            assert variant_obj['cadd_score'] == variant['cadd_score']
-            
-    assert index > 0
 
+            assert variant_obj['cadd_score'] == variant['cadd_score']
+
+    assert index > 0


### PR DESCRIPTION
Update pytest.ini to remove 'build' from the ignored test directories.
Previous default setting was:

.*', 'build', 'dist', 'CVS', '_darcs', '{arch}', '*.egg', ’venv'

This PR fixes a bug.

It will start breaking some unit tests that previously were ignored.

This update is needed in every product using the tests/build name structure!

Further reading [https://docs.pytest.org/en/3.0.0/customize.html]


**How to test**:
1. how to install it
Update your repository

    $ git pull

1. how to test it, possibly with real cases/data
Run the pytest

    $ pytest tests

**Expected outcome**:
Pytest will now enter tests/build and execute unit tests. 

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @moonso 
- [ ] "merge and deploy" approved by
