### PR TITLE
Fix #1305 - SV variants hover.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
 - Show transcripts with exon numbers for structural variants
 - Case sort order can now be toggled between ascending and descending.
+- Show a frequency tooltip hover for SV-variants.
 
 ### fixed
 - Fixed missing import for variants with comments

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -28,6 +28,23 @@
   </div>
 {% endmacro %}
 
+{% macro frequency_cell_general(variant) %}
+  <div data-toggle="tooltip" data-placement="left" data-html="true" title="
+      <div class='text-left'>
+        {% for freq_name, value in variant.frequencies %}
+          <div>
+            <strong>freq_name</strong>: {{ value|human_decimal}}
+          </div>
+        {% endfor %}
+        <div>
+          <strong>Local (arch.)</strong>: {{ variant.local_obs_old or 0 }} obs.
+        </div>
+      </div>
+    ">
+    {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency else '~' }}
+  </div>
+{% endmacro %}
+
 {% macro frequency_cell(variant) %}
   <div data-toggle="tooltip" data-placement="left" data-html="true" title="
     <div class='text-left'>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -1,5 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
+{% from "variants/components.html" import frequency_cell_general %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -236,9 +237,7 @@
       {% endif %}
     </td>
     <td>
-      {% if variant.gnomad_frequency %}
-        {{ variant.gnomad_frequency|human_decimal }}
-      {% endif %}
+      {{ frequency_cell_general(variant) }}
     </td>
     <td>
       <div class="d-flex justify-content-between align-items-center">
@@ -284,6 +283,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
   <script>
+    $('[data-toggle="tooltip"]').tooltip();
     $(function () {
       $('[data-toggle="popover"]').popover({
         container: 'body',

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -48,63 +48,60 @@
             {{ filters_form() }}
         </div>
       </div>
-        <div class="card mt-3">
-          <table class="table table-hover table-bordered">
-            <thead>
-                  <tr>
-                    <th class="col-xs-1" title="Rank position">Rank </th>
-                    <th class="col-xs-1" title="Rank score">Score</th>
-                    <th class="col-xs-1" title="Chromosome">Chr.</th>
-                    <th class="col-xs-1" title="HGNC symbols" >Gene</th>
-                    <th class="col-xs-1" title="1000 Genomes">PopFreq</th>
-                    <th class="col-xs-1" title="CADD score">CADD</th>
-                    <th class="col-xs-1" title="Gene region annotation">Gene annotation</th>
-                    <th class="col-xs-2" title="Functional annotation">Func. annotation</th>
-                    <th class="col-xs-2" title="Inheritance models">Inheritance model</th>
-                    <th class="col-xs-1" title="Overlapping">Overlapping</th>
-                  </tr>
-            </thead>
-            <tbody>
-              {% for variant in variants %}
-                {% if variant.dismiss_variant %}
-                  <tr class="dismiss">
-                {% else %}
-                  <tr>
-                {% endif %}
-                  <td class="d-flex justify-content-between align-items-center">{{ cell_rank(variant) }}</td>
-                  <td class="text-right">{{ variant.rank_score|int }}</td>
-                  <td>{{ variant.chromosome }}</td>
-                  <td>{{ gene_cell(variant) }}</td>
-                  <td class="text-right">{{ frequency_cell(variant) }}</td>
-                  <td class="text-right">{{ cell_cadd(variant) }}</td>
-                  <td>
-                    {% for annotation in variant.region_annotations %}
-                      <div>{{ annotation }}</div>
-                    {% endfor %}
-                  </td>
-                  <td>
-                    {% for annotation in variant.functional_annotations %}
-                      <div>{{ annotation }}</div>
-                    {% endfor %}
-                  </td>
-                  <td>{{ cell_models(variant) }}</td>
-                  <td>{{ overlapping_cell(variant) }}</td>
-                </tr>
+      <div class="card mt-3">
+        <table class="table table-hover table-bordered">
+          <thead>
+            <tr>
+              <th style="width:8%" title="Rank position">Rank </th>
+              <th style="width:8%" title="Rank score">Score</th>
+              <th style="width:8%" title="Chromosome">Chr.</th>
+              <th style="width:8%" title="HGNC symbols" >Gene</th>
+              <th style="width:8%" title="Poulation frequency">PopFreq</th>
+              <th style="width:8%" title="CADD score">CADD</th>
+              <th style="width:8%" title="Gene region annotation">Gene annotation</th>
+              <th style="width:18%"" title="Functional annotation">Func. annotation</th>
+              <th style="width:18%" title="Inheritance models">Inheritance model</th>
+              <th style="width:8%"" title="Overlapping">Overlapping</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for variant in variants %}
+              {% if variant.dismiss_variant %}
+                <tr class="dismiss">
               {% else %}
+                <tr>
+              {% endif %}
+                <td class="d-flex justify-content-between align-items-center">{{ cell_rank(variant) }}</td>
+                <td class="text-right">{{ variant.rank_score|int }}</td>
+                <td>{{ variant.chromosome }}</td>
+                <td>{{ gene_cell(variant) }}</td>
+                <td class="text-right">{{ frequency_cell(variant) }}</td>
+                <td class="text-right">{{ cell_cadd(variant) }}</td>
+                <td>
+                  {% for annotation in variant.region_annotations %}
+                    <div>{{ annotation }}</div>
+                  {% endfor %}
+                </td>
+                <td>
+                  {% for annotation in variant.functional_annotations %}
+                    <div>{{ annotation }}</div>
+                  {% endfor %}
+                </td>
+                <td>{{ cell_models(variant) }}</td>
+                <td>{{ overlapping_cell(variant) }}</td>
+              </tr>
+            {% else %}
               <tr>
                 <td colspan="{{ 10 if form.variant_type.data == 'clinical' else 9 }}">
                   No matching variants
                 </td>
               </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div><!-- end of <div class="card mt-3">-->
-        </div><!-- end of div class="card-body">-->
-      </div>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div><!-- end of <div class="card mt-3">-->
     </div> <!-- end of class="container-float"> -->
       {{ footer() }}
-    </div>
   </form>
 {% endblock %}
 


### PR DESCRIPTION
This PR adds a functionality - SV variants hover.

**How to test**:
1. In environment with cases with a few SV variant sources, 
1. hover over the frequency field of the SV variant and see frequencies.

<img width="1424" alt="Screenshot 2019-10-18 at 17 05 32" src="https://user-images.githubusercontent.com/758570/67105683-872b6780-f1c9-11e9-8e87-a8a317e65537.png">

**Expected outcome**:
The functionality should be working

**Review:**
- [x] code approved by CR
- [x] tests executed by CR

