### PR TITLE
Resize igv sample tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - MT report only shows variants occurring in the specific individual of the excel sheet
 - Disable SSL certifcate verification in requests to chanjo
 - Updates how intervaltree and pymongo is used to void deprecated functions
+- Increased size of IGV sample tracks
 
 
 ## [4.6.1]

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -28,7 +28,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-     <script type="text/javascript" src="https://igv.org/web/release/2.2.11/dist/igv.min.js"></script>    
+     <script type="text/javascript" src="https://igv.org/web/release/2.2.11/dist/igv.min.js"></script>
 </head>
 <body>
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>
@@ -62,8 +62,8 @@
                             indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
                             displayMode: "{{ genes_track.displayMode }}",
                             order: Number.MAX_VALUE,
-                            visibilityWindow: 300000000
-
+                            visibilityWindow: 300000000,
+                            height: 700
                       },
                       {% for track in sample_tracks %}
                       {

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -62,8 +62,7 @@
                             indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
                             displayMode: "{{ genes_track.displayMode }}",
                             order: Number.MAX_VALUE,
-                            visibilityWindow: 300000000,
-                            height: 700
+                            visibilityWindow: 300000000
                       },
                       {% for track in sample_tracks %}
                       {
@@ -71,7 +70,8 @@
                         url: '{{ url_for("alignviewers.remote_static", file=track.url) }}',
                         indexURL: '{{ url_for("alignviewers.remote_static", file=track.indexURL) }}',
                         sourceType: 'file',
-                        type: "alignment"
+                        type: "alignment",
+                        height: 700
                       },
                       {% endfor %}
                     ]

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -28,7 +28,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-     <script type="text/javascript" src="https://igv.org/web/release/2.2.11/dist/igv.min.js"></script>
+     <script type="text/javascript" src="https://igv.org/web/release/2.2.17/dist/igv.min.js"></script>
 </head>
 <body>
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>
@@ -71,7 +71,7 @@
                         indexURL: '{{ url_for("alignviewers.remote_static", file=track.indexURL) }}',
                         sourceType: 'file',
                         type: "alignment",
-                        height: 700
+                        height: "{{track.height}}"
                       },
                       {% endfor %}
                     ]

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -134,9 +134,8 @@ def igv():
         if bam_files[counter]:
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
-                                   'height' : 700,
-                                   'minHeight' : 700,
-                                   'maxHeight' : 1500,
+                                   'height' : "700",
+                                   'maxHeight' : "1500",
                                    'autoHeight': False
                                    })
         counter += 1

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -136,8 +136,9 @@ def igv():
                                    'indexURL' : bai_files[counter],
                                    'height' : 700,
                                    'minHeight' : 700,
-                                   'maxHeight' : 1500}
-                                   )
+                                   'maxHeight' : 1500,
+                                   'autoHeight': False
+                                   })
         counter += 1
 
     display_obj['sample_tracks'] = sample_tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -134,7 +134,10 @@ def igv():
         if bam_files[counter]:
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
-                                   'minHeight' : 700, 'maxHeight' : 1500})
+                                   'height' : 700,
+                                   'minHeight' : 700,
+                                   'maxHeight' : 1500}
+                                   )
         counter += 1
 
     display_obj['sample_tracks'] = sample_tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -134,7 +134,7 @@ def igv():
         if bam_files[counter]:
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
-                                   'minHeight' : 700, 'maxHeight' : 2000})
+                                   'minHeight' : 700, 'maxHeight' : 1500})
         counter += 1
 
     display_obj['sample_tracks'] = sample_tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -135,8 +135,7 @@ def igv():
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
                                    'height' : "700",
-                                   'maxHeight' : "1500",
-                                   'autoHeight': False
+                                   'maxHeight' : "1500"
                                    })
         counter += 1
 

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -134,7 +134,7 @@ def igv():
         if bam_files[counter]:
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
-                                   'height' : 700, 'maxHeight' : 2000})
+                                   'minHeight' : 700, 'maxHeight' : 2000})
         counter += 1
 
     display_obj['sample_tracks'] = sample_tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -134,8 +134,7 @@ def igv():
         if bam_files[counter]:
             sample_tracks.append({ 'name' : sample, 'url' : bam_files[counter],
                                    'indexURL' : bai_files[counter],
-                                   'height' : "700",
-                                   'maxHeight' : "1500"
+                                   'height' : 700
                                    })
         counter += 1
 


### PR DESCRIPTION
fix #1309.

I've finally understood why we had no power over the sample track height in igv. It was because we changed its value in the python view but we never passed it to the javascript of the template. Now I've fixed it at the template level. And it works. It's on stage now!

**How to test**:
1. Check IGV alignments of this case on stage: https://scout-stage.scilifelab.se/cust000/SWEDAC-2019-HG-05-Trio-NovaSeq/2d7c606e92383a8572556138d1310c10 and compare with any alignment in scout production. 

**Expected outcome**:
Stage sample tracks' height are 700 pixels on stage, prod ones are 300 pixels instead.

**Review:**
- [x] code approved by
- [x] tests executed by CR
