### PR TITLE
Fix #1395. Inactivate rerun cases only on re-upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Load all clinvar variants with clinvar Pathogenic, Likely Pathogenic and Conflicting pathogenic
 - Show transcripts with exon numbers for structural variants
 - Case sort order can now be toggled between ascending and descending.
-- Variants can be marked as partial causative if phenotype is available for case
+- Variants can be marked as partial causative if phenotype is available for case.
 
 ### fixed
 - Fixed missing import for variants with comments
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed a bug preventing loading samples using the command line
 - Better inheritance models customization for genes in gene panels
 - STR variant page back to list button now does its one job.
+- Request rerun no longer changes case status. Active or archived cases inactivate on upload.
 
 
 ## [4.7.3]

--- a/docs/admin-guide/server.md
+++ b/docs/admin-guide/server.md
@@ -35,6 +35,8 @@ REPORT_LANGUAGE = 'sv'
 MAIL_USERNAME = 'paul.anderson@gmail.com'
 MAIL_PASSWORD = 'mySecretPassw0rd'
 
+TICKET_SYSTEM_EMAIL = 'support@sekvens.nu'
+
 # emails to send error log message to
 ADMINS = ['robin.andeer@scilifelab.se']
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -516,7 +516,7 @@ class CaseHandler(object):
             {'_id': case_obj['_id']}
         )
 
-        # if case is updataed and was archived or active - make it inactive
+        # if case is updated and was archived or active - make it inactive
         updated_status = old_case.get('status')
         if old_case.get('status') in ['archived', 'active']:
             updated_status = 'inactive'

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -515,6 +515,12 @@ class CaseHandler(object):
         old_case = self.case_collection.find_one(
             {'_id': case_obj['_id']}
         )
+
+        # if case is updataed and was archived or active - make it inactive
+        updated_status = old_case.get('status')
+        if old_case.get('status') in ['archived', 'active']:
+            updated_status = 'inactive'
+
         updated_case = self.case_collection.find_one_and_update(
             {'_id': case_obj['_id']},
             {
@@ -544,7 +550,7 @@ class CaseHandler(object):
                     'research_requested': case_obj.get('research_requested', False),
                     'multiqc': case_obj.get('multiqc'),
                     'mme_submission': case_obj.get('mme_submission'),
-                    'status': old_case.get('status') if  old_case.get('status') != 'archived' else 'inactive'
+                    'status': updated_status
                 }
             },
             return_document=pymongo.ReturnDocument.AFTER

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -294,8 +294,7 @@ class CaseEventHandler(object):
             {'_id': case['_id']},
             {
                 '$set': {
-                    'rerun_requested': True,
-                    'status': case.get('status') if case.get('status') != 'archived' else 'inactive'
+                    'rerun_requested': True
                     }
             },
             return_document=pymongo.ReturnDocument.AFTER

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -457,7 +457,10 @@ def rerun(store, mail, current_user, institute_id, case_name, sender, recipient)
                   html=html, sender=sender, recipients=[recipient],
                   # cc the sender of the email for confirmation
                   cc=[user_obj['email']])
-    mail.send(msg)
+    if recipient:
+        mail.send(msg)
+    else:
+        LOG.error("Cannot send rerun message: no recipient defined in config.")
 
 
 def update_default_panels(store, current_user, institute_id, case_name, panel_ids):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -63,10 +63,10 @@ def cases(store, case_query, limit=100):
         case_obj['analysis_types'] = list(analysis_types)
         case_obj['assignees'] = [store.user(user_email) for user_email in
                                  case_obj.get('assignees', [])]
-        case_groups[case_obj['status']].append(case_obj)
         case_obj['is_rerun'] = len(case_obj.get('analyses', [])) > 0
         case_obj['clinvar_variants'] = store.case_to_clinVars(case_obj['_id'])
         case_obj['display_track'] = TRACKS[case_obj.get('track', 'rare')]
+        case_groups[case_obj['status']].append(case_obj)
 
     data = {
         'cases': [(status, case_groups[status]) for status in CASE_STATUSES],

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -514,7 +514,7 @@
                       </table>
                       <br><br>
                     {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
-                      (<span class="pull-left">
+                      (<span class="float-left">
                       {% for model in variant.genetic_models|sort %}
                         <span class="badge badge-info" title="{{genetic_models[model]}}"> {{model}}</span>
                       {% else %}
@@ -749,10 +749,10 @@
           {% endif %}
           </td>
           <td>
-            <span class="pull-left">{{ variant.cadd_score or '-' }}</strong>
+            <span class="float-left">{{ variant.cadd_score or '-' }}</strong>
           </td>
           <td>
-            <span class="pull-left">
+            <span class="float-left">
               {% for model in variant.genetic_models|sort %}
                 <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
               {% else %}
@@ -870,7 +870,7 @@
       </thead>
       <tbody>
         <tr>
-          <td><span class="badge badge-warning pull-left">{{variant.sub_category|upper}}</span></td>
+          <td><span class="badge badge-warning float-left">{{variant.sub_category|upper}}</span></td>
           <td>{{ variant.length }}</td>
           <td>
             {% if variant.chromosome == variant.end_chrom %}
@@ -983,7 +983,7 @@
           {% endif %}
           </td>
           <td>
-            <span class="pull-left">
+            <span class="float-left">
               {% for model in variant.genetic_models|sort %}
                 <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
               {% else %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -219,9 +219,9 @@
     <td>
       {{ case.analysis_date.date() }}
       {% if case.rerun_requested %}
-          <span class="badge badge-secondary pull-right">rerun pending</span>
+          <span class="badge badge-secondary float-right">rerun pending</span>
       {% elif case.is_rerun %}
-        <span class="badge badge-secondary pull-right">rerun</span>
+        <span class="badge badge-secondary float-right">rerun</span>
       {% endif %}
     </td>
     <td>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -219,7 +219,7 @@
     <td>
       {{ case.analysis_date.date() }}
       {% if case.rerun_requested %}
-          <span class="badge badge-secondary pull-right">rerun requested</span>
+          <span class="badge badge-secondary pull-right">rerun pending</span>
       {% elif case.is_rerun %}
         <span class="badge badge-secondary pull-right">rerun</span>
       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -216,12 +216,12 @@
         <span class="badge badge-primary">migrated</span>
       {% endif %}
     </td>
-    <td>
+    <td class="d-flex justify-content-between align-items-center">
       {{ case.analysis_date.date() }}
       {% if case.rerun_requested %}
-          <span class="badge badge-secondary float-right">rerun pending</span>
+          <span class="badge badge-secondary">rerun pending</span>
       {% elif case.is_rerun %}
-        <span class="badge badge-secondary float-right">rerun</span>
+        <span class="badge badge-secondary">rerun</span>
       {% endif %}
     </td>
     <td>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -218,7 +218,9 @@
     </td>
     <td>
       {{ case.analysis_date.date() }}
-      {% if case.is_rerun %}
+      {% if case.rerun_requested %}
+          <span class="badge badge-secondary pull-right">rerun requested</span>
+      {% elif case.is_rerun %}
         <span class="badge badge-secondary pull-right">rerun</span>
       {% endif %}
     </td>

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -112,7 +112,7 @@
                                     case_name=case.display_name) }}">
                   {{ case.display_name }}
                 </a>
-                <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} pull-right">
+                <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} float-right">
                   {{ case.status }}
                 </span>
               </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -195,7 +195,7 @@
 <!-- Submenu content -->
 <div id='submenu2' class="collapse sidebar-submenu">
   {% if case.research_requested %}
-    <i>Research pending</i>
+    <i class="text-white">Research pending</i>
   {% else %}
     <button type="button" class="btn btn-danger btn-sm form-control" data-toggle="modal" data-target="#research-modal">Request research</button>
   {% endif %}
@@ -213,7 +213,7 @@
 <!-- Submenu content -->
 <div id='submenu3' class="collapse sidebar-submenu">
   {% if case.rerun_requested %}
