### PR TITLE
Toggle date sort order - fix #1299.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dynamic gene panels get link out to chanjo-report for coverage report
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
 - Show transcripts with exon numbers for structural variants
+- Case date sort order can now be reversed (toggle old->new or new->old).
 
 ### fixed
 - Fixed missing import for variants with comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dynamic gene panels get link out to chanjo-report for coverage report
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
 - Show transcripts with exon numbers for structural variants
-- Case date sort order can now be reversed (toggle old->new or new->old).
+- Case sort order can now be toggled between ascending and descending.
 
 ### fixed
 - Fixed missing import for variants with comments

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -150,36 +150,28 @@
 {% endmacro %}
 
 {% macro cases_table(group_name, cases) %}
+{% if sort_order == 'asc' %}
+  {% set sort_option = 'desc'%}
+{% else %}
+  {% set sort_option = 'asc'%}
+{% endif %}
 <div class="card mt-3">
   <div class="card-body" style="padding: 0;">
     <table class="table table-hover table-bordered">
       <thead>
         <tr>
           <th style="width: 25%">{{ group_name|capitalize }} cases</th>
-          <th style="width: 10%">Status
-            <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status');" class="badge"
-                {% if (sort_by == "status") %}style="color:black;background-color:white;"
-                {% else %} style="color:gray;background-color:white;"
-                {%endif%}>
-              <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
-          <th style="width: 15%">Analysis date
-          {% if sort_by == "analysis_date_desc" %}
-          <a href="" id="{{group_name}}_analysis_date_asc" onclick="updateArgs('{{group_name}}','sort=analysis_date_asc');" class="badge" style="color:black;background-color:white;">
-            <i class="fa fa-sort-desc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
-          {% elif sort_by == "analysis_date_asc" %}
-              <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:black;background-color:white;">
-                <i class="fa fa-sort-asc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the oldest to the newest"></i></a></th>
-          {% else %}
-            <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:gray;background-color:white;">
-              <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the oldest to the newest"></i></a></th>
-          {% endif %}
-
+          <th style="width: 10%">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+            <i class="fa fa-sort{{'-'+sort_order if sort_by=='status' }}" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i>
+          </a></th>
+          <th style="width: 15%">Analysis date <a href="" id="{{group_name}}_analysis_date" onclick="updateArgs('{{group_name}}','sort=analysis_date','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+            <i class="fa fa-sort{{'-'+sort_order if sort_by=='analysis_date' }}" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date"></i>
+          </a></th>
           <th style="width: 20%">Link</th>
           <th style="width: 5%">Sequencing</th>
-          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track');" class="badge"
-            {% if (sort_by == "track") %}style="color:black;background-color:white;"
-            {% else %} style="color:gray;background-color:white;"{%endif%}>
-            <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
+          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+            <i class="fa fa-sort{{'-'+sort_order if sort_by=='track' }}" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i>
+          </a></th>
           <th style="width: 10%">Clinvar</th>
         </tr>
       </thead>
@@ -317,8 +309,8 @@
       });
     });
 
