### PR TITLE
Fix #1507, Fix #1500: dynamic gene panel addition meets users

### DIFF
--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -290,8 +290,10 @@ class CaseHandler(object):
         """
         dynamic_gene_list = []
         if add_only:
-            dynamic_gene_list  = self.case_collection.find_one({ '_id': case['_id'] },
-                { 'dynamic_gene_list': 1, '_id': 0 })['dynamic_gene_list']
+            dynamic_gene_list_doc  = self.case_collection.find_one({ '_id': case['_id'] },
+                { 'dynamic_gene_list': 1, '_id': 0 })
+            dynamic_gene_list = list(dynamic_gene_list_doc.get('dynamic_gene_list', []))
+
             LOG.debug("Add selected: current dynamic gene list: {}".format(dynamic_gene_list))
 
         res = []

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -284,15 +284,16 @@ class CaseHandler(object):
             case (dict): The case that should be updated
             hgnc_symbols (iterable): A list of hgnc_symbols
             hgnc_ids (iterable): A list of hgnc_ids
+            phenotype_id(list): optionally add phenotype_ids used to generate list
+            add_only(bool): set by eg ADDGENE to add genes, and NOT reset previous dynamic_gene_list
 
         Returns:
             updated_case(dict)
         """
         dynamic_gene_list = []
         if add_only:
-            dynamic_gene_list_doc  = self.case_collection.find_one({ '_id': case['_id'] },
-                { 'dynamic_gene_list': 1, '_id': 0 })
-            dynamic_gene_list = list(dynamic_gene_list_doc.get('dynamic_gene_list', []))
+            dynamic_gene_list  = list( self.case_collection.find_one({ '_id': case['_id'] },
+                { 'dynamic_gene_list': 1, '_id': 0 }).get('dynamic_gene_list', []))
 
             LOG.debug("Add selected: current dynamic gene list: {}".format(dynamic_gene_list))
 

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -177,7 +177,7 @@ def build_case(case_data, adapter):
 
     case_obj['panels'] = panels
 
-    case_obj['dynamic_gene_list'] = {}
+    case_obj['dynamic_gene_list'] = []
 
     # Meta data
     genome_build = case_data.get('genome_build', '37')

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -877,7 +877,7 @@
       <div class="card-body">
         <div class="form-inline">
           <div class="form-group col-8">
-            <input name="genes" class="typeahead_gene form-control" data-provide="typeahead" autocomplete="off" placeholder="Search...">
+            <input name="genes" pattern="^[0-9]+\s*\|\s*.*" class="typeahead_gene form-control" data-provide="typeahead" autocomplete="off" placeholder="Search...">
           </div>
           <div class="form-group col-4">
             <button class="btn btn-secondary form-control" type="submit" name="action" value="ADDGENE">Add gene</button>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -579,8 +579,12 @@ def phenotypes_actions(institute_id, case_name):
             # avoid empty lists
             if raw_symbol:
                 # take the first nubmer before |, and remove any space.
-                hgnc_symbol_split = raw_symbol.split('|', 1)[0]
-                hgnc_symbol = int(hgnc_symbol_split.replace(' ', ''))
+                try:
+                    hgnc_symbol_split = raw_symbol.split('|', 1)[0]
+                    hgnc_symbol = int(hgnc_symbol_split.replace(' ', ''))
+                except ValueError:
+                    flash("Provided gene info could not be parsed! "
+                          "Please allow autocompletion to finish.", 'warning')
             LOG.debug("Parsed HGNC symbol {}".format(hgnc_symbol))
             store.update_dynamic_gene_list(case_obj, hgnc_ids=[hgnc_symbol], add_only=True)
 
@@ -590,8 +594,12 @@ def phenotypes_actions(institute_id, case_name):
             LOG.debug("raw gene list: {}".format(raw_symbols))
             # avoid empty lists
             if raw_symbols:
-                hgnc_symbols.update(raw_symbol.split(' ', 1)[0] for raw_symbol in
+                try:
+                    hgnc_symbols.update(raw_symbol.split(' ', 1)[0] for raw_symbol in
                                     raw_symbols.split('|'))
+                except ValueError:
+                    flash("Provided gene info could not be parsed! "
+                          "Please allow autocompletion to finish.", 'warning')
             LOG.debug("HGNC symbols {}".format(hgnc_symbols))
         store.update_dynamic_gene_list(case_obj, hgnc_symbols=hgnc_symbols)
 

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -385,7 +385,7 @@ def test_update_dynamic_gene_list(gene_database, case_obj):
     # THEN a the gene list will contain a gene
     assert len(adapter.case(case_obj['_id'])['dynamic_gene_list']) == 1
 
-def test_update_dynamic_gene_list_with_bad_dict_entry(gene_database, case_obj)
+def test_update_dynamic_gene_list_with_bad_dict_entry(gene_database, case_obj):
 
     # GIVEN an populated gene database,
     adapter = gene_database

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -385,6 +385,29 @@ def test_update_dynamic_gene_list(gene_database, case_obj):
     # THEN a the gene list will contain a gene
     assert len(adapter.case(case_obj['_id'])['dynamic_gene_list']) == 1
 
+def test_update_dynamic_gene_list_with_bad_dict_entry(gene_database, case_obj)
+
+    # GIVEN an populated gene database,
+    adapter = gene_database
+
+    # GIVEN an **incorrectly** assigned dict instead of list as dynamic panel
+    case_obj['dynamic_gene_list'] = {}
+
+    # GIVEN a case with an empty dynamic_gene_list
+    adapter.case_collection.insert_one(case_obj)
+    assert adapter.case_collection.find_one()
+    assert len(adapter.case(case_obj['_id'])['dynamic_gene_list']) == 0
+
+    # GIVEN a gene with a gene symobl
+    gene_obj = gene_database.hgnc_collection.find_one({'build': '37'})
+    assert gene_obj
+    hgnc_symbol = gene_obj.get('hgnc_symbol')
+    assert hgnc_symbol
+
+    # WHEN updating dynamic gene list with gene
+    adapter.update_dynamic_gene_list(case_obj, hgnc_symbols=[hgnc_symbol])
+    # THEN a the gene list will contain a gene
+    assert len(adapter.case(case_obj['_id'])['dynamic_gene_list']) == 1
 
 def test_update_case_individuals(adapter, case_obj):
     # GIVEN an empty database (no cases)
@@ -433,8 +456,6 @@ def test_archive_unarchive_case(adapter, case_obj, institute_obj, user_obj):
     assert res['status'] == 'active'
     # and user becomes assignee
     assert user_obj['email'] in res['assignees']
-
-
 
 def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj, ):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,7 +251,7 @@ def case_obj(request, parsed_case):
     case['_id'] = parsed_case['case_id']
     case['owner'] = parsed_case['owner']
     case['created_at'] = parsed_case['analysis_date']
-    case['dynamic_gene_list'] = {}
+    case['dynamic_gene_list'] = []
     case['genome_version'] = None
     case['has_svvariants'] = True
 


### PR DESCRIPTION
This PR fixes two bugs on dynamic_gene_list entry:

1. It apparently happens that empty (deleted?) dynamic gene panels become dicts rather than lists in the db. Check and correct for that. #1507 
1. Also, if random strings are entered into the gene field for addition to the dynamic gene list, the view croaks trying to parse a gene with hgnc_id | etc. #1500. Flash a warning instead of crashing.

**How to test**:
1. with empty (deleted) dynamic (HPO) gene lists on a case, add a gene to the dynamic gene panel
1. add some well thought through QC manager / tester phrases into the gene field, and note flashed warnings. No gene should be added for simple phrases. No guarantees for handcrafted |- and ' ' containing ones.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by dNil
