### PR TITLE
Removes flask version from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - STR variant page back to list button now does its one job.
 - Allows to setup scout without a omim api key
 - Fixed error causing "favicon not found" flash messages
+- Removed flask --version from base cli
 
 
 ## [4.7.3]

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -65,7 +65,7 @@ def get_app(ctx):
 
 
 @click.version_option(__version__)
-@click.group(cls=FlaskGroup, create_app=get_app, invoke_without_command=True, add_default_commands=False)
+@click.group(cls=FlaskGroup, create_app=get_app, invoke_without_command=True, add_default_commands=False, add_version_option=False)
 @click.option('-c', '--config', type=click.Path(exists=True),
               help="Specify the path to a config file with database info.")
 @click.option('--loglevel', default='DEBUG', type=click.Choice(LOG_LEVELS),


### PR DESCRIPTION
This PR adds a fixes a bug at cli where `--version` shows twice, and one is from flask.

**How to test**:
```
scout --help
```

**Expected outcome**:
There should be one `--version` in output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR

This is a patch bump, as it is clearing up help and an inactive command line option,