### PR TITLE
Handle pymongo.OperationFailure errors when updating indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed issue on the case statistics view. The validation bars didn't show up when all institutes were selected. Now they do.
 - Included Font Awesome availability in general report
 - Fixed missing path import by importing pathlib.Path
+- Hadle index inconsistencies in the update index functions
 
 
 ## [4.9.0]

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -70,7 +70,7 @@ class IndexHandler(object):
                     nr_updated += 1
                     LOG.info("Adding index : %s" % index_name)
                     try:
-                        self.db[collection_name].create_indexes(indexes)
+                        self.db[collection_name].create_indexes(index)
                     except pymongo_errors.OperationFailure as op_failure:
                         LOG.warning('An Operation Failure occurred while updating Scout indexes: {}'.format(op_failure))
                     except Exception as ex:

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -70,7 +70,7 @@ class IndexHandler(object):
                     nr_updated += 1
                     LOG.info("Adding index : %s" % index_name)
                     try:
-                        self.db[collection_name].create_indexes(index)
+                        self.db[collection_name].create_indexes([index])
                     except pymongo_errors.OperationFailure as op_failure:
                         LOG.warning('An Operation Failure occurred while updating Scout indexes: {}'.format(op_failure))
                     except Exception as ex:

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -60,20 +60,21 @@ class IndexHandler(object):
         """
         LOG.info("Updating indexes...")
         nr_updated = 0
-        try:
-            for collection_name in INDEXES:
-                existing_indexes = self.indexes(collection_name)
-                indexes = INDEXES[collection_name]
-                for index in indexes:
-                    index_name = index.document.get('name')
-                    if index_name not in existing_indexes:
-                        nr_updated += 1
-                        LOG.info("Adding index : %s" % index_name)
+
+        for collection_name in INDEXES:
+            existing_indexes = self.indexes(collection_name)
+            indexes = INDEXES[collection_name]
+            for index in indexes:
+                index_name = index.document.get('name')
+                if index_name not in existing_indexes:
+                    nr_updated += 1
+                    LOG.info("Adding index : %s" % index_name)
+                    try:
                         self.db[collection_name].create_indexes(indexes)
-        except pymongo_errors.OperationFailure as op_failure:
-            LOG.warning('An Operation Failure occurred while updating Scout indexes: {}'.format(op_failure))
-        except Exception as ex:
-            LOG.warning('An error occurred while updating Scout indexes: {}'.format(ex))
+                    except pymongo_errors.OperationFailure as op_failure:
+                        LOG.warning('An Operation Failure occurred while updating Scout indexes: {}'.format(op_failure))
+                    except Exception as ex:
+                        LOG.warning('An error occurred while updating Scout indexes: {}'.format(ex))
 
         if nr_updated == 0:
             LOG.info("All indexes in place")


### PR DESCRIPTION
This PR should fix #1568 and eventually #1557 

**How to test**:
1. Install the branch on Hasta stage and use the stage environment with `us`
1. Run the command:
`scout update genes`

**Expected outcome**:
The command should update genes and run until the end, with no errors but just warnings
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
