### PR TITLE
Prevent the AttributeError: 'NoneType' object has no attribute 'message'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Fixed
+- Prevent the app from crashing with `AttributeError: 'NoneType' object has no attribute 'message'`
 
 
 

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -97,8 +97,8 @@ def authorized():
     try:
         oauth_response = google.authorized_response()
     except OAuthException as error:
-        current_app.logger.warning(oauth_response.message)
-        flash("{} - try again!".format(oauth_response.message), 'warning')
+        current_app.logger.warning('Google OAuthException: {}'.format(error))
+        flash("{} - try again!".format(error), 'warning')
         return redirect(url_for('public.index'))
 
     if oauth_response is None:

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -105,7 +105,7 @@ def authorized():
         flash("Access denied: reason={} error={}"
               .format(request.args.get['error_reason'],
                       request.args['error_description']), 'danger')
-        return abort(403)
+        return redirect(url_for('public.index'))
 
     # add token to session, do it before validation to be able to fetch
     # additional data (like email) on the authenticated user


### PR DESCRIPTION
Bug fix #1465

**How to test**:
1. Install on stage and log in using a valid Google account (email) for a user which is in Scout database.
1. Install on stage and log in using a valid Google account (email) that is not in Scout database.

**Expected outcome**:
The functionality should be working and allow the Scout login only in the first case

**Review:**
- [x] code approved by dNil
- [x] tests executed by CR
