### PR TITLE
Disable load and remove filter if there's no saved filter

### DIFF
--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -501,8 +501,9 @@
       {{ form.filters(class="form-control") }}
     </div>
     <div class="btn-group col-4" role="group">
-      {{ form.load_filter(class="btn btn-secondary") }}
-      {{ form.delete_filter(class="btn btn-secondary bg-danger", data_toggle="tooltip", data_placement="top", title="Delete selected filter for this institute.") }}
+      {{ form.load_filter(class="btn btn-secondary", disabled=form.filters.choices|length==0) }}
+      {{ form.delete_filter(class="btn btn-secondary bg-danger", data_toggle="tooltip", data_placement="top",
+        title="Delete selected filter for this institute.", disabled=form.filters.choices|length==0) }}
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
Bug fix #1479 

**How to test**:
1. Variants filter page (all types of variants) crashes when users try to remove or load a filter from an empty filter list
1. This fix disables load and delete filter buttons if filter select is empty:
![image](https://user-images.githubusercontent.com/28093618/68606302-73b0ab00-04ae-11ea-9b21-308b2b233891.png)
1. From a local instance of Scout:
- Make sure that you can create and remove filters from any type of variants page
- Make sure you can't remove or load filters from an empty filter select.

**Expected outcome**:
All should work according to instructions
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