-    <i>Rerun pending</i>
+    <i class="text-white">Rerun pending</i>
   {% else %}
     <button type="button" class="btn btn-warning form-control btn-sm" data-toggle="modal" data-target="#rerun-modal">Request rerun</button>
   {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/index.html
+++ b/scout/server/blueprints/cases/templates/cases/index.html
@@ -24,7 +24,7 @@
           {% if current_user.is_admin %}
             <span class="text-muted">({{ institute._id }})</span>
           {% endif %}
-            <span class="badge badge-secondary badge-pill pull-right">{{ case_count }} cases </span>
+            <span class="badge badge-secondary badge-pill float-right">{{ case_count }} cases </span>
         </li>
       {% endfor %}
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -791,7 +791,8 @@ def share(institute_id, case_name):
 def rerun(institute_id, case_name):
     """Request a case to be rerun."""
     sender = current_app.config['MAIL_USERNAME']
-    recipient = current_app.config['TICKET_SYSTEM_EMAIL']
+    recipient = current_app.config.get('TICKET_SYSTEM_EMAIL')
+    
     controllers.rerun(store, mail, current_user, institute_id, case_name, sender,
                       recipient)
     return redirect(request.referrer)

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -790,9 +790,9 @@ def share(institute_id, case_name):
 @cases_bp.route('/<institute_id>/<case_name>/rerun', methods=['POST'])
 def rerun(institute_id, case_name):
     """Request a case to be rerun."""
-    sender = current_app.config['MAIL_USERNAME']
+    sender = current_app.config.get('MAIL_USERNAME')
     recipient = current_app.config.get('TICKET_SYSTEM_EMAIL')
-    
+
     controllers.rerun(store, mail, current_user, institute_id, case_name, sender,
                       recipient)
     return redirect(request.referrer)

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -35,32 +35,32 @@
                 <ul class="list-group">
                   <li class="list-group-item">
                     Aliases
-                    <span class="pull-right">{{ aliases|join(', ') }}</span>
+                    <span class="float-right">{{ aliases|join(', ') }}</span>
                   </li>
                   <li class="list-group-item">
                     HGNC ID
-                    <span class="pull-right">
+                    <span class="float-right">
                       <a target="_blank" href={{ record.hgnc_link }} target="_blank"> {{ hgnc_id }}</a>
                     </span>
                   </li>
                   <li class="list-group-item">
                     HGNC symbol
-                    <span class="pull-right">{{ symbol }}</span>
+                    <span class="float-right">{{ symbol }}</span>
                   </li>
                   <li class="list-group-item">
                     Description
-                    <span class="pull-right">{{ description }}</span>
+                    <span class="float-right">{{ description }}</span>
                   </li>
                   <li class="list-group-item">
                     Incomplete penetrance (HPO)
-                    <span class="pull-right">
+                    <span class="float-right">
                       {{ 'yes' if incomplete_penetrance else 'unknown' }}
                     </span>
                   </li>
 
                   <li class="list-group-item">
                     Inheritance models
-                    <span class="pull-right">
+                    <span class="float-right">
                       {{ inheritance_models|join(', ') or '-' }}
                     </span>
                   </li>
@@ -71,25 +71,25 @@
               <div class="panel-heading">Links</div>
             <li class="list-group-item">
               OMIM
-              <span class="pull-right">
+              <span class="float-right">
                 <a target="_blank" href={{ record.omim_link }} target="_blank"> {{ omim_id }}</a>
               </span>
             </li>
             <li class="list-group-item">
               Entrez
-              <span class="pull-right">
+              <span class="float-right">
                 <a target="_blank" href={{ record.entrez_link }} target="_blank"> {{ entrez_id }}</a>
               </span>
             </li>
             <li class="list-group-item">
               pLi Score(ExAC)
-              <span class="pull-right">
+              <span class="float-right">
                 <a target="_blank" href={{ record.exac_link }} target="_blank"> {{ pli_score }}</a>
               </span>
             </li>
             <li class="list-group-item">
               Protein Paint
-              <span class="pull-right">
+              <span class="float-right">
                 <a target="_blank" href={{ record.ppaint_link }} target="_blank"> {{ symbol }}</a>
               </span>
             </li>
@@ -104,7 +104,7 @@
             {% for phenotype in record.phenotypes %}
                 <li class="list-group-item">
                     {{ phenotype.description }}
-                    <span class="pull-right">
+                    <span class="float-right">
                         <a target="_blank" href={{ record.omim_link }} target="_blank"> {{ phenotype.mim_number }}</a>
                     </span>
                 </li>
@@ -138,7 +138,7 @@
   <ul class="list-group">
     <li class="list-group-item">
       Ensembl ID
-      <span class="pull-right">
+      <span class="float-right">
         {%if gene.build == '37'%}
             <a target="_blank" href={{ gene.ensembl_37_link }} target="_blank"> {{ gene.ensembl_id }}</a>
         {% else %}
@@ -148,51 +148,51 @@
     </li>
     <li class="list-group-item">
       Chromosome
-      <span class="pull-right">{{ gene.chromosome }}</span>
+      <span class="float-right">{{ gene.chromosome }}</span>
     </li>
     <li class="list-group-item">
       Position
-      <span class="pull-right">{{ gene.position }}</span>
+      <span class="float-right">{{ gene.position }}</span>
     </li>
     <li class="list-group-item">
       Expression Atlas
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.expression_atlas_link }} target="_blank"> {{ gene.ensembl_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       Human Protein Atlas
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.hpa_link }} target="_blank"> {{ gene.ensembl_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       Reactome
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.reactome_link }} target="_blank"> {{ gene.ensembl_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       ClinGen
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.clingen_link }} target="_blank"> {{ gene.hgnc_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       String
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.string_link }} target="_blank"> {{ gene.ensembl_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       Vega Database
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.vega_link }} target="_blank"> {{ gene.vega_id }}</a>
       </span>
     </li>
     <li class="list-group-item">
       UCSC gene browser ({{ gene.build }})
