### PR TITLE
Flask login returns email as _id instead of risky ObjectId id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Fixed
+- Prevent login fail for users with id defined by ObjectId and not email
 - Prevent the app from crashing with `AttributeError: 'NoneType' object has no attribute 'message'`
 
 

--- a/scout/server/blueprints/login/models.py
+++ b/scout/server/blueprints/login/models.py
@@ -11,7 +11,7 @@ class LoginUser(UserMixin):
             setattr(self, key, value)
 
     def get_id(self):
-        return self._id
+        return self.email
 
     @property
     def is_admin(self):

--- a/tests/server/blueprints/login/test_models.py
+++ b/tests/server/blueprints/login/test_models.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from scout.server.blueprints.login.models import LoginUser, LdapUser
+
+def test_login_user(user_obj):
+    """Test the Flask login class used for general user login"""
+
+    user_dict = LoginUser(user_obj)
+    assert user_dict.get_id() == user_obj['email']

--- a/tests/server/blueprints/login/test_models.py
+++ b/tests/server/blueprints/login/test_models.py
@@ -5,4 +5,4 @@ def test_login_user(user_obj):
     """Test the Flask login class used for general user login"""
 
     user_dict = LoginUser(user_obj)
-    assert isinstance(user_dict.get_id(), str)
+    assert user_dict.get_id() == user_obj['email']

--- a/tests/server/blueprints/login/test_models.py
+++ b/tests/server/blueprints/login/test_models.py
@@ -5,4 +5,4 @@ def test_login_user(user_obj):
     """Test the Flask login class used for general user login"""
 
     user_dict = LoginUser(user_obj)
-    assert user_dict.get_id() == user_obj['email']
+    assert isinstance(user_dict.get_id(), str)


### PR DESCRIPTION
Fix #1467

**How to test**:
1. Create a new user from mongoDB compass. Don't provide any custom _id so it will be of type ObjectID. Example:
![image](https://user-images.githubusercontent.com/28093618/68525083-2b3a9700-02ce-11ea-98e1-7385f85a4c16.png)

1. Try to login with this user from master branch and this branch. 
1. Test even from Scout stage trying to log in a user that has ObjectID as _id 

**Expected outcome**:
Login from master should give error while from this branch it should work.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