-    function updateArgs(caseGroup, sortItem) {
-      sort_items = ['sort=status', 'sort=analysis_date_asc', 'sort=analysis_date_desc', 'sort=track'];
+    function updateArgs(caseGroup, sortItem, sortOrder) {
+      sort_items = ['sort=status', 'sort=analysis_date', 'sort=track', 'order=asc', 'order=desc'];
       //modifying the sorting of cases
       let searchList = window.location.search.split('&');
       if(!searchList[0]){
@@ -329,6 +321,7 @@
       searchList = searchList.filter(f => !sort_items.includes(f))
       //add specific sort param
       searchList.push(sortItem);
+      searchList.push("order="+sortOrder)
 
       sort_link = document.getElementById( caseGroup.concat('_',sortItem.split('=')[1]));
       const url = window.location.href.split('?')[0].concat(searchList.join('&'));

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -156,11 +156,30 @@
       <thead>
         <tr>
           <th style="width: 25%">{{ group_name|capitalize }} cases</th>
-          <th style="width: 10%">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
-          <th style="width: 15%">Analysis date <a href="" id="{{group_name}}_analysis_date" onclick="updateArgs('{{group_name}}','sort=analysis_date');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
+          <th style="width: 10%">Status
+            <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status');" class="badge"
+                {% if (sort_by == "status") %}style="color:black;background-color:white;"
+                {% else %} style="color:gray;background-color:white;"
+                {%endif%}>
+              <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i></a></th>
+          <th style="width: 15%">Analysis date
+          {% if sort_by == "analysis_date_desc" %}
+          <a href="" id="{{group_name}}_analysis_date_asc" onclick="updateArgs('{{group_name}}','sort=analysis_date_asc');" class="badge" style="color:black;background-color:white;">
+            <i class="fa fa-sort-desc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
+          {% elif sortby == "analysis_date_asc" %}
+              <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:black;background-color:white;">
+                <i class="fa fa-sort-asc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
+          {% else %}
+            <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:gray;background-color:white;">
+              <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the oldest to the newest"></i></a></th>
+          {% endif %}
+
           <th style="width: 20%">Link</th>
           <th style="width: 5%">Sequencing</th>
-          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track');" class="badge" style="color:black;background-color:white;"><i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
+          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track');" class="badge"
+            {% if (sort_by == "track") %}style="color:black;background-color:white;"
+            {% else %} style="color:gray;background-color:white;"{%endif%}>
+            <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i></a></th>
           <th style="width: 10%">Clinvar</th>
         </tr>
       </thead>
@@ -299,7 +318,7 @@
     });
 
     function updateArgs(caseGroup, sortItem) {
-      sort_items = ['sort=status', 'sort=analysis_date', 'sort=track'];
+      sort_items = ['sort=status', 'sort=analysis_date_asc', 'sort=analysis_date_desc', 'sort=track'];
       //modifying the sorting of cases
       let searchList = window.location.search.split('&');
       if(!searchList[0]){
@@ -310,6 +329,7 @@
       searchList = searchList.filter(f => !sort_items.includes(f))
       //add specific sort param
       searchList.push(sortItem);
+
       sort_link = document.getElementById( caseGroup.concat('_',sortItem.split('=')[1]));
       const url = window.location.href.split('?')[0].concat(searchList.join('&'));
       sort_link.href = url;

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -166,9 +166,9 @@
           {% if sort_by == "analysis_date_desc" %}
           <a href="" id="{{group_name}}_analysis_date_asc" onclick="updateArgs('{{group_name}}','sort=analysis_date_asc');" class="badge" style="color:black;background-color:white;">
             <i class="fa fa-sort-desc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
-          {% elif sortby == "analysis_date_asc" %}
+          {% elif sort_by == "analysis_date_asc" %}
               <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:black;background-color:white;">
-                <i class="fa fa-sort-asc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the newest to the oldest"></i></a></th>
+                <i class="fa fa-sort-asc" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the oldest to the newest"></i></a></th>
           {% else %}
             <a href="" id="{{group_name}}_analysis_date_desc" onclick="updateArgs('{{group_name}}','sort=analysis_date_desc');" class="badge" style="color:gray;background-color:white;">
               <i class="fa fa-sort" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date from the oldest to the newest"></i></a></th>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -161,15 +161,15 @@
       <thead>
         <tr>
           <th style="width: 25%">{{ group_name|capitalize }} cases</th>
-          <th style="width: 10%">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+          <th style="width: 10%">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status','{{sort_option}}');" class="badge" style="color:{{'black' if sort_by=='status' else 'grey'}};background-color:white;">
             <i class="fa fa-sort{{'-'+sort_order if sort_by=='status' }}" aria-hidden="true" data-toggle="tooltip" title="Sort cases by 'status'"></i>
           </a></th>
-          <th style="width: 15%">Analysis date <a href="" id="{{group_name}}_analysis_date" onclick="updateArgs('{{group_name}}','sort=analysis_date','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+          <th style="width: 15%">Analysis date <a href="" id="{{group_name}}_analysis_date" onclick="updateArgs('{{group_name}}','sort=analysis_date','{{sort_option}}');" class="badge" style="color:{{'black' if sort_by=='analysis_date' else 'grey'}};background-color:white;">
             <i class="fa fa-sort{{'-'+sort_order if sort_by=='analysis_date' }}" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis date"></i>
           </a></th>
           <th style="width: 20%">Link</th>
           <th style="width: 5%">Sequencing</th>
-          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track','{{sort_option}}');" class="badge" style="color:black;background-color:white;">
+          <th style="width: 15%">Track <a href="" id="{{group_name}}_track" onclick="updateArgs('{{group_name}}','sort=track','{{sort_option}}');" class="badge" style="color:{{'black' if sort_by=='track' else 'grey'}};background-color:white;">
             <i class="fa fa-sort{{'-'+sort_order if sort_by=='track' }}" aria-hidden="true" data-toggle="tooltip" title="Sort by analysis track: Rare Disease, Cancer.."></i>
           </a></th>
           <th style="width: 10%">Clinvar</th>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -59,25 +59,29 @@ def cases(institute_id):
 
     LOG.info(type(all_cases))
     sort_by = request.args.get('sort')
+    sort_order = request.args.get('order') or 'asc'
     if sort_by:
-        if sort_by == 'analysis_date_desc':
-            all_cases.sort('analysis_date', pymongo.DESCENDING)
-        elif sort_by == 'analysis_date_asc':
-            all_cases.sort('analysis_date', pymongo.ASCENDING)
+        pymongo_sort = pymongo.ASCENDING
+        if sort_order == 'desc':
+            pymongo_sort = pymongo.DESCENDING
+        if sort_by == 'analysis_date':
+            all_cases.sort('analysis_date', pymongo_sort)
         elif sort_by == 'track':
-            all_cases.sort('track', pymongo.ASCENDING)
+            all_cases.sort('track', pymongo_sort)
         elif sort_by == 'status':
-            all_cases.sort('status', pymongo.ASCENDING)
+            all_cases.sort('status', pymongo_sort)
 
     LOG.debug("Prepare all cases")
     data = controllers.cases(store, all_cases, limit)
+    data['sort_order'] = sort_order
+    data['sort_by'] = sort_by
 
     sanger_unevaluated = controllers.get_sanger_unevaluated(store, institute_id, current_user.email)
     if len(sanger_unevaluated)> 0:
         data['sanger_unevaluated'] = sanger_unevaluated
 
     return dict(institute=institute_obj, skip_assigned=skip_assigned,
-                is_research=is_research, sort_by=sort_by, query=query, **data)
+                is_research=is_research, query=query, **data)
 
 
 @cases_bp.route('/<institute_id>/<case_name>')

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -60,8 +60,10 @@ def cases(institute_id):
     LOG.info(type(all_cases))
     sort_by = request.args.get('sort')
     if sort_by:
-        if sort_by == 'analysis_date':
+        if sort_by == 'analysis_date_desc':
             all_cases.sort('analysis_date', pymongo.DESCENDING)
+        elif sort_by == 'analysis_date_asc':
+            all_cases.sort('analysis_date', pymongo.ASCENDING)
         elif sort_by == 'track':
             all_cases.sort('track', pymongo.ASCENDING)
         elif sort_by == 'status':
@@ -75,7 +77,7 @@ def cases(institute_id):
         data['sanger_unevaluated'] = sanger_unevaluated
 
     return dict(institute=institute_obj, skip_assigned=skip_assigned,
-                is_research=is_research, query=query, **data)
+                is_research=is_research, sort_by=sort_by, query=query, **data)
 
 
 @cases_bp.route('/<institute_id>/<case_name>')


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. Install in an environment with more than one case.
1. Click sort of track, status and date to see that date sorting reverses sort order on toggle and icon colour changes to indicate which order is active.

<img width="1605" alt="Screenshot 2019-10-15 at 12 44 29" src="https://user-images.githubusercontent.com/758570/66824963-97351400-ef49-11e9-82bf-a440ea114fb3.png">

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR

