### PR TITLE
Search user email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - export causative variants to Excel
 - Add support for ROH, WIG and chromosome PNGs in case-view
 
-### fixed
+### Fixed
 - Fixed missing import for variants with comments
 - Instructions on how to build docs
 - Keep sanger order + verification when updating/reloading variants
@@ -53,7 +53,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - General report crashing when dismissed variant has no valid dismiss code
 - Also show collaborative case variants on the All variants view.
 - Improved phenotype search using dataTables.js on phenotypes page
-
+- Search and delete users with `email` instead of `_id`
 
 ## [4.7.3]
 

--- a/scout/adapter/mongo/user.py
+++ b/scout/adapter/mongo/user.py
@@ -14,7 +14,6 @@ class UserHandler(object):
     def update_user(self, user_obj):
         """Update an existing user.
 
-
             Args:
                 user_obj(dict)
 
@@ -79,7 +78,7 @@ class UserHandler(object):
                 user_obj(dict)
         """
         LOG.info("Fetching user %s", email)
-        user_obj = self.user_collection.find_one({'_id': email})
+        user_obj = self.user_collection.find_one({'email': email})
 
         return user_obj
 
@@ -94,6 +93,6 @@ class UserHandler(object):
 
         """
         LOG.info("Deleting user %s", email)
-        user_obj = self.user_collection.delete_one({'_id': email})
+        user_obj = self.user_collection.delete_one({'email': email})
 
         return user_obj

--- a/scout/adapter/mongo/user.py
+++ b/scout/adapter/mongo/user.py
@@ -68,17 +68,28 @@ class UserHandler(object):
         res = self.user_collection.find(query)
         return res
 
-    def user(self, email):
+    def user(self, email=None, user_id=None):
         """Fetch a user from the database.
 
             Args:
                 email(str)
