### PR TITLE
Fix #1487. Actually ignore same case previous evaluations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Same case evaluations are no longer shown as gray previous evaluations on the variants page
 - Bug when ordering sanger
 
 ## [4.8.2]

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -54,9 +54,10 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
         for evaluation_obj in store.get_evaluations(variant_obj):
             classification = evaluation_obj['classification']
             # Only show pathogenic/likely pathogenic from other cases on variants page
-            if evaluation_obj['case_id'] != case_obj['_id']:
-                if not classification in ['pathogenic', 'likely_pathogenic']:
-                    continue
+            if evaluation_obj['case_id'] == case_obj['_id']:
+                continue
+            if not classification in ['pathogenic', 'likely_pathogenic']:
+                continue
             # Convert the classification int to readable string
             evaluation_obj['classification'] = ACMG_COMPLETE_MAP.get(classification)
             evaluations.append(evaluation_obj)


### PR DESCRIPTION
This PR fixes a bug.
P/LP ACMG classifications in the same case would appear also as previous evaluation, due to loop logic.

**How to test**:
1. on master, classify some variants and note that they appear on the variants list both as ACMG-P and previous-P.
1. with this branch, repeat and note that only the current ACMP-P event is shown for the case/variant.
1. pick a reasonably common variant on one case, where you also have shared variants with other cases. Classify it in one of the cases and check that it is still shown as previously classified in the other.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @dnil 

