### PR TITLE
Exon ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Genes can be manually added to the dynamic gene list directly on the case page
 - Dynanmic gene panels can optionally be used with clinical filter, instead of default gene panel
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
+- Show transcripts with exon numbers for structural variants
 
 ### fixed
 
@@ -22,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Instructions on how to build docs
 - Keep sanger order + verification when updating/reloading variants
 - Fixed and moved broken filter actions (HPO gene panel and reset filter)
+- UCSC links for structural variants are now separated per breakpoint (and whole variant where applicable)
 
 ## [4.7.3]
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -241,7 +241,7 @@
             <a class="nav-item nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
           </div>
         </nav>
-        <div class="tab-content" id="nav-tabContent">
+        <div class="tab-content mt-3" id="nav-tabContent">
           <div class="tab-pane fade show active" id="nav-genes" role="tabpanel" aria-labelledby="nav-genes-tab">{{ genes_panel(variant) }}</div>
           <div class="tab-pane fade" id="nav-transcripts" role="tabpanel" aria-labelledby="nav-transcripts-tab">{{ transcripts_panel() }}</div>
         </div>
@@ -369,7 +369,6 @@
 
 {% macro genes_panel(variant) %}
   <div class="card panel-default">
-    <div class="panel-heading">Genes</div>
     <div class="table-responsive">
       <table class="table table-bordered">
         <thead>

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -141,6 +141,7 @@
               {% else %}
                 - BAM file(s) missing
               {% endif %}
+              - <a class="btn btn-outline-secondary btn-sm" href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{{ variant.chromosome }}:{{ variant.position }}&dgv=pack&knownGene=pack&omimGene=pack" target="_blank">UCSC</a>
             </div>
           </li>
           <li class="list-group-item">
@@ -156,6 +157,7 @@
               {% else %}
                 - BAM file(s) missing
               {% endif %}
+                - <a class="btn btn-outline-secondary btn-sm" href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{{ variant.end_chrom }}:{{ variant.end }}&dgv=pack&knownGene=pack&omimGene=pack" target="_blank">UCSC</a>
             </div>
           </li>
   	      <li class="list-group-item">
@@ -184,6 +186,9 @@
                 - Complex rearrangement: check breakpoint alignments.
               {% else %}
                 - BAM file(s) missing
+              {% endif %}
+              {% if variant.chromosome == variant.end_chrom %}
+              - <a class="btn btn-outline-secondary btn-sm" href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}&dgv=pack&knownGene=pack&omimGene=pack" target="_blank">UCSC</a>
               {% endif %}
             </div>
 
@@ -485,9 +490,6 @@
         <tr>
           <td>
             <a class="btn btn-outline-secondary form-control" href="http://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;r={{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}" target="_blank">Ensembl</a>
-          </td>
-          <td>
-            <a class="btn btn-outline-secondary form-control" href="http://genome.ucsc.edu/cgi-bin/hgTracks?db=hg19&position=chr{{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}&dgv=pack&knownGene=pack&omimGene=pack" target="_blank">UCSC</a>
           </td>
 	  <td>
 	    <a class="btn btn-outline-secondary form-control" href="https://decipher.sanger.ac.uk/browser#q/{{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}%20/location/{{ variant.chromosome }}:{{ variant.position }}-{{ variant.end }}" target ="_blank">DECIPHER</a>

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -439,8 +439,6 @@
           <th>Strand</th>
           <th>Exon</th>
           <th>Intron</th>
-          <th>cDNA</th>
-          <th>Amino acid</th>
         </tr>
       </thead>
       <tbody>
@@ -472,8 +470,6 @@
               <td class="text-center">{{ transcript.strand }}</td>
               <td>{{ transcript.exon or '' }}</td>
               <td>{{ transcript.intron or '' }}</td>
