### PR TITLE
Loading fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Next and first buttons order swap
 - Added pagination (and POST capability) to cancer variants.
 - Improves loading speed for variant page
+- Problem with updating variant rank when no variants
 
 ## [4.7.3]
 

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -338,7 +338,7 @@ class VariantLoader(object):
         Returns:
             object_ids
         """
-        if not len(variants) > 0:
+        if len(variants) == 0:
             return
 
         LOG.debug("Loading variant bulk")
@@ -362,7 +362,23 @@ class VariantLoader(object):
 
         This is the function that loops over the variants, parse them and build the variant
         objects so they are ready to be inserted into the database.
-
+        
+        Args:
+            variants(iterable(cyvcf2.Variant))
+            variant_type(str): ['clinical', 'research']
+            case_obj(dict)
+            individual_positions(dict): How individuals are positioned in vcf
+            rank_treshold(int): Only load variants with a rank score > than this
+            institute_id(str)
+            build(str): Genome build
+            rank_results_header(list): Rank score categories
+            vep_header(list)
+            category(str): ['snv','sv','cancer','str']
+            sample_info(dict): A dictionary with info about samples.
+                               Strictly for cancer to tell which is tumor
+        
+        Returns:
+            nr_inserted(int)
         """
         build = build or '37'
         genes = [gene_obj for gene_obj in self.all_genes(build=build)]

--- a/tests/adapter/mongo/test_variant_loader.py
+++ b/tests/adapter/mongo/test_variant_loader.py
@@ -1,0 +1,29 @@
+from pprint import pprint as pp
+from cyvcf2 import VCF
+
+def test_update_variant_rank_no_variants(real_populated_database):
+    adapter = real_populated_database
+    ## GIVEN a database without any variants
+    assert sum(1 for i in adapter.variant_collection.find()) == 0
+    case_obj = {'_id': 'test'}
+    ## WHEN Trying to update variant rank for nen existing variants
+    adapter.update_variant_rank(case_obj, variant_type='clinical', category='snv')
+    ## THEN assert that the operation was succesfull
+    assert True
+    
+
+def test_load_variants_high_treshold(real_populated_database, case_obj):
+    ## GIVEN a populated database and a case
+    adapter = real_populated_database
+    ## WHEN Trying to load variants where no one are above the rank score treshold
+    vcf = VCF(case_obj['vcf_files']['vcf_sv'])
+    rankscore_treshold = 1000000
+    individual_positions = {
+        'ADM1059A2': 0,
+        'ADM1059A1': 1,
+        'ADM1059A1': 1,
+    }
+    ## THEN assert that no variants are inserted
+    nr_inserted = adapter._load_variants(vcf, 'clinical', case_obj, individual_positions, 
+                                         rankscore_treshold, 'cut000')
+    assert nr_inserted == 0

--- a/tests/adapter/mongo/test_variant_loader.py
+++ b/tests/adapter/mongo/test_variant_loader.py
@@ -21,7 +21,7 @@ def test_load_variants_high_treshold(real_populated_database, case_obj):
     individual_positions = {
         'ADM1059A2': 0,
         'ADM1059A1': 1,
-        'ADM1059A1': 1,
+        'ADM1059A3': 2,
     }
     ## THEN assert that no variants are inserted
     nr_inserted = adapter._load_variants(vcf, 'clinical', case_obj, individual_positions, 


### PR DESCRIPTION
This PR fixes a bug that scout raised an `pymongo.errors.InvalidOperation` when updating variant ranks for a case without variants

**How to test**:
1. travis tests

**Review:**
- [x] code approved by @b4ckm4n 
- [ ] tests executed by Travis
