### PR TITLE
Always use datetime object when loading a case.

### DIFF
--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -14,8 +14,33 @@ from scout.constants import (PHENOTYPE_MAP, SEX_MAP, REV_SEX_MAP,
 from scout.parse.peddy import (parse_peddy_ped, parse_peddy_ped_check,
                                parse_peddy_sex_check)
 
-log = logging.getLogger(__name__)
+from scout.utils.date import get_date
 
+LOG = logging.getLogger(__name__)
+
+def get_correct_date(date_info):
+    """Convert dateinfo to correct date
+    
+    Args:
+        dateinfo: Something that represents a date
+    
+    Returns:
+        correct_date(datetime.datetime)
+    """
+    if isinstance(date_info, datetime.datetime):
+        return date_info
+
+    if isinstance(date_info, str):
+        try:
+            correct_date = get_date(date_info)
+        except ValueError as err:
+            LOG.warning('Analysis date is on wrong format')
+            LOG.info('Setting analysis date to todays date')
+            correct_date = datetime.datetime.now()
+        return correct_date
+
+    LOG.info('Setting analysis date to todays date')
+    return datetime.datetime.now()
 
 def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
                     vcf_sv=None, vcf_cancer=None, vcf_str=None, peddy_ped=None,
@@ -43,8 +68,7 @@ def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
     """
     config_data = copy.deepcopy(config) or {}
     # Default the analysis date to now if not specified in load config
-    if 'analysis_date' not in config_data:
-        config_data['analysis_date'] = datetime.datetime.now()
+    config_data['analysis_date'] = get_correct_date(config_data.get('analysis_date'))
 
     # If the family information is in a ped file we nned to parse that
     if ped:
@@ -81,7 +105,7 @@ def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
     config_data['vcf_snv'] = vcf_snv if vcf_snv else config_data.get('vcf_snv')
     config_data['vcf_sv'] = vcf_sv if vcf_sv else config_data.get('vcf_sv')
     config_data['vcf_str'] = vcf_str if vcf_str else config_data.get('vcf_str')
-    log.debug("Config vcf_str set to {0}".format(config_data['vcf_str']))
+    LOG.debug("Config vcf_str set to {0}".format(config_data['vcf_str']))
 
     config_data['vcf_cancer'] = vcf_cancer if vcf_cancer else config_data.get('vcf_cancer')
 
@@ -100,7 +124,11 @@ def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
 
 
 def add_peddy_information(config_data):
-    """Add information from peddy outfiles to the individuals"""
+    """Add information from peddy outfiles to the individuals
+    
+    Args:
+        config_data(dict)
+    """
     ped_info = {}
     ped_check = {}
     sex_check = {}
@@ -144,18 +172,20 @@ def add_peddy_information(config_data):
         # Check if peddy har confirmed parental relations
         for parent in ['mother', 'father']:
             # If we are looking at individual with parents
-            if ind[parent] != '0':
-                # Check if the child/parent pair is in peddy data
-                for pair in ped_check:
-                    if (ind_id in pair and ind[parent] in pair):
-                        # If there is a parent error we mark that
-                        if ped_check[pair]['parent_error']:
-                            analysis_inds[ind[parent]]['confirmed_parent'] = False
-                        else:
-                            # Else if parent confirmation has not been done
-                            if 'confirmed_parent' not in analysis_inds[ind[parent]]:
-                                # Set confirmatio to True
-                                analysis_inds[ind[parent]]['confirmed_parent'] = True
+            if ind[parent] == '0':
+                continue
+            # Check if the child/parent pair is in peddy data
+            for pair in ped_check:
+                if not (ind_id in pair and ind[parent] in pair):
+                    continue
+                # If there is a parent error we mark that
+                if ped_check[pair]['parent_error']:
+                    analysis_inds[ind[parent]]['confirmed_parent'] = False
+                    continue
+                # Else if parent confirmation has not been done
+                if 'confirmed_parent' not in analysis_inds[ind[parent]]:
+                    # Set confirmatio to True
+                    analysis_inds[ind[parent]]['confirmed_parent'] = True
 
 def parse_individual(sample):
     """Parse individual information
@@ -194,7 +224,7 @@ def parse_individual(sample):
         raise PedigreeError("Sample %s is missing 'sex'" % sample_id)
     sex = sample['sex']
     if sex not in REV_SEX_MAP:
-        log.warning("'sex' is only allowed to have values from {}"
+        LOG.warning("'sex' is only allowed to have values from {}"
                     .format(', '.join(list(REV_SEX_MAP.keys()))))
         raise PedigreeError("Individual %s has wrong formated sex" % sample_id)
 
@@ -204,7 +234,7 @@ def parse_individual(sample):
                             % sample_id)
     phenotype = sample['phenotype']
     if phenotype not in REV_PHENOTYPE_MAP:
-        log.warning("'phenotype' is only allowed to have values from {}"
+        LOG.warning("'phenotype' is only allowed to have values from {}"
                     .format(', '.join(list(REV_PHENOTYPE_MAP.keys()))))
         raise PedigreeError("Individual %s has wrong formated phenotype" % sample_id)
 
@@ -304,7 +334,7 @@ def parse_case(config):
         'rank_model_version': config.get('rank_model_version'),
         'rank_score_threshold': config.get('rank_score_threshold', 0),
         'sv_rank_model_version': config.get('sv_rank_model_version'),
-        'analysis_date': config['analysis_date'],
+        'analysis_date': config.get('analysis_date'),
         'individuals': individuals,
         'vcf_files': {
             'vcf_snv': config.get('vcf_snv'),
@@ -338,6 +368,8 @@ def parse_case(config):
 
     if (case_data['vcf_files']['vcf_cancer'] or case_data['vcf_files']['vcf_cancer_research']):
         case_data['track'] = 'cancer'
+    
+    case_data['analysis_date'] = get_correct_date(case_data.get('analysis_date'))
 
     return case_data
 

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -1,5 +1,6 @@
 import pytest
 
+from datetime import datetime
 from pprint import pprint as pp
 from scout.parse.case import (parse_case, parse_ped, parse_individuals,
                               parse_individual, parse_case_data,
@@ -7,7 +8,45 @@ from scout.parse.case import (parse_case, parse_ped, parse_individuals,
 from scout.exceptions import PedigreeError
 from scout.constants import REV_SEX_MAP
 
-def test_parse_case(scout_config):
+
+def test_parse_case_no_date(scout_config):
+    # GIVEN a load config without a date
+    scout_config.pop('analysis_date')
+    # WHEN case is parsed
+    case_data = parse_case(scout_config)
+    # THEN the todays date should have been set
+    assert 'analysis_date' not in scout_config
+    assert isinstance(case_data['analysis_date'], datetime)
+
+def test_parse_case_wrong_date_string(scout_config):
+    # GIVEN you load info thats not a date
+    scout_config['analysis_date'] = 'not a date'
+    # WHEN case is parsed
+    case_data = parse_case(scout_config)
+    # THEN the todays date should have been set
+    assert isinstance(scout_config['analysis_date'], str)
+    assert isinstance(case_data['analysis_date'], datetime)
+
+def test_parse_case_date_string(scout_config):
+    # GIVEN a load config with date string
+    # WHEN case is parsed
+    scout_config['analysis_date'] = '2019-11-05'
+    case_data = parse_case(scout_config)
+    # THEN the case should have a datetime object
+    assert isinstance(scout_config['analysis_date'], str)
+    assert isinstance(case_data['analysis_date'], datetime)
+
+
+def test_parse_case_date(scout_config):
+    # GIVEN you load sample information from a scout config
+    # WHEN case is parsed
+    case_data = parse_case(scout_config)
+    # THEN the case should have a owner
+    assert isinstance(scout_config['analysis_date'], datetime)
+    assert isinstance(case_data['analysis_date'], datetime)
+
+
+def test_parse_case_owner(scout_config):
     # GIVEN you load sample information from a scout config
     # WHEN case is parsed
     case_data = parse_case(scout_config)

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -41,7 +41,7 @@ def test_parse_case_date(scout_config):
     # GIVEN you load sample information from a scout config
     # WHEN case is parsed
     case_data = parse_case(scout_config)
-    # THEN the case should have a owner
+    # THEN the case should have an analysis_date
     assert isinstance(scout_config['analysis_date'], datetime)
     assert isinstance(case_data['analysis_date'], datetime)
 


### PR DESCRIPTION
This PR fixes a problem when analysis date is a string in load config.  Fix #1448

See tests for parse_case

**Expected outcome**:
Analysis dates will always be date time objects

**Review:**
- [x] code approved by dNil
- [x] tests executed by @travis