+                user_id(str)
 
             Returns:
                 user_obj(dict)
         """
-        LOG.info("Fetching user %s", email)
-        user_obj = self.user_collection.find_one({'email': email})
+        if not (user_id or email):
+            LOG.warning("No key provided to fetch user")
+            return None
+        query = {}
+        if user_id:
+            LOG.info("Fetching user %s", user_id)
+            query['_id'] = user_id
+        else:
+            LOG.info("Fetching user %s", email)
+            query['email'] = email
+            
+        user_obj = self.user_collection.find_one(query)
 
         return user_obj
 

--- a/tests/adapter/mongo/test_user_handling.py
+++ b/tests/adapter/mongo/test_user_handling.py
@@ -21,8 +21,7 @@ def test_delete_user(adapter):
     ## THEN assert that there is only ine user left
     assert sum(1 for user in adapter.users()) == 1
 
-def test_update_user(real_adapter):
-    adapter = real_adapter
+def test_update_user(adapter):
     ## GIVEN an adapter with a user
     user_info = {
         'email': 'clark.kent@mail.com',

--- a/tests/adapter/mongo/test_user_handling.py
+++ b/tests/adapter/mongo/test_user_handling.py
@@ -21,7 +21,8 @@ def test_delete_user(adapter):
     ## THEN assert that there is only ine user left
     assert sum(1 for user in adapter.users()) == 1
 
-def test_update_user(adapter):
+def test_update_user(real_adapter):
+    adapter = real_adapter
     ## GIVEN an adapter with a user
     user_info = {
         'email': 'clark.kent@mail.com',

--- a/tests/adapter/mongo/test_user_handling.py
+++ b/tests/adapter/mongo/test_user_handling.py
@@ -1,7 +1,48 @@
 from scout.build.user import build_user
 
+def test_delete_user(adapter):
+    institutes = ['test-1', 'test-2']
+    ## GIVEN an adapter with two users
+    for i,ins in enumerate(institutes,1):
+        user_info = {
+            'email': 'clark.kent{}@mail.com'.format(i),
+            'id': 'clke0'+str(i),
+            'location': 'here',
+            'name': 'Clark Kent',
+            'institutes': [ins],
+            
+        }
+        user_obj = build_user(user_info)
+        user_obj = adapter.add_user(user_obj)
+    assert sum(1 for user in adapter.users()) == 2
+    ## WHEN deleting a user
+    adapter.delete_user(email='clark.kent1@mail.com')
+    
+    ## THEN assert that there is only ine user left
+    assert sum(1 for user in adapter.users()) == 1
 
-def test_get_insert_user(adapter):
+def test_update_user(adapter):
+    ## GIVEN an adapter with a user
+    user_info = {
+        'email': 'clark.kent@mail.com',
+        'location': 'here',
+        'name': 'Clark Kent',
+        'institutes': ['test-1'],
+        
+    }
+    user_obj = build_user(user_info)
+    user_obj = adapter.add_user(user_obj)
+    assert user_obj['institutes'] == ['test-1']
+    ## WHEN updating a user
+    user_info['institutes'].append('test-2')
+    user_obj = build_user(user_info)
+
+    adapter.update_user(user_obj)
+    ## THEN assert that the user is in the database
+    updated_user = adapter.user_collection.find_one()
+    assert set(updated_user['institutes']) == set(['test-1','test-2'])
+
+def test_insert_user(adapter):
     user_info = {
         'email': 'clark.kent@mail.com',
         'location': 'here',
@@ -12,18 +53,77 @@ def test_get_insert_user(adapter):
     user_obj = build_user(user_info)
     ## GIVEN a empty adapter
     
-    assert adapter.user(email=user_info['email']) is None
+    assert adapter.user_collection.find_one() is None
 
-    ## WHEN insaerting a user
+    ## WHEN inserting a user
     user_obj = adapter.add_user(user_obj)
 
     ## THEN assert that the user is in the database
-    
-    assert user_obj['_id'] == user_info['email']
+    assert adapter.user_collection.find_one()
 
+def test_get_users_institute(adapter):
+    institutes = ['test-1', 'test-2']
+    ## GIVEN an adapter with multiple users
+    for i,ins in enumerate(institutes,1):
+        user_info = {
+            'email': 'clark.kent{}@mail.com'.format(i),
+            'id': 'clke0'+str(i),
+            'location': 'here',
+            'name': 'Clark Kent',
+            'institutes': [ins],
+            
+        }
+        user_obj = build_user(user_info)
+        user_obj = adapter.add_user(user_obj)
+    ## WHEN fetching all users
+    users = adapter.users(institute=institutes[0])
+    
+    ## THEN assert that both users are fetched
+    assert sum(1 for user in users) == 1
+
+def test_get_users(adapter):
+    institutes = ['test-1', 'test-2']
+    ## GIVEN an adapter with multiple users
+    for i,ins in enumerate(institutes,1):
+        user_info = {
+            'email': 'clark.kent{}@mail.com'.format(i),
+            'id': 'clke0'+str(i),
+            'location': 'here',
+            'name': 'Clark Kent',
+            'institutes': [ins],
+            
+        }
+        user_obj = build_user(user_info)
+        user_obj = adapter.add_user(user_obj)
+    ## WHEN fetching all users
+    users = adapter.users()
+    
+    ## THEN assert that both users are fetched
+    assert sum(1 for user in users) == len(institutes) 
+
+
+def test_get_user_email(adapter):
+    user_info = {
+        'email': 'clark.kent@mail.com',
+        'id': 'clke01',
+        'location': 'here',
+        'name': 'Clark Kent',
+        'institutes': ['test-1'],
+        
+    }
+    user_obj = build_user(user_info)
+    user_obj = adapter.add_user(user_obj)
+    ## WHEN fetching the user with email
+    user = adapter.user(email='clark.kent@mail.com')
+    
+    ## THEN assert that the user is fetched
+    assert user
 
 def test_get_nonexisting_user(adapter):
-    """docstring for test_get_nonexisting_user"""
+    ## GIVEN an empty adapter
+    assert adapter.user_collection.find_one() is None
+    ## WHEN fetching a non existing user
     user_obj = adapter.user(email='john.doe@mail.com')
+    ## THEN assert the user is None
     assert user_obj == None
     

--- a/tests/adapter/mongo/test_user_handling.py
+++ b/tests/adapter/mongo/test_user_handling.py
@@ -101,6 +101,22 @@ def test_get_users(adapter):
     ## THEN assert that both users are fetched
     assert sum(1 for user in users) == len(institutes) 
 
+def test_get_user_id(adapter):
+    user_info = {
+        'email': 'clark.kent@mail.com',
+        'id': 'clke01',
+        'location': 'here',
+        'name': 'Clark Kent',
+        'institutes': ['test-1'],
+        
+    }
+    user_obj = build_user(user_info)
+    user_obj = adapter.add_user(user_obj)
+    ## WHEN fetching the user with email
+    user = adapter.user(user_id='clke01')
+    
+    ## THEN assert that the user is fetched
+    assert user
 
 def test_get_user_email(adapter):
     user_info = {


### PR DESCRIPTION
This PR fixes a problem when `_id != email` in the `user_objs`

**Expected outcome**:
Users can now be fetched even if the _id is not the email adress
Check tests in https://github.com/Clinical-Genomics/scout/blob/search-user-email/tests/adapter/mongo/test_user_handling.py

**Review:**
- [x] code approved by CR
- [x] tests executed by @travis, CR
