### PR TITLE
Fix #1328 - case search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Fixed igv search not working due to igv.js dist 2.2.17
-
+- Fixed searches for cases with a gene with variants pinned or marked causative.
 
 
 ## [4.7.1]

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -178,34 +178,42 @@ class CaseHandler(object):
                             query['_id'] = {'$in': similar_case_ids}
             elif name_query.startswith('causative:'):
                 if name_value:
-                    cases_with_gene_doc=self.case_collection.aggregate([
-                        { '$lookup':
-                            {'from': 'variant',
-                            'localField': 'causatives',
-                            'foreignField': '_id',
-                            'as': 'causative_variant'}
-                        },
-                        {'$match': {
-                            'causative_variant.hgnc_symbols': name_value
-                        }},
-                        {'$project': {'_id': 1}}])
-                    case_ids = [case['_id'] for case in cases_with_gene_doc]
-                    query['_id'] = {'$in': case_ids}
+                    hgnc_id=self.hgnc_id(hgnc_symbol=name_value)
+                    if hgnc_id:
+                        cases_with_gene_doc=self.case_collection.aggregate([
+                            { '$lookup':
+                                {'from': 'variant',
+                                'localField': 'causatives',
+                                'foreignField': '_id',
+                                'as': 'causative_variant'}
+                            },
+                            {'$match': {
+                                'causative_variant.hgnc_ids': hgnc_id
+                            }},
+                            {'$project': {'_id': 1}}])
+                        case_ids = [case['_id'] for case in cases_with_gene_doc]
+                        query['_id'] = {'$in': case_ids}
+                    else:
+                        LOG.info("No gene with the HGNC symbol {} found.".format(name_value))
             elif name_query.startswith('pinned:'):
                 if name_value:
-                    cases_with_gene_doc=self.case_collection.aggregate([
-                        { '$lookup':
-                            {'from': 'variant',
-                            'localField': 'suspects',
-                            'foreignField': '_id',
-                            'as': 'suspect_variant'}
-                        },
-                        {'$match': {
-                            'suspect_variant.hgnc_symbols': name_value
-                        }},
-                        {'$project': {'_id': 1}}])
-                    case_ids = [case['_id'] for case in cases_with_gene_doc]
-                    query['_id'] = {'$in': case_ids}
+                    hgnc_id=self.hgnc_id(hgnc_symbol=name_value)
+                    if hgnc_id:
+                        cases_with_gene_doc=self.case_collection.aggregate([
+                            { '$lookup':
+                                {'from': 'variant',
+                                'localField': 'suspects',
+                                'foreignField': '_id',
+                                'as': 'suspect_variant'}
+                            },
+                            {'$match': {
+                                'suspect_variant.hgnc_ids': hgnc_id
+                            }},
+                            {'$project': {'_id': 1}}])
+                        case_ids = [case['_id'] for case in cases_with_gene_doc]
+                        query['_id'] = {'$in': case_ids}
+                    else:
+                        LOG.info("No gene with the HGNC symbol {} found.".format(name_value))
             elif name_query.startswith('synopsis:'):
                 if name_value:
                     query['$text']={'$search':name_value}

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -181,11 +181,12 @@ class CaseHandler(object):
                     hgnc_id=self.hgnc_id(hgnc_symbol=name_value)
                     if hgnc_id:
                         cases_with_gene_doc=self.case_collection.aggregate([
+                            { '$unwind': "$causatives" },
                             { '$lookup':
                                 {'from': 'variant',
                                 'localField': 'causatives',
                                 'foreignField': '_id',
-                                'as': 'causative_variant'}
+                                'as': 'causative_variant'
                             },
                             {'$match': {
                                 'causative_variant.hgnc_ids': hgnc_id
@@ -200,6 +201,7 @@ class CaseHandler(object):
                     hgnc_id=self.hgnc_id(hgnc_symbol=name_value)
                     if hgnc_id:
                         cases_with_gene_doc=self.case_collection.aggregate([
+                            { '$unwind': "$suspects"}
                             { '$lookup':
                                 {'from': 'variant',
                                 'localField': 'suspects',

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -201,7 +201,7 @@ class CaseHandler(object):
                     hgnc_id=self.hgnc_id(hgnc_symbol=name_value)
                     if hgnc_id:
                         cases_with_gene_doc=self.case_collection.aggregate([
-                            { '$unwind': "$suspects"}
+                            { '$unwind': "$suspects"},
                             { '$lookup':
                                 {'from': 'variant',
                                 'localField': 'suspects',

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -186,7 +186,7 @@ class CaseHandler(object):
                                 {'from': 'variant',
                                 'localField': 'causatives',
                                 'foreignField': '_id',
-                                'as': 'causative_variant'
+                                'as': 'causative_variant'}
                             },
                             {'$match': {
                                 'causative_variant.hgnc_ids': hgnc_id


### PR DESCRIPTION
Bug fix #1328

**How to test**:
With a fresh db, 
1. pin a variant for a case, say in POT1 
2. ensure you can find the case again by searching cases for pinned:POT1
3. Repeat for causatives, by marking the variant causative and searching for the case as causative:POT1

**Expected outcom**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR
