### PR TITLE
Fix missing comments_table import in current master (fix #1372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved dashboard using Chart.js
 
 ### fixed
-
+- Fixed missing import for variants with comments
 
 ## [4.7.3]
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -1,4 +1,5 @@
 {% extends "layout_bs4.html" %}
+{% from "utils.html" import comments_table %}
 {% from "variants/utils.html" import compounds_table, svs_table %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 

--- a/scout/server/templates/bootstrap4.html
+++ b/scout/server/templates/bootstrap4.html
@@ -23,7 +23,7 @@
   <!-- Optional JavaScript -->
   <!-- jQuery first, then Popper.js, then Bootstrap JS -->
   {% block scripts %}
-	<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+	<script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
 	{% endblock scripts %}


### PR DESCRIPTION
fixes a bug affecting variants page. 

**How to test**:
1. Can be tested on a local installation of Scout after adding a global comment and/or a local comment for a variant. Variants page for that case won't work.
2. Alternatively go to stage and make sure that variants page for this sample doesn't work: https://scout-stage.scilifelab.se/cust000/620573fam30M/
3. Install this branch and check that the problem is fixed.
4. Click on the first variant, which has 1 global and 1 local comment. Variant page should work as well.

**Expected outcome**:
The pages work on stage when using this branch, crashes while using master branch

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @moonso 
