### PR TITLE
Fix #1344 - show clinical assessment/dismiss on research page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Rank score model in causatives page
 - Exportable HPO terms from phenotypes page
 - AMP guideline tiers for cancer variants
-- Adds scroll for the trancript tab 
+- Adds scroll for the trancript tab
+- Shadow clinical assessments also on research variants display
 
 ### Fixed
 - Fixed update OMIM command bug due to change in the header of the genemap2 file

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -220,7 +220,8 @@ class VariantHandler(VariantLoader):
 
         return self.variant_collection.find(query)
 
-    def variant(self, document_id=None, gene_panels=None, case_id=None, simple_id=None):
+    def variant(self, document_id=None, gene_panels=None, case_id=None,
+                simple_id=None, variant_type='clinical'):
         """Returns the specified variant.
 
            Arguments:
@@ -228,6 +229,7 @@ class VariantHandler(VariantLoader):
                gene_panels(List[GenePanel])
                case_id (str): case id (will search with "variant_id")
                simple_id (str): a variant simple_id (example: 1_161184089_G_GTA)
+               variant_type(str): 'research' or 'clinical' - default 'clinical'
 
            Returns:
                variant_object(Variant): A odm variant object
@@ -241,6 +243,7 @@ class VariantHandler(VariantLoader):
             # search for a variant in a case by its simple_id
             query['case_id'] = case_id
             query['simple_id'] = simple_id
+            query['variant_type'] = variant_type
         else:
             # search with a unique id
             query['_id'] = document_id

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -215,6 +215,8 @@ def case(store, institute_obj, case_obj):
         'partial_causatives' : partial_causatives,
         'collaborators': collab_ids,
         'cohort_tags': COHORT_TAGS,
+        'manual_rank_options': MANUAL_RANK_OPTIONS,
+        'cancer_tier_options': CANCER_TIER_OPTIONS
     }
 
     return data

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -10,7 +10,7 @@
 
 {% block css %}
 {{ super() }}
-  
+
 {% endblock %}
 
 {% block top_nav %}
@@ -493,7 +493,7 @@
                 {% elif variant.sanger_ordered %}
                   <span class="badge badge-success">Validated</span>
                 {% elif variant.manual_rank or variant.cancer_tier %}
-                  {{ tier_cell(variant) }}
+                  {{ tier_cell(variant, manual_rank_options, cancer_tier_options) }}
                 {% endif %}
                 {% if variant.mosaic_tags %}
                   <span class="badge badge-info">mosaic</span>

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -51,9 +51,7 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
         variant_obj['overlapping'] = overlapping_svs or None
 
         # show previous classifications for research variants,
-        is_research = False
-        if variant_obj['variant_type'] == 'research':
-            is_research = True
+        is_research = variant_obj['variant_type'] == 'research'
 
         # Get all previous ACMG evalautions of the variant
         evaluations = []
@@ -61,9 +59,11 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
             classification = evaluation_obj['classification']
             # Only show pathogenic/likely pathogenic from other cases on variants page
             if evaluation_obj['case_id'] == case_obj['_id']:
+                # research cases will have have previous evaluation shown regardless
                 if not is_research:
                     continue
             if not classification in ['pathogenic', 'likely_pathogenic']:
+                # research cases will have have previous evaluation shown regardless
                 if not is_research:
                     continue
             # Convert the classification int to readable string
@@ -73,8 +73,7 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
 
         # Show previous classifications from the clinical side for research
         if is_research:
-            # get variant by simple_id. That will really just return the first variant found -
-            # but mostly that would be clinical.. Its a start.
+            # get variant by simple_id.
             clinical_var_obj = store.variant(case_id=case_obj['_id'],
                                 simple_id =variant_obj['simple_id'], variant_type='clinical')
             # Get all previous ACMG evalautions of the variant

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -97,9 +97,6 @@ def get_manual_assessments(variant_obj):
         'acmg_classification',
         'dismiss_variant',
         'mosaic_tags',
-        'suspects',
-        'causatives',
-        'is_commented'
     ]
 
     assessments = []
@@ -107,7 +104,6 @@ def get_manual_assessments(variant_obj):
     for assessment_type in assessment_keywords:
         assessment = {}
         if variant_obj.get(assessment_type) != None:
-            LOG.info('Assessment type {}: {}'.format(assessment_type, variant_obj))
             if assessment_type == 'manual_rank':
                 manual_rank = variant_obj[assessment_type]
                 LOG.info('Assessement type {}: {}'.format(assessment_type, manual_rank))

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -106,7 +106,8 @@ def get_manual_assessments(variant_obj):
 
     for assessment_type in assessment_keywords:
         assessment = {}
-        if variant_obj.get(assessment_type):
+        if variant_obj.get(assessment_type) != None:
+            LOG.info('Assessment type {}: {}'.format(assessment_type, variant_obj))
             if assessment_type == 'manual_rank':
                 manual_rank = variant_obj[assessment_type]
                 LOG.info('Assessement type {}: {}'.format(assessment_type, manual_rank))

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -90,6 +90,8 @@ def variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50
     }
 
 def get_manual_assessments(variant_obj):
+    """Return manual assessments ready for display. """
+
     ## display manual input of interest: classified, commented, tagged or dismissed.
     assessment_keywords = [
         'manual_rank',

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -101,7 +101,7 @@ def sv_variants(store, institute_obj, case_obj, variants_query, page=1, per_page
 
     variants = []
 
-    for variant in variants_query.skip(skip_count).limit(per_page)):
+    for variant_obj in variants_query.skip(skip_count).limit(per_page):
         # show previous classifications for research variants
         if variant_obj['variant_type'] == 'research':
             # get variant by simple_id. That will really just return the first variant found -
@@ -111,7 +111,7 @@ def sv_variants(store, institute_obj, case_obj, variants_query, page=1, per_page
             # Get all previous ACMG evalautions of the variant
             variant_obj['clinical_assessments'] = get_manual_assessments(clinical_var_obj)
 
-        variants.append(parse_variant(store, institute_obj, case_obj, variant, genome_build=genome_build))
+        variants.append(parse_variant(store, institute_obj, case_obj, variant_obj, genome_build=genome_build))
 
     return {
         'variants': variants,

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -115,6 +115,16 @@
   {% if variant._id in case.suspects %}
     <i class="fa fa-map-pin"></i>
   {% endif %}
+  {% if form.variant_type.data == 'research' %}
+    {% if variant.clinical_assessments %}
+      {% for assessment in variant.clinical_assessments %}
+        <span class="badge badge-secondary" data-toggle="tooltip" data-placement="right"
+            title="{{ assessment.title }}">
+            {{ assessment.label }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endif %}
+
 {% endmacro %}
 
 {% macro variant_row(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -131,6 +131,15 @@
       </span>
     {% endfor %}
   {% endif %}
+  {% if form.variant_type.data == 'research' %}
+    {% if variant.clinical_assessments %}
+      {% for assessment in variant.clinical_assessments %}
+        <span class="badge badge-secondary" data-toggle="tooltip" data-placement="right"
+            title="{{ assessment.title }}">
+            {{ assessment.label }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endif %}
 
   {% if comment_count > 0 %}
     {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -1,5 +1,76 @@
-from scout.server.blueprints.variants.controllers import (variants_export_header, 
-                                                          variant_export_lines)
+import copy
+import logging
+
+from scout.server.blueprints.variants.controllers import (variants_export_header,
+                                                          variant_export_lines, variants)
+
+LOG = logging.getLogger(__name__)
+
+def test_variants_research_no_shadow_clinical_assessments(real_variant_database, institute_obj, case_obj):
+    # GIVEN a db with variants,
+    adapter = real_variant_database
+    case_id = case_obj['_id']
+
+    # GIVEN a clinical variant from one case
+    variant_clinical = adapter.variant_collection.find_one({'case_id': case_id, 'variant_type': 'clinical'})
+
+    # GIVEN a copy of that variant marked research
+    variant_research = copy.deepcopy(variant_clinical)
+    variant_research['_id'] = 'research_version'
+    variant_research['variant_type'] = 'research'
+    adapter.variant_collection.insert_one(variant_research)
+
+    # WHEN filtering for that variant in research
+    variants_query = {'variant_type': 'research'}
+    variants_query_res = adapter.variants(case_obj['_id'], query=variants_query,
+                                            category=variant_clinical['category'])
+
+    res = variants(adapter, institute_obj, case_obj, variants_query_res)
+    res_variants = res['variants']
+
+    LOG.debug('Variants: {}'.format(res_variants))
+    # THEN it is returned
+    assert any([variant['_id'] == variant_research['_id'] for variant in res_variants])
+
+    # THEN no previous annotations are reported back for the reseach case..
+    assert not any([variant.get('clinical_assessments') for variant in res_variants])
+
+def test_variants_research_shadow_clinical_assessments(real_variant_database, institute_obj, case_obj):
+    # GIVEN a db with variants,
+    adapter = real_variant_database
+    case_id = case_obj['_id']
+
+    # GIVEN a clinical variant from one case
+    variant_clinical = adapter.variant_collection.find_one({'case_id': case_id, 'variant_type': 'clinical'})
+
+    # GIVEN a copy of that variant marked research
+    variant_research = copy.deepcopy(variant_clinical)
+    variant_research['_id'] = 'research_version'
+    variant_research['variant_type'] = 'research'
+    adapter.variant_collection.insert_one(variant_research)
+
+    # WHEN updating the manual assessments of the clinical variant
+    adapter.variant_collection.update_one({'_id': variant_clinical['_id']},
+        {'$set' : {
+                    'manual_rank': 2,
+                    'mosaic_tags': [ "1" ],
+                    'dismiss_variant': [ "2", "3" ],
+                    'acmg_classification': 0
+        }})
+
+    # WHEN filtering for that variant in research
+    variants_query = {'variant_type': 'research'}
+    variants_query_res = adapter.variants(case_obj['_id'], query=variants_query,
+                                            category=variant_clinical['category'])
+
+    res = variants(adapter, institute_obj, case_obj, variants_query_res)
+    res_variants = res['variants']
+
+    # THEN it is returned
+    assert any([variant['_id'] == variant_research['_id'] for variant in res_variants])
+
+    # THEN previous annotations are reported back for the reseach case.
+    assert any([variant.get('clinical_assessments') for variant in res_variants])
 
 def test_variant_csv_export(real_variant_database, case_obj):
     adapter = real_variant_database

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -2,7 +2,8 @@ import copy
 import logging
 
 from scout.server.blueprints.variants.controllers import (variants_export_header,
-                                                          variant_export_lines, variants)
+                                                          variant_export_lines,
+                                                          variants, sv_variants)
 
 LOG = logging.getLogger(__name__)
 
@@ -71,6 +72,51 @@ def test_variants_research_shadow_clinical_assessments(real_variant_database, in
 
     # THEN previous annotations are reported back for the reseach case.
     assert any([variant.get('clinical_assessments') for variant in res_variants])
+
+def test_sv_variants_research_shadow_clinical_assessments(real_variant_database, institute_obj, case_obj):
+    # GIVEN a db with variants,
+    adapter = real_variant_database
+    case_id = case_obj['_id']
+
+    # GIVEN a clinical variant from one case
+    variant_clinical = adapter.variant_collection.find_one({'case_id': case_id, 'variant_type': 'clinical'})
+    # GIVEN the variant is an SV
+    adapter.variant_collection.update_one({'_id': variant_clinical['_id']},
+        {'$set' : {'category': 'sv', 'sub_category': 'dup'}})
+
+    # GIVEN a copy of that variant marked research
+    variant_research = copy.deepcopy(variant_clinical)
+    variant_research['_id'] = 'research_version'
+    variant_research['variant_type'] = 'research'
+    variant_research['category'] = 'sv'
+    variant_research['sub_category']: 'dup'
+    adapter.variant_collection.insert_one(variant_research)
+
+    # WHEN updating the manual assessments of the clinical variant
+    adapter.variant_collection.update_one({'_id': variant_clinical['_id']},
+        {'$set' : {
+                    'manual_rank': 2,
+                    'mosaic_tags': [ "1" ],
+                    'dismiss_variant': [ "2", "3" ]
+        }})
+
+    # WHEN filtering for that variant in research
+    variants_query = {'variant_type': 'research'}
+    variants_query_res = adapter.variants(case_obj['_id'], query=variants_query,
+                                            category='sv')
+    assert variants_query_res
+
+    res = sv_variants(adapter, institute_obj, case_obj, variants_query_res)
+    res_variants = res['variants']
+
+    LOG.debug('Variants: {}'.format(res_variants))
+
+    # THEN it is returned
+    assert any([variant['_id'] == variant_research['_id'] for variant in res_variants])
+
+    # THEN previous annotations are reported back for the reseach case.
+    assert any([variant.get('clinical_assessments') for variant in res_variants])
+
 
 def test_variant_csv_export(real_variant_database, case_obj):
     adapter = real_variant_database


### PR DESCRIPTION
This PR adds a functionality - show clinical assessments / dismissals on research page.

<img width="771" alt="Screenshot 2019-11-28 at 11 21 12" src="https://user-images.githubusercontent.com/758570/69798248-4a438f00-11d1-11ea-95bb-5e729acd4a6d.png">

**How to test**:
1. manually rank, dismiss, tag, comment and evaluate to your hearts content on a clinical case variant page
1. ensure that you can see shadows from all your clinical assessments on the research page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
