### PR TITLE
Bugfix: log print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed string conversion to number
 - UCSC links for structural variants are now separated per breakpoint (and whole variant where applicable)
 - Reintroduced missing coverage report
+- Fixed a bug preventing loading samples using the command line
 
 
 ## [4.7.3]

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -759,7 +759,7 @@ class CaseHandler(object):
                         updated_variants['updated_ordered'].append(updated_var['_id'])
 
         n_status_updated = len(updated_variants['updated_verified'])+len(updated_variants['updated_ordered'])
-        LOG.info('Verification status updated for %n variants', n_status_updated)
+        LOG.info('Verification status updated for {} variants'.format(n_status_updated))
         return updated_variants
 
 


### PR DESCRIPTION
Change %n to {}.format in log.info print.

This PR fixes a bug.

I ran into a crash this morning when loading configs:  

```
2019-10-12 10:59:26 mikaellmbp scout.adapter.mongo.case[65669] DEBUG Updating verification status for variants in case:internal_id
--- Logging error ---
Traceback (most recent call last):
  File "/miniconda3/envs/python3.6/lib/python3.6/logging/__init__.py", line 994, in emit
    msg = self.format(record)
  File "/miniconda3/envs/python3.6/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/coloredlogs/__init__.py", line 1116, in format
    return logging.Formatter.format(self, record)
  File "/miniconda3/envs/python3.6/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/miniconda3/envs/python3.6/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
ValueError: unsupported format character 'n' (0x6e) at index 33
Call stack:
  File "/miniconda3/envs/python3.6/bin/scout", line 11, in <module>
    load_entry_point('scout-browser==4.7.3', 'console_scripts', 'scout')()
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/cli.py", line 569, in main
    return super(FlaskGroup, self).main(*args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/cli.py", line 419, in decorator
    return __ctx.invoke(f, *args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/scout_browser-4.7.3-py3.6.egg/scout/commands/load/case.py", line 106, in case
    case_obj = adapter.load_case(config_data, update)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/scout_browser-4.7.3-py3.6.egg/scout/adapter/mongo/case.py", line 463, in load_case
    self.update_case_sanger_variants(institute_obj,case_obj, old_sanger_variants)
  File "/miniconda3/envs/python3.6/lib/python3.6/site-packages/scout_browser-4.7.3-py3.6.egg/scout/adapter/mongo/case.py", line 762, in update_case_sanger_variants
    LOG.info('Verification status updated for %n variants', n_status_updated)
Message: 'Verification status updated for %n variants'
Arguments: (0,)
```

OS X 10.14.6
Python 3.6.8


**How to test**:
1. how to install it
1. how to test it, possibly with real cases/data

scout --demo load case scout/demo/643594.config.yaml -u

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

Demo config is loaded without crash.


**Review:**
- [x] code approved by CR
- [x] tests executed by CR
