### PR TITLE
Use FontAwesome library in general report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixes issue with unaligned table headers that comes with hidden Datatables
 - Layout in general report PDF export
 - Fixed issue on the case statistics view. The validation bars didn't show up when all institutes were selected. Now they do.
+- Included Font Awesome availability in general report
 
 
 ## [4.9.0]

--- a/scout/server/templates/report_base.html
+++ b/scout/server/templates/report_base.html
@@ -5,6 +5,7 @@
 
 	{% block css %}
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 	{% endblock %}
 
 	{% block css_style %}{% endblock %}


### PR DESCRIPTION
This is exactly the same PR as #1563, but without conflicts!

**How to test**:
1. General report using the current master should not show any info regarding patients' sex
1. Branching out to this PR will fix it and when patient gender is available it will be shown as an icon:
![image](https://user-images.githubusercontent.com/28093618/69910982-e90bfd80-1414-11ea-858f-85db2f3d1a7b.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by Dnil
- [x] tests executed by Dnil