### PR TITLE
Avoid coverage report opening an extra blank page 

### DIFF
--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -52,9 +52,9 @@
       </a>
     {% endif %}
     {% if config.SQLALCHEMY_DATABASE_URI %}
-      <form method="POST" id="coverage_form" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
+      <form method="POST" id="coverage_form" target="_blank" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
         <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
-        <a target="_blank" href="javascript:;" onclick="document.getElementById('coverage_form').submit();" class="list-group-item list-group-item-action bg-dark text-white">
+        <a href="javascript:;" onclick="document.getElementById('coverage_form').submit();" class="list-group-item list-group-item-action bg-dark text-white">
             <span class="menu-collapsed">Coverage report</span>
         </a>
       </form>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -52,7 +52,7 @@
       </a>
     {% endif %}
     {% if config.SQLALCHEMY_DATABASE_URI %}
-      <form method="POST" id="coverage_form" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}" target="_blank">
+      <form method="POST" id="coverage_form" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
         <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
         <a target="_blank" href="javascript:;" onclick="document.getElementById('coverage_form').submit();" class="list-group-item list-group-item-action bg-dark text-white">
             <span class="menu-collapsed">Coverage report</span>


### PR DESCRIPTION
fix #1477

**How to test**:
1. Clicking on coverage report on the sidebar now opens an extra blank page
1. This change should avoid this
1. To be tested on stage where there are actual coverage reports to open for cases.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
