### PR TITLE
fix conflict between scout css and selectpicker css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - General report crashing when dismissed variant has no valid dismiss code
 - Also show collaborative case variants on the All variants view.
 - Improved phenotype search using dataTables.js on phenotypes page
+- Fixed css styles so that multiselect options will all fit one column
 
 
 ## [4.7.3]

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -9,15 +9,15 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ case.display_name }}</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -19,28 +19,28 @@
 
   <div class="collapse navbar-collapse" id="navbarText">
     <ul class="navbar-nav mr-auto">
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#phenotype">Phenotype overview<span class="sr-only">(current)</span></a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#gene_panels">Gene panels</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#causative_variants">Causative Variants</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#pinned_variants">Pinned variants</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#acmg_variants">ACMG-classified variants</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#manual_ranked_variants">Manual ranked</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#commented_variants">Commented variants</a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item custom-li">
         <a class="nav-link" href="#dismissed_variants">Dismissed variants</a>
       </li>
     </ul>

--- a/scout/server/blueprints/cases/templates/cases/cases.html
+++ b/scout/server/blueprints/cases/templates/cases/cases.html
@@ -6,21 +6,21 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <a class="nav-link" href="#">{{ institute.display_name }} Cases</a>
   </li>
   {% if config.SHOW_CAUSATIVES %}
-    <li class="nav-item">
+    <li class="nav-item custom-li">
       <a class="nav-link" href="{{ url_for('cases.causatives', institute_id=institute._id) }}">Causatives</a>
     </li>
   {% endif %}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.gene_variants', institute_id=institute._id, variant_type=['clinical'], rank_score=15) }}">All SNVs and INDELs</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.clinvar_submissions', institute_id=institute._id) }}">Clinvar submissions</a>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -13,22 +13,22 @@
 
 {% block top_nav %}
 {{ super() }}
-<li class="nav-item">
+<li class="nav-item custom-li">
   <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
 </li>
-<li class="nav-item">
+<li class="nav-item custom-li">
   <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">{{ institute.display_name }}
     Cases</a>
 </li>
-<li class="nav-item active">
+<li class="nav-item custom-li active">
   <a class="nav-link" href="{{ url_for('cases.causatives', institute_id=institute._id) }}">Causatives</a>
 </li>
-<li class="nav-item">
+<li class="nav-item custom-li">
   <a class="nav-link"
     href="{{ url_for('cases.gene_variants', institute_id=institute._id, variant_type=['clinical'], rank_score=15) }}">All
     SNVs and INDELs</a>
 </li>
-<li class="nav-item">
+<li class="nav-item custom-li">
   <a class="nav-link" href="{{ url_for('cases.clinvar_submissions', institute_id=institute._id) }}">Clinvar
     submissions</a>
 </li>

--- a/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
+++ b/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
@@ -6,23 +6,23 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute_id) }}">
       {{ institute_id }} Cases
     </a>
   </li>
   {% if config.SHOW_CAUSATIVES %}
-    <li class="nav-item">
+    <li class="nav-item custom-li">
       <a class="nav-link" href="{{ url_for('cases.causatives', institute_id=institute_id) }}">Causatives</a>
     </li>
    {% endif %}
-    <li class="nav-item">
+    <li class="nav-item custom-li">
       <a class="nav-link" href="{{ url_for('cases.gene_variants', institute_id=institute_id, variant_type=['clinical'], rank_score=15) }}">All SNVs and INDELs</a>
     </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">Clinvar submissions</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/gene_variants.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_variants.html
@@ -8,20 +8,20 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }} Cases
     </a>
   </li>
   {% if config.SHOW_CAUSATIVES %}
-    <li class="nav-item">
+    <li class="nav-item custom-li">
       <a class="nav-link" href="{{ url_for('cases.causatives', institute_id=institute._id) }}">Causatives</a>
     </li>
    {% endif %}
-   <li class="nav-item active">
+   <li class="nav-item custom-li active">
      <span class="navbar-text">All SNVs and INDELs</span>
    </li>
    <li>

--- a/scout/server/blueprints/cases/templates/cases/index.html
+++ b/scout/server/blueprints/cases/templates/cases/index.html
@@ -7,7 +7,7 @@
 {% block top_nav %}
   {{ super() }}
 
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <a class="nav-link" href="#">Institutes</a>
   </li>
 

--- a/scout/server/blueprints/cases/templates/cases/matchmaker.html
+++ b/scout/server/blueprints/cases/templates/cases/matchmaker.html
@@ -6,20 +6,20 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name ) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">MatchMaker</span>
   </li>
 {% endblock %}
