### PR TITLE
Link genemania

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Improved MatchMaker pages, including visible patient contacts email address
 - New badges for the github repo
+- Links to [GENEMANIA](genemania.org)
 
 ### Fixed
 - Manual rank variant tags could be saved in a "Select a tag"-state, a problem in the variants view.

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -185,6 +185,12 @@
       </span>
     </li>
     <li class="list-group-item">
+      GENEMANIA
+      <span class="float-right">
+        <a target="_blank" href={{ gene.genemania_link }} target="_blank"> {{ gene.hgnc_symbol }}</a>
+      </span>
+    </li>
+    <li class="list-group-item">
       Vega Database
       <span class="float-right">
         <a target="_blank" href={{ gene.vega_link }} target="_blank"> {{ gene.vega_id }}</a>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -1244,6 +1244,7 @@
           <a href="{{ gene.ensembl_link }}" class="btn btn-outline-secondary" target="_blank">Ensembl</a>
           <a href="{{ gene.hpa_link }}" class="btn btn-outline-secondary" target="_blank">HPA</a>
           <a href="{{ gene.string_link }}" class="btn btn-outline-secondary" target="_blank">STRING</a>
+          <a href="{{ gene.genemania_link }}" class="btn btn-outline-secondary" target="_blank">GENEMANIA</a>
           <a href="{{ variant.ucsc_link }}" class="btn btn-outline-secondary" target="_blank">UCSC</a>
           {% if gene.entrez_link %}
             <a href="{{ gene.entrez_link }}" class="btn btn-outline-secondary" target="_blank">Entrez</a>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -53,6 +53,13 @@ def add_gene_links(gene_obj, build=37):
     gene_obj['vega_link'] = vega(gene_obj.get('vega_id'))
     # Add links that use ucsc link
     gene_obj['ucsc_link'] = ucsc(gene_obj.get('ucsc_id'))
+    gene_obj['genemania_link'] = genemania(hgnc_symbol)
+
+def genemania(hgnc_symbol):
+    link = "https://genemania.org/search/homo-sapiens/{}/"
+    if not hgnc_symbol:
+        return None
+    return link.format(hgnc_symbol)
 
 def genenames(hgnc_id):
     link = "https://www.genenames.org/cgi-bin/gene_symbol_report?hgnc_id=HGNC:{}"


### PR DESCRIPTION
This PR adds links to [genemania](genemania.org) on variant and gene pages.

**How to test**:
1. Install the branch
1. Browse a variant and a gene and check that the link is there and works

**Expected outcome**:
![genemania-network](https://user-images.githubusercontent.com/405278/69155281-b80cfe00-0ae1-11ea-806e-9fbddf678f20.jpg)


**Review:**
- [x] code approved by CR
- [x] tests executed by @moonso 