-      <span class="pull-right">
+      <span class="float-right">
         <a target="_blank" href={{ gene.ucsc_link }} target="_blank"> {{ gene.ucsc_id }}</a>
       </span>
     </li>
@@ -208,7 +208,7 @@
             <a target="_blank" href={{ transcript.ensembl_link }} target="_blank"> {{ transcript.ensembl_transcript_id }}</a>
             /  {{ transcript.refseq_identifiers|join(', ') or '-' }}
             {% if transcript.is_primary %}<small>(primary)</small>{% endif %}
-		  <span class="pull-right">{{ transcript['position'] }}</span>
+		  <span class="float-right">{{ transcript['position'] }}</span>
         </li>
       {% endfor %}
     </ul>

--- a/scout/server/blueprints/institutes/templates/overview/institutes.html
+++ b/scout/server/blueprints/institutes/templates/overview/institutes.html
@@ -24,19 +24,19 @@
           <ul class="list-group list-group-flush">
             <li class="list-group-item">
               Coverage Cutoff
-              <span class="pull-right">{{ institute.coverage_cutoff }}</span>
+              <span class="float-right">{{ institute.coverage_cutoff }}</span>
             </li>
             <div class="list-group-item">
               Sanger Recipients
-              <span class="pull-right">{{ institute.sanger_recipients|join(', ') or '-' }}</span>
+              <span class="float-right">{{ institute.sanger_recipients|join(', ') or '-' }}</span>
             </div>
             <li class="list-group-item">
               Frequency Cutoff
-              <span class="pull-right">{{ institute.frequency_cutoff }}</span>
+              <span class="float-right">{{ institute.frequency_cutoff }}</span>
             </li>
             <li class="list-group-item">
               Number of Cases
-              <span class="pull-right">{{ institute.case_count }}</span>
+              <span class="float-right">{{ institute.case_count }}</span>
             </li>
           </ul>
         </div>

--- a/scout/server/blueprints/login/templates/login/users.html
+++ b/scout/server/blueprints/login/templates/login/users.html
@@ -30,7 +30,7 @@
               <td>
                 {{ user.name }}
                 {% if 'admin' in user.roles %}
-                  <span class="badge badge-info pull-right">ADMIN</span>
+                  <span class="badge badge-info float-right">ADMIN</span>
                 {% endif %}
               </td>
               <td>
@@ -42,11 +42,11 @@
                 {% endfor %}
               </td>
               <td>
-                <div class="pull-left">
+                <div class="float-left">
                   <strong>{{ user.events_rank|capitalize }}</strong><br>
                   <span class="text-muted">{{ user.events }} events</span>
                 </div>
-                <img class="rank-shield pull-right" src="{{ url_for('login.static', filename=(user.events_rank + '.svg')) }}" alt="{{ user.events_rank }}">
+                <img class="rank-shield float-right" src="{{ url_for('login.static', filename=(user.events_rank + '.svg')) }}" alt="{{ user.events_rank }}">
               </td>
             </tr>
           {% endfor %}

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -33,11 +33,11 @@
     <ul class="list-group">
       <li class="list-group-item">
         <label for="display_name">Full name</label>
-        <span class="pull-right" id="display_name">{{ panel.display_name }}</span>
+        <span class="float-right" id="display_name">{{ panel.display_name }}</span>
       </li>
       <li class="list-group-item">
         <label for="panel_name">Panel ID</label>
-        <span class="pull-right" id="panel_name">{{ panel.panel_name }}</span>
+        <span class="float-right" id="panel_name">{{ panel.panel_name }}</span>
       </li>
 
       <div class="list-group-item">
@@ -59,21 +59,21 @@
       </div>
       <li class="list-group-item">
         <label for="version">Version</label>
-        <span class="pull-right" id="version">{{ panel.version }}</span>
+        <span class="float-right" id="version">{{ panel.version }}</span>
       </li>
       <li class="list-group-item">
         <label for="n_genes">Number of genes</label>
-        <span class="pull-right" id="n_genes">{{ panel.genes|length }}</span>
+        <span class="float-right" id="n_genes">{{ panel.genes|length }}</span>
       </li>
       <li class="list-group-item">
         <label for="date">Date</label>
-        <span class="pull-right" id="date">{{ panel.date.date() }}</span>
+        <span class="float-right" id="date">{{ panel.date.date() }}</span>
       </li>
       {% if config.SQLALCHEMY_DATABASE_URI and case %}
         <li class="list-group-item">
           <label for="coverage_report">Coverage report</label>
           Coverage report
