### PR TITLE
Moved and fixed variants filter actions (fix #1374)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### fixed
 - Fixed missing import for variants with comments
 - Keep sanger order + verification when updating/reloading variants
+- Fixed and moved broken filter actions (HPO gene panel and reset filter)
 
 
 ## [4.7.3]

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -32,21 +32,6 @@
 
 {% block top_nav_right %}
   <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
-  <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Actions <span class="caret"></span></a>
-    <ul class="dropdown-menu">
-      <li>
-        <a class="dropdown-item" href="{{ url_for('variants.sv_variants', institute_id=institute._id,
-                            case_name=case.display_name, variant_type=variant_type,
-                            gene_panels=['hpo']) }}">
-          HPO gene list
-        </a>
-      </li>
-      <li>
-        <a class="dropdown-item" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type=form.variant_type.data, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">Reset filters</a>
-      </li>
-    </ul>
-  </li>
   {{ super() }}
 {% endblock %}
 
@@ -99,15 +84,22 @@
 {% macro filters_form() %}
     <input type="hidden" name="variant_type" value="{{ variant_type }}">
       <div class="row">
-        <div class="col-3">
+        <div class="col-2">
           {{ form.gene_panels.label(class="control-label") }}
+          <div class="btn-group d-flex">
+            <a class="btn btn-outline-secondary btn-sm " href="{{ url_for('variants.sv_variants', institute_id=institute._id,
+              case_name=case.display_name, variant_type=form.variant_type.data,
+              gene_panels=['hpo']) }}">HPO gene list</a>
+          </div>
+        </div>
+        <div class="col-2">
           {{ form.gene_panels(class="selectpicker") }}
         </div>
         <div class="col-3">
           {{ form.region_annotations.label(class="control-label") }}
           {{ form.region_annotations(class="selectpicker") }}
         </div>
-        <div class="col-3">
+        <div class="col-2">
           {{ form.functional_annotations.label(class="control-label") }}
           {{ form.functional_annotations(class="selectpicker") }}
         </div>
@@ -164,17 +156,19 @@
         </div>
       </div>
     </div>
-    <div class="form-group d-flex">
-      <div class="row d-flex justify-content-between">
-        <div class="col">
-          {{ form.filter_variants(class_="btn btn-primary form-control") }}
-        </div>
-        <div class="col">
-         {{ form.clinical_filter(class_="btn btn-outline-secondary form-control") }}
-        </div>
-        <div class="col">
-          {{ form.export(class_="btn btn-warning form-control") }}
-        </div>
+    <div class="row">
+      <div class="col-2">
+        <a href="{{ url_for('variants.sv_variants', institute_id=institute._id,
+          case_name=case.display_name, variant_type='clinical',
+          gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}"
+          class="btn btn-secondary btn-sm" style="color: #ffffff !important;">
+          reset filters
+        </a>
+      </div>
+      <div class="col-10 form-group d-flex">
+        {{ form.filter_variants(class_="btn btn-primary form-control") }}
+        {{ form.clinical_filter(class_="btn btn-outline-secondary form-control") }}
+        {{ form.export(class_="btn btn-warning form-control") }}
       </div>
     </div>
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -34,21 +34,6 @@
 
 {% block top_nav_right %}
   <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
-  <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Actions <span class="caret"></span></a>
-    <ul class="dropdown-menu">
-      <li>
-        <a class="dropdown-item href="{{ url_for('variants.variants', institute_id=institute._id,
-                            case_name=case.display_name, variant_type=form.variant_type.data,
-                            gene_panels=['hpo']) }}">
-          HPO gene list
-        </a>
-      </li>
-      <li>
-        <a class="dropdown-item href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type=form.variant_type.data, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">Reset filters</a>
-      </li>
-    </ul>
-  </li>
   {{ super() }}
 {% endblock %}
 
@@ -231,14 +216,20 @@
 {% endmacro %}
 
 {% macro filters_form() %}
-    {{ form.csrf_token }}
-    {{ form.variant_type() }}
     <div class="form-group">
       <div class="row">
-        <div class="col-3">
-          {{ form.gene_panels.label}}{{form.gene_panels(class="selectpicker")}}
+        <div class="col-2">
+          {{ form.gene_panels.label}}
+          <div class="btn-group d-flex">
+            <a class="btn btn-outline-secondary btn-sm " href="{{ url_for('variants.variants', institute_id=institute._id,
+              case_name=case.display_name, variant_type=form.variant_type.data,
+              gene_panels=['hpo']) }}">HPO gene list</a>
+          </div>
         </div>
-      	<div class="col-3">
+        <div class="col-2">
+          {{form.gene_panels(class="selectpicker")}}
+        </div>
+      	<div class="col-2">
       	  {{ form.symbol_file.label(class="control-label") }}
       	  {{ form.symbol_file(class="form-control-file") }}
       	</div>
@@ -314,6 +305,11 @@
         </div>
       </div>
     </div>
+    <a href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name,
+      variant_type='clinical', gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}"
+       class="btn btn-secondary btn-sm" style="color: #ffffff !important;">
+      reset filters
+    </a>
 {% endmacro %}
 
 {% block scripts %}


### PR DESCRIPTION
This functionality is bug fix #1374

**How to test**:
1. install the branch and check that variants page filter look like this:
![image](https://user-images.githubusercontent.com/28093618/66374738-f7591280-e9ab-11e9-93db-d9d58589cd2e.png)
1. sv-variants should also look like the picture above (action dropdown missing from the top bar and 2 new buttons available in filter form)
1. "HPO gene list" and "reset filter" buttons should do what they are supposed to do (compare with scout prod, where the functionality is working)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @moonso 
