### PR TITLE
Reintroduce tooltip in cancer variants page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed error causing "favicon not found" flash messages
 - Removed flask --version from base cli
 - Request rerun no longer changes case status. Active or archived cases inactivate on upload.
+- Fixed missing tooltip on the cancer variants page
 
 
 ## [4.7.3]

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -232,6 +232,7 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
   <script>
     $(function () {
+      $('[data-toggle="tooltip"]').tooltip();
       $('select[multiple]').multiselect({
         buttonWidth: '100%'
       });


### PR DESCRIPTION
Bug fix #1417

**How to test**:
1. From a demo instance of scout, load the demo cancer sample:
```
scout --demo load case scout/demo/cancer.load_config.yaml
```
1. From master branch go to the variants of this case
1. try to hover above cancer variants frequencies and observe that popup doesn't work
1. Switch to this branch and see the difference

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
