### PR TITLE
Global comments get a dedicated icon in variants list

### DIFF
--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -111,17 +111,21 @@
     <span class="badge pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
   {% endif %}
   {% if comment_count > 0 %}
+    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
     <a href="#"
        class="badge pull-right"
        data-toggle="popover"
        data-placement="right"
        data-html="true"
        data-trigger="hover click"
-       data-content="{{ comments_table(institute, case, variant.comments, variant._id) }}"
+       data-content="{{ comments_content }}"
        title=""
        >
       {{ comment_count }}
-      <span class="glyphicon glyphicon-comment"></span>
+      <i class="fa fa-comment"></i>
+      {% if 'GLOBAL' in comments_content %}
+        <i class="fa fa-globe" aria-hidden="true"></i>
+      {% endif %}
     </a>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -229,15 +229,19 @@
   {% endif %}
 
   {% if comment_count > 0 %}
+    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
     <a href="#"
       class="badge pull-right"
       data-toggle="popover"
       data-placement="right"
       data-html="true"
       data-trigger="hover click"
-      data-content="<small>{{ comments_table(institute, case, variant.comments, variant._id) }}</small>">
+      data-content="<small>{{ comments_content }}</small>">
       {{ comment_count }}
-      <span class="glyphicon glyphicon-comment"></span>
+      <i class="fa fa-comment"></i>
+      {% if 'GLOBAL' in comments_content %}
+        <i class="fa fa-globe" aria-hidden="true"></i>
+      {% endif %}
     </a>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -138,24 +138,28 @@
   {% endif %}
 
   {% if comment_count > 0 %}
+    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
     <a href="#"
        class="badge pull-right"
        data-toggle="popover"
        data-placement="right"
        data-html="true"
        data-trigger="hover click"
-       data-content="{{ comments_table(institute, case, variant.comments, variant._id) }}"
+       data-content="{{ comments_content }}"
        title=""
        >
       {{ comment_count }}
-      <span class="glyphicon glyphicon-comment"></span>
+      <i class="fa fa-comment"></i>
+      {% if 'GLOBAL' in comments_content %}
+        <i class="fa fa-globe" aria-hidden="true"></i>
+      {% endif %}
     </a>
   {% endif %}
 
   {% if variant._id in case.suspects %}
     <span class="glyphicon glyphicon-pushpin"></span>
   {% endif %}
-    
+
 {% endmacro %}
 
 {% macro cell_cadd(variant) %}
@@ -177,8 +181,8 @@
   {% endfor %}
 
   {% if variant.compounds %}
-    <a href="#" class="label label-primary" data-toggle="popover" data-placement="left" 
-    data-html="true" data-trigger="hover click" 
+    <a href="#" class="label label-primary" data-toggle="popover" data-placement="left"
+    data-html="true" data-trigger="hover click"
     data-content="{{ compounds_table(institute, case, variant.compounds[:20]) }}">Compounds</a>
   {% endif %}
   {% if variant.mosaic_tags %}
@@ -188,13 +192,13 @@
 
 {% macro overlapping_cell(variant) %}
   {% if variant.overlapping %}
-    <a href="#" class="label label-warning" data-toggle="popover" data-placement="left" 
-    data-html="true" data-trigger="hover click" 
+    <a href="#" class="label label-warning" data-toggle="popover" data-placement="left"
+    data-html="true" data-trigger="hover click"
     data-content="{{ svs_table(institute, case, variant.overlapping[:20]) }}">Overlapping SVs</a>
   {% else %}
     -
   {% endif %}
-  
+
 {% endmacro %}
 
 


### PR DESCRIPTION
fix #1302

**How to test**:
- Create a local command for a variant
- Create a local and a global comment for another variant (or just a global comment)

**Expected outcome**:
When the variants are displayed in the rank list, the one with the global comment should have a globe icon close to the comment one: 
![image](https://user-images.githubusercontent.com/28093618/64687676-41bda100-d48b-11e9-84cb-b83bb5b881b7.png)

I've fix snvs, STRs and SVs to behave this way. 

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
