### PR TITLE
Fix #1343 - Allow case collaborators to view variants on their gene-variants view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improves loading speed for variant page
 - Problem with updating variant rank when no variants
 - Improved Clinvar submission form
+- Also show collaborative case variants on the All variants view.
 
 
 ## [4.7.3]


### PR DESCRIPTION
This PR adds a functionality / removes a limitation.

**How to test**:
1. On a populated server, search for a gene in the gene-variants view and note that collaborator cases are shown.

**Expected outcome**:
The functionality should be working

**Review:**
- [ ] code approved by
- [ ] tests executed by

