### PR TITLE
Dynamic panel coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Ask before inactivating a case where last assigned user leaves it
 - Genes can be manually added to the dynamic gene list directly on the case page
 - Dynanmic gene panels can optionally be used with clinical filter, instead of default gene panel
+- Dynamic gene panels get link out to chanjo-report for coverage report
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
 - Show transcripts with exon numbers for structural variants
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -841,7 +841,7 @@
       <span data-toggle="tooltip" data-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
           {{ case.dynamic_panel_phenotypes|length }} phenotypes</span>
       {% endif %})
-      {% if config.SQLALCHEMY_DATABASE_URI %}
+      {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
         <a class="pull-right text-white" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage</a>
         <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
           <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -839,7 +839,14 @@
       HPO gene panel ({{ case.dynamic_gene_list|length }} genes)
       {%- if case.dynamic_panel_phenotypes %},
       <span data-toggle="tooltip" data-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
-          {{ case.dynamic_panel_phenotypes|length }} phenotypes</span>{% endif %})
+          {{ case.dynamic_panel_phenotypes|length }} phenotypes</span>
+      {% endif %})
+      {% if config.SQLALCHEMY_DATABASE_URI %}
+        <a class="pull-right text-white" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage</a>
+        <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+          <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+        </form>
+      {% endif %}
     </div>
     <ul class="list-group fixed-panel">
       {% for hpo_gene in case.dynamic_gene_list %}


### PR DESCRIPTION
This PR adds a functionality and so indirectly amends the impact of a bug.

Users should be able to see coverage for the dynamic gene panel. As a benefit, as single genes can now be added to the dynamic panel, this can be used together to quickly create a coverage report for a few genes of interest, indirectly solving the issue in #499.

**How to test**:
1. Use a setup with chanjo-report configured.
1. See that when dynamic gene panel is populated, a link to a coverage report for the panel is added to the case page. 
<img width="667" alt="Screenshot 2019-10-12 at 17 17 19" src="https://user-images.githubusercontent.com/758570/66703555-3a9ce380-ed14-11e9-843b-1c7ef24fdaeb.png">
1. When the dynamic panel is empty, no Coverage link should be shown.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by dNil
