### PR TITLE
Fix #1515 - don't generate 'Select a tag' and catch them if we do.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- Manual rank variant tags could be saved in a "Select a tag"-state, a problem in the variants view.
 - Same case evaluations are no longer shown as gray previous evaluations on the variants page
 - Bug when ordering sanger
 

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -87,41 +87,41 @@ SPIDEX_LEVELS = (
 
 MANUAL_RANK_OPTIONS = {
     8: {
-        'label': 'known pathogenic',
+        'label': 'Known pathogenic',
         'description': 'Previously known pathogenic in Clinvar Hgmd literature etc',
     },
     7: {
-        'label': 'pathogenic',
+        'label': 'Pathogenic',
         'description': ("Novel mutation but overlapping phenotype with known pathogenic, "
                         "no further experimental validation needed"),
     },
     6: {
-        'label': 'novel validated pathogenic',
+        'label': 'Novel validated pathogenic',
         'description': 'Novel mutation and validated experimentally',
     },
     5: {
-        'label': 'pathogenic partial phenotype',
+        'label': 'Pathogenic partial phenotype',
         'description': ("Pathogenic variant explains part of patients phenotype, but "
                         "not all symptoms"),
     },
     4: {
-        'label': 'likely pathogenic',
+        'label': 'Likely pathogenic',
         'description': 'Experimental validation required to prove causality',
     },
     3: {
-        'label': 'possibly pathogenic',
+        'label': 'Possibly pathogenic',
         'description': 'Uncertain significance, but cannot disregard yet',
     },
     2: {
-        'label': 'likely benign',
+        'label': 'Likely benign',
         'description': 'Uncertain significance, but can discard',
     },
     1: {
-        'label': 'benign',
+        'label': 'Benign',
         'description': 'Does not cause phenotype',
     },
     0: {
-        'label': 'other',
+        'label': 'Other',
         'description': 'Phenotype not related to disease',
     },
 }

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -79,7 +79,7 @@
                   <div class="row">
                     <div class="col-8">
                       <select name="manual_rank" class="form-control ml-3">
-                        <option>Select a tag</option>
+                        <option value="-1">Select a tag...</option>
                         {% for rank, data in manual_rank_options.items() %}
                           <option {% if rank == variant.manual_rank %} selected {% endif %} value="{{ rank }}">
                             {{ data.label }}

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -91,7 +91,13 @@ def variant_update(institute_id, case_name, variant_id):
 
     manual_rank = request.form.get('manual_rank')
     if manual_rank:
-        new_manual_rank = int(manual_rank) if manual_rank != '-1' else None
+        try:
+            new_manual_rank = int(manual_rank) if manual_rank != '-1' else None
+        except:
+            LOG.warning("Attempt to update manual rank with invalid value {}".format(manual_rank))
+            manual_rank = '-1'
+            new_manual_rank = -1
+
         store.update_manual_rank(institute_obj, case_obj, user_obj, link, variant_obj,
                                  new_manual_rank)
         if new_manual_rank:

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -85,7 +85,7 @@
 {% endblock %}
 
 {% macro cell_rank(variant) %}
-  <a class="variants-row-item flex-small layout"
+  <a
      href="{{ url_for('variant.sv_variant', institute_id=institute._id,
                       case_name=case.display_name, variant_id=variant._id) }}">
     {{ variant.variant_rank }}
@@ -123,7 +123,7 @@
   {% else %}
   <tr>
   {% endif %}
-    <td>
+    <td class="d-flex justify-content-between align-items-center">
       {{ cell_rank(variant) }}
     </td>
     <td>{{ variant.rank_score|int }}</td>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -92,7 +92,7 @@
   </a>
   {% set comment_count = variant.comments.count() %}
   {% if variant.manual_rank %}
-    <span class="badge badge-primary" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right" title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">{{  manual_rank_options[variant.manual_rank]['label'] }}</span>
   {% endif %}
 
   {% if comment_count > 0 %}
@@ -123,15 +123,15 @@
   {% else %}
   <tr>
   {% endif %}
-    <td class="d-flex justify-content-between align-items-center">
+    <td class="text-left">
       {{ cell_rank(variant) }}
     </td>
-    <td>{{ variant.rank_score|int }}</td>
+    <td class="text-right">{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
     <td>{{ variant.position }}</td>
     <td>{{ 'inf' if variant.end == 100000000000 else variant.end }}</td>
-    <td>{{ variant.length }}</td>
+    <td class="text-right">{{ variant.length }}</td>
     <td>
       {% if 'region_annotations' in variant %}
         {% for annotation in variant.region_annotations[:3] %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -92,7 +92,7 @@
   </a>
   {% set comment_count = variant.comments.count() %}
   {% if variant.manual_rank %}
-    <span class="badge float-right" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge badge-primary" title="Manual rank">{{ variant.manual_rank }}</span>
   {% endif %}
 
   {% if comment_count > 0 %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -119,7 +119,9 @@
     </span>
   {% endif %}
   {% if variant.manual_rank %}
-    <span class="badge badge-primary" data-toggle="tooltip" title="Manual rank">{{ variant.manual_rank }}</span>
+    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right"
+        title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">
+        {{ manual_rank_options[variant.manual_rank].label }}</span>
   {% endif %}
   {% if variant.evaluations %}
     {% for evaluation in (variant.evaluations or []) %}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -12,7 +12,7 @@ from flask import (Blueprint, request, redirect, abort, flash, current_app, url_
 from werkzeug.datastructures import (Headers, MultiDict)
 from flask_login import current_user
 
-from scout.constants import SEVERE_SO_TERMS
+from scout.constants import SEVERE_SO_TERMS, MANUAL_RANK_OPTIONS
 from scout.server.extensions import store
 from scout.server.utils import (templated, institute_and_case)
 from . import controllers
@@ -151,7 +151,7 @@ def variants(institute_id, case_name):
 
     data = controllers.variants(store, institute_obj, case_obj, variants_query, page)
 
-    return dict(institute=institute_obj, case=case_obj, form=form,
+    return dict(institute=institute_obj, case=case_obj, form=form, manual_rank_options=MANUAL_RANK_OPTIONS,
                     severe_so_terms=SEVERE_SO_TERMS, page=page, **data)
 
 @variants_bp.route('/<institute_id>/<case_name>/str/variants')
@@ -287,7 +287,7 @@ def sv_variants(institute_id, case_name):
                                        variants_query, page)
 
     return dict(institute=institute_obj, case=case_obj, variant_type=variant_type,
-                form=form, severe_so_terms=SEVERE_SO_TERMS, page=page, **data)
+                form=form, severe_so_terms=SEVERE_SO_TERMS, manual_rank_options=MANUAL_RANK_OPTIONS, page=page, **data)
 
 @variants_bp.route('/<institute_id>/<case_name>/cancer/variants', methods=['GET','POST'])
 @templated('variants/cancer-variants.html')


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. Ask @AnnHam, @1ctw, @4WGH or some other Power-user how they manage to generate a "Select a tag" for a variant (I couldn't without explicitly crafting a URL for it 😊) and ensure that this PR handles the issue without crashes. Or perhaps just review for errors and test that you can assign- and unassign manual rank to variants and sv-variants without crashes.

**Expected outcome**:
The functionality should be working

**Review:**
- [x] code approved by CR
- [x] tests executed by CR

