### PR TITLE
Skip omim genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed a bug preventing loading samples using the command line
 - Better inheritance models customization for genes in gene panels
 - STR variant page back to list button now does its one job.
+- Allows to setup scout without a omim api key
 
 
 ## [4.7.3]

--- a/scout/commands/setup/setup_scout.py
+++ b/scout/commands/setup/setup_scout.py
@@ -48,8 +48,8 @@ def database(context, institute_name, user_name, user_mail, api_key):
     # Fetch the omim information
     api_key = api_key or current_app.config.get('OMIM_API_KEY')
     if not api_key:
-        LOG.warning("Please provide a omim api key with --api-key")
-        raise click.Abort()
+        LOG.warning("No omim api key provided. This means information will be lost in scout")
+        LOG.info("Please request an OMIM api key and run scout update genes")
 
     institute_name = institute_name or context.obj['institute_name']
     user_name = user_name or context.obj['user_name']

--- a/scout/load/hgnc_gene.py
+++ b/scout/load/hgnc_gene.py
@@ -106,7 +106,7 @@ def load_hgnc_genes(adapter, genes = None, ensembl_lines=None, hgnc_lines=None, 
             exac_lines=exac_lines,
             hpo_lines=hpo_lines,
             mim2gene_lines=mim2gene_lines,
-            genemap_lines=genemap_lines,
+            genemap_lines=genemap_lines
         )
 
     non_existing = 0

--- a/scout/load/hgnc_gene.py
+++ b/scout/load/hgnc_gene.py
@@ -89,10 +89,11 @@ def load_hgnc_genes(adapter, genes = None, ensembl_lines=None, hgnc_lines=None, 
         exac_lines = exac_lines or fetch_exac_constraint()
         if not (mim2gene_lines and genemap_lines):
             if not omim_api_key:
-                raise SyntaxError("Need to provide omim api key")
-            mim_files = fetch_mim_files(omim_api_key, mim2genes=True, genemap2=True)
-            mim2gene_lines = mim_files['mim2genes']
-            genemap_lines = mim_files['genemap2']
+                LOG.warning("No omim api key provided!")
+            else:
+                mim_files = fetch_mim_files(omim_api_key, mim2genes=True, genemap2=True)
+                mim2gene_lines = mim_files['mim2genes']
+                genemap_lines = mim_files['genemap2']
         if not hpo_lines:
             hpo_files = fetch_hpo_files(hpogenes=True)
             hpo_lines = hpo_files['hpogenes']
@@ -103,9 +104,9 @@ def load_hgnc_genes(adapter, genes = None, ensembl_lines=None, hgnc_lines=None, 
             ensembl_lines=ensembl_lines,
             hgnc_lines=hgnc_lines,
             exac_lines=exac_lines,
+            hpo_lines=hpo_lines,
             mim2gene_lines=mim2gene_lines,
             genemap_lines=genemap_lines,
-            hpo_lines=hpo_lines
         )
 
     non_existing = 0

--- a/scout/load/hpo.py
+++ b/scout/load/hpo.py
@@ -44,6 +44,10 @@ def load_hpo(adapter, disease_lines, hpo_disease_lines=None, hpo_lines=None, hpo
 
     load_hpo_terms(adapter, hpo_lines, hpo_gene_lines, alias_genes)
 
+    if not disease_lines:
+        LOG.warning("No omim information, skipping to load disease terms")
+        return
+
     load_disease_terms(adapter, disease_lines, alias_genes, hpo_disease_lines)
 
 def load_hpo_terms(adapter, hpo_lines=None, hpo_gene_lines=None, alias_genes=None):

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -80,16 +80,18 @@ def setup_scout(adapter, institute_id='cust000', user_name='Clark Kent',
     adapter.add_user(user_obj)
 
     ### Get the mim information ###
-
+    mim2gene_lines = None
+    genemap_lines = None
     if not demo:
         # Fetch the mim files
-        try:
-            mim_files = fetch_mim_files(api_key, mim2genes=True, morbidmap=True, genemap2=True)
-        except Exception as err:
-            LOG.warning(err)
-            raise err
-        mim2gene_lines = mim_files['mim2genes']
-        genemap_lines = mim_files['genemap2']
+        if api_key:
+            try:
+                mim_files = fetch_mim_files(api_key, mim2genes=True, morbidmap=True, genemap2=True)
+            except Exception as err:
+                LOG.warning(err)
+                raise err
+            mim2gene_lines = mim_files['mim2genes']
+            genemap_lines = mim_files['genemap2']
 
         # Fetch the genes to hpo information
         hpo_gene_lines = fetch_hpo_genes()
@@ -97,7 +99,6 @@ def setup_scout(adapter, institute_id='cust000', user_name='Clark Kent',
         hgnc_lines = fetch_hgnc()
         # Fetch the latest exac pli score information
         exac_lines = fetch_exac_constraint()
-
 
     else:
         mim2gene_lines = [line for line in get_file_handle(mim2gene_reduced_path)]

--- a/scout/utils/link.py
+++ b/scout/utils/link.py
@@ -67,6 +67,9 @@ def add_ensembl_info(genes, ensembl_lines):
     ensembl_genes = parse_ensembl_genes(ensembl_lines)
 
     for ensembl_gene in ensembl_genes:
+        if not 'hgnc_id' in ensembl_gene:
+            continue
+        pp(ensembl_gene)
         gene_obj = genes.get(ensembl_gene['hgnc_id'])
         if not gene_obj:
             continue
@@ -161,8 +164,8 @@ def get_correct_ids(hgnc_symbol, alias_genes):
             return set(hgnc_id_info['ids'])
     return hgnc_ids
 
-def link_genes(ensembl_lines, hgnc_lines, exac_lines, mim2gene_lines,
-               genemap_lines, hpo_lines):
+def link_genes(ensembl_lines, hgnc_lines, exac_lines, hpo_lines, mim2gene_lines=None, 
+               genemap_lines=None):
     """Gather information from different sources and return a gene dict
 
     Extract information collected from a number of sources and combine them
@@ -203,9 +206,10 @@ def link_genes(ensembl_lines, hgnc_lines, exac_lines, mim2gene_lines,
 
     add_exac_info(genes, symbol_to_id, exac_lines)
 
-    add_omim_info(genes, symbol_to_id, genemap_lines, mim2gene_lines)
-
     add_incomplete_penetrance(genes, symbol_to_id, hpo_lines)
+    
+    if (mim2gene_lines and genemap_lines):
+        add_omim_info(genes, symbol_to_id, genemap_lines, mim2gene_lines)
 
     return genes
 

--- a/tests/commands/test_setup_cmd.py
+++ b/tests/commands/test_setup_cmd.py
@@ -2,20 +2,29 @@
 
 from scout.commands import cli
 
-def test_setup_database(mock_app):
+def test_setup_database_invalid_omim_key(mock_app):
     """Testing the cli to setup a full scale database"""
 
     runner = mock_app.test_cli_runner()
     assert runner
-
-    # test the CLI command:
-    result =  runner.invoke(cli, ['setup', 'database'], input='y')
-    # It should fail because no OMIM API key is provided
-    assert 'Please provide a omim api key with --api-key' in result.output
 
     # test the CLI command with non-valid API key
     result =  runner.invoke(cli, ['setup', 'database',
         '--api-key', 'not_a_valid_key'], input='y')
     # Make sure that setup enters in setup function correctly but stops because
     # there is no valid OMIM API KEY
+    assert result.exit_code != 0
     assert 'Seems like url https://data.omim.org/downloads/not_a_valid_key/morbidmap.txt does not exist' in result.output
+
+def test_setup_database(mock_app):
+    """Testing the cli to setup a full scale database"""
+
+    runner = mock_app.test_cli_runner()
+    assert runner
+
+    # test the CLI command for seting up scout
+    result =  runner.invoke(cli, ['setup', 'demo'], input='y')
+    # Make sure that setup function works correctly
+    assert result.exit_code == 0
+    assert 'Scout instance setup successful' in result.output
+    


### PR DESCRIPTION
This PR fixes so that it is possible to setup scout without an OMIM api key

**How to test**:
1. Install this branch
1. Setup scout in the usual way but without an api key:
    1. `scout -db gene-test setup database`
    1. `scout -db gene-test load panel scout/demo/panel_1.txt` 
    1. `scout -db gene-test load case scout/demo/643594.config.yaml`
    1. `scout -db gene-test serve`

**Expected outcome**:
Everything should work as usual but there will not be any OMIM information. This means reduced gene information and no disease terms.

**Comments**

Don't forget to apply for a api-key from OMIM: https://omim.org/downloads/
And when you have it run:

`scout update genes --api-key <your key>`
`scout update diseases --api-key <your key>`


**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil

