### PR TITLE
Show total number of available cases in cases search footer

### DIFF
--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -32,7 +32,7 @@
       {{ search_form() }}
     </div>
     <div class="card-footer text-center">
-      Showing {{ limit if limit < found_cases else found_cases }} /  {{ found_cases }} cases
+      Showing {{ limit if limit < found_cases else found_cases }} /  {{ nr_cases }} cases
     </div>
   </div>
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -57,7 +57,6 @@ def cases(institute_id):
     all_cases = store.cases(collaborator=institute_id, name_query=query,
                         skip_assigned=skip_assigned, is_research=is_research)
 
-    LOG.info(type(all_cases))
     sort_by = request.args.get('sort')
     sort_order = request.args.get('order') or 'asc'
     if sort_by:
@@ -75,6 +74,7 @@ def cases(institute_id):
     data = controllers.cases(store, all_cases, limit)
     data['sort_order'] = sort_order
     data['sort_by'] = sort_by
+    data['nr_cases'] = store.nr_cases(institute_id=institute_id)
 
     sanger_unevaluated = controllers.get_sanger_unevaluated(store, institute_id, current_user.email)
     if len(sanger_unevaluated)> 0:

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -56,6 +56,15 @@ def test_get_cases(adapter, case_obj):
     assert sum(1 for i in result) == 1
 
 
+def test_nr_cases(adapter, case_obj):
+    ## GIVEN an empty database (no cases)
+    ## WHEN adding one case to the case collection
+    adapter.case_collection.insert_one(case_obj)
+    ## THEN the function nr_cases should return number of cases = 1
+    result = adapter.nr_cases(institute_id=case_obj['owner'])
+    assert result == 1
+
+
 def test_search_active_case(real_adapter, case_obj, institute_obj, user_obj):
     adapter = real_adapter
 


### PR DESCRIPTION
fix #1445

**Behavior before the fix**:
1. From a local instance of Scout load demo sample:
```
scout setup demo
```
1. Load another test sample as well:
```
scout --demo load case scout/demo/643595.config.yaml
```
1. You will now have these 2 samples:
![image](https://user-images.githubusercontent.com/28093618/68219324-1a480800-ffe6-11e9-919c-d1861a82a93a.png)

1. If you filter for cases with the name: 643594
1. Then in the footer of the search form there will be written **Showing 1 / 1 cases**

**Behavior after the fix**
1. Checkout to this branch and perform the same search.
1. Then in the footer of the search form there will be written **Showing 1 / 2 cases**

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @moonso 
