### PR TITLE
Show overlapping variants on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Manual rank variant tags could be saved in a "Select a tag"-state, a problem in the variants view.
 - Same case evaluations are no longer shown as gray previous evaluations on the variants page
 - Stay on research pages, even if reset, next first buttons are pressed..
+- Overlapping variants will now be visible on variant page again
 
 
 ## [4.8.3]

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -497,15 +497,17 @@ class VariantHandler(VariantLoader):
         """
         #This is the category of the variants that we want to collect
         category = 'snv' if variant_obj['category'] == 'sv' else 'sv'
+        variant_type = variant_obj.get('variant_type', 'clinical')
+        hgnc_ids = variant_obj['hgnc_ids']
 
         query = {
             '$and': [
                 {'case_id': variant_obj['case_id']},
                 {'category': category},
-                {'hgnc_ids' : { '$in' : variant_obj['hgnc_ids']}}
+                {'variant_type': variant_type},
+                {'hgnc_ids' : { '$in' : hgnc_ids}}
             ]
         }
-
         sort_key = [('rank_score', pymongo.DESCENDING)]
         # We collect the 30 most severe overlapping variants
         variants = self.variant_collection.find(query).sort(sort_key).limit(30)

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -230,7 +230,7 @@
 
   <div class="row">
     <div class="col-md-12">
-      {{ overlapping(overlapping_snvs, variant.rank_score) }}
+      {{ overlapping(overlapping_vars, variant.rank_score) }}
     </div>
   </div>
 

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -1005,7 +1005,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for sv_variant in overlapping_svs %}
+          {% for sv_variant in overlapping_vars %}
             <tr>
               <td>
                 <a href="{{url_for('variant.sv_variant', institute_id=institute._id,

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -152,7 +152,6 @@ def variants(institute_id, case_name):
                         headers=headers)
 
     data = controllers.variants(store, institute_obj, case_obj, variants_query, page)
-
     return dict(institute=institute_obj, case=case_obj, form=form, manual_rank_options=MANUAL_RANK_OPTIONS,
                     severe_so_terms=SEVERE_SO_TERMS, page=page, **data)
 


### PR DESCRIPTION
This PR adds a functionality fixes #1499

**How to test**:
1. Go to stage and browse a variant that should have overlapping variants. See that no variants are shown on variant page:

![Skärmavbild 2019-11-19 kl  17 12 53](https://user-images.githubusercontent.com/405278/69164242-ee517a00-0aef-11ea-924d-195dfa078f8b.png)


1. Install this branch
1. Browse the same variant and check that the overlapping are there:

![Skärmavbild 2019-11-19 kl  17 17 06](https://user-images.githubusercontent.com/405278/69164560-79cb0b00-0af0-11ea-85d4-3fc48d270427.png)


**Expected outcome**:
Overlapping variants should now show up on variant page

**Review:**
- [x] code approved by CR
- [x] tests executed by @moonso 