-              <td>{{ (transcript.coding_sequence_name or '') }}</td>
-              <td>{{ (transcript.protein_sequence_name or '')|url_decode }}</td>
             </tr>
           {% endfor %}
         {% endfor %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -223,13 +223,24 @@
 
   <div class="row">
     <div class="col-md-12">
-      {{ genes(variant) }}
+      {{ overlapping(overlapping_snvs, variant.rank_score) }}
     </div>
   </div>
 
   <div class="row">
-    <div class="col-md-12">
-      {{ overlapping(overlapping_snvs, variant.rank_score) }}
+    <div class="col-12">
+      <div class="card">
+        <nav>
+          <div class="nav nav-tabs" id="nav-tab" role="tablist">
+            <a class="nav-item nav-link active" id="nav-genes-tab" data-toggle="tab" href="#nav-genes" role="tab" aria-controls="nav-genes" aria-selected="true">Genes</a>
+            <a class="nav-item nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
+          </div>
+        </nav>
+        <div class="tab-content" id="nav-tabContent">
+          <div class="tab-pane fade show active" id="nav-genes" role="tabpanel" aria-labelledby="nav-genes-tab">{{ genes_panel(variant) }}</div>
+          <div class="tab-pane fade" id="nav-transcripts" role="tabpanel" aria-labelledby="nav-transcripts-tab">{{ transcripts_panel() }}</div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -351,7 +362,7 @@
   </div>
 {% endmacro %}
 
-{% macro genes(variant) %}
+{% macro genes_panel(variant) %}
   <div class="card panel-default">
     <div class="panel-heading">Genes</div>
     <div class="table-responsive">
@@ -371,8 +382,8 @@
             <tr>
               {% if gene.common %}
               <td>
-                <a href="http://www.genenames.org/cgi-bin/gene_symbol_report?match={{ gene.hgnc_symbol }}" target="_blank">
-                  {{ gene.common.hgnc_symbol }}
+                <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
+                  {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
               </td>
               <td>
@@ -407,6 +418,62 @@
         </tbody>
       </table>
     </div>
+  </div>
+{% endmacro %}
+
+{% macro transcripts_panel() %}
+  <div class="card panel-default table-responsive fixed-panel">
+    <table class="table table-bordered card-sm">
+      <thead>
+        <tr>
+          <th>Gene</th>
+          <th>Transcript</th>
+          <th>RefSeq</th>
+          <th>Biotype</th>
+          <th>Mutation type</th>
+          <th>Strand</th>
+          <th>Exon</th>
+          <th>Intron</th>
+          <th>cDNA</th>
+          <th>Amino acid</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for gene in variant.genes %}
+          {% for transcript in gene.transcripts %}
+            <tr class="{{ 'danger' if transcript.is_disease_associated }}">
+              <td>
+                <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
+                  {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+                </a>
+              </td>
+              <td class="d-flex justify-content-around align-items-center">
+                <a target="_blank" href="{{ transcript.ensembl_link }}">
+                  {{ transcript.transcript_id }}
+                </a>
+                {% if transcript.is_canonical %}
+                  <span class="badge badge-info">C</span>
+                {% endif %}
+              </td>
+              <td>
+                {{ transcript.refseq_identifiers|join(',') }}
+              </td>
+              <td>{{ transcript.biotype or '' }}</td>
+              <td data-toggle="tooltip" data-placement="right" title="{{ transcript.functional_annotations|join(', ') }}">
+                {{ transcript.functional_annotations
+                      |join(', ')
+                      |truncate(20, True) }}
+              </td>
+              <td class="text-center">{{ transcript.strand }}</td>
+              <td>{{ transcript.exon or '' }}</td>
+              <td>{{ transcript.intron or '' }}</td>
+              <td>{{ (transcript.coding_sequence_name or '') }}</td>
+              <td>{{ (transcript.protein_sequence_name or '')|url_decode }}</td>
+            </tr>
+          {% endfor %}
+        {% endfor %}
+      </tbody>
+    </table>
   </div>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -246,7 +246,6 @@ def sv_variants(institute_id, case_name):
             'region_annotations': ['exonic','splicing'],
             'functional_annotations': SEVERE_SO_TERMS,
             'thousand_genomes_frequency': str(institute_obj['frequency_cutoff']),
-            'variant_type': 'clinical',
             'clingen_ngi': 10,
             'swegen': 10,
             'size': 100,


### PR DESCRIPTION
This PR adds a functionality and fixes a bug.

**How to test**:
1. look at the SV variants page on stage. make sure you can see exon ranges for a couple of SV variants that should have it (eg an exonic 100kb or so deletion or duplication)
![Screenshot 2019-10-11 at 11 48 46](https://user-images.githubusercontent.com/758570/66642502-2e822a80-ec1d-11e9-8486-0625b83a2314.png)

1. look at a SV variant and see that UCSC coordinates are visible. See that you cannot see the button for the whole variant for variants that span across contigs such as translocations (BND).

![Screenshot 2019-10-11 at 11 47 51](https://user-images.githubusercontent.com/758570/66642516-32ae4800-ec1d-11e9-85db-302f6476ffb7.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR
