### PR TITLE
fix #1534

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Manual rank variant tags could be saved in a "Select a tag"-state, a problem in the variants view.
 - Same case evaluations are no longer shown as gray previous evaluations on the variants page
 - Stay on research pages, even if reset, next first buttons are pressed..
+- Fix missing classification comments and links in evaluations page
 
 
 ## [4.8.3]

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -51,11 +51,14 @@
                         <label for="checkbox-{{ criterion_code }}"></label>
                       </div>
                     </div>
-                    <div id="comment-{{ criterion_code }}" class="collapse {{ 'in' if evaluation and evaluation.criteria.get(criterion_code).comment }} mt-2">
+                    <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not (evaluation and evaluation.criteria.get(criterion_code).comment) }} mt-2">
                       <div class="form-group">
-                        <textarea class="form-control" name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ evaluation.criteria.get(criterion_code).comment if evaluation and evaluation.criteria.get(criterion_code).comment }}</textarea>
+                        <textarea {{ 'disabled' if evaluation and evaluation.criteria.get(criterion_code).comment }} class="form-control"
+                          name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ evaluation.criteria.get(criterion_code).comment if evaluation and evaluation.criteria.get(criterion_code).comment }}</textarea>
                       </div>
-                      <input type="url" class="form-control" name="link-{{ criterion_code }}" placeholder="Supporting link (optional)" value="{{ evaluation.criteria.get(criterion_code).link if evaluation and evaluation.criteria.get(criterion_code).link }}">
+                      <input type="url" {{ 'disabled' if evaluation and evaluation.criteria.get(criterion_code).comment }}
+                        class="form-control" name="link-{{ criterion_code }}" placeholder="Supporting link (optional)"
+                        value="{{ evaluation.criteria.get(criterion_code).link if evaluation and evaluation.criteria.get(criterion_code).link }}">
                     </div>
                   </div>
                 {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -35,11 +35,19 @@
         {% for category, criteria_group in CRITERIA.items() %}
           <div class="flex-1 {{ 'mr-3' if not loop.last }}">
             <h4>Evidence of {{ category }}</h4>
-
             {% for evidence, criteria in criteria_group.items() %}
               <ul class="list-group mt-3">
                 <li class="list-group-item">{{ evidence }}</li>
                 {% for criterion_code, criterion in criteria.items() %}
+
+                  {% if evaluation and evaluation.criteria.get(criterion_code).comment %}
+                    {% set comment = evaluation.criteria.get(criterion_code).comment %}
+                  {% endif %}
+                  {% if evaluation and evaluation and evaluation.criteria.get(criterion_code).links %}
+                    {% set link = evaluation.criteria.get(criterion_code).links[0] %}
+                    {{ link }}
+                  {% endif %}
+
                   <div class="list-group-item">
                     <div class="d-flex justify-content-between">
                       <div data-toggle="tooltip" data-placement="top" title="{{ criterion.description }}">
@@ -51,14 +59,13 @@
                         <label for="checkbox-{{ criterion_code }}"></label>
                       </div>
                     </div>
-                    <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not (evaluation and evaluation.criteria.get(criterion_code).comment) }} mt-2">
+                    <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not comment }} mt-2">
                       <div class="form-group">
-                        <textarea {{ 'disabled' if evaluation and evaluation.criteria.get(criterion_code).comment }} class="form-control"
-                          name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ evaluation.criteria.get(criterion_code).comment if evaluation and evaluation.criteria.get(criterion_code).comment }}</textarea>
+                        <textarea {{ 'disabled' if comment }} class="form-control"
+                          name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ comment }}</textarea>
                       </div>
-                      <input type="url" {{ 'disabled' if evaluation and evaluation.criteria.get(criterion_code).comment }}
-                        class="form-control" name="link-{{ criterion_code }}" placeholder="Supporting link (optional)"
-                        value="{{ evaluation.criteria.get(criterion_code).link if evaluation and evaluation.criteria.get(criterion_code).link }}">
+                      <input type="url" {{ 'disabled' if link or comment }} class="form-control" name="link-{{ criterion_code }}"
+                        placeholder="{{ link or 'Supporting link (optional)' }}" value="">
                     </div>
                   </div>
                 {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -45,7 +45,6 @@
                   {% endif %}
                   {% if evaluation and evaluation.criteria.get(criterion_code).links %}
                     {% set link = evaluation.criteria.get(criterion_code).links[0] %}
-                    {{ link }}
                   {% endif %}
 
                   <div class="list-group-item">
@@ -59,7 +58,7 @@
                         <label for="checkbox-{{ criterion_code }}"></label>
                       </div>
                     </div>
-                    <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not comment }} mt-2">
+                    <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not (comment or link) }} mt-2">
                       <div class="form-group">
                         <textarea {{ 'disabled' if comment }} class="form-control"
                           name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ comment }}</textarea>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -43,7 +43,7 @@
                   {% if evaluation and evaluation.criteria.get(criterion_code).comment %}
                     {% set comment = evaluation.criteria.get(criterion_code).comment %}
                   {% endif %}
-                  {% if evaluation and evaluation and evaluation.criteria.get(criterion_code).links %}
+                  {% if evaluation and evaluation.criteria.get(criterion_code).links %}
                     {% set link = evaluation.criteria.get(criterion_code).links[0] %}
                     {{ link }}
                   {% endif %}


### PR DESCRIPTION
Bug fix #1534

**How to test**:
1. On current master it is possible to classify a variant using the acmg criteria and add comments and links to the classification.
1. When clicking on the classification at a later moment comments and links are not shown.
1. Install the branch and make sure that classification comment and eventual link are visible on the evaluation page but disabled. ( I don't remember how it was before but sounds logical that they can be only visualized )  

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