@@ -37,9 +37,9 @@
       </nav>
       <br>
       <ul class="nav nav-tabs" id="myTab" role="tablist">
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 1 %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>Patient Overview</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 2 %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>External Matches</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 3 %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Internal Matches</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 1 %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>Patient Overview</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 2 %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>External Matches</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 3 %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Internal Matches</h4></a></li>
       </ul>
       <div class="tab-content" id="tabs">
         <div class="tab-pane" id="1">

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -4,9 +4,9 @@
 {% set panel = panel|int %}
   <div class="container-float mt-3">
       <ul class="nav nav-tabs" id="myTab" role="tablist">
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 1 %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>General statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 2 %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>Case statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 3 %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Variant statistics</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 1 %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>General statistics</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 2 %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>Case statistics</h4></a></li>
+        <li class="nav-item custom-li"><a href="#" class="nav-link {% if panel == 3 %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Variant statistics</h4></a></li>
       </ul>
     <div class="tab-content" id="tabs">
       <div class="tab-pane" id="1">

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -5,10 +5,10 @@
 {% endblock %}
 
 {% block top_nav %}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('genes.genes') }}">Genes</a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ symbol }}</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/genes/templates/genes/genes.html
+++ b/scout/server/blueprints/genes/templates/genes/genes.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block top_nav %}
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">Genes</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/login/templates/login/users.html
+++ b/scout/server/blueprints/login/templates/login/users.html
@@ -6,7 +6,7 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">Users</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -6,13 +6,13 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('panels.panels') }}">Gene Panels</a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ panel.display_name }} {{ panel.version }}</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -6,10 +6,10 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">Gene Panels</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/phenotypes/templates/phenotypes/hpo_terms.html
+++ b/scout/server/blueprints/phenotypes/templates/phenotypes/hpo_terms.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block top_nav %}
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">HPO terms</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -21,17 +21,17 @@
 {% endfor %}
 
 {% block top_nav %}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     {% if cancer %}
       <a class="nav-link" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
         {{ variant.variant_type|capitalize }} cancer variants
@@ -42,7 +42,7 @@
       </a>
     {% endif %}
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <p class="navbar-text">{{ variant.display_name|truncate(20, True) }}</p>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -12,22 +12,22 @@
 {% endblock %}
 
 {% block top_nav %}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
       {{ variant.variant_type|capitalize }} structural variants
     </a>
   </li>
-  <li class="active nav-item">
+  <li class="active nav-item custom-li">
     <p class="navbar-text text-nowrap">{{ variant.display_name|truncate(20, True) }}</p>
   </li>
 {% endblock %}
