### PR TITLE
Mark SV variants as partial causative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show a frequency tooltip hover for SV-variants.
 - Added support for LDAP login system
 - Search snv and structural variants by chromosomal coordinates
+- structural variants can be marked as partial causative if phenotype is available for case.
 
 ### fixed
 - Fixed missing import for variants with comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show a frequency tooltip hover for SV-variants.
 - Added support for LDAP login system
 - Search snv and structural variants by chromosomal coordinates
-- structural variants can be marked as partial causative if phenotype is available for case.
+- Structural variants can be marked as partial causative if phenotype is available for case.
 
 ### fixed
 - Fixed missing import for variants with comments

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -323,7 +323,7 @@
         <li class="list-group-item">
           {% if variant._id %}
             <div class="row align-items-between align-items-center">
-              <div class="col-8">
+              <div class="col-10">
                 <i class="fa fa-check-circle-o"></i>
 		            {% if variant.category == "snv" %}
                   <a href="{{ url_for('variants.variant',
@@ -345,7 +345,7 @@
                   <span class="badge badge-success">Validated</span>
                 {% endif %}
               </div>
-              <div class="col-4">
+              <div class="col-2">
                 {{ remove_form(url_for('cases.mark_causative',
                                        institute_id=institute._id,
                                        case_name=case.display_name,
@@ -366,7 +366,7 @@
         <div class="list-group-item">
           {% if variant._id %}
             <div class="row align-items-between align-items-center">
-              <div class="col-8">
+              <div class="col-10">
                 <i class="fa fa-check-circle-o"></i>
                 {% if variant.category == "snv" %}
                   <a href="{{ url_for('variants.variant',
@@ -384,7 +384,7 @@
 		             {% endif %}
                  </a>
               </div>
-              <div class="col-4">
+              <div class="col-2">
                 {{ remove_form(url_for('cases.mark_causative',
                                        institute_id=institute._id,
                                        case_name=case.display_name,

--- a/scout/server/blueprints/variants/templates/variants/sv-variant.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variant.html
@@ -1,5 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_panel, pedigree_panel %}
+{% from "variants/utils.html" import modal_causative %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ variant.display_name }}
@@ -264,7 +265,7 @@
     {# Email setting must be setup #}
     {{ modal_cancel_verify() }}
   {% endif %}
-
+{{ modal_causative(case, institute, variant) }}
 {% endblock %}
 
 {% macro pin_button() %}
@@ -299,17 +300,21 @@
           Reset causative
         </button>
       </form>
-  {% else %}
-    <form action="{{ url_for('cases.mark_causative',
-                             institute_id=institute._id,
-                             case_name=case.display_name,
-                             variant_id=variant._id,
-                             partial_causative=False) }}"
-          method="POST">
-      <button name="action" value="ADD" type="submit" class="btn btn-light navbar-btn" title="Mark causative" onclick="return confirm('Are you sure?')">
+      {% elif variant._id in case.partial_causatives %}
+        <form action="{{ url_for('cases.mark_causative',
+                                 institute_id=institute._id,
+                                 case_name=case.display_name,
+                                 variant_id=variant._id,
+                                 partial_causative=True) }}"
+              method="POST">
+        <button name="action" value="DELETE" type="submit" class="btn btn-light navbar-btn" title="Reset causative">
+          Reset partial causative
+        </button>
+      </form>
+      {% else %}
+      <button class="btn btn-light navbar-btn" data-toggle="modal" data-target="#causativeModal">
         Mark causative
       </button>
-    </form>
   {% endif %}
 {% endmacro %}
 
@@ -653,5 +658,17 @@
         width: '100%'
       });
     })
+
+    function validate_causative_form(){
+      var partial_checkbox = document.getElementById("partial_causative");
+      if (partial_checkbox.checked == true){
+        var nOmimTerms = $('#omim_select option:selected').length;
+        var nHpoTerms = $('#hpo_select option:selected').length;
+        if ( nOmimTerms== 0 & nHpoTerms==0){
+          alert('Select at least a phenotype term or diagnosis')
+          return false
+        }
+      }
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
This PR adds a new feature (fix #1408)

1. Install the branch on stage
1. Mark one or more (SV) variants as causative or partial causative
1. Make sure that you have to associate a phenotype (HPO terms or OMIM diagnosis) to each partial causative.
1. Make sure case is not marked as solved when a partial causative variant is assigned.
1. Make sure that specific links to phenotypes on case page work.
1. Make sure events are correctly recorded.
1. Make sure you can remove causative and partial causative variants.
**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
