### PR TITLE
Fix deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed a bug that showed wrong gene coverage in general panel PDF export
 - MT report only shows variants occurring in the specific individual of the excel sheet
 - Disable SSL certifcate verification in requests to chanjo
+- Updates how intervaltree and pymongo is used to void deprecated functions
 
 ## [4.6.1]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # everything the developer needs in addition to the production requirements
 
 # testing
-pytest==3.6
+pytest==3.8
 pytest-flask==0.11
 pytest-cov
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ PyYaml>=5.1
 ped_parser
 
 # extras
-intervaltree<3.1
+intervaltree==3.0.2
 
 # chanjo-report
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ PyYaml>=5.1
 ped_parser
 
 # extras
-intervaltree<3.0
+intervaltree<3.1
 
 # chanjo-report
 python-dateutil

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -563,7 +563,7 @@ class GeneHandler(object):
                 intervals[chrom].addi(start, end, i)
                 continue
 
-            res = intervals[chrom].search(start, end)
+            res = intervals[chrom].overlap(start, end)
 
             # If the interval did not overlap any other intervals we insert it and continue
             if not res:

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -253,7 +253,7 @@ class VariantLoader(object):
                         new_region = None
 
                         # Check if the variant is in a coding region
-                        genomic_regions = coding_intervals.get(var_chrom, IntervalTree()).search(var_start, var_end)
+                        genomic_regions = coding_intervals.get(var_chrom, IntervalTree()).overlap(var_start, var_end)
 
 
                         # If the variant is in a coding region
@@ -426,7 +426,8 @@ class VariantLoader(object):
                 load = True
                 new_region = None
 
-                genomic_regions = genomic_intervals.get(var_chrom, IntervalTree()).search(var_start, var_end)
+                intervals = genomic_intervals.get(var_chrom, IntervalTree())
+                genomic_regions = intervals.overlap(var_start, var_end)
 
                 # If the variant is in a coding region
                 if genomic_regions:

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -258,7 +258,7 @@ def build_variant(variant, institute_id, gene_to_panels = None,
         if gene_obj:
             hgnc_symbols.append(gene_obj['hgnc_symbol'])
         # else:
-            # LOG.warn("missing HGNC symbol for: %s", hgnc_id)
+            # LOG.warning("missing HGNC symbol for: %s", hgnc_id)
 
     if hgnc_symbols:
         variant_obj['hgnc_symbols'] = hgnc_symbols

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -101,4 +101,4 @@ def research(case_id, institute, force):
             case_obj['research_requested'] = False
             adapter.update_case(case_obj)
         else:
-            LOG.warn("research not requested, use '--force'")
+            LOG.warning("research not requested, use '--force'")

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -76,7 +76,7 @@ def variants(case_id, institute, force, cancer, cancer_research, sv,
             i += 1
             if variant_type == 'research':
                 if not (force or case_obj['research_requested']):
-                    LOG.warn("research not requested, use '--force'")
+                    LOG.warning("research not requested, use '--force'")
                     raise click.Abort()
 
             LOG.info("Delete {0} {1} variants for case {2}".format(

--- a/scout/export/panel.py
+++ b/scout/export/panel.py
@@ -61,14 +61,14 @@ def export_panels(adapter, panels, versions=None, build='37'):
     for hgnc_id in panel_geneids:
         hgnc_geneobj = gene_objs.get(hgnc_id)
         if hgnc_geneobj is None:
-            LOG.warn("missing HGNC gene: %s", hgnc_id)
+            LOG.warning("missing HGNC gene: %s", hgnc_id)
             continue
         chrom = hgnc_geneobj['chromosome']
         start = hgnc_geneobj['start']
         chrom_int = CHROMOSOME_INTEGERS.get(chrom)
 
         if not chrom_int:
-            LOG.warn("Chromosome %s out of scope", chrom)
+            LOG.warning("Chromosome %s out of scope", chrom)
             continue
 
         hgnc_geneobjs.append((chrom_int, start, hgnc_geneobj))

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -70,7 +70,7 @@ def authorized():
     try:
         oauth_response = google.authorized_response()
     except OAuthException as error:
-        current_app.logger.warn(oauth_response.message)
+        current_app.logger.warning(oauth_response.message)
         flash("{} - try again!".format(oauth_response.message), 'warning')
         return redirect(url_for('public.index'))
 

--- a/scout/utils/coordinates.py
+++ b/scout/utils/coordinates.py
@@ -18,7 +18,7 @@ def is_par(chromosome, position, build='37'):
     if not chrom in ['X','Y']:
         return False
     # Check if variant is in first PAR region
-    if PAR_COORDINATES[build][chrom].search(position):
+    if PAR_COORDINATES[build][chrom].at(position):
         return True
     
     return False

--- a/tests/commands/export/test_export_hpo_cmd.py
+++ b/tests/commands/export/test_export_hpo_cmd.py
@@ -26,7 +26,7 @@ def test_export_hpo(mock_app):
         "description" : "Multicystic kidney dysplasia",
         "genes" : [ 17582, 1151 ]
     }
-    store.hpo_term_collection.insert(hpo_term)
+    store.hpo_term_collection.insert_one(hpo_term)
     assert store.hpo_term_collection.find().count() == 1
 
 

--- a/tests/commands/update/test_update_groups_cmd.py
+++ b/tests/commands/update/test_update_groups_cmd.py
@@ -34,7 +34,7 @@ def test_update_groups(mock_app, tmpdir):
         "description" : "Short chin",
         "genes" : [ 13890 ]
     }]
-    store.hpo_term_collection.insert_one(hpo_terms)
+    store.hpo_term_collection.insert_many(hpo_terms)
 
     # Test CLI with new phenotype group
     result =  runner.invoke(cli, ['update', 'groups',

--- a/tests/commands/update/test_update_groups_cmd.py
+++ b/tests/commands/update/test_update_groups_cmd.py
@@ -34,7 +34,7 @@ def test_update_groups(mock_app, tmpdir):
         "description" : "Short chin",
         "genes" : [ 13890 ]
     }]
-    store.hpo_term_collection.insert(hpo_terms)
+    store.hpo_term_collection.insert_one(hpo_terms)
 
     # Test CLI with new phenotype group
     result =  runner.invoke(cli, ['update', 'groups',

--- a/tests/commands/view/test_view_diseases_cmd.py
+++ b/tests/commands/view/test_view_diseases_cmd.py
@@ -26,7 +26,7 @@ def test_view_diseases(mock_app):
         'inheritance' : None,
         'hpo_terms' : None
     }
-    store.disease_term_collection.insert(omim_term)
+    store.disease_term_collection.insert_one(omim_term)
 
     # Test CLI
     result =  runner.invoke(cli, ['view', 'diseases'])

--- a/tests/commands/view/test_view_hpo_cmd.py
+++ b/tests/commands/view/test_view_hpo_cmd.py
@@ -24,7 +24,7 @@ def test_view_hpo(mock_app):
         'description' : 'Round face',
         'genes' : [4392, 30832],
     }
-    store.hpo_term_collection.insert(hpo_term)
+    store.hpo_term_collection.insert_one(hpo_term)
 
     # Test CLI providing a term
     result =  runner.invoke(cli, ['view', 'hpo',

--- a/tests/commands/view/test_view_whitelist_cmd.py
+++ b/tests/commands/view/test_view_whitelist_cmd.py
@@ -17,7 +17,7 @@ def test_view_witelist(mock_app):
     assert 'INFO Running scout view users' in result.output
 
     # insert mock obj in whitelist collection
-    store.whitelist_collection.insert({'_id' : 'fake_whitelist_id'})
+    store.whitelist_collection.insert_one({'_id' : 'fake_whitelist_id'})
 
     # Test CLI
     result =  runner.invoke(cli, ['view', 'whitelist'])

--- a/tests/utils/test_par.py
+++ b/tests/utils/test_par.py
@@ -8,7 +8,7 @@ def test_par_coordinates():
     build = '37'
         
     ## WHEN checking the coordinates for a variant
-    res = PAR_COORDINATES[build][chromosome].search(position)
+    res = PAR_COORDINATES[build][chromosome].at(position)
     
     ## THEN assert that there way a hit
     assert res
@@ -19,7 +19,7 @@ def test_par_coordinates():
     build = '37'
         
     ## WHEN checking the coordinates for a variant
-    res = PAR_COORDINATES[build][chromosome].search(position)
+    res = PAR_COORDINATES[build][chromosome].at(position)
     
     ## THEN assert that there way a hit
     assert not res


### PR DESCRIPTION
This PR adds updates some of the deprecated functions.

**How to test**:
1. Install this branch
1. Run the tests and see that most deprecation warnings are gone

**Expected outcome**:
Deprecation warnings from pymongo, interval tree and logging should be gone

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "merge and deploy" approved by