### PR TITLE
no mosaic for cancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Fixed
-- Remooved Mosaic Tag from Cancer variants
+- Removed Mosaic Tag from Cancer variants
 
 
 ## [x.x.x]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+
+## [x.x.x]
+
+### Fixed
+- Remooved Mosaic Tag from Cancer variants
+
+
 ## [x.x.x]
 
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -363,6 +363,7 @@
           </div>
         </div>
       </form>
+      {% if not cancer %}
       <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
         <label class="mt-3">Mosaic Tags</label>
         <div class="row">
@@ -380,6 +381,7 @@
           </div>
         </div>
       </form>
+      {% endif %}
       {{ acmg_form(variant.acmg_classification.code if variant.acmg_classification) }}
       <div class="mt-3">
         <a href="{{ url_for('variant.variant_acmg', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" class="btn btn-outline-secondary form-control">Classify</a>


### PR DESCRIPTION
This PR disables Mosaic Tags for cancer variants

**How to test**:
1. Install on stage

**Expected outcome**:
See that the Mosaic Tags form is gone for cancer, but not for SNVs and INDELS

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil

