### PR TITLE
Export gene and gene panels to chr build GRCh38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [4.x.x]
 
 ### Added
+- Export genes and gene panels in build GRCh38
 
 ### Fixed
 

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -188,6 +188,9 @@ class GeneHandler(object):
             Returns:
                 result()
         """
+        if build == 'GRCh38':
+            build = '38'
+
         LOG.info("Fetching all genes")
         return self.hgnc_collection.find({'build': build}).sort('chromosome', 1)
 

--- a/scout/commands/export/gene.py
+++ b/scout/commands/export/gene.py
@@ -1,9 +1,7 @@
 import logging
 
 import click
-
 from bson.json_util import dumps
-
 from flask.cli import with_appcontext
 
 from scout.commands.utils import builds_option
@@ -22,15 +20,22 @@ def genes(build, json):
     """Export all genes from a build"""
     LOG.info("Running scout export genes")
     adapter = store
-
     result = adapter.all_genes(build=build)
+    gene_list = list(result)
+    if build == 'GRCh38':
+        for gene_obj in gene_list:
+            if gene_obj['chromosome'] == 'MT':
+                gene_obj['chromosome'] = 'M'
+            gene_obj['chromosome'] = ''.join(['chr',gene_obj['chromosome']])
+
     if json:
-        click.echo(dumps(result))
+        click.echo(dumps(gene_list))
         return
 
+
     gene_string = ("{0}\t{1}\t{2}\t{3}\t{4}")
-    click.echo("#Chromosom\tStart\tEnd\tHgnc_id\tHgnc_symbol")
-    for gene_obj in result:
+    click.echo("#Chromosome\tStart\tEnd\tHgnc_id\tHgnc_symbol")
+    for gene_obj in gene_list:
         click.echo(gene_string.format(
             gene_obj['chromosome'],
             gene_obj['start'],

--- a/scout/commands/export/utils.py
+++ b/scout/commands/export/utils.py
@@ -7,9 +7,8 @@ json_option = click.option('--json',
     help='Output result in json format'
 )
 
-build_option = click.option('-b', '--build', 
-    default='37', 
+build_option = click.option('-b', '--build',
+    default='37',
     type=click.Choice(BUILDS),
     show_default=True
 )
-

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -40,7 +40,7 @@ COLLECTIONS = [
     'acmg',
 ]
 
-BUILDS = ['37', '38']
+BUILDS = ['37', '38', 'GRCh38']
 
 CYTOBANDS = parse_cytoband(cytobands_handle)
 

--- a/tests/commands/export/test_export_gene.py
+++ b/tests/commands/export/test_export_gene.py
@@ -46,3 +46,20 @@ def test_export_genes(mock_app):
     # assert that gene is returned
     assert result.exit_code == 0
     assert 'hgnc_symbol": "ACP6", "ensembl_id": "ENSG00000162836"' in result.output
+
+    # Test exporting a gene in genome build GRCh38
+    # Test the export panel cli by passing build=GRCh38
+    result =  runner.invoke(cli, ['export', 'genes',
+        '-b', 'GRCh38'
+        ])
+    # assert that gene is returned
+    assert result.exit_code == 0
+    assert '1\t147629652\t147670496\t29609\tACP6\n' in result.output
+
+    # Test CLI to return json-formatted genes
+    result =  runner.invoke(cli, ['export', 'genes',
+        '-b', 'GRCh38',
+        '--json'
+        ])
+    assert result.exit_code == 0
+    assert 'hgnc_symbol": "ACP6", "ensembl_id": "ENSG00000162836"' in result.output

--- a/tests/commands/export/test_export_panel_cmd.py
+++ b/tests/commands/export/test_export_panel_cmd.py
@@ -56,3 +56,15 @@ def test_export_panel(mock_app):
     # The CLI command shoud return gene panel formatted in the expected way
     assert result.exit_code == 0
     assert '22\t26995242\t27014052\t2397\tCRYBB1\n22\t38452318\t38471708\t9394\tPICK1\n' in result.output
+
+    # Pass a valid panel name, valid version, bed file format option and genome build GRCh38
+    result =  runner.invoke(cli, ['export', 'panel',
+        panel_obj['panel_name'],
+        '--version', 1.0,
+        '-b', 'GRCh38',
+        '--bed'
+        ])
+
+    # The CLI command shoud return gene panel formatted in the expected way
+    assert result.exit_code == 0
+    assert '##genome_build=GRCh38' in result.output


### PR DESCRIPTION
This PR adds the functionality to export genes and panels to build GRCh38. It's addressing #1276

**How to test**:

** 1) Testing the gene export**
- from a local installation of scout, master branch run the following command:
```
scout --demo export genes -b 38 
```
You should get a list of gene coordinates where the first column is a chromosome such as 1,2..X,Y,**MT**
- switch to this branch (git checkout export_grch38)
- run now the following command
```
scout --demo export genes -b GRCh38
```
Expected outcome is list of gene coordinates where the first column is a chromosome formatted like this:
chr1, chr2... chrX, chrY, **chrM**

The formatting above should be valid also using the --json option 

** 1) Testing the gene panels export**
- from master branch run the following command:
```
scout --demo export panel panel1 -b 38 --bed
```
- You should see a list of gene coordinates where the first column is a chromosome such as 1,2..X,Y,**MT**. If you look up at the beginning of what is printed (contig list) the following contigs should be printed:

##genome_build=38
##gene_panel=panel1,version=1.0,updated_at=2019-08-06,display_name=Test panel
##contig=1
##contig=2
##contig=3
##contig=4
##contig=5
##contig=6
##contig=7
##contig=8
##contig=9
##contig=10
##contig=11
##contig=12
##contig=13
##contig=14
##contig=15
##contig=16
##contig=17
##contig=18
##contig=19
##contig=20
##contig=21
##contig=22
##contig=X
##contig=Y
##contig=MT

- checkout to this branch again and run the following command:
```
scout --demo export panel panel1 -b GRCh38 --bed
```
- expected outcome is that contigs in the result are formatted like this: chr1, chr2... chrX, chrY, **chrM** and the contig list above is the following:
##genome_build=GRCh38
##gene_panel=panel1,version=1.0,updated_at=2019-08-06,display_name=Test panel
##contig=chr1
##contig=chr2
##contig=chr3
##contig=chr4
##contig=chr5
##contig=chr6
##contig=chr7
##contig=chr8
##contig=chr9
##contig=chr10
##contig=chr11
##contig=chr12
##contig=chr13
##contig=chr14
##contig=chr15
##contig=chr16
##contig=chr17
##contig=chr18
##contig=chr19
##contig=chr20
##contig=chr21
##contig=chr22
##contig=chrX
##contig=chrY
##contig=chrM


**Review:**
- [ ] code approved by
- [x] tests executed by
- [ ] "merge and deploy" approved by
