### PR TITLE
Disable ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed bug affecting variant observations in other cases
 - Fixed a bug that showed wrong gene coverage in general panel PDF export
 - MT report only shows variants occurring in the specific individual of the excel sheet
+- Disable SSL certifcate verification in requests to chanjo
 
 ## [4.6.1]
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -303,7 +303,7 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
     request_data['level'] = institute_obj.get('coverage_cutoff', 15)
 
     #send get request to chanjo report
-    # Disable default certificate verification
+    #disable default certificate verification
     resp = requests.post(base_url+'reports/report', data=request_data, verify=False)
 
     #read response content

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 
 from bs4 import BeautifulSoup
-import ssl
 from xlsxwriter import Workbook
 from flask import url_for, current_app
 from flask_mail import Message
@@ -305,8 +304,7 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
 
     #send get request to chanjo report
     # Disable default certificate verification
-    ssl._create_default_https_context = ssl._create_unverified_context
-    resp = requests.post(base_url+'reports/report', data=request_data)
+    resp = requests.post(base_url+'reports/report', data=request_data, verify=False)
 
     #read response content
     soup = BeautifulSoup(resp.text)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 
 from bs4 import BeautifulSoup
+import ssl
 from xlsxwriter import Workbook
 from flask import url_for, current_app
 from flask_mail import Message
@@ -303,6 +304,8 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
     request_data['level'] = institute_obj.get('coverage_cutoff', 15)
 
     #send get request to chanjo report
+    # Disable default certificate verification
+    ssl._create_default_https_context = ssl._create_unverified_context
     resp = requests.post(base_url+'reports/report', data=request_data)
 
     #read response content


### PR DESCRIPTION
This PR fixes the SSL: CERTIFICATE_VERIFY_FAILED error in #1289.

This is a workaround before changing the settings in servers (see here: https://github.com/Clinical-Genomics/servers/issues/179)

**How to test**:
1. It's not possible to download PDF reports from the 'general report' page. You can test on any case on scout-stage
1. How to install the branch on clinical-db stage:
```
ssh your.user@clinical-db.scilifelab.se
sudo -iu hiseq.clinical
cd servers/resources/clinical-dbscilifelab.se
bash update-scout-stage.sh disable_ssl
```

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