-          <a class="pull-right" id="coverage_report" href="#" onclick="document.getElementById('report-form').submit();">
+          <a class="float-right" id="coverage_report" href="#" onclick="document.getElementById('report-form').submit();">
             {{ case.display_name }}
           </a>
           <form id="report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name=panel.name_and_version, level=institute.coverage_cutoff) }}" method="POST" target="_blank">
@@ -82,8 +82,8 @@
         </li>
         <li class="list-group-item">
           Coverage overview
-          <span class="pull-right">
-            <a class="pull-right" href="#" onclick="document.getElementById('report-genes-form').submit();">
+          <span class="float-right">
+            <a class="float-right" href="#" onclick="document.getElementById('report-genes-form').submit();">
               {{ case.display_name }}
             </a>
             <form id="report-genes-form" action="{{ url_for('report.genes', level=institute.coverage_cutoff, sample_id=case.individuals|map(attribute='individual_id')|list) }}" target="_blank" method="POST">
@@ -135,7 +135,7 @@
               <td>
                 {% if not panel.is_archived %}
                   <a class="btn btn-outline-secondary btn-xs" href="{{ url_for('panels.gene_edit', panel_id=panel._id, hgnc_id=gene.hgnc_id) }}">Edit</a>
-                  <form class="pull-right" action="{{ url_for('panels.panel', panel_id=panel._id) }}" method="POST">
+                  <form class="float-right" action="{{ url_for('panels.panel', panel_id=panel._id) }}" method="POST">
                     <input type="hidden" name="hgnc_id" value="{{ gene.hgnc_id }}">
                     <button name="action" type="submit" value="delete" class="btn btn-danger btn-xs">Delete</button>
                   </form>
@@ -190,11 +190,11 @@
             {{ gene.symbol }}
           </span>
           {% if gene.action == 'add' %}
-            <span class="badge badge-primary badge-pill pull-right">{{ gene.action }}</span>
+            <span class="badge badge-primary badge-pill float-right">{{ gene.action }}</span>
           {% elif gene.action == 'delete' %}
-            <span class="badge badge-danger badge-pill pull-right">{{ gene.action }}</span>
+            <span class="badge badge-danger badge-pill float-right">{{ gene.action }}</span>
           {% else %}
-            <span class="badge badge-secondary badge-pill pull-right">{{ gene.action }}</span>
+            <span class="badge badge-secondary badge-pill float-right">{{ gene.action }}</span>
           {% endif %}
         </li>
       {% else %}

--- a/scout/server/blueprints/variants/templates/variants/clinvar.html
+++ b/scout/server/blueprints/variants/templates/variants/clinvar.html
@@ -106,9 +106,9 @@
           <div class="panel-heading">
             <h5>
             {% if pinned.category == 'snv' %}
-              <span class="badge badge-success pull-left">snv</span>
+              <span class="badge badge-success float-left">snv</span>
             {% else %}
-              <span class="badge badge-warning pull-left">sv</span>
+              <span class="badge badge-warning float-left">sv</span>
             {% endif %}
             {% if pinned.simple_id|length > 25 and pinned.cytoband_start %}
               #Variant --> {{ pinned.sub_category+"("+pinned.chromosome+pinned.cytoband_start+"-"+pinned.end_chrom+pinned.cytoband_end+")" }}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -69,8 +69,8 @@
             <td>{{ variant.str_status }}</td>
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}
-                    <div class="pull-left">{{ sample.display_name }}</div>
-                    <div class="pull-right">{{ sample.genotype_call }}</div><br>
+                    <div class="float-left">{{ sample.display_name }}</div>
+                    <div class="float-right">{{ sample.genotype_call }}</div><br>
                   {% endif %}
                 {% endfor %}
             </td>
@@ -78,7 +78,7 @@
             <td>
               {{ variant.position }}
               {% if case.bam_files %}
-                <a class="btn btn-default btn-sm pull-right" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.bam_files, bai=case.bai_files, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.position + 50), center_guide="T") }}" target="_blank">IGV viewer</a>
+                <a class="btn btn-default btn-sm float-right" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.bam_files, bai=case.bai_files, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.position + 50), center_guide="T") }}" target="_blank">IGV viewer</a>
               {% endif %}
             </td>
         </tr>
@@ -104,12 +104,12 @@
   </a>
   {% set comment_count = variant.comments.count() %}
   {% if variant.manual_rank %}
