### PR TITLE
fix #1294

### DIFF
--- a/scout/commands/load/base.py
+++ b/scout/commands/load/base.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 @click.group()
 def load():
-    """Load the Scout database."""
+    """Load items into the scout database."""
     pass
 
 


### PR DESCRIPTION
This PR changes the 'load' help command of the cli

**How to test**:
- run 'scout --help'

**Expected outcome**:
the load command help should display **' Load items into the scout database.' instead of 'Load the scout database'**

**Review:**
- [x] code approved by DN
- [x] tests executed by CR