### PR TITLE
Display earlier ACMG classifications in the variants list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [4.x.x]
 
 ### Added
+- Show earlier ACMG classification in the variant list
 
 ### Fixed
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -48,6 +48,14 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
     for variant_obj in variant_res:
         overlapping_svs = [sv for sv in store.overlapping(variant_obj)]
         variant_obj['overlapping'] = overlapping_svs or None
+
+        # Get all previous ACMG evalautions of the variant
+        evaluations = []
+        for evaluation_obj in store.get_evaluations(variant_obj):
+            evaluation_obj['classification'] = ACMG_COMPLETE_MAP[evaluation_obj['classification']]
+            evaluations.append(evaluation_obj)
+        variant_obj['evaluations'] = evaluations
+            
         variants.append(parse_variant(store, institute_obj, case_obj, variant_obj,
                         update=True, genome_build=genome_build))
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -129,12 +129,21 @@
     {{ variant.variant_rank }}
   </a>
   {% set comment_count = variant.comments.count() %}
+
   {% if variant.acmg_classification %}
     <span class="badge pull-right" title="{{ variant.acmg_classification.label }}">
       {{ variant.acmg_classification.short }}
     </span>
+  
   {% elif variant.manual_rank %}
     <span class="badge pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
+
+  {% elif variant.evaluations %}
+    {% for evaluation in (variant.evaluations or []) %}
+      <span class="label label-primary pull-right" style="margin-left:1px" title="Previously classified as {{ evaluation.classification.label }}">
+      {{ evaluation.classification.short }}
+      </span>
+    {% endfor %}
   {% endif %}
 
   {% if comment_count > 0 %}


### PR DESCRIPTION
This PR shows earlier ACMG evalautions (ie in other cases) to the variants list, to allow quick identification of previously evalauated variants.

Not sure how this affects performance on large databases. Do you have tests for such things? I see no noticable slow-down on our installation.

See screenshot below.  I used "label-primary" to visually differentiate it from ACMG-classifications made in the specific case, but I could change that to something else.
![image](https://user-images.githubusercontent.com/11991860/65252401-3278cc00-daf9-11e9-9c07-d465915bf08d.png)