@@ -35,10 +35,10 @@
 {% block top_nav_right %}
   {% if config['MAIL_USERNAME'] %}
     {# Email setting must be setup #}
-    <li class="nav-item text-nowrap">{{ verify_button() }}</li>
+    <li class="nav-item custom-li text-nowrap">{{ verify_button() }}</li>
   {% endif %}
-  <li class="nav-item text-nowrap">{{ pin_button() }}</li>
-  <li class="nav-item text-nowrap">{{ causative_button() }}</li>
+  <li class="nav-item custom-li text-nowrap">{{ pin_button() }}</li>
+  <li class="nav-item custom-li text-nowrap">{{ causative_button() }}</li>
   {{ super() }}
 {% endblock %}
 
@@ -239,8 +239,8 @@
       <div class="card">
         <nav>
           <div class="nav nav-tabs" id="nav-tab" role="tablist">
-            <a class="nav-item nav-link active" id="nav-genes-tab" data-toggle="tab" href="#nav-genes" role="tab" aria-controls="nav-genes" aria-selected="true">Genes</a>
-            <a class="nav-item nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
+            <a class="nav-item custom-li nav-link active" id="nav-genes-tab" data-toggle="tab" href="#nav-genes" role="tab" aria-controls="nav-genes" aria-selected="true">Genes</a>
+            <a class="nav-item custom-li nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
           </div>
         </nav>
         <div class="tab-content mt-3" id="nav-tabContent">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -13,17 +13,17 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     {% if cancer %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
         {{ variant.variant_type|capitalize }} cancer variants
@@ -38,7 +38,7 @@
       </a>
     {% endif %}
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <p class="navbar-text text-nowrap">{{ variant.display_name|truncate(20, True) }}</p>
   </li>
 {% endblock %}
@@ -46,10 +46,10 @@
 {% block top_nav_right %}
   {% if config['MAIL_USERNAME'] %}
     {# Email setting must be setup #}
-    <li class="nav-item text-nowrap">{{ sanger_button() }}</li>
+    <li class="nav-item custom-li text-nowrap">{{ sanger_button() }}</li>
   {% endif %}
-  <li class="nav-item">{{ pin_button() }}</li>
-  <li class="nav-item text-nowrap">{{ causative_button() }}</li>
+  <li class="nav-item custom-li">{{ pin_button() }}</li>
+  <li class="nav-item custom-li text-nowrap">{{ causative_button() }}</li>
   {{ super() }}
 {% endblock %}
 
@@ -102,9 +102,9 @@
         <div class="card ">
           <nav>
             <div class="nav nav-tabs" id="nav-tab" role="tablist">
-              <a class="nav-item nav-link active" id="nav-genes-tab" data-toggle="tab" href="#nav-genes" role="tab" aria-controls="nav-genes" aria-selected="true">Genes</a>
-              <a class="nav-item nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
-              <a class="nav-item nav-link" id="nav-proteins-tab" data-toggle="tab" href="#nav-proteins" role="tab" aria-controls="nav-proteins" aria-selected="false">Proteins</a>
+              <a class="nav-item custom-li nav-link active" id="nav-genes-tab" data-toggle="tab" href="#nav-genes" role="tab" aria-controls="nav-genes" aria-selected="true">Genes</a>
+              <a class="nav-item custom-li nav-link" id="nav-transcripts-tab" data-toggle="tab" href="#nav-transcripts" role="tab" aria-controls="nav-transcripts" aria-selected="false">Transcripts</a>
+              <a class="nav-item custom-li nav-link" id="nav-proteins-tab" data-toggle="tab" href="#nav-proteins" role="tab" aria-controls="nav-proteins" aria-selected="false">Proteins</a>
             </div>
 
           </nav>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -13,20 +13,20 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ form.variant_type.data|capitalize }} Cancer Variants</span>
   </li>
 {% endblock %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -9,20 +9,20 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ form.variant_type.data|capitalize }} STRs</span>
   </li>
 {% endblock %}
@@ -137,7 +137,7 @@
       {% if more_variants %}
         <div class="row">
             <div class="col-6">
-              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">	
+              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
                   First page
               </a>
               </div>
@@ -149,7 +149,7 @@
         </div>
       {% else %}
         <i class="text-muted">No more variants to display</i>
-        <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">	
+        <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
       First page
         </a>
       {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -14,26 +14,26 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ variant_type|capitalize }}  Structural variants</span>
   </li>
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item custom-li text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -14,26 +14,26 @@
 
 {% block top_nav %}
   {{ super() }}
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>
   </li>
-  <li class="nav-item">
+  <li class="nav-item custom-li">
     <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
       {{ case.display_name }}
     </a>
   </li>
-  <li class="nav-item active">
+  <li class="nav-item custom-li active">
     <span class="navbar-text">{{ form.variant_type.data|capitalize }} SNV and INDELs</span>
   </li>
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item custom-li text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 {% block content_main %}

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -114,7 +114,7 @@
 	margin-bottom: 0;
 }
 
-ul li {
+.custom-li {
   font-size: 16px;
   display: inline-block;
   padding: 5px 15px;

--- a/scout/server/templates/layout_bs4.html
+++ b/scout/server/templates/layout_bs4.html
@@ -26,7 +26,7 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav mr-auto">
-            <li class="nav-item dropdown">
+            <li class="nav-item custom-li dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="fa fa-bars"></span>
               </a>
@@ -48,7 +48,7 @@
           <ul class="navbar-nav navbar-right">
             {% block top_nav_right %}
               {% if current_user.is_authenticated %}
-                <li class="nav-item dropdown">
+                <li class="nav-item custom-li dropdown">
                   <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ current_user.name }} <span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     <li>


### PR DESCRIPTION
fix #1450

**How to test**:
1. Multiple selects look messy in current master when there are long and short options: for instance open variants page and variants filter. Clinsig filter looks like this, with options all over the place:
![image](https://user-images.githubusercontent.com/28093618/68256190-a0d50780-002f-11ea-86d1-4b916152ec9a.png)

1. Before checking out to this branch clear the history of the browser (cached images and files)
1. Checkout to this branch and refresh the variants page. 

**Expected outcome**:
1. Multiselects should look ordered with all options on one column:

![image](https://user-images.githubusercontent.com/28093618/68256321-150fab00-0030-11ea-88ec-68d9e7f8ed96.png)

Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
