### PR TITLE
added rank score model to causatives page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
-
+- Rank score model in causatives page
 
 ### Fixed
 - Fixed update OMIM command bug due to change in the header of the genemap2 file

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -72,7 +72,14 @@
               </span>
             </td>
             <td><span class="badge badge-secondary">{{ variant.category|upper }}</span></td>
-            <td><a href="#"><span class="badge badge-pill badge-secondary">{{ variant.rank_score }}</span></a></td>
+            <td><a href="#"><span class="badge badge-pill badge-secondary">
+              {{ variant.rank_score }}
+              {% if variant.category == 'sv' %}
+                (v. {{case.sv_rank_model_version or 'na'}})
+              {% else %}
+                (v. {{case.rank_model_version or 'na'}})
+              {% endif %}
+            </span></a></td>
             <td>
               {% for sample in variant.samples %}
               {% for ind in case.individuals %}


### PR DESCRIPTION
fix #1532

**How to test**:
- Causatives page from master branch doesn't show the rank model used to rank the specific variant
- On a local instance of Scout (master) mark a snv variant and a sv variant as causatives.
- Go on the causatives page and make sure that no model is displayed alongside the rank value for the variants.
- Checkout to this branch and see that now rank model is shown:
![image](https://user-images.githubusercontent.com/28093618/69642349-e5b5f200-1061-11ea-965f-d08e0de36397.png)
- Can alternatively be tested on stage


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
