### PR TITLE
fixed conflict between our css and multiselects css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - General report crashing when dismissed variant has no valid dismiss code
 - Also show collaborative case variants on the All variants view.
 - Improved phenotype search using dataTables.js on phenotypes page
+- Fixed css styles so that multiselect options will all fit one column
 
 
 ## [4.7.3]

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -114,7 +114,7 @@
 	margin-bottom: 0;
 }
 
-ul li {
+li.nav-item {
   font-size: 16px;
   display: inline-block;
   padding: 5px 15px;


### PR DESCRIPTION
fix #1450

**How to test**:
1. Multiple selects look messy in current master when there are long and short options: for instance open variants page and variants filter. Clinsig filter looks like this, with options all over the place:
![image](https://user-images.githubusercontent.com/28093618/68256190-a0d50780-002f-11ea-86d1-4b916152ec9a.png)

1. Before checking out to this branch clear the history of the browser (cached images and files)
1. Checkout to this branch and refresh the variants page. 

**Expected outcome**:
1. Multiselects should look ordered with all options on one column:

![image](https://user-images.githubusercontent.com/28093618/68256321-150fab00-0030-11ea-88ec-68d9e7f8ed96.png)

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by CR
