### PR TITLE
Keep sanger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### fixed
 
+- Keep sanger order + verification when updating/reloading variants
+
 
 ## [4.7.3]
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -757,7 +757,7 @@ class CaseHandler(object):
                         variant=new_var
                     )
                     if updated_variant:
-                        updated_variants['updated_ordered'].append(updated_var['_id'])
+                        updated_variants['updated_ordered'].append(updated_variant['_id'])
 
         n_status_updated = len(updated_variants['updated_verified'])+len(updated_variants['updated_ordered'])
         LOG.debug('Verification status updated for {} variants'.format(n_status_updated))

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -406,7 +406,7 @@ class CaseHandler(object):
         old_caseid = '-'.join([case_obj['owner'], case_obj['display_name']])
         old_case = self.case(old_caseid)
         # This is to keep sanger order and validation status
-        old_sanger_variants = case_sanger_variants(case_obj['_id'])
+        old_sanger_variants = self.case_sanger_variants(case_obj['_id'])
 
         if old_case:
             LOG.info("Update case id for existing case: %s -> %s", old_caseid, case_obj['_id'])
@@ -660,9 +660,9 @@ class CaseHandler(object):
                     continue
                 case_verif_variants[category].append(variant_obj)
             
-        LOG.info("Nr variants with sanger verification found: %n",
+        LOG.info("Nr variants with sanger verification found: %s",
                  len(case_verif_variants['sanger_verified']))
-        LOG.info("Nr variants with sanger ordered found: %n",
+        LOG.info("Nr variants with sanger ordered found: %s",
                  len(case_verif_variants['sanger_ordered']))
         
         return case_verif_variants
@@ -753,7 +753,7 @@ class CaseHandler(object):
                         updated_variants['updated_ordered'].append(updated_var['_id'])
 
         n_status_updated = len(updated_variants['updated_verified'])+len(updated_variants['updated_ordered'])
-        LOG.debug('Verification status updated for {} variants'.format(n_status_updated))
+        LOG.info('Verification status updated for %n variants', n_status_updated)
         return updated_variants
 
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -618,6 +618,138 @@ class CaseHandler(object):
         self.case_collection.find_one_and_delete({'_id': case_obj['_id']})
         return new_case
 
+    def case_sanger_variants(self, case_id):
+        """Get all variants with verification ordered or
+            already verified for a case.
+
+        Accepts:
+            case_id(str): a case _id
+
+        Returns:
+            case_verif_variants(dict): a dictionary like this: {
+                'sanger_verified' : [list of vars],
+                'sanger_ordered' : [list of vars]
+            }
+        """
+        case_verif_variants = {
+            'sanger_verified' : [],
+            'sanger_ordered' : []
+        }
+
+        sanger_verified =  self.sanger_variants(case_id=case_id)
+        # This is a pymongo cursor containing variant objects
+
+        case_verif_variants['sanger_verified'] = list(sanger_verified)
+
+        sanger_ordered = self.sanger_ordered(case_id=case_id)
+        if sanger_ordered:
+            sanger_ordered = sanger_ordered[0]
+        # sanger_ordered is an object like this:
+        # sanger_ordered = {
+        #   '_id' : case_obj[_id],
+        #   'vars' : [var_obj['variant_id'], ...]
+        #}
+            for var_id in sanger_ordered['vars']:
+                variant_obj = self.variant(case_id=case_id, document_id=var_id)
+                if variant_obj:
+                    case_verif_variants['sanger_ordered'].append(variant_obj)
+
+        return case_verif_variants
+
+    def update_case_sanger_variants(self, institute_obj, case_obj, case_verif_variants):
+        """Update existing variants for a case according to a previous
+            verification status.
+
+            Accepts:
+                institute_obj(dict): an institute object
+                case_obj(dict): a case object
+                case_verif_variants(dict): a dictionary like this: {
+                    'sanger_verified' : [list of vars],
+                    'sanger_ordered' : [list of vars]
+                }
+
+            Returns:
+                updated_variants(dict): a dictionary like this: {
+                    'updated_verified' : [list of variant ids],
+                    'updated_ordered' : [list of variant ids]
+                }
+
+        """
+        LOG.debug('Updating verification status for variants in case:{}'.format(case_obj['_id']))
+
+        updated_variants = {
+            'updated_verified' : [],
+            'updated_ordered' : []
+        }
+        # update verification status for verified variants of a case
+        for category, values in case_verif_variants.items():
+            for old_var in case_verif_variants[category]:
+                # new var display name should be the same as old display name:
+                display_name = old_var['display_name']
+
+                # check if variant still exists
+                new_var = self.variant_collection.find_one({
+                    'case_id' : case_obj['_id'],
+                    'display_name': display_name }
+                )
+
+                if new_var is None: # if variant doesn't exist any more
+                    continue
+
+                # create a link to the new variant for the events
+                link="/{0}/{1}/{2}".format(new_var['institute'], case_obj['display_name'],
+                    new_var['_id'])
+
+                if category == 'sanger_verified':
+                    old_verif_event = self.event_collection.find_one({
+                        'case' : case_obj['_id'],
+                        'verb' : 'validate',
+                        'variant_id': old_var['variant_id']
+                    })
+                    user_obj = self.user(old_verif_event['user_id'])
+
+                    # if a new variant coresponds to the old and
+                    # there exist a verification event for the old one
+                    if new_var and old_verif_event:
+                        # validate new variant as well:
+                        updated_var = self.validate(
+                            institute=institute_obj,
+                            case=case_obj,
+                            user=user_obj,
+                            link=link,
+                            variant=new_var,
+                            validate_type=old_var.get('validation')
+                        )
+                        if updated_var:
+                            updated_variants['updated_verified'].append(updated_var['_id'])
+
+                else: # old variant had Sanger validation ordered
+                    # check old event to collect user_obj that ordered the verification:
+                    old_sanger_event = self.event_collection.find_one({
+                        'case' : case_obj['_id'],
+                        'verb' : 'sanger',
+                        'variant_id': old_var['variant_id']
+                    })
+                    if old_sanger_event is None:
+                        continue
+
+                    user_obj = self.user(old_sanger_event['user_id'])
+
+                    # set sanger ordered status for the new variant as well:
+                    updated_variant = self.order_verification(
+                        institute=institute_obj,
+                        case=case_obj,
+                        user=user_obj,
+                        link=link,
+                        variant=new_var
+                    )
+                    if updated_variant:
+                        updated_variants['updated_ordered'].append(updated_var['_id'])
+
+        n_status_updated = len(updated_variants['updated_verified'])+len(updated_variants['updated_ordered'])
+        LOG.debug('Verification status updated for {} variants'.format(n_status_updated))
+        return updated_variants
+
 
 def get_variantid(variant_obj, family_id):
     """Create a new variant id.

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -405,6 +405,8 @@ class CaseHandler(object):
         # Check if case exists with old case id
         old_caseid = '-'.join([case_obj['owner'], case_obj['display_name']])
         old_case = self.case(old_caseid)
+        old_sanger_variants = None
+
         if old_case:
             LOG.info("Update case id for existing case: %s -> %s", old_caseid, case_obj['_id'])
             self.update_caseid(old_case, case_obj['_id'])
@@ -422,6 +424,9 @@ class CaseHandler(object):
             {'file_name': 'vcf_str', 'variant_type': 'clinical', 'category': 'str'}
         ]
 
+        if update:
+            # collect variants with verification ordered or already validated for this case
+            old_sanger_variants = self.case_sanger_variants(case_obj['_id'])
         try:
             for vcf_file in files:
                 # Check if file exists
@@ -449,6 +454,14 @@ class CaseHandler(object):
 
         if existing_case and update:
             self.update_case(case_obj)
+
+            # update Sanger status for the new inserted variants
+            self.update_case_sanger_variants(
+                institute_obj,
+                case_obj,
+                old_sanger_variants
+            )
+
         else:
             LOG.info('Loading case %s into database', case_obj['display_name'])
             self._add_case(case_obj)

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -105,12 +105,12 @@ class VariantEventHandler(object):
         LOG.info("Creating event for ordering validation for variant" \
                     " {0}".format(variant['display_name']))
 
+        LOG.info("Set sanger order to 'True' for %s", variant['display_name'])
         updated_variant = self.variant_collection.find_one_and_update(
             {'_id': variant['_id']},
             {'$set': {'sanger_ordered': True}},
             return_document=pymongo.ReturnDocument.AFTER
         )
-
         self.create_event(
             institute=institute,
             case=case,
@@ -222,6 +222,43 @@ class VariantEventHandler(object):
         sanger_ordered =  [item for item in results]
         return sanger_ordered
 
+    def validated(self, institute_id=None, user_id=None, case_id=None):
+        """Get all variants that have been validated.
+
+        Args:
+            institute_id(str) : The id of an institute
+            user_id(str) : The id of an user
+            case_id(str) : Id of a case
+
+        Returns:
+            validated(list) : a list of dictionaries, each with "case_id" as keys
+                and list of variant ids (variant_id, not _id) as values
+        """
+        query = {'$match': {
+                '$and': [
+                    {'verb': 'validate'},
+                ],
+            }}
+
+        if institute_id:
+            query['$match']['$and'].append({'institute': institute_id})
+        if user_id:
+            query['$match']['$and'].append({'user_id': user_id})
+        if case_id:
+            query['$match']['$and'].append({'case': case_id})
+
+        # Get all sanger ordered variants grouped by case_id
+        results = self.event_collection.aggregate([
+            query,
+            {'$group': {
+                '_id': "$case",
+                'vars': {'$addToSet' : '$variant_id'}
+            }}
+        ])
+
+        sanger_ordered =  [item for item in results]
+        return sanger_ordered
+
     def validate(self, institute, case, user, link, variant, validate_type):
         """Mark validation status for a variant.
 
@@ -241,6 +278,8 @@ class VariantEventHandler(object):
             LOG.warning("Invalid validation string: %s", validate_type)
             LOG.info("Validation options: %s", ', '.join(SANGER_OPTIONS))
             return
+
+        LOG.info("Set validation status to %s for %s", validate_type, variant['display_name'])
         updated_variant = self.variant_collection.find_one_and_update(
             {'_id': variant['_id']},
             {'$set': {'validation': validate_type}},

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -257,7 +257,6 @@ class VariantEventHandler(object):
             variant=variant,
             subject=variant['display_name'],
         )
-        LOG.debug('----->1-4-7')
         return updated_variant
 
     def mark_causative(self, institute, case, user, link, variant):

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -185,15 +185,17 @@ class VariantEventHandler(object):
         )
         return updated_variant
 
-    def sanger_ordered(self, institute_id=None, user_id=None):
+    def sanger_ordered(self, institute_id=None, user_id=None, case_id=None):
         """Get all variants with validations ever ordered.
 
         Args:
             institute_id(str) : The id of an institute
             user_id(str) : The id of an user
+            case_id(str) : Id of a case
 
         Returns:
-            sanger_ordered(list) : a list of dictionaries, each with "case_id" as keys and list of variant ids as values
+            sanger_ordered(list) : a list of dictionaries, each with "case_id" as keys
+                and list of variant ids (variant_id, not _id) as values
         """
         query = {'$match': {
                 '$and': [
@@ -205,6 +207,8 @@ class VariantEventHandler(object):
             query['$match']['$and'].append({'institute': institute_id})
         if user_id:
             query['$match']['$and'].append({'user_id': user_id})
+        if case_id:
+            query['$match']['$and'].append({'case': case_id})
 
         # Get all sanger ordered variants grouped by case_id
         results = self.event_collection.aggregate([
@@ -237,7 +241,6 @@ class VariantEventHandler(object):
             LOG.warning("Invalid validation string: %s", validate_type)
             LOG.info("Validation options: %s", ', '.join(SANGER_OPTIONS))
             return
-
         updated_variant = self.variant_collection.find_one_and_update(
             {'_id': variant['_id']},
             {'$set': {'validation': validate_type}},
@@ -254,6 +257,7 @@ class VariantEventHandler(object):
             variant=variant,
             subject=variant['display_name'],
         )
+        LOG.debug('----->1-4-7')
         return updated_variant
 
     def mark_causative(self, institute, case, user, link, variant):

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -72,6 +72,7 @@ def variants(case_id, institute, force, cancer, cancer_research, sv,
             LOG.warning("The gene could not be found")
             raise click.Abort()
 
+    old_sanger_variants = adapter.case_sanger_variants(case_obj['_id'])
     i = 0
     for file_type in files:
         variant_type = file_type['variant_type']
@@ -120,4 +121,4 @@ def variants(case_id, institute, force, cancer, cancer_research, sv,
         return
     
     # update Sanger status for the new inserted variants
-    sanger_updated = adapter.update_case_sanger_variants(institute_obj,case_obj)
+    sanger_updated = adapter.update_case_sanger_variants(institute_obj,case_obj, old_sanger_variants)

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -79,6 +79,9 @@ def variants(case_id, institute, force, cancer, cancer_research, sv,
                     LOG.warning("research not requested, use '--force'")
                     raise click.Abort()
 
+            # collect variants with verification ordered or already validated for this case
+            old_sanger_variants = adapter.case_sanger_variants(case_obj['_id'])
+
             LOG.info("Delete {0} {1} variants for case {2}".format(
                          variant_type, category, case_id))
             adapter.delete_variants(case_id=case_obj['_id'],
@@ -99,8 +102,21 @@ def variants(case_id, institute, force, cancer, cancer_research, sv,
                     end=end,
                     gene_obj=gene_obj
                 )
+
             except Exception as e:
                 LOG.warning(e)
                 raise click.Abort()
+
+            # update Sanger status for the new inserted variants
+            institute_obj = adapter.institute(case_obj['owner'])
+            case_obj = adapter.case(case_id=case_obj['_id'])
+
+            if institute_obj and case_obj:
+                sanger_updated = adapter.update_case_sanger_variants(
+                    institute_obj,
+                    case_obj,
+                    old_sanger_variants
+                )
+
     if i == 0:
         LOG.info("No files where specified to upload variants from")

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -16,6 +16,12 @@ MAIL_PORT = 587
 MAIL_USE_TLS = True
 MAIL_USE_SSL = False
 
+MAIL_USERNAME = 'dummyscoutuser@gmail.com'
+MAIL_PASSWORD = 'scoutPWD01'
+ADMINS = [
+    'dummyscoutuser@gmail.com',
+]
+
 # Chanjo-Report
 REPORT_LANGUAGE = 'en'
 ACCEPT_LANGUAGES = ['en', 'sv']

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -64,16 +64,10 @@ def test_update_case_sanger_variants(adapter, institute_obj, case_obj, user_obj,
 
     variant_obj['validation'] = 'True positive'
     # When assigning a verification to a new variant
-    test_case_verif_variants = {
-        'sanger_verified' : [variant_obj],
-        'sanger_ordered' : [variant_obj]
-    }
-
     # and using the function to update sanger status for the variants
     # of a case
 
-    updated_variants = adapter.update_case_sanger_variants(
-        institute_obj, case_obj, test_case_verif_variants)
+    updated_variants = adapter.update_case_sanger_variants(institute_obj, case_obj)
 
     # Then the verification status should be updated for
     # verified variants

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -82,9 +82,6 @@ def test_update_case_sanger_variants(adapter, institute_obj, case_obj, user_obj,
     # and variants with Sanger ordered
     assert updated_variants['updated_ordered'] == [variant_obj['_id']]
 
-
-
-
 def test_get_sanger_unevaluated(real_populated_database, variant_objs, institute_obj, case_obj, user_obj):
     """Test get all sanger ordered but not evaluated for an institute"""
 

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -215,14 +215,14 @@ def test_sanger_ordered(adapter, institute_obj, case_obj, user_obj, variant_obj)
     # by querying database using the user_id
     sanger_results = adapter.sanger_ordered(user_id=user_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]
+    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}
 
     # by querying database using the institute_id
     sanger_results = adapter.sanger_ordered(institute_id=institute_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]
+    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}
 
     # or by querying database using the case id
     sanger_results = adapter.sanger_ordered(case_id=case_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]
+    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -215,14 +215,14 @@ def test_sanger_ordered(adapter, institute_obj, case_obj, user_obj, variant_obj)
     # by querying database using the user_id
     sanger_results = adapter.sanger_ordered(user_id=user_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}
+    assert [var for var in sanger_results[0]['vars']] == [updated_variant['variant_id']]
 
     # by querying database using the institute_id
     sanger_results = adapter.sanger_ordered(institute_id=institute_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}
+    assert [var for var in sanger_results[0]['vars']] == [updated_variant['variant_id']]
 
     # or by querying database using the case id
     sanger_results = adapter.sanger_ordered(case_id=case_obj['_id'])
     assert sanger_results[0]['_id'] == case_obj['_id']
-    assert sanger_results[0]['vars'] == {updated_variant['variant_id']}
+    assert [var for var in sanger_results[0]['vars']] == [updated_variant['variant_id']]

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -1,4 +1,3 @@
-from pprint import pprint as pp
 import pytest
 import logging
 import datetime
@@ -6,10 +5,8 @@ import pymongo
 
 from scout.constants import VERBS_MAP
 
-logger = logging.getLogger(__name__)
-
 def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-    logger.info("Testing mark a variant causative")
+
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -42,7 +39,6 @@ def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj)
     assert event_obj['link'] == link
 
 def test_unmark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-    logger.info("Testing mark a variant causative")
 
     ## GIVEN a adapter with a variant that is marked causative
     adapter.case_collection.insert_one(case_obj)
@@ -81,7 +77,7 @@ def test_unmark_causative(adapter, institute_obj, case_obj, user_obj, variant_ob
 
 
 def test_order_verification(adapter, institute_obj, case_obj, user_obj, variant_obj):
-    logger.info("Testing ordering verification for a variant")
+
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -120,7 +116,7 @@ def test_order_verification(adapter, institute_obj, case_obj, user_obj, variant_
 
 
 def test_cancel_verification(adapter, institute_obj, case_obj, user_obj, variant_obj):
-    logger.info("Testing cancel verification ordering for a variant")
+
     # GIVEN a populated database with a variant that has sanger ordered
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -160,7 +156,6 @@ def test_cancel_verification(adapter, institute_obj, case_obj, user_obj, variant
 
 
 def test_dismiss_variant(adapter, institute_obj, case_obj, user_obj, variant_obj):
-    logger.info("Test dismiss variant")
 
     # GIVEN a variant db with at least one variant, and no events
     adapter.case_collection.insert_one(case_obj)
@@ -196,3 +191,38 @@ def test_dismiss_variant(adapter, institute_obj, case_obj, user_obj, variant_obj
 
     # THEN the variant should be dismissed
     assert updated_variant.get('dismiss_variant') == dismiss_reason
+
+def test_sanger_ordered(adapter, institute_obj, case_obj, user_obj, variant_obj):
+    """Test function that retrieved all variants ordered by institute, user or case"""
+
+    # GIVEN a variant db with at least one variant, and no events
+    adapter.case_collection.insert_one(case_obj)
+    adapter.institute_collection.insert_one(institute_obj)
+    adapter.user_collection.insert_one(user_obj)
+    adapter.variant_collection.insert_one(variant_obj)
+
+    # WHEN ordering sanger for the variant
+    updated_variant = adapter.order_verification(
+        institute=institute_obj,
+        case=case_obj,
+        user=user_obj,
+        link='orderSangerlink',
+        variant=variant_obj
+    )
+    updated_variant = adapter.variant_collection.find_one()
+
+    # THEN the 'sanger_ordered' function should retrieve the variant
+    # by querying database using the user_id
+    sanger_results = adapter.sanger_ordered(user_id=user_obj['_id'])
+    assert sanger_results[0]['_id'] == case_obj['_id']
+    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]
+
+    # by querying database using the institute_id
+    sanger_results = adapter.sanger_ordered(institute_id=institute_obj['_id'])
+    assert sanger_results[0]['_id'] == case_obj['_id']
+    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]
+
+    # or by querying database using the case id
+    sanger_results = adapter.sanger_ordered(case_id=case_obj['_id'])
+    assert sanger_results[0]['_id'] == case_obj['_id']
+    assert sanger_results[0]['vars'] == [updated_variant['variant_id']]

--- a/tests/commands/load/test_load_variants_cmd.py
+++ b/tests/commands/load/test_load_variants_cmd.py
@@ -110,6 +110,16 @@ def test_reload_variants(mock_app, case_obj, user_obj, institute_obj):
         validate_type = 'True positive'
     )
 
+    # then one variant should have an associated Sanger event
+    assert sum(1 for i in store.event_collection.find({'verb':'validate',
+        'category':'variant'})) == 1
+
+    # Check that the variant is validated
+    new_variant = store.variant_collection.find_one(
+        {'display_name':one_variant['display_name']}
+    )
+    assert new_variant['validation'] == 'True positive'
+
     # force re-upload the same variants using the command line:
     result =  runner.invoke(cli, ['load', 'variants', case_obj['_id'],
         '--snv',


### PR DESCRIPTION
fix #1326 ---> Keep Sanger validation status or Sanger validation ordered after reuploading the variants for a case


Updating of variants in scout may occur in 2 ways: 
- **Force re-uploading of variants**
- **Updating of case**
This PR modifies both ways so that Sanger info is retained.

**------->How to test Force re-uploading of variants (on a local installation)**

requirements:
1. Make sure you are on the master branch of scout
1. open config.py file in scout/server/ and add the following lines to it:

```
ADMINS = ['your_scilifelab_username']
MAIL_USERNAME = 'your_scilifelab_username'
MAIL_PASSWORD = 'your_real_scilifelab_password'
```
This way you can order Sanger from your installation.

1. Go on a variant and order Sanger for it.
1. Then go to another and pin it then, from the case page, set it to True or False Positive, you choose.
1. From the command line (master branch) reupload the snvs with the following command:
```
scout --demo load variants internal_id --snv -f
```
4. The Sanger info for the 2 variants you interacted with should be lost, and they will be only pinned (with no sanger ordered for one and not validated the other).

5. Validate again one the the two pinned variants and order sanger for the other.
6. Repeat step 3 from the cli of this branch.
7. You should see that Sanger info is retained this time 

**------->How to test Sanger retention after Updating of case (on a local installation)**
8. A rerun can be simulated using the CLI (master branch) and running this command:
```
scout --demo load case scout/demo/643594.config.yaml -u
```
9. This command will have leave the 2 variants pinned but with no validation or Sanger info.
10. Repeat step 5
11. Switch to this branch
12. Repeat 8.
13. This time Sanger and validation info should be retained

**Review:**
- [ ] code approved by
- [x] tests executed by @moonso 