-    <span class="badge pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge float-right" title="Manual rank">{{ variant.manual_rank }}</span>
   {% endif %}
   {% if comment_count > 0 %}
     {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
     <a href="#"
-       class="badge pull-right"
+       class="badge float-right"
        data-toggle="popover"
        data-placement="right"
        data-html="true"

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -50,20 +50,20 @@
       <div class="card mt-3">
         <div class="class-body">
           <ul class="list-group">
-            <li class="list-group-item">Rank <span class="badge badge-pill badge-secondary pull-right">{{ variant.variant_rank }}</span></li>
+            <li class="list-group-item">Rank <span class="badge badge-pill badge-secondary float-right">{{ variant.variant_rank }}</span></li>
             <li class="list-group-item">
               Rank score
-              <span class="badge badge-pill badge-secondary pull-right">{{ variant.rank_score }}</span>
+              <span class="badge badge-pill badge-secondary float-right">{{ variant.rank_score }}</span>
             </li>
 
             <li class="list-group-item">
               Category
-              <span class="badge badge-pill badge-secondary pull-right">{{ variant.sub_category|upper }}</span>
+              <span class="badge badge-pill badge-secondary float-right">{{ variant.sub_category|upper }}</span>
             </li>
 
             <div class="list-group-item">
               Gene panels
-              <ul class="list-inline pull-right">
+              <ul class="list-inline float-right">
                 {% for panel_id in variant.panels %}
                   <li>
                     <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>
@@ -124,13 +124,13 @@
         <ul class="list-group">
           <li class="list-group-item">
             Position
-            <div class="pull-right">
+            <div class="float-right">
               {{ variant.chromosome }}:{{ variant.position }} {{ "-" if variant.end_chrom == variant.chromosome else " / "+variant.end_chrom+":" }}{{ variant.end }}
             </div>
           </li>
           <li class="list-group-item">
             Breakpoint 1
-            <div class="pull-right">
+            <div class="float-right">
               {{ variant.chromosome }}:{{ variant.position }}
               {% if variant.chromosome == "MT" and case.mt_bams %}
                 - Alignment:
@@ -146,7 +146,7 @@
           </li>
           <li class="list-group-item">
             Breakpoint 2
-            <div class="pull-right">
+            <div class="float-right">
               {{ variant.end_chrom }}:{{ variant.end }}
               {% if variant.end_chrom == "MT" and case.mt_bams %}
                 - Alignment:
@@ -162,7 +162,7 @@
           </li>
   	      <li class="list-group-item">
   	        Cytoband
-            <div class="pull-right">
+            <div class="float-right">
               {% if variant.chromosome == variant.end_chrom and variant.cytoband_start == variant.cytoband_end %}
                 {{ variant.chromosome }}{{ variant.cytoband_start }}
               {% elif variant.chromosome == variant.end_chrom %}
@@ -174,7 +174,7 @@
   	      </li>
   	      <li class="list-group-item">
   	        Length
-            <div class="pull-right">
+            <div class="float-right">
               {{ variant.length }}
               {% if variant.chromosome == "MT" and case.mt_bams %}
                 - Alignment:
@@ -194,7 +194,7 @@
 
   	      </li>
   	      <li class="list-group-item">
-  	        Type <div class="pull-right">{{ variant.sub_category|upper }}</div>
+  	        Type <div class="float-right">{{ variant.sub_category|upper }}</div>
   	      </li>
           {% if variant._id in case.suspects and not variant.clinvar_clinsig %}
             <a href="{{ url_for('variants.clinvar', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" class="btn btn-default form-control">Submit to ClinVar</a>
@@ -321,9 +321,9 @@
         <li class="list-group-item">
           {{ freq_name }}
           {% if value %}
-            <span class="badge badge-secondary pull-right">{{ value|human_decimal }}</span>
+            <span class="badge badge-secondary float-right">{{ value|human_decimal }}</span>
           {% else %}
-            <span class="pull-right">-</span>
+            <span class="float-right">-</span>
           {% endif %}
         </li>
       {% endfor %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -182,7 +182,7 @@
   </a>
   {% set comment_count = variant.comments.count() %}
   {% if variant.manual_rank %}
-    <span class="badge pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge float-right" title="Manual rank">{{ variant.manual_rank }}</span>
   {% endif %}
 
   {% if comment_count > 0 %}

--- a/scout/server/blueprints/variants/templates/variants/variant.html
+++ b/scout/server/blueprints/variants/templates/variants/variant.html
@@ -278,7 +278,7 @@
           <tr>
             <td>
               Position
-              <span class="pull-right">
+              <span class="float-right">
                 <strong>{{ variant.chromosome }}:<span class="text-muted">{{ variant.position }}</span></strong>
                 {% if variant.is_par %}
                   <span class="badge badge-info">PAR</span>
@@ -287,7 +287,7 @@
             </td>
             <td>
               Change
-              <span class="pull-right"><strong>{{ variant.reference }} → {{ variant.alternative }}</strong></span>
+              <span class="float-right"><strong>{{ variant.reference }} → {{ variant.alternative }}</strong></span>
             </td>
           </tr>
         </tbody>
@@ -319,7 +319,7 @@
       <ul class="list-group">
         <div class="list-group-item">
           <strong>Gene panels</strong>
-          <ul class="list-inline pull-right">
+          <ul class="list-inline float-right">
             {% for panel_id in variant.panels %}
               <li>
                   <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>
@@ -429,14 +429,14 @@
             <td>
               Matches OMIM inhert.
               {% if variant.is_matching_inheritance %}
-                <span class="badge badge-success pull-right">Yes</span>
+                <span class="badge badge-success float-right">Yes</span>
               {% else %}
-                <div class="badge badge-warning pull-right">No</div>
+                <div class="badge badge-warning float-right">No</div>
               {% endif %}
             </td>
             <td>
               Frequency
-              <div class="badge badge-{% if variant.frequency == 'common' %}danger{% elif variant.frequency == 'uncommon' %}warning{% else %}success{% endif %} pull-right">
+              <div class="badge badge-{% if variant.frequency == 'common' %}danger{% elif variant.frequency == 'uncommon' %}warning{% else %}success{% endif %} float-right">
                 {{ variant.frequency }}
               </div>
             </td>
@@ -473,7 +473,7 @@
         {% if variant.dbsnp_id %}
           <li class="list-group-item">
             SNPedia
-            <span class="pull-right">
+            <span class="float-right">
               <a target="_blank" href="http://snpedia.com/index.php/{{ variant.dbsnp_id }}">
                 {{ variant.dbsnp_id }}
               </a>
@@ -556,7 +556,7 @@
                 </td>
                 <td title="{{ transcript.coding_sequence_name or '' }}">
                   {{ (transcript.coding_sequence_name or '')|truncate(20, True) }}
-                  <span class="text-muted pull-right">
+                  <span class="text-muted float-right">
                     {{ (transcript.protein_sequence_name or '')|url_decode }}
                   </span>
                 </td>
@@ -585,7 +585,7 @@
                   </td>
                   <td title="{{ transcript.coding_sequence_name or '' }}">
                     {{ (transcript.coding_sequence_name or '')|truncate(20, True) }}
-                    <span class="text-muted pull-right">
+                    <span class="text-muted float-right">
                       {{ (transcript.protein_sequence_name or '')|url_decode }}
                     </span>
                   </td>
@@ -609,7 +609,7 @@
         {% else %}
           1000G
         {% endif %}
-        <span class="pull-right">
+        <span class="float-right">
           {% if variant.max_thousand_genomes_frequency %}
             {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small> |
           {% endif %}
@@ -618,7 +618,7 @@
       </li>
       <li class="list-group-item">
         <a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a>
-        <span class="pull-right">
+        <span class="float-right">
           {% if variant.max_exac_frequency %}
             {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small> |
           {% endif %}
@@ -627,7 +627,7 @@
       </li>
       <li class="list-group-item">
         <a title="genome Aggregation Database" target="_blank" href="{{ variant.gnomad_link }}">gnomAD</a>
-        <span class="pull-right">
+        <span class="float-right">
           {% if 'gnomad_frequency' in variant%}
             {% if variant.max_gnomad_frequency %}
               {{ variant.max_gnomad_frequency|human_decimal }}
@@ -719,30 +719,30 @@
     <ul class="list-group">
       <li class="list-group-item">
         Sift
-        <span class="pull-right">{{ variant.sift_predictions|join(', ') }}</span>
+        <span class="float-right">{{ variant.sift_predictions|join(', ') }}</span>
       </li>
       <li class="list-group-item">
         <a href="http://genetics.bwh.harvard.edu/pph2/" target="_blank">Polyphen</a>
-        <span class="pull-right">{{ variant.polyphen_predictions|join(', ') }}</span>
+        <span class="float-right">{{ variant.polyphen_predictions|join(', ') }}</span>
       </li>
       <li class="list-group-item">
         SPIDEX
-        <span class="pull-right">{{ variant.spidex_human }}</span>
+        <span class="float-right">{{ variant.spidex_human }}</span>
       </li>
     </ul>
     <div class="panel-heading">Conservation</div>
     <ul class="list-group">
       <li class="list-group-item">
         PHAST
-        <span class="pull-right">{{ variant.phast_conservation|join(', ') or '-' }}</span>
+        <span class="float-right">{{ variant.phast_conservation|join(', ') or '-' }}</span>
       </li>
       <li class="list-group-item">
         GERP
-        <span class="pull-right">{{ variant.gerp_conservation|join(', ') or '-' }}</span>
+        <span class="float-right">{{ variant.gerp_conservation|join(', ') or '-' }}</span>
       </li>
       <li class="list-group-item">
         phyloP
-        <span class="pull-right">{{ variant.phylop_conservation|join(', ') or '-' }}</span>
+        <span class="float-right">{{ variant.phylop_conservation|join(', ') or '-' }}</span>
       </li>
     </ul>
     <div class="panel-heading">Mappability (<a href="http://genome.ucsc.edu/cgi-bin/hgTrackUi?g=genomicSuperDups" target="_blank">fracMatch</a>)</div>
@@ -773,7 +773,7 @@
       <ul class="list-group">
         <li class="list-group-item">
           Variant inheritance models
-          <span class="pull-right">
+          <span class="float-right">
             {% for model in variant.genetic_models|sort %}
               <span class="badge badge-info">{{ model }}</span>
             {% else %}
@@ -790,11 +790,11 @@
           <tr>
             <td>
               Length
-              <span class="pull-right">{{ variant.azlength }}</span>
+              <span class="float-right">{{ variant.azlength }}</span>
             </td>
             <td>
               Qual
-              <span class="pull-right">{{ variant.azqual }}</span>
+              <span class="float-right">{{ variant.azqual }}</span>
             </td>
           </tr>
         </tbody>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -120,7 +120,7 @@
 
   {% elif variant.manual_rank %}
 
-    <span class="badge badge-secondary pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge badge-secondary float-right" title="Manual rank">{{ variant.manual_rank }}</span>
   {% endif %}
   {% if variant.evaluations %}
     {% for evaluation in (variant.evaluations or []) %}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -436,7 +436,7 @@ def verify(institute_id, case_name, variant_id, variant_category, order):
 
     try:
         controllers.variant_verification(store=store, mail=mail, institute_obj=institute_obj, case_obj=case_obj, user_obj=user_obj, comment=comment,
-                           variant_obj=variant_obj, sender=current_app.config['MAIL_USERNAME'], variant_url=request.referrer, order=order, url_builder=url_for)
+                           variant_obj=variant_obj, sender=current_app.config.get('MAIL_USERNAME'), variant_url=request.referrer, order=order, url_builder=url_for)
     except controllers.MissingVerificationRecipientError:
         flash('No verification recipients added to institute.', 'danger')
 

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -433,7 +433,6 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     assert sum(1 for i in adapter.cases()) == 0
     adapter.case_collection.insert_one(case_obj)
     assert sum(1 for i in adapter.cases()) == 1
-    logger.info("Testing to update case")
 
     res = adapter.case(case_obj['_id'])
     assert res['status'] == 'inactive'
@@ -447,10 +446,14 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     # request rerun for test case
     adapter.request_rerun(institute_obj, res, user_obj, 'blank')
     res = adapter.case(case_obj['_id'])
-
+    # THEN rerun_reuquested is flagged
     assert res['rerun_requested'] == True
+    # Make sure case is still archived
+    assert res['status'] == 'archived'
 
-    # Make sure case is not archived
+    # and WHEN updating the case agagin
+    adapter.update_case(case_obj)
+    # THEN it is inactivated
     assert res['status'] == 'inactive'
 
     # Make sure user becomes assignee of the case

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -446,7 +446,7 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     # request rerun for test case
     adapter.request_rerun(institute_obj, res, user_obj, 'blank')
     res = adapter.case(case_obj['_id'])
-    # THEN rerun_reuquested is flagged
+    # THEN rerun_requested is flagged
     assert res['rerun_requested'] == True
     # Make sure case is still archived
     assert res['status'] == 'archived'

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -451,11 +451,6 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     # Make sure case is still archived
     assert res['status'] == 'archived'
 
-    # and WHEN updating the case agagin
-    adapter.update_case(case_obj)
-    # THEN it is inactivated
-    assert res['status'] == 'inactive'
-
     # Make sure user becomes assignee of the case
     assert user_obj['email'] in res['assignees']
 
@@ -463,6 +458,12 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
     with pytest.raises(ValueError):
         adapter.request_rerun(institute_obj, res, user_obj, 'blank')
 
+    # and WHEN updating the case agagin
+    res = adapter.update_case(case_obj)
+
+    # THEN it is inactivated
+    res = adapter.case(case_obj['_id'])
+    assert res['status'] == 'inactive'
 
 def test_get_similar_cases(hpo_database, test_hpo_terms, case_obj):
     adapter = hpo_database


### PR DESCRIPTION
This PR fixes a bug.

**How to test**:
1. Activate (or archive) a case.
1. Request rerun, and ensure that case does not become inactive.
1. See that the case gets a rerun-pending badge on cases list.
1. Re-upload case, e.g.  ```scout --demo load case --update scout/demo/643594.config.yaml```
and ensure that it now becomes inactive, a rerun badge is shown but no pending badge.

**Expected outcome**:
The functionality should be working.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR

