### PR TITLE
De-archive re-runs and sorting of cases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Export genes and gene panels in build GRCh38
+- Dearchive reruns and flad them as 'inactive' if archived
+- Sort cases by analysis_date, track or status
 
 ### Fixed
 - Fixed bug affecting variant observations in other cases
 - Fixed a bug that showed wrong gene coverage in general panel PDF export
 - MT report only shows variants occurring in the specific individual of the excel sheet
-- Disable SSL certifcate verification in requests to chanjo
 
 ## [4.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dearchive reruns and flad them as 'inactive' if archived
 - Sort cases by analysis_date, track or status
 - Display cases in the following order: prioritized, active, inactive, archived, solved
+- Assign case to user when user activates it or asks for rerun
+- Case becomes inactive when it has no assignees
 
 ### Fixed
 - Fixes of and induced by build tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Export genes and gene panels in build GRCh38
 - Search for cases with variants pinned or marked causative in a given gene.
-- Search for cases phenotypically similiar to a case also from WUI.
+- Search for cases phenotypically similar to a case also from WUI.
 - Case variant searches can be limited to similar cases, matching HPO-terms,
   phenogroups and cohorts.
-- Dearchive reruns and flad them as 'inactive' if archived
+- Dearchive reruns and flag them as 'inactive' if archived
 - Sort cases by analysis_date, track or status
 - Display cases in the following order: prioritized, active, inactive, archived, solved
 - Assign case to user when user activates it or asks for rerun

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed bug affecting variant observations in other cases
 - Fixed a bug that showed wrong gene coverage in general panel PDF export
 - MT report only shows variants occurring in the specific individual of the excel sheet
+- Disable SSL certifcate verification in requests to chanjo
 
 ## [4.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Export genes and gene panels in build GRCh38
 - Dearchive reruns and flad them as 'inactive' if archived
 - Sort cases by analysis_date, track or status
+- Display cases in the following order: prioritized, active, inactive, archived, solved
 
 ### Fixed
 - Fixed bug affecting variant observations in other cases

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -19,15 +19,15 @@ LOG = logging.getLogger(__name__)
 
 class CaseHandler(object):
     """Part of the pymongo adapter that handles cases and institutes"""
-    
+
     def get_similar_cases(self, case_obj):
         """Take a case obj and return a iterable with the most phenotypically similar cases
-        
+
         Args:
             case_obj(models.Case)
-        
+
         Returns:
-            scores(list(tuple)): Returns a list of tuples like (case_id, score) with the most 
+            scores(list(tuple)): Returns a list of tuples like (case_id, score) with the most
                                  similar case first
         """
         scores = {}
@@ -464,6 +464,7 @@ class CaseHandler(object):
                     'research_requested': case_obj.get('research_requested', False),
                     'multiqc': case_obj.get('multiqc'),
                     'mme_submission': case_obj.get('mme_submission'),
+                    'status': old_case.get('status') if  old_case.get('status') != 'archived' else 'inactive'
                 }
             },
             return_document=pymongo.ReturnDocument.AFTER

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -81,16 +81,19 @@ class CaseEventHandler(object):
         LOG.info("Updating {0} to be unassigned with {1}".format(
             case['display_name'], user['name']))
 
+        # if no other user is assigned to the case and case is not prioritized
+        if case['status'] != 'prioritized' and case.get('assignees') == [user['email']]:
+            # flag case as inactive:
+            case['status'] = 'inactive'
+
         updated_case = self.case_collection.find_one_and_update(
             {'_id': case['_id']},
-            {'$pull': {'assignees': user['_id']}},
+            {
+                '$pull': {'assignees': user['_id']},
+                '$set': { 'status': case['status']}
+            },
             return_document=pymongo.ReturnDocument.AFTER
         )
-        # if no user is assigned to case
-        if updated_case['status']!= 'prioritized' and updated_case['assignees'] == []:
-            # flag case as inactive
-            self.update_status(institute, updated_case, user, 'inactive', link)
-
         LOG.debug("Case updated")
         return updated_case
 

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -120,10 +120,10 @@ class CaseEventHandler(object):
             LOG.warning("Status {0} is invalid".format(status))
             return None
 
-        LOG.info("Creating event for updating status of {0} to {1} -- {2}".format(
-            case['display_name'], status, case['status']))
+        LOG.info("Creating event for updating status of {0} to {1}".format(
+            case['display_name'], status))
 
-        # assign case to user if case is going to be unarchived
+        # assign case to user if user unarchives it
         if case.get('status') == 'archived' and status == 'active':
             LOG.info('assign case to user {}'.format(user['email']))
             self.assign(institute, case, user, link)
@@ -277,7 +277,6 @@ class CaseEventHandler(object):
 
         if case.get('status') == 'archived':
             # assign case to user requesting rerun
-
             self.assign(institute, case, user, link)
 
         self.create_event(

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -86,6 +86,11 @@ class CaseEventHandler(object):
             {'$pull': {'assignees': user['_id']}},
             return_document=pymongo.ReturnDocument.AFTER
         )
+        # if no user is assigned to case
+        if updated_case['status']!= 'prioritized' and updated_case['assignees'] == []:
+            # flag case as inactive
+            self.update_status(institute, updated_case, user, 'inactive', link)
+
         LOG.debug("Case updated")
         return updated_case
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -303,7 +303,7 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
     request_data['level'] = institute_obj.get('coverage_cutoff', 15)
 
     #send get request to chanjo report
-    # Disable default certificate verification
+    #disable default certificate verification
     resp = requests.post(base_url+'reports/report', data=request_data, verify=False)
 
     #read response content

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -7,7 +7,6 @@ import datetime
 import logging
 
 from bs4 import BeautifulSoup
-import ssl
 from xlsxwriter import Workbook
 from flask import url_for, current_app
 from flask_mail import Message
@@ -305,8 +304,7 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
 
     #send get request to chanjo report
     # Disable default certificate verification
-    ssl._create_default_https_context = ssl._create_unverified_context
-    resp = requests.post(base_url+'reports/report', data=request_data)
+    resp = requests.post(base_url+'reports/report', data=request_data, verify=False)
 
     #read response content
     soup = BeautifulSoup(resp.text)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -7,6 +7,7 @@ import datetime
 import logging
 
 from bs4 import BeautifulSoup
+import ssl
 from xlsxwriter import Workbook
 from flask import url_for, current_app
 from flask_mail import Message
@@ -303,6 +304,8 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
     request_data['level'] = institute_obj.get('coverage_cutoff', 15)
 
     #send get request to chanjo report
+    # Disable default certificate verification
+    ssl._create_default_https_context = ssl._create_unverified_context
     resp = requests.post(base_url+'reports/report', data=request_data)
 
     #read response content

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -303,8 +303,7 @@ def coverage_report_contents(store, institute_obj, case_obj, base_url):
     request_data['level'] = institute_obj.get('coverage_cutoff', 15)
 
     #send get request to chanjo report
-    #disable default certificate verification
-    resp = requests.post(base_url+'reports/report', data=request_data, verify=False)
+    resp = requests.post(base_url+'reports/report', data=request_data)
 
     #read response content
     soup = BeautifulSoup(resp.text)

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -81,11 +81,15 @@
     </div>
   {% endif %}
 
-  {% for group_name, case_group in cases %}
-    {% if case_group|length > 0 %}
-      <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
-    {% endif %}
+  {% set ordered_statuses = ['prioritized', 'active', 'inactive', 'archived', 'solved', ] -%}
+  {% for status in ordered_statuses %}
+    {% for group_name, case_group in cases %}
+      {% if status == group_name and case_group|length > 0 %}
+        <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
+      {% endif %}    
+    {% endfor %}
   {% endfor %}
+
 {% endblock %}
 
 {% macro search_form() %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -144,11 +144,11 @@
     <thead>
       <tr>
         <th class="col-xs-2">{{ group_name|capitalize }} cases</th>
-        <th class="col-xs-1">Status<a href="" id="status" onclick="updateArgs('sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
-        <th class="col-xs-2">Analysis date<a href="" id="analysis_date" onclick="updateArgs('sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
+        <th class="col-xs-1">Status<a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
+        <th class="col-xs-2">Analysis date<a href="" id="{{group_name}}_analysis_date" onclick="updateArgs('{{group_name}}','sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
         <th class="col-xs-2">Link</th>
         <th class="col-xs-2">Sequencing</th>
-        <th class="col-xs-2">Track<a href="" id="track" onclick="updateArgs('sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
+        <th class="col-xs-2">Track<a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
         <th class="col-xs-1">Clinvar</th>
       </tr>
     </thead>
@@ -284,7 +284,7 @@
       });
     });
 
-    function updateArgs(sortItem) {
+    function updateArgs(caseGroup, sortItem) {
       sort_items = ['sort=status', 'sort=analysis_date', 'sort=track'];
       //modifying the sorting of cases
       let searchList = window.location.search.split('&');
@@ -296,7 +296,7 @@
       searchList = searchList.filter(f => !sort_items.includes(f))
       //add specific sort param
       searchList.push(sortItem);
-      sort_link = document.getElementById(sortItem.split('=')[1]);
+      sort_link = document.getElementById( caseGroup.concat('_',sortItem.split('=')[1]));
       const url = window.location.href.split('?')[0].concat(searchList.join('&'));
       sort_link.href = url;
       //submit link

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -81,7 +81,6 @@
     </div>
   {% endif %}
 
-
   {% for group_name, case_group in cases %}
     {% if case_group|length > 0 %}
       <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
@@ -146,11 +145,11 @@
       <tr>
         <th class="col-xs-2">{{ group_name|capitalize }} cases</th>
         <th class="col-xs-1">Status</th>
-        <th class="col-xs-1">Analysis date</th>
+        <th class="col-xs-2">Analysis date <a href="{{ url_for('cases.cases', institute_id=institute._id) }}" onclick="updateArgs('sort=analysis_date')" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
         <th class="col-xs-2">Link</th>
         <th class="col-xs-2">Sequencing</th>
         <th class="col-xs-2">Track</th>
-        <th class="col-xs-2">Clinvar</th>
+        <th class="col-xs-1">Clinvar</th>
       </tr>
     </thead>
     <tbody>
@@ -283,6 +282,21 @@
       $('table').stickyTableHeaders({
         fixedOffset: $(".navbar-fixed-top")
       });
-    })
+    });
+
+    function updateArgs(sortItem) {
+      //modifying the sorting of cases
+      let searchList = window.location.search.substr(1).split('&');
+      //if case list was already sorted by sortItem
+      if(searchList.includes(sortItem)){
+        alert('found!');
+        searchList.splice(searchList.indexOf(sortItem),1);
+      } else {
+        // sort by sortItem
+        alert('nope!');
+        searchList.pop(sortItem);
+      }
+    }
+
   </script>
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -144,11 +144,11 @@
     <thead>
       <tr>
         <th class="col-xs-2">{{ group_name|capitalize }} cases</th>
-        <th class="col-xs-1">Status</th>
-        <th class="col-xs-2">Analysis date <a href="{{ url_for('cases.cases', institute_id=institute._id) }}" onclick="updateArgs('sort=analysis_date')" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
+        <th class="col-xs-1">Status<a href="" id="status" onclick="updateArgs('sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
+        <th class="col-xs-2">Analysis date<a href="" id="analysis_date" onclick="updateArgs('sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
         <th class="col-xs-2">Link</th>
         <th class="col-xs-2">Sequencing</th>
-        <th class="col-xs-2">Track</th>
+        <th class="col-xs-2">Track<a href="" id="track" onclick="updateArgs('sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
         <th class="col-xs-1">Clinvar</th>
       </tr>
     </thead>
@@ -285,17 +285,22 @@
     });
 
     function updateArgs(sortItem) {
+      sort_items = ['sort=status', 'sort=analysis_date', 'sort=track'];
       //modifying the sorting of cases
-      let searchList = window.location.search.substr(1).split('&');
-      //if case list was already sorted by sortItem
-      if(searchList.includes(sortItem)){
-        alert('found!');
-        searchList.splice(searchList.indexOf(sortItem),1);
-      } else {
-        // sort by sortItem
-        alert('nope!');
-        searchList.pop(sortItem);
+      let searchList = window.location.search.split('&');
+      if(!searchList[0]){
+        //fix url if sorting is the only param
+        searchList[0] = '?';
       }
+      //remove all sort params
+      searchList = searchList.filter(f => !sort_items.includes(f))
+      //add specific sort param
+      searchList.push(sortItem);
+      sort_link = document.getElementById(sortItem.split('=')[1]);
+      const url = window.location.href.split('?')[0].concat(searchList.join('&'));
+      sort_link.href = url
+      //submit link
+      sort_link.submit();
     }
 
   </script>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -81,7 +81,7 @@
     </div>
   {% endif %}
 
-  {% set ordered_statuses = ['prioritized', 'active', 'inactive', 'archived', 'solved', ] -%}
+  {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', ] -%}
   {% for status in ordered_statuses %}
     {% for group_name, case_group in cases %}
       {% if status == group_name and case_group|length > 0 %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -144,11 +144,11 @@
     <thead>
       <tr>
         <th class="col-xs-2">{{ group_name|capitalize }} cases</th>
-        <th class="col-xs-1">Status<a href="" id="status" onclick="updateArgs('sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
-        <th class="col-xs-2">Analysis date<a href="" id="analysis_date" onclick="updateArgs('sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
+        <th class="col-xs-1">Status<a href="" id="status" onclick="updateArgs('sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
+        <th class="col-xs-2">Analysis date<a href="" id="analysis_date" onclick="updateArgs('sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
         <th class="col-xs-2">Link</th>
         <th class="col-xs-2">Sequencing</th>
-        <th class="col-xs-2">Track<a href="" id="track" onclick="updateArgs('sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true"></i></a></th>
+        <th class="col-xs-2">Track<a href="" id="track" onclick="updateArgs('sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
         <th class="col-xs-1">Clinvar</th>
       </tr>
     </thead>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -298,7 +298,7 @@
       searchList.push(sortItem);
       sort_link = document.getElementById(sortItem.split('=')[1]);
       const url = window.location.href.split('?')[0].concat(searchList.join('&'));
-      sort_link.href = url
+      sort_link.href = url;
       //submit link
       sort_link.submit();
     }

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -44,6 +44,7 @@ def index():
 @templated('cases/cases.html')
 def cases(institute_id):
     """Display a list of cases for an institute."""
+
     institute_obj = institute_and_case(store, institute_id)
     query = request.args.get('query')
 
@@ -55,6 +56,17 @@ def cases(institute_id):
     is_research = request.args.get('is_research')
     all_cases = store.cases(collaborator=institute_id, name_query=query,
                         skip_assigned=skip_assigned, is_research=is_research)
+
+    LOG.info(type(all_cases))
+    sort_by = request.args.get('sort')
+    if sort_by:
+        if sort_by == 'analysis_date':
+            all_cases.sort('analysis_date', pymongo.DESCENDING)
+        elif sort_by == 'track':
+            all_cases.sort('track', pymongo.ASCENDING)
+        elif sort_by == 'status':
+            all_cases.sort('status', pymongo.ASCENDING)
+
     LOG.debug("Prepare all cases")
     data = controllers.cases(store, all_cases, limit)
 

--- a/scout/server/templates/layout.html
+++ b/scout/server/templates/layout.html
@@ -12,7 +12,7 @@
 
 {% block styles %}
   {{ super() }}
-
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.13/css/bootstrap-multiselect.css">
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 {% endblock %}

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -380,7 +380,7 @@ def test_update_case_individuals(adapter, case_obj):
     assert len(res['individuals']) == 1
 
 
-def test_update_case_rerun_status(adapter, case_obj):
+def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj):
     case_obj['rerun_requested'] = True
     # GIVEN an empty database (no cases)
     assert adapter.cases().count() == 0
@@ -391,11 +391,22 @@ def test_update_case_rerun_status(adapter, case_obj):
     res = adapter.case(case_obj['_id'])
     assert res['rerun_requested'] is True
 
+    # flag case as 'archived'
+    # WHEN flagging the case as active
+    adapter.update_status(institute_obj, case_obj, user_obj, 'archived', 'blank')
+
+    # case should be archived
+    res = adapter.case(case_obj['_id'])
+    assert res['status'] == 'archived'
+
     # WHEN updating a case
     res = adapter.update_case(case_obj)
 
     # THEN assert that 'rerun_requested' is set to False
     assert res['rerun_requested'] is False
+
+    # and assert that the case status is changed to 'inactive'
+    assert res['status'] == 'inactive'
 
 
 def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -392,7 +392,7 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj):
     assert res['rerun_requested'] is True
 
     # flag case as 'archived'
-    # WHEN flagging the case as active
+    # WHEN flagging the case as archived
     adapter.update_status(institute_obj, case_obj, user_obj, 'archived', 'blank')
 
     # case should be archived

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -431,7 +431,7 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
 
     assert res['rerun_requested'] == True
 
-    # Make sure case is not inactive and not archived
+    # Make sure case is not archived
     assert res['status'] == 'inactive'
 
     # Make sure user becomes assignee of the case
@@ -440,10 +440,6 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     # And that a new rerun request triggers an error:
     with pytest.raises(ValueError):
         adapter.request_rerun(institute_obj, res, user_obj, 'blank')
-
-
-
-
 
 
 def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):

--- a/tests/adapter/mongo/test_event_handling.py
+++ b/tests/adapter/mongo/test_event_handling.py
@@ -62,11 +62,12 @@ def test_unassign(adapter, institute_obj, case_obj, user_obj):
 
     case_obj['status'] = 'active'
 
-    # GIVEN an adapter to a database with one assigned case
+    # GIVEN an adapter to a database with one case
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
     adapter.user_collection.insert_one(user_obj)
 
+    # assign case to test user
     link = 'assignlink'
     updated_case = adapter.assign(
         institute=institute_obj,
@@ -74,30 +75,32 @@ def test_unassign(adapter, institute_obj, case_obj, user_obj):
         user=user_obj,
         link=link
     )
-    
-    """
 
+    # Make sure that case is active
+    assert updated_case['status'] == 'active'
     assert updated_case['assignees'] == [user_obj['_id']]
     assert adapter.event_collection.find().count() == 1
 
-    # WHEN unassigning a user from a case
+    # WHEN unassigning the only user assigned to case
     updated_case = adapter.unassign(
          institute=institute_obj,
          case=updated_case,
          user=user_obj,
          link='unassignlink'
     )
-    # since case has no assignees case gets deactivated:
+    # case should become inactive
     assert updated_case['status'] == 'inactive'
+
     # THEN two events should have been created
     assert adapter.event_collection.find().count() == 2
+
     # THEN the case should not be assigned
     assert updated_case.get('assignees') == []
+
     # THEN a unassign event should be created
     event = adapter.event_collection.find_one({'verb': 'unassign'})
     assert event['link'] == 'unassignlink'
 
-    """
 
 def test_update_synopsis(adapter, institute_obj, case_obj, user_obj):
     ## GIVEN a populated database without events

--- a/tests/adapter/mongo/test_event_handling.py
+++ b/tests/adapter/mongo/test_event_handling.py
@@ -59,6 +59,9 @@ def test_assign(adapter, institute_obj, case_obj, user_obj):
     assert event_obj['link'] == link
 
 def test_unassign(adapter, institute_obj, case_obj, user_obj):
+
+    case_obj['status'] = 'active'
+
     # GIVEN an adapter to a database with one assigned case
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -71,27 +74,30 @@ def test_unassign(adapter, institute_obj, case_obj, user_obj):
         user=user_obj,
         link=link
     )
+    
+    """
 
     assert updated_case['assignees'] == [user_obj['_id']]
-
     assert adapter.event_collection.find().count() == 1
 
     # WHEN unassigning a user from a case
     updated_case = adapter.unassign(
          institute=institute_obj,
-         case=case_obj,
+         case=updated_case,
          user=user_obj,
          link='unassignlink'
     )
-
+    # since case has no assignees case gets deactivated:
+    assert updated_case['status'] == 'inactive'
     # THEN two events should have been created
     assert adapter.event_collection.find().count() == 2
-
     # THEN the case should not be assigned
     assert updated_case.get('assignees') == []
     # THEN a unassign event should be created
     event = adapter.event_collection.find_one({'verb': 'unassign'})
     assert event['link'] == 'unassignlink'
+
+    """
 
 def test_update_synopsis(adapter, institute_obj, case_obj, user_obj):
     ## GIVEN a populated database without events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,6 +329,7 @@ def case_obj(request, parsed_case):
     case['status'] = 'inactive'
     case['synopsis'] = ''
     case['updated_at'] = parsed_case['analysis_date']
+    case['assignees'] = []
 
     return case
 

--- a/tests/load/test_load_case.py
+++ b/tests/load/test_load_case.py
@@ -38,7 +38,7 @@ def test_load_case_rank_model_version(case_obj, panel_database):
 
     assert loaded_case['rank_model_version'] == case_obj['rank_model_version']
     assert loaded_case['sv_rank_model_version'] == case_obj['sv_rank_model_version']
-    
+
 
 def test_load_case_delivery_report(case_obj, panel_database):
     adapter = panel_database

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -19,30 +19,28 @@ def test_cases(app, user_obj, institute_obj):
         # THEN it should return a page
         assert resp.status_code == 200
 
-        # test query passing limit and 'analysis_date' as sorting parameter
+        # test query passing parameters in seach form
         request_data = {
             'limit' : '100',
-            'sort' : 'analysis_date'
+            'skip_assigned' : 'on',
+            'is_research' : 'on',
+            'query' : 'case_id'
         }
-        # THEN it should return a page
+        resp = client.get(url_for('cases.cases',
+                                  institute_id=institute_obj['internal_id'], data = request_data))
+        # response should return a page
         assert resp.status_code == 200
 
-        # test query passing limit and 'status' as sorting parameters
-        request_data = {
-            'limit' : '100',
-            'sort' : 'status'
-        }
-        # THEN it should return a page
-        assert resp.status_code == 200
-
-        # test query passing limit and 'track' as sorting parameters
-        request_data = {
-            'limit' : '100',
-            'sort' : 'track'
-        }
-        # THEN it should return a page
-        assert resp.status_code == 200
-
+        sorting_options = ['analysis_date', 'track', 'status']
+        for option in sorting_options:
+            # test query passing the sorting option to the cases view
+            request_data = {
+                'sort' : option
+            }
+            resp = client.get(url_for('cases.cases',
+                                      institute_id=institute_obj['internal_id'], data = request_data))
+            # response should return a page
+            assert resp.status_code == 200
 
 
 def test_cases_query(app, user_obj, case_obj, institute_obj):

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -19,6 +19,32 @@ def test_cases(app, user_obj, institute_obj):
         # THEN it should return a page
         assert resp.status_code == 200
 
+        # test query passing limit and 'analysis_date' as sorting parameter
+        request_data = {
+            'limit' : '100',
+            'sort' : 'analysis_date'
+        }
+        # THEN it should return a page
+        assert resp.status_code == 200
+
+        # test query passing limit and 'status' as sorting parameters
+        request_data = {
+            'limit' : '100',
+            'sort' : 'status'
+        }
+        # THEN it should return a page
+        assert resp.status_code == 200
+
+        # test query passing limit and 'track' as sorting parameters
+        request_data = {
+            'limit' : '100',
+            'sort' : 'track'
+        }
+        # THEN it should return a page
+        assert resp.status_code == 200
+
+
+
 def test_cases_query(app, user_obj, case_obj, institute_obj):
     # GIVEN an initialized app
     # GIVEN a valid user and institute

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -115,6 +115,29 @@ def test_case(app, case_obj, institute_obj):
             # THEN it should return a page
             assert resp.status_code == 200
 
+
+def test_case_synopsis(app, institute_obj, case_obj):
+    # GIVEN an initialized app
+    # GIVEN a valid user and institute
+
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for('auto_login'))
+        assert resp.status_code == 200
+
+        req_data = {
+            'synopsis' : 'test synopsis'
+        }
+
+        # WHEN updating the synopsis of a case
+        resp = client.get(url_for('cases.case_synopsis',
+                                  institute_id=institute_obj['internal_id'],
+                                  case_name=case_obj['display_name'],
+                                  data=req_data ))
+        # then it should return a redirected page
+        assert resp.status_code == 302
+
+
 def test_causatives(app, user_obj, institute_obj, case_obj):
     # GIVEN an initialized app
     # GIVEN a valid user and institute
@@ -187,6 +210,47 @@ def test_case_report(app, institute_obj, case_obj):
         assert resp.status_code == 200
 
 
+def test_case_diagnosis(app, institute_obj, case_obj):
+    # Test the web page containing the general case report
+
+    # GIVEN an initialized app and a valid user and institute
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for('auto_login'))
+        assert resp.status_code == 200
+
+        req_data = {
+            'omim_id' : 'OMIM:615349'
+        }
+
+        # When updating an OMIM diagnosis for a case
+        resp = client.get(url_for('cases.case_diagnosis',
+                                  institute_id=institute_obj['internal_id'],
+                                  case_name=case_obj['display_name']),
+                                  data=req_data
+                                  )
+        # Response should be redirected to case page
+        assert resp.status_code == 302
+
+
+def test_pdf_case_report(app, institute_obj, case_obj):
+    # Test the web page containing the general case report
+
+    # GIVEN an initialized app and a valid user and institute
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for('auto_login'))
+        assert resp.status_code == 200
+
+        # When clicking on 'Download PDF' button on general report page
+        resp = client.get(url_for('cases.pdf_case_report',
+                                  institute_id=institute_obj['internal_id'],
+                                  case_name=case_obj['display_name']),
+                                  )
+        # a successful response should be returned
+        assert resp.status_code == 200
+
+
 def test_clinvar_submissions(app, institute_obj):
     # Test the web page containing the clinvar submissions for an institute
 
@@ -202,27 +266,6 @@ def test_clinvar_submissions(app, institute_obj):
 
         # a successful response should be returned
         assert resp.status_code == 200
-
-
-def test_pdf_case_report(app, institute_obj, case_obj):
-    # Test the web page containing the general case PDF report
-
-    # GIVEN an initialized app and a valid user and institute
-    with app.test_client() as client:
-        # GIVEN that the user could be logged in
-        resp = client.get(url_for('auto_login'))
-        assert resp.status_code == 200
-
-        # When clicking on 'download PDF' on general report page
-        resp = client.get(url_for('cases.pdf_case_report',
-                                  institute_id=institute_obj['internal_id'],
-                                  case_name=case_obj['display_name']),
-                                  )
-        # a successful response should be returned
-        assert resp.status_code == 200
-        # and it should contain a pdf file, not HTML code
-        assert resp.mimetype == 'application/pdf'
-
 
 
 def test_mt_report(app, institute_obj, case_obj):


### PR DESCRIPTION
This PR adds the following functionalities:
- Cases that are **re-run become 'inactive'** if they were previously archived (fix #1271)
- Makes it possible to **sort cases by 'Status', 'Analysis date' and 'Track'** in cases page (fix #1271)
- Orders the categories of displayed cases (cases page) like this: **'prioritized', 'active', 'inactive', 'archived', 'solved'** (fix #1285)


**How to test dearchiving of re-runs**:
1. On a local installation of scout-stage, archive the test case
1. From the command line update the case with the following command:
```
 scout --demo load case scout/demo/643594.config.yaml --update
```
3. Expected outcome: Refresh the page and make sure that the case status is now 'inactive'


**How to test the case sorting by 'Status', 'Analysis date' or 'Track' :**
1. Install the branch on stage with the following commands:
```
ssh your.user@clinical-db.scilifelab.se
sudo -iu hiseq.clinical
cd servers/resources/clinical-dbscilifelab.se
bash update-scout-stage.sh dearchive_reruns
```
2. Go to 'cases' web page of scout-stage and make sure that you see sorting icons near the 3 fields:
![image](https://user-images.githubusercontent.com/28093618/63768440-7d276f80-c8d0-11e9-8c22-e840930c45e7.png)
Play with the sorting commands. Does the sorting make sense? Tip: Limit the number of cases to 1000 instead of 100


**How to test the status category order in case page:**
1. After installing the branch on stage (already done in previous step) go to cases page and make sure that the categories displayed follow **always this order: 'prioritized', 'active', 'inactive', 'archived', 'solved'** . Compare with the display order of scout production and you'll see that the order is different. 
1. Note that the status category order might be affected if you choose to sort cases according to status, analysis_date or track if you are limiting the cases displayed to 100 (or less). One could always remove the limit option when using this type of sorting..

**Review:**
- [x ] code approved by dNil
- [x] tests executed by dNil
