### PR TITLE
Make sure rank model version are always strings. Fix #1475

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Fixed a problem when rank model version was saved as floats and not strings
+
 
 ## [4.8.1]
 

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -111,10 +111,10 @@ def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
 
     config_data['delivery_report'] = delivery_report if delivery_report else config_data.get('delivery_report')
 
-    config_data['rank_model_version'] = config_data.get('rank_model_version')
+    config_data['rank_model_version'] = str(config_data.get('rank_model_version', ''))
     config_data['rank_score_threshold'] = config_data.get('rank_score_threshold', 0)
 
-    config_data['sv_rank_model_version'] = config_data.get('sv_rank_model_version')
+    config_data['sv_rank_model_version'] = str(config_data.get('sv_rank_model_version', ''))
 
     config_data['track'] = config_data.get('track', 'rare')
     if config_data['vcf_cancer']:
@@ -331,9 +331,9 @@ def parse_case(config):
         'case_id': config['family'],
         'display_name': config.get('family_name', config['family']),
         'genome_build': config.get('human_genome_build'),
-        'rank_model_version': config.get('rank_model_version'),
+        'rank_model_version': str(config.get('rank_model_version', '')),
         'rank_score_threshold': config.get('rank_score_threshold', 0),
-        'sv_rank_model_version': config.get('sv_rank_model_version'),
+        'sv_rank_model_version': str(config.get('sv_rank_model_version', '')),
         'analysis_date': config.get('analysis_date'),
         'individuals': individuals,
         'vcf_files': {

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -156,7 +156,7 @@ def case(store, institute_obj, case_obj):
             [
                 sv_rank_model_link_prefix, 
                 str(case_obj['sv_rank_model_version']), 
-                sv_rank_model_link_postfix)
+                sv_rank_model_link_postfix
             ]
         )
     # other collaborators than the owner of the case

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -142,13 +142,23 @@ def case(store, institute_obj, case_obj):
     rank_model_link_prefix = current_app.config.get('RANK_MODEL_LINK_PREFIX')
     if case_obj.get('rank_model_version'):
         rank_model_link_postfix = current_app.config.get('RANK_MODEL_LINK_POSTFIX','')
-        case_obj['rank_model_link'] = str(rank_model_link_prefix +
-                                      case_obj['rank_model_version'] + rank_model_link_postfix)
+        case_obj['rank_model_link'] = ''.join(
+            [
+                rank_model_link_prefix, 
+                str(case_obj['rank_model_version']), 
+                rank_model_link_postfix
+            ]
+        )
     sv_rank_model_link_prefix = current_app.config.get('SV_RANK_MODEL_LINK_PREFIX','')
     if case_obj.get('sv_rank_model_version'):
         sv_rank_model_link_postfix = current_app.config.get('SV_RANK_MODEL_LINK_POSTFIX','')
-        case_obj['sv_rank_model_link'] = str(sv_rank_model_link_prefix +
-                                         case_obj['sv_rank_model_version'] + sv_rank_model_link_postfix)
+        case_obj['sv_rank_model_link'] = ''.join(
+            [
+                sv_rank_model_link_prefix, 
+                str(case_obj['sv_rank_model_version']), 
+                sv_rank_model_link_postfix)
+            ]
+        )
     # other collaborators than the owner of the case
     o_collaborators = []
     for collab_id in case_obj.get('collaborators',[]):


### PR DESCRIPTION
This PR fixes a bug when rank model version where stored as strings in the database.

**How to test**
On stage:

1. Try to open a case where rank_model_version is a float (try 15078-miptest)
1. En exception is raised
1. Pull this branch and repeat the above.
1. Check that it works

**Expected outcome**:
Old cases should be possible to open.

**Review:**
- [x] code approved by @dnil 
- [ ] tests executed by @moonso 
