### PR TITLE
Wui similar case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Export genes and gene panels in build GRCh38
+- Search for cases with variants pinned or marked causative in a given gene.
+- Search for cases phenotypically similiar to a case also from WUI.
+- Case variant searches can be limited to similar cases, matching HPO-terms,
+  phenogroups and cohorts.
 
 ### Fixed
 - Fixed bug affecting variant observations in other cases

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -175,6 +175,36 @@ class CaseHandler(object):
                                 similar_case_ids.append(i[0])
                                 order.append(i[1])
                             query['_id'] = {'$in': similar_case_ids}
+            elif name_query.startswith('causative:'):
+                if name_value:
+                    cases_with_gene_doc=self.case_collection.aggregate([
+                        { '$lookup':
+                            {'from': 'variant',
+                            'localField': 'causatives',
+                            'foreignField': '_id',
+                            'as': 'causative_variant'}
+                        },
+                        {'$match': {
+                            'causative_variant.hgnc_symbols': name_value
+                        }},
+                        {'$project': {'_id': 1}}])
+                    case_ids = [case['_id'] for case in cases_with_gene_doc]
+                    query['_id'] = {'$in': case_ids}
+            elif name_query.startswith('pinned:'):
+                if name_value:
+                    cases_with_gene_doc=self.case_collection.aggregate([
+                        { '$lookup':
+                            {'from': 'variant',
+                            'localField': 'suspects',
+                            'foreignField': '_id',
+                            'as': 'suspect_variant'}
+                        },
+                        {'$match': {
+                            'suspect_variant.hgnc_symbols': name_value
+                        }},
+                        {'$project': {'_id': 1}}])
+                    case_ids = [case['_id'] for case in cases_with_gene_doc]
+                    query['_id'] = {'$in': case_ids}
             elif name_query.startswith('synopsis:'):
                 if name_value:
                     query['$text']={'$search':name_value}

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -27,6 +27,7 @@ class QueryHandler(object):
             category(str): 'snv', 'sv', 'str' or 'cancer'
             variant_type(str): 'clinical' or 'research'
 
+        Possible query dict keys:
             phenotype_terms
             phenotype_groups
             cohorts
@@ -47,26 +48,42 @@ class QueryHandler(object):
 
         mongo_variant_query['category'] = category
 
+        select_cases = None
+        select_case_obj = None
+        mongo_case_query = {}
+
         if query.get('phenotype_terms'):
-            mongo_variant_query['phenotype_terms.phenotype_id'] = {'$in': query['phenotype_terms']}
+            mongo_case_query['phenotype_terms.phenotype_id'] = {'$in': query['phenotype_terms']}
 
         if query.get('phenotype_groups'):
-            mongo_variant_query['phenotype_groups.phenotype_id'] = {'$in': query['phenotype_groups']}
+            mongo_case_query['phenotype_groups.phenotype_id'] = {'$in': query['phenotype_groups']}
 
         if query.get('cohorts'):
-            mongo_variant_query['cohort'] = {'$in': query['cohorts']}
+            mongo_case_query['cohorts'] = {'$in': query['cohorts']}
+
+        if mongo_case_query != {}:
+            mongo_case_query['owner'] = institute_id
+            LOG.debug("Search cases for selection set, using query {0}".format(select_case_obj))
+            select_case_obj = self.case_collection.find(mongo_case_query)
+            select_cases = [case_id.get('display_name') for case_id in select_case_obj]
 
         if query.get('similar_case'):
-            similar_case_display_name = query['similar_case']
+            similar_case_display_name = query['similar_case'][0]
             case_obj = self.case(display_name=similar_case_display_name, institute_id=institute_id)
             if case_obj:
                 LOG.debug("Search for cases similar to %s", case_obj.get('display_name'))
                 similar_cases = self.get_similar_cases(case_obj)
                 LOG.debug("Similar cases: %s",similar_cases)
+                select_cases = [similar[0] for similar in similar_cases]
+            else:
+                LOG.debug("Case %s not found.", similar_case_display_name)
+
+        if select_cases:
+            mongo_variant_query['case_id'] = {'$in': select_cases}
 
         rank_score = query.get('rank_score') or 15
-
         mongo_variant_query['rank_score'] = {'$gte': rank_score}
+
         LOG.debug("Querying %s" % mongo_variant_query)
 
         return mongo_variant_query

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -272,10 +272,11 @@ class VariantHandler(VariantLoader):
             nr_of_variants(int): if -1 return all variants
             skip(int): How many variants to skip
 
-            phenotype_terms=phenotype_terms,
-            phenotype_groups=phenotype_groups,
-            similar_case=similar_case,
-            cohorts=cohorts
+        Query can contain:
+            phenotype_terms,
+            phenotype_groups,
+            similar_case,
+            cohorts
         """
         mongo_variant_query = self.build_variant_query(query=query,
                                    institute_id=institute_id,

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -269,8 +269,12 @@ class VariantHandler(VariantLoader):
             category(str): 'sv', 'str', 'snv' or 'cancer'
             nr_of_variants(int): if -1 return all variants
             skip(int): How many variants to skip
-        """
 
