### PR TITLE
show GQ and allele depth in causatives page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Delivery report PDF export
 - New mosaicism tag option
 - Add or modify individuals' age or tissue type from case page
+- Display GC and allele depth in causatives table.
 
 ### Fixed
 - Fixed update OMIM command bug due to change in the header of the genemap2 file

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -37,7 +37,7 @@
 
 <div class="card mt-3">
   <div class="card-body">
-      <table id="causatives_table" class="table display nowrap" cellspacing="0" width="100%">
+      <table id="causatives_table" class="table display table-sm" cellspacing="0" width="100%">
         <thead>
           <tr>
             <th style="width:5%">Gene</th>

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -44,8 +44,8 @@
             <th style="width:10%">Variant Name</th>
             <th style="width:20%">Change</th>
             <th style="width:3%">Category</th>
-            <th style="width:3%">Rank score</th>
-            <th style="width:5%">Zygosity</th>
+            <th style="width:3%" data-toggle='tooltip' data-container='body' title="score(model version)">Rank score</th>
+            <th style="width:5%" data-toggle='tooltip' data-container='body' title="ref/alt-GQ">Zygosity</th>
             <th style="width:3%">Inheritance</th>
             <th style="width:5%">ACMG</th>
             <th style="width:5%">Case Name</th>
@@ -82,15 +82,12 @@
             </span></a></td>
             <td>
               {% for sample in variant.samples %}
-              {% for ind in case.individuals %}
-              {% if sample.sample_id == ind.individual_id %}
-              {% if ind.phenotype == 2%}
-              <span class="badge badge-danger">{{sample.genotype_call}}</span>
-              {% else %}
-              <span class="badge badge-success">{{sample.genotype_call}}</span>
-              {% endif %}
-              {% endif %}
-              {% endfor %}
+                {% for ind in case.individuals %}
+                  {% if sample.sample_id == ind.individual_id %}
+                    {% set allele_depths = ['ref depth', sample.allele_depths[0]]|join(":") + ' - ' + ['alt depth', sample.allele_depths[1]]|join(":") %}
+                    <span data-toggle='tooltip' data-container='body' title="{{allele_depths}}" class="badge badge-{{'danger' if ind.phenotype == 2 else 'success' }}">{{sample.genotype_call}} GQ:{{sample.genotype_quality}}</span>
+                  {% endif %}
+                {% endfor %}
               {% endfor %}
             </td>
             <td>{% for model in variant.genetic_models %}

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -81,14 +81,14 @@
               {% endif %}
             </span></a></td>
             <td>
-              {% for sample in variant.samples %}
-                {% for ind in case.individuals %}
-                  {% if sample.sample_id == ind.individual_id %}
+              {%- for sample in variant.samples -%}
+                {%- for ind in case.individuals -%}
+                  {%- if sample.sample_id == ind.individual_id -%}
                     {% set allele_depths = ['ref depth', sample.allele_depths[0]]|join(":") + ' - ' + ['alt depth', sample.allele_depths[1]]|join(":") %}
                     <span data-toggle='tooltip' data-container='body' title="{{allele_depths}}" class="badge badge-{{'danger' if ind.phenotype == 2 else 'success' }}">{{sample.genotype_call}} GQ:{{sample.genotype_quality}}</span>
-                  {% endif %}
-                {% endfor %}
-              {% endfor %}
+                  {%- endif -%}
+                {%- endfor -%}
+              {%- endfor -%}
             </td>
             <td>{% for model in variant.genetic_models %}
               <span class="badge badge-info">{{model}}</span>


### PR DESCRIPTION
fix #1572. 
Introduce QG and read depth along with zygosity.
 
The field should look like this:
![image](https://user-images.githubusercontent.com/28093618/70708656-56ecda80-1cdb-11ea-97cf-57dde4a0829c.png)

**How to test**:
1. Mark causatives some variants (good-bad quality, snv, svs, str vars) and see how the new causatives page shows them. Make sure that:
- [x] QC is reported in the table, in the same badge as zygosity.
- [x] read depth is a popover thinghy.
- [x] Only QC will be exported to excel, not read depth.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
