### PR TITLE
Check dismissed variant code when printing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improves loading speed for variant page
 - Problem with updating variant rank when no variants
 - Improved Clinvar submission form
+- General report crashing when dismissed variant has no valid dismiss code
 
 
 ## [4.7.3]

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -445,120 +445,122 @@
             <td>
               {% for reason in variant.dismiss_variant %}
                 <ul>
-                  <li>{{dismissed_options[reason|int]['description']}}
-                    {% if reason == '2' and variant.category == 'snv'%} <!--variant dismissed as too common in public databases-->
-                      <table class="table-borderless table-sm">
-                        <thead>
-                          <tr style="background-color: transparent">
-                            <th>Frequency
-                              {% if variant.frequency == 'common' %}
-                                <span class="badge badge-danger">{{variant.frequency}}</span>
-                              {% elif variant.frequency == 'uncommon' %}
-                                <span class="badge badge-warning">{{variant.frequency}}</span>
-                              {% else %}
-                                <span class="badge badge-success">{{variant.frequency}}</span>
-                              {% endif %}
-                            </th>
-                            <th>
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr style="background-color: transparent">
-                            <td>
-                              {% if variant.dbsnp_id %}
-                                <a href="{{ variant.thousandg_link }}" target="_blank">1000G</a>
-                              {% else %}
-                                1000G
-                              {% endif %}
-                            </td>
-                            <td>
-                              {% if variant.max_thousand_genomes_frequency %}
-                                {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small> |
-                              {% endif %}
-                              {{ variant.thousand_genomes_frequency|human_decimal if variant.thousand_genomes_frequency }}
-                              {% if not variant.max_thousand_genomes_frequency and not variant.thousand_genomes_frequency %}
-                                <span class="text-muted">Not annotated</span>
-                              {% endif %}
-                            </td>
-                          </tr>
-                          <tr style="background-color: transparent">
-                            <td><a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a></td>
-                            <td>
-                              {% if variant.max_exac_frequency %}
-                                {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small> |
-                              {% endif %}
-                              {{ variant.exac_frequency|human_decimal if variant.exac_frequency }}
-                              {% if not variant.max_exac_frequency and not variant.exac_frequency %}
-                                <span class="text-muted">Not annotated</span>
-                              {% endif %}
-                            </td>
-                          </tr>
-                          <tr style="background-color: transparent">
-                            <td><a title="genome Aggregation Database" target="_blank" href="{{ variant.gnomad_link }}">gnomAD</a></td>
-                            <td>
-                              {% if 'gnomad_frequency' in variant%}
-                                {% if variant.max_gnomad_frequency %}
-                                  {{ variant.max_gnomad_frequency|human_decimal }}
-                                  <small>(max)</small> |
+                  {% if reason is number %}
+                    <li>{{dismissed_options[reason|int]['description']}}
+                      {% if reason == '2' and variant.category == 'snv'%} <!--variant dismissed as too common in public databases-->
+                        <table class="table-borderless table-sm">
+                          <thead>
+                            <tr style="background-color: transparent">
+                              <th>Frequency
+                                {% if variant.frequency == 'common' %}
+                                  <span class="badge badge-danger">{{variant.frequency}}</span>
+                                {% elif variant.frequency == 'uncommon' %}
+                                  <span class="badge badge-warning">{{variant.frequency}}</span>
+                                {% else %}
+                                  <span class="badge badge-success">{{variant.frequency}}</span>
                                 {% endif %}
-                                {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency }}
-                              {% else %}
-                                <span class="text-muted">Not annotated</span>
-                              {% endif %}
-                            </td>
-                            <td>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </table>
-                      <br><br>
-                    {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
-                      (<span class="float-left">
-                      {% for model in variant.genetic_models|sort %}
-                        <span class="badge badge-info" title="{{genetic_models[model]}}"> {{model}}</span>
-                      {% else %}
-                        <span class="badge badge-warning">No models followed</span>
-                      {% endfor %})
-                      <br><br>
-
-                    {% elif reason== '23' %} <!-- inherited from unaffected -->
-                      <br>
-                      <table id="panel-table" class="table-borderless table-sm" >
-                        <thead>
-                          <tr style="background-color: transparent">
-                            <th rowspan="2">Sample</th>
-                              <th rowspan="2">Genotype (GT)</th>
-                              <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                              <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality</th>
+                              </th>
+                              <th>
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr style="background-color: transparent">
+                              <td>
+                                {% if variant.dbsnp_id %}
+                                  <a href="{{ variant.thousandg_link }}" target="_blank">1000G</a>
+                                {% else %}
+                                  1000G
+                                {% endif %}
+                              </td>
+                              <td>
+                                {% if variant.max_thousand_genomes_frequency %}
+                                  {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small> |
+                                {% endif %}
+                                {{ variant.thousand_genomes_frequency|human_decimal if variant.thousand_genomes_frequency }}
+                                {% if not variant.max_thousand_genomes_frequency and not variant.thousand_genomes_frequency %}
+                                  <span class="text-muted">Not annotated</span>
+                                {% endif %}
+                              </td>
                             </tr>
                             <tr style="background-color: transparent">
-                              <th>Ref.</th>
-                              <th>Alt.</th>
+                              <td><a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a></td>
+                              <td>
+                                {% if variant.max_exac_frequency %}
+                                  {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small> |
+                                {% endif %}
+                                {{ variant.exac_frequency|human_decimal if variant.exac_frequency }}
+                                {% if not variant.max_exac_frequency and not variant.exac_frequency %}
+                                  <span class="text-muted">Not annotated</span>
+                                {% endif %}
+                              </td>
                             </tr>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {% for sample in variant.samples %}
-                            <tr style="background-color: transparent" {% if sample.display_name in affected %} class="table-danger" {% endif %}>
-                              <td>{{ sample.display_name }}</td>
-                              <td class="text-center">{{ sample.genotype_call }}</td>
-                              {% if sample.allele_depths %}
-                                  {% for number in sample.allele_depths %}
-                                    <td class="text-center">{{ number }}</td>
-                                  {% endfor %}
-                              {% else %}
-                                  <td class="text-center"><small>N/A</small></td>
-                                  <td class="text-center"><small>N/A</small></td>
-                              {% endif %}
-                              <td class="text-center">{{ sample.genotype_quality }}</td>
+                            <tr style="background-color: transparent">
+                              <td><a title="genome Aggregation Database" target="_blank" href="{{ variant.gnomad_link }}">gnomAD</a></td>
+                              <td>
+                                {% if 'gnomad_frequency' in variant%}
+                                  {% if variant.max_gnomad_frequency %}
+                                    {{ variant.max_gnomad_frequency|human_decimal }}
+                                    <small>(max)</small> |
+                                  {% endif %}
+                                  {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency }}
+                                {% else %}
+                                  <span class="text-muted">Not annotated</span>
+                                {% endif %}
+                              </td>
+                              <td>
+                              </td>
                             </tr>
-                          {% endfor %}
-                        </tbody>
-                      </table>
-                      <br><br>
-                    {% endif %}
-                  </li>
+                          </tbody>
+                        </table>
+                        <br><br>
+                      {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
+                        (<span class="float-left">
+                        {% for model in variant.genetic_models|sort %}
+                          <span class="badge badge-info" title="{{genetic_models[model]}}"> {{model}}</span>
+                        {% else %}
+                          <span class="badge badge-warning">No models followed</span>
+                        {% endfor %})
+                        <br><br>
+
+                      {% elif reason== '23' %} <!-- inherited from unaffected -->
+                        <br>
+                        <table id="panel-table" class="table-borderless table-sm" >
+                          <thead>
+                            <tr style="background-color: transparent">
+                              <th rowspan="2">Sample</th>
+                                <th rowspan="2">Genotype (GT)</th>
+                                <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
+                                <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality</th>
+                              </tr>
+                              <tr style="background-color: transparent">
+                                <th>Ref.</th>
+                                <th>Alt.</th>
+                              </tr>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {% for sample in variant.samples %}
+                              <tr style="background-color: transparent" {% if sample.display_name in affected %} class="table-danger" {% endif %}>
+                                <td>{{ sample.display_name }}</td>
+                                <td class="text-center">{{ sample.genotype_call }}</td>
+                                {% if sample.allele_depths %}
+                                    {% for number in sample.allele_depths %}
+                                      <td class="text-center">{{ number }}</td>
+                                    {% endfor %}
+                                {% else %}
+                                    <td class="text-center"><small>N/A</small></td>
+                                    <td class="text-center"><small>N/A</small></td>
+                                {% endif %}
+                                <td class="text-center">{{ sample.genotype_quality }}</td>
+                              </tr>
+                            {% endfor %}
+                          </tbody>
+                        </table>
+                        <br><br>
+                      {% endif %}
+                    </li>
+                  {% endif %}
                 </ul>
               {% endfor %}
             </td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -442,130 +442,130 @@
 	      {% endfor %}
 
 	    </td>
-            <td>
-              {% for reason in variant.dismiss_variant %}
-                <ul>
-                  {% if reason is number %}
-                    <li>{{dismissed_options[reason|int]['description']}}
-                      {% if reason == '2' and variant.category == 'snv'%} <!--variant dismissed as too common in public databases-->
-                        <table class="table-borderless table-sm">
-                          <thead>
-                            <tr style="background-color: transparent">
-                              <th>Frequency
-                                {% if variant.frequency == 'common' %}
-                                  <span class="badge badge-danger">{{variant.frequency}}</span>
-                                {% elif variant.frequency == 'uncommon' %}
-                                  <span class="badge badge-warning">{{variant.frequency}}</span>
-                                {% else %}
-                                  <span class="badge badge-success">{{variant.frequency}}</span>
-                                {% endif %}
-                              </th>
-                              <th>
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            <tr style="background-color: transparent">
-                              <td>
-                                {% if variant.dbsnp_id %}
-                                  <a href="{{ variant.thousandg_link }}" target="_blank">1000G</a>
-                                {% else %}
-                                  1000G
-                                {% endif %}
-                              </td>
-                              <td>
-                                {% if variant.max_thousand_genomes_frequency %}
-                                  {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small> |
-                                {% endif %}
-                                {{ variant.thousand_genomes_frequency|human_decimal if variant.thousand_genomes_frequency }}
-                                {% if not variant.max_thousand_genomes_frequency and not variant.thousand_genomes_frequency %}
-                                  <span class="text-muted">Not annotated</span>
-                                {% endif %}
-                              </td>
-                            </tr>
-                            <tr style="background-color: transparent">
-                              <td><a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a></td>
-                              <td>
-                                {% if variant.max_exac_frequency %}
-                                  {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small> |
-                                {% endif %}
-                                {{ variant.exac_frequency|human_decimal if variant.exac_frequency }}
-                                {% if not variant.max_exac_frequency and not variant.exac_frequency %}
-                                  <span class="text-muted">Not annotated</span>
-                                {% endif %}
-                              </td>
-                            </tr>
-                            <tr style="background-color: transparent">
-                              <td><a title="genome Aggregation Database" target="_blank" href="{{ variant.gnomad_link }}">gnomAD</a></td>
-                              <td>
-                                {% if 'gnomad_frequency' in variant%}
-                                  {% if variant.max_gnomad_frequency %}
-                                    {{ variant.max_gnomad_frequency|human_decimal }}
-                                    <small>(max)</small> |
-                                  {% endif %}
-                                  {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency }}
-                                {% else %}
-                                  <span class="text-muted">Not annotated</span>
-                                {% endif %}
-                              </td>
-                              <td>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
-                        <br><br>
-                      {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
-                        (<span class="float-left">
-                        {% for model in variant.genetic_models|sort %}
-                          <span class="badge badge-info" title="{{genetic_models[model]}}"> {{model}}</span>
+      <td>
+      {% for reason in variant.dismiss_variant %}
+        <ul>
+          {% if reason is number %}
+            <li>{{dismissed_options[reason|int]['description']}}
+              {% if reason == '2' and variant.category == 'snv'%} <!--variant dismissed as too common in public databases-->
+                <table class="table-borderless table-sm">
+                  <thead>
+                    <tr style="background-color: transparent">
+                      <th>Frequency
+                        {% if variant.frequency == 'common' %}
+                          <span class="badge badge-danger">{{variant.frequency}}</span>
+                        {% elif variant.frequency == 'uncommon' %}
+                          <span class="badge badge-warning">{{variant.frequency}}</span>
                         {% else %}
-                          <span class="badge badge-warning">No models followed</span>
-                        {% endfor %})
-                        <br><br>
+                          <span class="badge badge-success">{{variant.frequency}}</span>
+                        {% endif %}
+                      </th>
+                      <th>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr style="background-color: transparent">
+                      <td>
+                        {% if variant.dbsnp_id %}
+                          <a href="{{ variant.thousandg_link }}" target="_blank">1000G</a>
+                        {% else %}
+                          1000G
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if variant.max_thousand_genomes_frequency %}
+                          {{ variant.max_thousand_genomes_frequency|human_decimal }} <small>(max)</small> |
+                        {% endif %}
+                        {{ variant.thousand_genomes_frequency|human_decimal if variant.thousand_genomes_frequency }}
+                        {% if not variant.max_thousand_genomes_frequency and not variant.thousand_genomes_frequency %}
+                          <span class="text-muted">Not annotated</span>
+                        {% endif %}
+                      </td>
+                    </tr>
+                    <tr style="background-color: transparent">
+                      <td><a title="Exome Aggregation Consortium" target="_blank" href="{{ variant.exac_link }}">ExAC</a></td>
+                      <td>
+                        {% if variant.max_exac_frequency %}
+                          {{ variant.max_exac_frequency|human_decimal }} <small>(max)</small> |
+                        {% endif %}
+                        {{ variant.exac_frequency|human_decimal if variant.exac_frequency }}
+                        {% if not variant.max_exac_frequency and not variant.exac_frequency %}
+                          <span class="text-muted">Not annotated</span>
+                        {% endif %}
+                      </td>
+                    </tr>
+                    <tr style="background-color: transparent">
+                      <td><a title="genome Aggregation Database" target="_blank" href="{{ variant.gnomad_link }}">gnomAD</a></td>
+                      <td>
+                        {% if 'gnomad_frequency' in variant%}
+                          {% if variant.max_gnomad_frequency %}
+                            {{ variant.max_gnomad_frequency|human_decimal }}
+                            <small>(max)</small> |
+                          {% endif %}
+                          {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency }}
+                        {% else %}
+                          <span class="text-muted">Not annotated</span>
+                        {% endif %}
+                      </td>
+                      <td>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+                <br><br>
+                {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
+                  (<span class="float-left">
+                  {% for model in variant.genetic_models|sort %}
+                    <span class="badge badge-info" title="{{genetic_models[model]}}"> {{model}}</span>
+                  {% else %}
+                    <span class="badge badge-warning">No models followed</span>
+                  {% endfor %})
+                  <br><br>
 
-                      {% elif reason== '23' %} <!-- inherited from unaffected -->
-                        <br>
-                        <table id="panel-table" class="table-borderless table-sm" >
-                          <thead>
-                            <tr style="background-color: transparent">
-                              <th rowspan="2">Sample</th>
-                                <th rowspan="2">Genotype (GT)</th>
-                                <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                                <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality</th>
-                              </tr>
-                              <tr style="background-color: transparent">
-                                <th>Ref.</th>
-                                <th>Alt.</th>
-                              </tr>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {% for sample in variant.samples %}
-                              <tr style="background-color: transparent" {% if sample.display_name in affected %} class="table-danger" {% endif %}>
-                                <td>{{ sample.display_name }}</td>
-                                <td class="text-center">{{ sample.genotype_call }}</td>
-                                {% if sample.allele_depths %}
-                                    {% for number in sample.allele_depths %}
-                                      <td class="text-center">{{ number }}</td>
-                                    {% endfor %}
-                                {% else %}
-                                    <td class="text-center"><small>N/A</small></td>
-                                    <td class="text-center"><small>N/A</small></td>
-                                {% endif %}
-                                <td class="text-center">{{ sample.genotype_quality }}</td>
-                              </tr>
-                            {% endfor %}
-                          </tbody>
-                        </table>
-                        <br><br>
-                      {% endif %}
-                    </li>
-                  {% endif %}
-                </ul>
-              {% endfor %}
-            </td>
-          </tr>
-        {% endfor %}
+                {% elif reason== '23' %} <!-- inherited from unaffected -->
+                  <br>
+                  <table id="panel-table" class="table-borderless table-sm" >
+                    <thead>
+                      <tr style="background-color: transparent">
+                        <th rowspan="2">Sample</th>
+                          <th rowspan="2">Genotype (GT)</th>
+                          <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
+                          <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality</th>
+                        </tr>
+                        <tr style="background-color: transparent">
+                          <th>Ref.</th>
+                          <th>Alt.</th>
+                        </tr>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {% for sample in variant.samples %}
+                        <tr style="background-color: transparent" {% if sample.display_name in affected %} class="table-danger" {% endif %}>
+                          <td>{{ sample.display_name }}</td>
+                          <td class="text-center">{{ sample.genotype_call }}</td>
+                          {% if sample.allele_depths %}
+                              {% for number in sample.allele_depths %}
+                                <td class="text-center">{{ number }}</td>
+                              {% endfor %}
+                          {% else %}
+                              <td class="text-center"><small>N/A</small></td>
+                              <td class="text-center"><small>N/A</small></td>
+                          {% endif %}
+                          <td class="text-center">{{ sample.genotype_quality }}</td>
+                        </tr>
+                      {% endfor %}
+                    </tbody>
+                  </table>
+                  <br><br>
+                {% endif %}
+                </li>
+              {% endif %}
+            </ul>
+          {% endfor %}
+          </td>
+        </tr>
+      {% endfor %}
       </table>
     {% else %}
       No dismissed variants for this case


### PR DESCRIPTION
Bug fix #1444 

Looking at the files changes it looks like I changed a lot of stuff, but it's not this big deal, I've just added 2 lines of code:

- line 448: {% if reason is number %}
- line 569 {% endif %}

**How to test**:
1. To recreate this bug on a local instance of scout create the following key value in a variant object:
![image](https://user-images.githubusercontent.com/28093618/68200774-d2fb5080-ffc0-11e9-8c3e-854982ed3459.png)
1. Using master branch notice that it is not possible to open the general report for the demo case
1. Switch to this branch and make sure that general report is working and the variant is among the dismissed variants in the report. The reason why the variant is dismissed should be empty.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by CR
