### PR TITLE
Improve str layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added CLI option to query cases on time since case event was added
 - Shadow clinical assessments also on research variants display
 - Support for CRAM alignment files
+- Improved str variants view : sorting by locus, grouped by allele.
 
 ### Fixed
 - Fixed update OMIM command bug due to change in the header of the genemap2 file

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -192,9 +192,7 @@ class VariantHandler(VariantLoader):
         if sort_key == 'rank_score':
             sorting = [('rank_score', pymongo.DESCENDING)]
         if sort_key == 'position':
-            if category == 'str':
-                sorting = [('chromosome', pymongo.ASCENDING)]
-            sorting.append(('position', pymongo.ASCENDING))
+            sorting = [('position', pymongo.ASCENDING)]
 
         result = self.variant_collection.find(
             mongo_query,

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -194,7 +194,7 @@ class VariantHandler(VariantLoader):
         if sort_key == 'position':
             if category == 'str':
                 sorting = [('chromosome', pymongo.ASCENDING)]
-            sorting.append('position', pymongo.ASCENDING)
+            sorting.append(('position', pymongo.ASCENDING))
 
         result = self.variant_collection.find(
             mongo_query,

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -192,7 +192,9 @@ class VariantHandler(VariantLoader):
         if sort_key == 'rank_score':
             sorting = [('rank_score', pymongo.DESCENDING)]
         if sort_key == 'position':
-            sorting = [('position', pymongo.ASCENDING)]
+            if category == 'str':
+                sorting = [('chromosome', pymongo.ASCENDING)]
+            sorting.append('position', pymongo.ASCENDING)
 
         result = self.variant_collection.find(
             mongo_query,

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -90,15 +90,13 @@ def igv():
     sample_tracks = []
     counter = 0
     for sample in samples:
-        # some samples might not have an associated bam file, take care if this
-        if bam_files.get(counter) and bai_files.get(counter):
-            sample_tracks.append({
-                'name' : sample,
-                'url' : bam_files[counter],
-                'format': bam_files[counter].split(".")[-1], # "bam" or "cram"
-                'indexURL' : bai_files[counter],
-                'height' : 700
-            })
+        sample_tracks.append({
+            'name' : sample,
+            'url' : bam_files[counter],
+            'format': bam_files[counter].split(".")[-1], # "bam" or "cram"
+            'indexURL' : bai_files[counter],
+            'height' : 700
+        })
         else:
             flash('Missing alignment track/index for individual {}!'.format(sample), 'danger')
         counter += 1

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -97,8 +97,6 @@ def igv():
             'indexURL' : bai_files[counter],
             'height' : 700
         })
-        else:
-            flash('Missing alignment track/index for individual {}!'.format(sample), 'danger')
         counter += 1
 
     display_obj['sample_tracks'] = sample_tracks

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -37,7 +37,7 @@
     <table class="table table-bordered table-hover">
       <thead>
         <tr>
-          <th style="width:8%" title="Rank position">Rank</th>
+          <th style="width:8%" title="Index">Index</th>
           <th style="width:8%" title="Repeat ID">Repeat locus</th>
           <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
           <th style="width:8%" title="ALT">Estimated size</th>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -176,10 +176,6 @@
       $('table').stickyTableHeaders({
         fixedOffset: $(".navbar-fixed-top")
       });
-
-      $('select[multiple]').multiselect({
-        buttonWidth: '100%'
-      });
     })
 
   </script>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -82,7 +82,7 @@
             <td>
               {{ variant.position }}
               {% if case.bam_files %}
-                <a class="btn btn-default btn-sm float-right" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.bam_files, bai=case.bai_files, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.position + 50), center_guide="T") }}" target="_blank">IGV viewer</a>
+                <a class="btn btn-outline-secondary btn-sm float-right" href="{{ url_for('alignviewers.igv', sample=case.sample_names, build=case.genome_build, bam=case.bam_files, bai=case.bai_files, contig=variant.chromosome, start=(variant.position - 50), stop=(variant.position + 50), center_guide="T") }}" target="_blank">IGV viewer</a>
               {% endif %}
             </td>
         </tr>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -51,7 +51,12 @@
         </tr>
       </thead>
       <tbody>
+        {% set ns = namespace(allele0='') %}
         {% for variant in variants %}
+          {% if variant.chromosome + variant.position|string != ns.allele0 %}
+            <tr style="height:10px;"></tr>
+          {% endif %}
+          {% set ns.allele0 = variant.chromosome + variant.position|string %}
           {% if variant.dismiss_variant %}
               <tr class="dismiss">
           {% elif variant.str_status == 'normal' %}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -171,7 +171,7 @@ def str_variants(institute_id, case_name):
     query['variant_type'] = variant_type
 
     variants_query = store.variants(case_obj['_id'], category=category,
-        query=query)
+        query=query, sort_key='position')
     data = controllers.str_variants(store, institute_obj, case_obj,
         variants_query, page)
     return dict(institute=institute_obj, case=case_obj,

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -6,6 +6,7 @@ import logging
 import datetime
 import zipfile
 import pathlib
+import pymongo
 
 from flask import (Blueprint, request, redirect, abort, flash, current_app, url_for, Response,
                    send_file)
@@ -171,7 +172,7 @@ def str_variants(institute_id, case_name):
     query['variant_type'] = variant_type
 
     variants_query = store.variants(case_obj['_id'], category=category,
-        query=query, sort_key='position')
+        query=query).sort('str_repid', pymongo.ASCENDING)
     data = controllers.str_variants(store, institute_obj, case_obj,
         variants_query, page)
     return dict(institute=institute_obj, case=case_obj,

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -171,8 +171,8 @@ def str_variants(institute_id, case_name):
     query = form.data
     query['variant_type'] = variant_type
 
-    variants_query = store.variants(case_obj['_id'], category=category,
-        query=query).sort('str_repid', pymongo.ASCENDING)
+    variants_query = store.variants(case_obj['_id'], category=category, query=query).sort([('str_repid', pymongo.ASCENDING),
+        ('chromosome', pymongo.ASCENDING),('position', pymongo.ASCENDING)])
     data = controllers.str_variants(store, institute_obj, case_obj,
         variants_query, page)
     return dict(institute=institute_obj, case=case_obj,


### PR DESCRIPTION
This PR addresses the easiest requests from #1501

- [x] Fix borders of igv buttons on str_variants page
- [x] Rename "Rank" to "Index" on str_variants page
- [x] Sort str variants by Repeat Locus ID
- [x] Group 2 alleles from a single repeat together in str variants list
For clarity sake I found this solution, what do you think?
![image](https://user-images.githubusercontent.com/28093618/70128210-c3812d00-167c-11ea-83a6-42c6b8ef334e.png)


**How to test**:
1. Install the branch on clinical-db stage and see the difference with scout production

**Expected outcome**:
The functionalities in the checkbox should be working as described

**Review:**
- [x] code approved by dNil
- [x] tests executed by dNil
 