### PR TITLE
Fix broken links

### DIFF
--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -221,17 +221,17 @@ def verify(institute_id, case_name, variant_id, variant_category, order):
     comment = request.form.get('verification_comment')
 
     try:
-        controllers.variant_verification(
-                                    store=store,
-                                    institute_id=institute_id,
-                                    case_name=case_name,
-                                    comment=comment,
-                                    variant_obj=variant_id,
-                                    sender=current_app.config.get('MAIL_USERNAME'),
-                                    variant_url=request.referrer,
-                                    order=order,
-                                    url_builder=url_for
-                                )
+        variant_verification(
+            store=store,
+            institute_id=institute_id,
+            case_name=case_name,
+            comment=comment,
+            variant_obj=variant_id,
+            sender=current_app.config.get('MAIL_USERNAME'),
+            variant_url=request.referrer,
+            order=order,
+            url_builder=url_for
+        )
     except MissingVerificationRecipientError:
         flash('No verification recipients added to institute.', 'danger')
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -22,10 +22,14 @@ def add_gene_links(gene_obj, build=37):
     gene_obj['hgnc_link'] = genenames(hgnc_id)
     gene_obj['omim_link'] = omim(hgnc_id)
     # Add links that use ensembl_id
-    if not 'ensembl_id' in gene_obj:
-        ensembl_id = gene_obj.get('common',{}).get('ensembl_id')
-    else:
-        ensembl_id = gene_obj['ensembl_id']
+    ensembl_id = gene_obj.get('common',{}).get('ensembl_id')
+    if not ensembl_id:
+        ensembl_id = gene_obj.get('ensembl_id')
+
+    hgnc_symbol = gene_obj.get('common',{}).get('hgnc_symbol')
+    if not hgnc_symbol:
+        hgnc_symbol = gene_obj.get('hgnc_symbol')
+
     ensembl_37_link = ensembl(ensembl_id, build=37)
     ensembl_38_link = ensembl(ensembl_id, build=38)
     gene_obj['ensembl_37_link'] = ensembl_37_link
@@ -44,7 +48,7 @@ def add_gene_links(gene_obj, build=37):
     # Add links that use omim id
     gene_obj['omim_link'] = omim(gene_obj.get('omim_id'))
     # Add links that use hgnc_symbol
-    gene_obj['ppaint_link'] = ppaint(gene_obj['hgnc_symbol'])
+    gene_obj['ppaint_link'] = ppaint(hgnc_symbol)
     # Add links that use vega_id
     gene_obj['vega_link'] = vega(gene_obj.get('vega_id'))
     # Add links that use ucsc link

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -146,13 +146,15 @@ def vega(vega_id):
 
     return link.format(vega_id)
 
-def ucsc(ucsc_id, build=37):
-    link = "https://genome.ucsc.edu/cgi-bin/hgGene?db=hg{0}&hgg_chrom=chr10&hgg_gene={0}"
+def ucsc(ucsc_id):
+    
+    link = ("http://genome.cse.ucsc.edu/cgi-bin/hgGene?org=Human&hgg_chrom=none&hgg_type=knownGene"\
+            "&hgg_gene={}")
 
     if not ucsc_id:
         return None
 
-    return link.format(build,ucsc_id)
+    return link.format(ucsc_id)
 
 def add_tx_links(tx_obj, build=37):
     try:

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -1,6 +1,7 @@
+from urllib import request
 from pprint import pprint as pp
 
-from scout.server.links import (add_gene_links)
+from scout.server.links import (add_gene_links, ucsc)
 
 def test_add_gene_links():
     ## GIVEN a minimal gene and a genome build
@@ -10,3 +11,20 @@ def test_add_gene_links():
     add_gene_links(gene_obj, build)
     ## THEN assert some links are added
     assert 'hgnc_link' in gene_obj
+
+def test_ucsc_link():
+    ## GIVEN a minimal gene and a genome build
+    gene_obj = {'hgnc_id': 257, 'ucsc_id':'uc001jwi.4'}
+    build = 37
+    ## WHEN adding the gene links
+    add_gene_links(gene_obj, build)
+    ## THEN assert some links are added
+    link = gene_obj.get('ucsc_link')
+    assert link is not None
+    try:
+        request.urlopen(link)
+        assert True
+    except Exception as e:
+        print(e)
+        assert False
+

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -1,0 +1,12 @@
+from pprint import pprint as pp
+
+from scout.server.links import (add_gene_links)
+
+def test_add_gene_links():
+    ## GIVEN a minimal gene and a genome build
+    gene_obj = {'hgnc_id': 257}
+    build = 37
+    ## WHEN adding the gene links
+    add_gene_links(gene_obj, build)
+    ## THEN assert some links are added
+    assert 'hgnc_link' in gene_obj


### PR DESCRIPTION
This PR fixes three (small) bugs.

1. ppaint link will not cause error if hgnc symbol is missing (#1478 )
1. Variant verification will work (#1490 )
1. USCS gene link was broken but will now work

**Review:**
- [x] code approved by @dnil 
- [x] tests executed by @moonso 