+            phenotype_terms=phenotype_terms,
+            phenotype_groups=phenotype_groups,
+            similar_case=similar_case,
+            cohorts=cohorts
+        """
         mongo_variant_query = self.build_variant_query(query=query,
                                    category=category, variant_type=variant_type)
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -258,6 +258,7 @@ class VariantHandler(VariantLoader):
 
     def gene_variants(self, query=None,
                    category='snv', variant_type=['clinical'],
+                   institute_id=None,
                    nr_of_variants=50, skip=0):
         """Return all variants seen in a given gene.
 
@@ -267,6 +268,7 @@ class VariantHandler(VariantLoader):
             query(dict): A dictionary with querys for the database, including
             variant_type: 'clinical', 'research'
             category(str): 'sv', 'str', 'snv' or 'cancer'
+            institute_id: institute ID (required for similarity query)
             nr_of_variants(int): if -1 return all variants
             skip(int): How many variants to skip
 
@@ -276,6 +278,7 @@ class VariantHandler(VariantLoader):
             cohorts=cohorts
         """
         mongo_variant_query = self.build_variant_query(query=query,
+                                   institute_id=institute_id,
                                    category=category, variant_type=variant_type)
 
         sorting = [('rank_score', pymongo.DESCENDING)]

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -463,7 +463,7 @@ def vcf2cytosure(store, institute_id, case_name, individual_id):
 
     return (individual_obj['display_name'], individual_obj['vcf2cytosure'])
 
-def gene_variants(store, variants_query, page=1, per_page=50):
+def gene_variants(store, variants_query, institute_id, page=1, per_page=50):
     """Pre-process list of variants."""
     variant_count = variants_query.count()
     skip_count = per_page * max(page - 1, 0)

--- a/scout/server/blueprints/cases/forms.py
+++ b/scout/server/blueprints/cases/forms.py
@@ -28,3 +28,7 @@ class GeneVariantFiltersForm(FlaskForm):
     hgnc_symbols = TagListField('HGNC Symbols/Ids (case sensitive)')
     filter_variants = SubmitField(label='Filter variants')
     rank_score = IntegerField()
+    phenotype_terms = TagListField('HPO terms')
+    phenotype_groups = TagListField('Phenotype groups')
+    similar_case = TagListField('Phenotypically similar case')
+    cohorts = TagListField('Cohorts')

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -106,7 +106,11 @@
               panel=<strong>panel:NMD</strong>,
               status=<strong>status:active</strong>,
               phenotype&nbsp;group=<strong>PG:0100022</strong>,
-              cohort=<strong>cohort:pedhep</strong>.<br><br>
+              cohort=<strong>cohort:pedhep</strong>,
+              similar&nbsp;case=<strong>similar:18201</strong>,
+              gene_pinned=<strong>pinned:POT1</strong>,
+              gene_causative=<strong>causative:POT1</strong>,
+              assigned_user=<strong>Kent</strong>.<br><br>
               Use key without value to search for cases with missing info (<strong>HP:</strong>, <strong>PG:</strong>, <strong>synopsis:</strong>).
             </div>
           "></input>

--- a/scout/server/blueprints/cases/templates/cases/gene_variants.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_variants.html
@@ -115,7 +115,7 @@
       <strong>Sift</strong>
       {{ variant.sift_predictions|join(',') }} <br>
       <strong>PolyPhen</strong>
-      {{ (variant.polyphen_predictions or ['-'])|join(',') }}		
+      {{ (variant.polyphen_predictions or ['-'])|join(',') }}
     </div>
     ">
     {{ variant.cadd_score }}
@@ -160,7 +160,24 @@
           {{ form.variant_type(class="form-control") }}
         </div>
       </div>
-    </div>
+      <div class="row">
+        <div class="col-xs-3">
+          {{ form.phenotype_terms.label(class="control-label") }}
+          {{ form.phenotype_terms(class="form-control") }}
+        </div>
+        <div class="col-xs-3">
+          {{ form.phenotype_groups.label(class="control-label") }}
+          {{ form.phenotype_groups(class="form-control") }}
+        </div>
+        <div class="col-xs-3">
+          {{ form.cohorts.label(class="control-label") }}
+          {{ form.cohorts(class="form-control") }}
+        </div>
+        <div class="col-xs-3">
+          {{ form.similar_case.label(class="control-label") }}
+          {{ form.similar_case(class="form-control") }}
+        </div>
+      </div>
     <div class="form-group">
       <div class="row">
         <div class="col-xs-6">

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -398,10 +398,10 @@ def gene_variants(institute_id):
 
         LOG.debug("query {}".format(form.data))
 
-        variants_query = store.gene_variants(query=form.data, category='snv',
-                            variant_type=variant_type)
+        variants_query = store.gene_variants(query=form.data, institute_id=institute_id,
+                                             category='snv', variant_type=variant_type)
 
-        data = controllers.gene_variants(store, variants_query, page)
+        data = controllers.gene_variants(store, variants_query, institute_id, page)
 
     return dict(institute=institute_obj, form=form, page=page, **data)
 

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -474,11 +474,11 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
     assert adapter.case_collection.find().count() == 2
 
     # WHEN querying for a similar case
-    name_query= "similar:{}".format(case_obj['_id'])
+    name_query= "similar:{}".format(case_obj['display_name'])
 
     # THEN one case should be returned
     cases = list(adapter.cases(collaborator=case_obj['owner'], name_query=name_query))
-    assert len(cases) == 2
+    assert len(cases) == 1
 
 def test_get_cases_cohort(real_adapter, case_obj, user_obj):
     adapter = real_adapter

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -397,12 +397,12 @@ def test_update_case_rerun_status(adapter, case_obj):
     # THEN assert that 'rerun_requested' is set to False
     assert res['rerun_requested'] is False
 
-
 def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):
     adapter = hpo_database
 
     # Make sure database contains HPO terms
     assert adapter.hpo_terms().count()
+
 
     # update test case using test HPO terms
     case_obj['phenotype_terms'] = test_hpo_terms
@@ -413,6 +413,7 @@ def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):
     # insert case into database
     adapter.case_collection.insert_one(case_obj)
     assert adapter.case_collection.find().count() == 1
+
 
     # Add another case with slightly different phenotype
     case_2 = copy.deepcopy(case_obj)
@@ -441,3 +442,40 @@ def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):
 
     # and the first element of the list has a score higher or equal than the second
     assert similar_cases[0][1] > similar_cases[1][1]
+
+def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj):
+    adapter = hpo_database
+
+    # Make sure database contains HPO terms
+    assert adapter.hpo_terms().count()
+
+    # GIVEN a real database with no cases
+#        assert adapter.cases().count() == 0
+
+    # Give the case HPO terms
+    case_obj['phenotype_terms'] = test_hpo_terms
+    adapter.case_collection.find_one_and_update(
+        { '_id' : case_obj['_id'] },
+        { '$set' : {'phenotype_terms' : test_hpo_terms }},
+        return_document=pymongo.ReturnDocument.AFTER)
+
+    # Insert a case into the db
+    adapter.case_collection.insert_one(case_obj)
+    assert adapter.case_collection.find().count() == 1
+
+    # Add another case with slightly different phenotype:
+
+    case_2 = copy.deepcopy(case_obj)
+    case_2['_id']='case_2'
+    case_2['phenotype_terms'] = test_hpo_terms[:-1] # exclude last term
+
+    # insert this case in database:
+    adapter.case_collection.insert_one(case_2)
+    assert adapter.case_collection.find().count() == 2
+
+    # WHEN querying for a similar case
+    name_query= "similar:{}".format(case_obj['_id'])
+
+    # THEN one case should be returned
+    cases = list(adapter.cases(collaborator=case_obj['owner'], name_query=name_query))
+    assert len(cases) == 2

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -479,3 +479,18 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
     # THEN one case should be returned
     cases = list(adapter.cases(collaborator=case_obj['owner'], name_query=name_query))
     assert len(cases) == 2
+
+def test_get_cases_cohort(real_adapter, case_obj, user_obj):
+    adapter = real_adapter
+    # GIVEN an empty database (no cases)
+    assert adapter.cases().count() == 0
+
+    cohort_name = 'cohort'
+
+    case_obj['cohorts'] = [ cohort_name ]
+    adapter.case_collection.insert_one(case_obj)
+
+    # WHEN retreiving cases by a cohort name query
+    result = adapter.cases(name_query="cohort:{}".format(cohort_name))
+    # THEN we should get the case returned
+    assert result.count() == 1


### PR DESCRIPTION
I'm going to PR this now so I don't get tempted to add more features.
This adds three features as it is now:
- Solves the last remaining item in #1065 by allowing case queries for cases with pinned or causative variants in a particular genes. 
- Allows local case searches for phenotypically similar cases using the HPO-tree queries previously available from scout CLI.
- Solves the remaining suggested items in #1064 by allowing limitation of case_variants searches to HPO-terms, phenogroups and cohorts - and for good measure similar cases as well, which didn't exist when the issue was written.

Not ready for merge, obviously - automated tests to follow.

**How to test**:
1. Pin variants on case and ensure you can search with pinned gene and find these cases in the case view.
2. Mark variants on case causative and ensure you can search with causative:gene and find them on the case view. 
3. Construct phenotypically similar cases and search in case view, ensuring they can be found.
4. Ensure you can find variants from said newly marked phenotypically similar cases in the gene_variants view, and only these variants, when searching for variants in a gene, e.g. POT1. 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "merge and deploy" approved by