### PR TITLE
Fix #1391 - STR back link (and column layout) broken.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Reintroduced missing coverage report
 - Fixed a bug preventing loading samples using the command line
 - Better inheritance models customization for genes in gene panels
+- STR variant page back to list button now does its one job.
 
 
 ## [4.7.3]

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -61,7 +61,7 @@
                 {% for uneval_obj in sanger_unevaluated %}
                 {% for case, var_list in uneval_obj.items() %}
                 <li>
-                  Case <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case) }}" target="_blank">{{case}}</strong></a> ---> <strong>{{var_list|length}}</strong> variants:
+                  Case <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case) }}" target="_blank">{{case}}</a></strong> ---> <strong>{{var_list|length}}</strong> variants:
                   <ul>
                     {% for var in var_list %}
                       <li><a href="{{ url_for('variants.variant', institute_id=institute._id, case_name=case, variant_id=var) }}" target="_blank">{{var}}</a></li>
@@ -122,7 +122,7 @@
         </div>
       </div>
       <div class="col-md-2 col-sm-2">
-        <button type="submit" class="form-control">Search</input>
+        <button type="submit" class="form-control">Search</button>
       </div>
       <div class="col-md-2 col-sm-2">
         <div class="number">

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -37,15 +37,15 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th class="col-xs-1" title="Rank position">Rank</th>
-          <th class="col-xs-1" title="Repeat ID">Repeat locus</th>
-          <th class="col-xs-2" title="Repeat unit">Reference repeat unit</th>
-          <th class="col-xs-1" title="ALT">Estimated size</th>
-          <th class="col-xs-1" title="ReferenceSize">Reference size</th>
-          <th class="col-xs-1" title="Status">Status</th>
-          <th class="col-xs-2" title="GT">Genotype</th>
-          <th class="col-xs-1" title="Chromosome">Chr.</th>
-          <th class="col-xs-2" title="Position">Position</th>
+          <th style="width:8%" title="Rank position">Rank</th>
+          <th style="width:8%" title="Repeat ID">Repeat locus</th>
+          <th style="width:15%" title="Repeat unit">Reference repeat unit</th>
+          <th style="width:8%" title="ALT">Estimated size</th>
+          <th style="width:8%" title="ReferenceSize">Reference size</th>
+          <th style="width:10%"title="Status">Status</th>
+          <th style="width:18%" title="GT">Genotype</th>
+          <th style="width:8%" title="Chromosome">Chr.</th>
+          <th style="width:17%" title="Position">Position</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -37,15 +37,15 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th class="col-1" title="Rank position">Rank</th>
-          <th class="col-1" title="Repeat ID">Repeat locus</th>
-          <th class="col-2" title="Repeat unit">Reference repeat unit</th>
-          <th class="col-1" title="ALT">Estimated size</th>
-          <th class="col-1" title="ReferenceSize">Reference size</th>
-          <th class="col-1" title="Status">Status</th>
-          <th class="col-2" title="GT">Genotype</th>
-          <th class="col-1" title="Chromosome">Chr.</th>
-          <th class="col-2" title="Position">Position</th>
+          <th class="col-xs-1" title="Rank position">Rank</th>
+          <th class="col-xs-1" title="Repeat ID">Repeat locus</th>
+          <th class="col-xs-2" title="Repeat unit">Reference repeat unit</th>
+          <th class="col-xs-1" title="ALT">Estimated size</th>
+          <th class="col-xs-1" title="ReferenceSize">Reference size</th>
+          <th class="col-xs-1" title="Status">Status</th>
+          <th class="col-xs-2" title="GT">Genotype</th>
+          <th class="col-xs-1" title="Chromosome">Chr.</th>
+          <th class="col-xs-2" title="Position">Position</th>
         </tr>
       </thead>
       <tbody>
@@ -99,7 +99,7 @@
 {% macro cell_rank(variant) %}
   <a class="variants-row-item flex-small layout"
      href="{{ url_for('variants.variant', institute_id=institute._id, case_name=case.display_name,
-                      variant_id=variant._id) }}">
+                      variant_id=variant._id, str='yes') }}">
     {{ variant.variant_rank }}
   </a>
   {% set comment_count = variant.comments.count() %}

--- a/scout/server/blueprints/variants/templates/variants/variant.html
+++ b/scout/server/blueprints/variants/templates/variants/variant.html
@@ -34,6 +34,10 @@ $(document).ready(function(){
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
         {{ variant.variant_type|capitalize }} cancer variants
       </a>
+    {% elif str %}
+      <a class="nav-link text-nowrap" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
+        {{ variant.variant_type|capitalize }} STR variants
+      </a>
     {% else %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
         {{ variant.variant_type|capitalize }} SNV and INDELs

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -198,6 +198,7 @@ def variant(institute_id, case_name, variant_id):
         data['observations'] = controllers.observations(store, loqusdb,
             case_obj, data['variant'])
     data['cancer'] = request.args.get('cancer') == 'yes'
+    data['str'] = request.args.get('str') == 'yes'
     return dict(institute=institute_obj, case=case_obj, **data)
 
 @variants_bp.route('/<institute_id>/<case_name>/str/variants')


### PR DESCRIPTION
This PR fixes a bug / adds a missing function.

**How to test**:
1. click an STR variant (rank link). 
1. see that the variant page shows a link back to the STR variants list, and that it works.

<img width="790" alt="Screenshot 2019-10-16 at 14 22 16" src="https://user-images.githubusercontent.com/758570/66918794-67a50b00-f020-11e9-9b6d-2978ce84e15d.png">

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
