### PR TITLE
Fix igv bugs and display genes track on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show earlier ACMG classification in the variant list
 
 ### Fixed
+- Fixed igv search not working due to igv.js dist 2.2.17
 
 
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -50,7 +50,7 @@
                         indexURL: "{{ reference_track.indexURL }}",
                         cytobandURL: "{{ reference_track.cytobandURL }}"
                     },
-                    search: 'https://igv.org/services/locus.php',
+                    search: "https://igv.org/services/locus.php",
                     locus: "{{locus}}",
                     tracks: [
                       {
@@ -77,7 +77,7 @@
                     ]
                 };
 
-        igv.createBrowser(div, options, url="");
+        igv.createBrowser(div, options);
 
     });
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -19,9 +19,6 @@
     <link rel="stylesheet" type="text/css"
           href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css"/>
 
-    <!-- IGV CSS -->
-    <link rel="stylesheet" type="text/css" href="https://igv.org/web/release/1.0.9/igv-1.0.9.css">
-
     <!-- jQuery JS -->
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script type="text/javascript"

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -56,7 +56,7 @@
                             url: "{{ genes_track.url|replace('%2F','/') }}",
                             indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
                             displayMode: "{{ genes_track.displayMode }}",
-                            order: Number.MAX_VALUE,
+                            order: Number.MIN_VALUE,
                             visibilityWindow: 300000000
                       },
                       {% for track in sample_tracks %}

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -36,7 +36,6 @@
 <script type="text/javascript">
 
     $(document).ready(function () {
-
         var div = $("#igvDiv")[0],
                 options = {
                     showNavigation: true,
@@ -51,6 +50,7 @@
                         indexURL: "{{ reference_track.indexURL }}",
                         cytobandURL: "{{ reference_track.cytobandURL }}"
                     },
+                    search: 'https://igv.org/services/locus.php',
                     locus: "{{locus}}",
                     tracks: [
                       {
@@ -77,7 +77,7 @@
                     ]
                 };
 
-        igv.createBrowser(div, options);
+        igv.createBrowser(div, options, url="");
 
     });
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -34,7 +34,6 @@
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>
 
 <script type="text/javascript">
