### PR TITLE
Fix path dependency problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Layout in general report PDF export
 - Fixed issue on the case statistics view. The validation bars didn't show up when all institutes were selected. Now they do.
 - Included Font Awesome availability in general report
+- Fixed missing path import by importing pathlib.Path
 
 
 ## [4.9.0]

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -4,7 +4,7 @@ import datetime
 
 from pprint import pprint as pp
 
-from path import Path
+from pathlib import Path
 from ped_parser import FamilyParser
 
 from scout.exceptions import (PedigreeError, ConfigError)
@@ -20,10 +20,10 @@ LOG = logging.getLogger(__name__)
 
 def get_correct_date(date_info):
     """Convert dateinfo to correct date
-    
+
     Args:
         dateinfo: Something that represents a date
-    
+
     Returns:
         correct_date(datetime.datetime)
     """
@@ -125,7 +125,7 @@ def parse_case_data(config=None, ped=None, owner=None, vcf_snv=None,
 
 def add_peddy_information(config_data):
     """Add information from peddy outfiles to the individuals
-    
+
     Args:
         config_data(dict)
     """
@@ -368,7 +368,7 @@ def parse_case(config):
 
     if (case_data['vcf_files']['vcf_cancer'] or case_data['vcf_files']['vcf_cancer_research']):
         case_data['track'] = 'cancer'
-    
+
     case_data['analysis_date'] = get_correct_date(case_data.get('analysis_date'))
 
     return case_data

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -1,25 +1,21 @@
 # -*- coding: UTF-8 -*-
 import tempfile
-import pytest
 from urllib.error import HTTPError
 from urllib.parse import urlencode
 from scout.utils import ensembl_rest_clients as eracs
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_ping_ensemble_37():
     """Test ping ensembl server containing human build 37"""
     client = eracs.EnsemblRestApiClient()
     data = client.ping_server()
     assert data == {'ping':1}
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_ping_ensemble_38():
     """Test ping ensembl server containing human build 38"""
     client = eracs.EnsemblRestApiClient(build='38')
     data = client.ping_server()
     assert data == {'ping':1}
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_send_gene_request():
     """Test send request with correct params and endpoint"""
     url = 'https://grch37.rest.ensembl.org/overlap/id/ENSG00000103591?feature=gene'
@@ -31,7 +27,6 @@ def test_send_gene_request():
     assert data[0]['start']
     assert data[0]['end']
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_send_request_wrong_url():
     """Successful requests are tested by other tests in this file.
        This test will trigger errors instead.
@@ -45,7 +40,6 @@ def test_send_request_wrong_url():
     data = client.send_request(url)
     assert type(data) == HTTPError
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_use_api():
     """Test the use_api method of the EnsemblRestClient"""
 
@@ -63,7 +57,6 @@ def test_use_api():
     assert data[0]['start']
     assert data[0]['strand']
 
-@pytest.mark.skip(reason="Ensembl rest API server might be down")
 def test_xml_filters():
     """test method that creates filter lines for the biomart xml file"""
 


### PR DESCRIPTION
fix #1565. This PR fixes the following problem:
- On clinical-db stage and prod environment path dependency is missing
- It is not possible to install the current master on clinical-db stage using the bash script because before installing from git you get this error:
```
from scout.parse.case import parse_case
File "/home/hiseq.clinical/SERVER/apps/scout-stage/git/scout-stage/scout/parse/case.py", line 7, in
from path import Path
ModuleNotFoundError: No module named 'path'
```

**How to test**:
1. Try to run the bash command `bash update-scout-stage.sh master` as user hiseq-clinical from /home/hiseq.clinical/servers/resources/clinical-db.scilifelab.se. You should get the: No module named 'path' error described above.
1. Try to install master branch from scout stage environment on clinical-db:
- `source activate prod-stage`
- `cd /home/hiseq.clinical/SERVER/apps/scout-stage/git/scout-stage`
- `git branch` --> you should be on master branch
- `git pull`
- `pip install -e .` should not fail
- `scout --version` should fail with the path lib error above

1. Install this branch from prod-stage environment:
- `git checkout fix_path_dependency`
- `pip install -e .`
- `scout --version` should NOT fail

1. After this:
- try 'bash update-scout-stage.sh fix_path_dependency' and the script should not fail

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by Dnil
- [x] tests executed by CR
