### PR TITLE
bugfix: Case loading crashes if CLNACC is an integer

### DIFF
--- a/scout/parse/variant/clnsig.py
+++ b/scout/parse/variant/clnsig.py
@@ -42,7 +42,7 @@ def parse_clnsig(variant, transcripts=None):
         return clnsig_accsessions
 
     # There are some versions where clinvar uses integers to represent terms
-    if acc.isdigit():
+    if isinstance(acc, int) or acc.isdigit():
         revstat_groups = []
         if revstat:
             revstat_groups = [rev.lstrip('_') for rev in revstat.split(',')]


### PR DESCRIPTION
We have CLNACC as an integer in our VCFs. Since 59559116901fe189fa7b46e7f7bdeb3bed6e95a6 this causes case loading to crash with this error:

```
  File "/opt/scout/scout/parse/variant/clnsig.py", line 45, in parse_clnsig
    if acc.isdigit():
AttributeError: 'int' object has no attribute 'isdigit'
```

Which makes sense, since isdigit() is a string method. 

This PR fixes this error. :)

- [x] code review dNil
- [x] tests by bjhall