-
     $(document).ready(function () {
         var div = $("#igvDiv")[0],
                 options = {
@@ -50,7 +49,6 @@
                         indexURL: "{{ reference_track.indexURL }}",
                         cytobandURL: "{{ reference_track.cytobandURL }}"
                     },
-                    search: "https://igv.org/services/locus.php",
                     locus: "{{locus}}",
                     tracks: [
                       {

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -25,7 +25,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-     <script type="text/javascript" src="https://igv.org/web/release/2.2.17/dist/igv.min.js"></script>
+     <script type="text/javascript" src="https://igv.org/web/release/2.3.0-rc1/dist/igv.min.js"></script>
 </head>
 <body>
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -64,6 +64,53 @@ def pileup():
                            genome=genome, exons=exons)
 
 
+@alignviewers_bp.route('/igvtest')
+def igv_test():
+    """Test shit"""
+    LOG.info('------------->')
+    LOG.info(str(request.args))
+    LOG.info('<-------------')
+
+    chrom = '6'
+    start = '5670'
+    stop = '5680'
+
+    locus = "chr{0}:{1}-{2}".format(chrom,start,stop)
+    LOG.debug('Displaying locus %s', locus)
+
+    genome = 'hg19'
+    fastaURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta'
+    indexURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai'
+    cytobandURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt'
+    gene_track_format = 'bed'
+    gene_track_URL = 'https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz'
+    gene_track_indexURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi'
+
+
+    display_obj = {}
+
+    display_obj['reference_track'] = {
+        'genome' : genome,
+        'fastaURL' : fastaURL,
+        'indexURL' : indexURL,
+        'cytobandURL' : cytobandURL
+    }
+
+    display_obj['genes_track'] = {
+        'name' : 'Genes',
+        'type' : 'annotation',
+        'format': gene_track_format,
+        'sourceType': 'file',
+        'url' : gene_track_URL,
+        'indexURL' : gene_track_indexURL,
+        'displayMode' : 'EXPANDED'
+    }
+    display_obj['sample_tracks'] = []
+    locus = "chr{0}:{1}-{2}".format(chrom,start,stop)
+    LOG.debug('Displaying locus %s', locus)
+    return render_template('alignviewers/igv_viewer.html', locus=locus, **display_obj )
+
+
 @alignviewers_bp.route('/igv')
 def igv():
     """Visualize BAM alignments using igv.js (https://github.com/igvteam/igv.js)"""
@@ -128,6 +175,8 @@ def igv():
     }
 
     sample_tracks = []
+
+    """
     counter = 0
     for sample in samples:
         # some samples might not have an associated bam file, take care if this
@@ -137,6 +186,7 @@ def igv():
                                    'height' : 700
                                    })
         counter += 1
+    """
 
     display_obj['sample_tracks'] = sample_tracks
 

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -63,54 +63,6 @@ def pileup():
                            position=position, vcf_file=vcf_file,
                            genome=genome, exons=exons)
 
-
-@alignviewers_bp.route('/igvtest')
-def igv_test():
-    """Test shit"""
-    LOG.info('------------->')
-    LOG.info(str(request.args))
-    LOG.info('<-------------')
-
-    chrom = '6'
-    start = '5670'
-    stop = '5680'
-
-    locus = "chr{0}:{1}-{2}".format(chrom,start,stop)
-    LOG.debug('Displaying locus %s', locus)
-
-    genome = 'hg19'
-    fastaURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta'
-    indexURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta.fai'
-    cytobandURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt'
-    gene_track_format = 'bed'
-    gene_track_URL = 'https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz'
-    gene_track_indexURL = 'https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi'
-
-
-    display_obj = {}
-
-    display_obj['reference_track'] = {
-        'genome' : genome,
-        'fastaURL' : fastaURL,
-        'indexURL' : indexURL,
-        'cytobandURL' : cytobandURL
-    }
-
-    display_obj['genes_track'] = {
-        'name' : 'Genes',
-        'type' : 'annotation',
-        'format': gene_track_format,
-        'sourceType': 'file',
-        'url' : gene_track_URL,
-        'indexURL' : gene_track_indexURL,
-        'displayMode' : 'EXPANDED'
-    }
-    display_obj['sample_tracks'] = []
-    locus = "chr{0}:{1}-{2}".format(chrom,start,stop)
-    LOG.debug('Displaying locus %s', locus)
-    return render_template('alignviewers/igv_viewer.html', locus=locus, **display_obj )
-
-
 @alignviewers_bp.route('/igv')
 def igv():
     """Visualize BAM alignments using igv.js (https://github.com/igvteam/igv.js)"""
@@ -176,7 +128,6 @@ def igv():
 
     sample_tracks = []
 
-    """
     counter = 0
     for sample in samples:
         # some samples might not have an associated bam file, take care if this
@@ -186,7 +137,6 @@ def igv():
                                    'height' : 700
                                    })
         counter += 1
-    """
 
     display_obj['sample_tracks'] = sample_tracks
 


### PR DESCRIPTION
fix #1331 and ugly IGV logo (top left of igv view). fix #1329 (display genes track on top)

**How to test**:
1. On prod, choose a case variant and open it in igv viewer. 
- Gene track should be at the bottom of the page
- You should see the ugly igv logo (two logos juxtaposed)
![image](https://user-images.githubusercontent.com/28093618/65678811-4457f300-e054-11e9-9d35-2a9735e0f96c.png)
- Try to search for a gene and you'll get error code:
![image](https://user-images.githubusercontent.com/28093618/65678861-56d22c80-e054-11e9-9dd2-43f36afbb952.png)

1. how to test it:
- This branch is already on stage.
- Open case on stage: (https://scout-stage.scilifelab.se/cust002/643594-300M) and load one of its variants in IGV

**Expected outcome**:
- The above mentioned problems don't occur
- Genes track is displayed on top of the samples tracks
- Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
