### PR TITLE
Include partial causatives in general report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add or modify individuals' age or tissue type from case page
 - Display GC and allele depth in causatives table.
 - Included primary reference transcript in general report
+- Included partial causative variants in general report
 
 ### Fixed
 - Fixed update OMIM command bug due to change in the header of the genemap2 file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Rank score model in causatives page
 - Exportable HPO terms from phenotypes page
 - AMP guideline tiers for cancer variants
-- Adds scroll for the trancript tab
+- Adds scroll for the transcript tab
 - Added CLI option to query cases on time since case event was added
 - Shadow clinical assessments also on research variants display
 - Support for CRAM alignment files
@@ -31,7 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed issue on the case statistics view. The validation bars didn't show up when all institutes were selected. Now they do.
 - Included Font Awesome availability in general report
 - Fixed missing path import by importing pathlib.Path
-- Hadle index inconsistencies in the update index functions
+- Handle index inconsistencies in the update index functions
 - Fixed layout problems
 
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -236,6 +236,7 @@ def case_report_content(store, institute_obj, case_obj):
     """
     variant_types = {
         'causatives_detailed': 'causatives',
+        'partial_causatives_detailed': 'partial_causatives',
         'suspects_detailed': 'suspects',
         'classified_detailed': 'acmg_classification',
         'tagged_detailed': 'manual_rank',
@@ -263,16 +264,17 @@ def case_report_content(store, institute_obj, case_obj):
     data['report_created_at'] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
 
     evaluated_variants = {vt:[] for vt in variant_types}
-    # We collect all causatives and suspected variants
+    # We collect all causatives (including the partial ones) and suspected variants
     # These are handeled in separate since they are on case level
-    for var_type in ['causatives', 'suspects']:
+    for var_type in ['causatives', 'suspects', 'partial_causatives']:
         #These include references to variants
         vt = '_'.join([var_type, 'detailed'])
-        for var_id in case_obj.get(var_type,[]):
+        for var_id in case_obj.get(var_type, []):
             variant_obj = store.variant(var_id)
             if not variant_obj:
                 continue
-            # If the variant exists we add it to the evaluated variants
+            if var_type == 'partial_causatives': # Collect associated phenotypes
+                variant_obj['phenotypes'] = [ value for key,value in case_obj['partial_causatives'].items() if key==var_id][0]
             evaluated_variants[vt].append(variant_obj)
 
     ## get variants for this case that are either classified, commented, tagged or dismissed.

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -119,7 +119,7 @@
                         n.a.
                       {% endif %}
 	                    {% if ind.confirmed_sex %}
-	                      <span class="badge badge-pill badge-sm badge-light">V</span>
+	                      <span class="badge badge-pill badge-sm badge-secondary">V</span>
 	                    {% endif %}
 	                  </td>
 	                  <td>
@@ -134,7 +134,7 @@
 	                  <td>{{ ind.predicted_ancestry or 'N/A' }}</td>
 	                  <td>
 	                    {% if ind.confirmed_parent == True %}
-	                      <span class="badge badge-pill badge-sm badge-light">V</span>
+	                      <span class="badge badge-pill badge-sm badge-secondary">V</span>
 	                    {% elif ind.confirmed_parent == False %}
 	                      <span class="badge badge-pill badge-sm badge-danger">!</span>
 	                    {% else %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -265,7 +265,7 @@
   </div>
   <div class="card-body">
     {% if causatives_detailed %}
-      {% for causative in causatives_detailed|sort(attribute='variant_rank') %}
+      {% for causative in causatives_detailed|sort(attribute='variant_rank') + partial_causatives_detailed|sort(attribute='variant_rank') %}
         {% do printed_vars.append(causative['_id']) %}
         {% if causative.category == 'snv' %}
           {{ sn_variant_content(causative, loop.index) }}
@@ -431,6 +431,17 @@
             <span class="badge badge-info" title="sanger-status">Verification ordered</span>
           {% endif %}
       </div>
+      {% if variant.get('phenotypes') %}
+        <div class="row mt-3">
+          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+            OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
+            HPO terms:&nbsp;
+            {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
+              {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
+            {%- endfor -%}
+          </h6>
+        </div>
+      {% endif %}
     </div>
     <div class="card-body">
       <table id="panel-table" class="table table-sm">
@@ -860,8 +871,21 @@
 {% macro sv_variant_content(variant,index) %} <!--The entire description of a structural variant, dynamic contentc -->
   <div class="card" style="border-width: 5px;">
     <div class="card-header">
+      <div class="row">
       # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
       &nbsp;<span class="badge badge-pill badge-warning">SV</span>
+      </div>
+      {% if variant.get('phenotypes') %}
+        <div class="row mt-3">
+          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+            OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
+            HPO terms:&nbsp;
+            {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
+              {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
+            {%- endfor -%}
+          </h6>
+        </div>
+      {% endif %}
     </div>
     <div class="card-body">
       <table id="panel-table" class="table table-sm" style="background-color: transparent">

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -264,7 +264,7 @@
     <a name="causative_variants"><strong>Causative Variants</strong></a>
   </div>
   <div class="card-body">
-    {% if causatives_detailed %}
+    {% if causatives_detailed or partial_causatives_detailed %}
       {% for causative in causatives_detailed|sort(attribute='variant_rank') + partial_causatives_detailed|sort(attribute='variant_rank') %}
         {% do printed_vars.append(causative['_id']) %}
         {% if causative.category == 'snv' %}
@@ -422,7 +422,7 @@
 {% macro sn_variant_content(variant, index) %} <!--The entire description of a single nucleotide variant, dynamic content -->
   <div class="card" style="border-width: 5px;">
     <div class="card-header">
-      <div class="row">
+      <div class="row d-flex align-items-center">
         # <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name}}</strong></a>&nbsp;
           <span class="badge badge-pill badge-success">SNV</span>&nbsp;
           {% if variant.sanger_ordered and variant.validation %}
@@ -869,252 +869,23 @@
 {% endmacro %}
 
 {% macro sv_variant_content(variant,index) %} <!--The entire description of a structural variant, dynamic contentc -->
-  <div class="card" style="border-width: 5px;">
-    <div class="card-header">
-      <div class="row">
-      # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
-      &nbsp;<span class="badge badge-pill badge-warning">SV</span>
-      </div>
-      {% if variant.get('phenotypes') %}
-        <div class="row mt-3">
-          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
-            OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
-            HPO terms:&nbsp;
-            {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
-              {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
-            {%- endfor -%}
-          </h6>
-        </div>
-      {% endif %}
-    </div>
-    <div class="card-body">
-      <table id="panel-table" class="table table-sm" style="background-color: transparent">
-        <thead>
-          <tr>
-            <th>Variant type</th>
-            <th>length</td>
-            <th>Coordinates</th>
-            <th>Cytoband</th>
-            <th>Gene panels</th>
-            <th>Callers</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><span class="badge badge-warning float-left">{{variant.sub_category|upper}}</span></td>
-            <td>{{ variant.length }}</td>
-            <td>
-              {% if variant.chromosome == variant.end_chrom %}
-                chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
-              {% else %}
-                chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}
-              {% endif %}
-            </td>
-            {% if variant.cytoband_start and variant.cytoband_end %}
-              <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
-            {% else %}
-              <td>-</td>
-            {% endif %}
-            <td>
-              {% for panel_id in variant.panels %}
-                <a href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank">{{ panel_id }}</a><br>
-              {% endfor %}
-            </td>
-            <td>
-              {% if variant.callers %}
-                {% for caller,call in variant.callers|sort %}
-                  <span class="badge badge-secondary">{{ caller+':'+call }}</span>
-                {% endfor %}
-              {% else %}
-              -
-              {% endif %}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table id="panel-table" class="table table-sm" style="background-color: transparent">
-        <tr>
-          <td>
-            <table id="panel-table" class="table table-bordered table-sm" style="background-color: transparent">
-              <thead>
-                <tr>
-                  <th rowspan="2">Sample</th>
-                    <th rowspan="2">Genotype (GT)</th>
-                    <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                    <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th>
-                  </tr>
-                  <tr>
-                    <th>Reference</th>
-                    <th>Alternative</th>
-                  </tr>
-                </tr>
-              </thead>
-              <tbody>
-                {% for sample in variant.samples %}
-                  <tr {% if sample.display_name in affected %} class="table-danger" {% endif %}>
-                    <td>{{ sample.display_name }}</td>
-                    <td class="text-center">{{ sample.genotype_call }}</td>
-                    {% if sample.allele_depths %}
-                        {% for number in sample.allele_depths %}
-                          <td class="text-right">{{ number }}</td>
-                        {% endfor %}
-                    {% else %}
-                        <td class="text-right"><small>N/A</small></td>
-                        <td class="text-right"><small>N/A</small></td>
-                    {% endif %}
-                    <td class="text-right">{{ sample.genotype_quality }}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </td>
-          <td style="width:3%"></td>
-          <td>
-            <table id="panel-table" class="table table-sm" style="background-color: transparent">
-              <thead>
-                <th colspan=2>Frequencies</th>
-              </thead>
-              <tbody>
-                {% for freq_name, value in variant.frequencies %}
-                  <tr>
-                    <td>{{ freq_name }}</td>
-                    <td>
-                      {% if value %}
-                        <span class="badge badge-secondary">{{ value|human_decimal }}</span>
-                      {% else %}
-                        <span class="text-muted">Not annotated</span>
-                      {% endif %}
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      </table>
-      <table id="panel-table" class="table table-sm" style="background-color: transparent">
-        <thead>
-          <tr>
-            <th>Scout Rank</th>
-            <th>Scout score</th>
-            <th>Manual rank</th>
-            <th>Inheritance models</th>
-            <th>ACMG classification</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>{{variant.variant_rank}}</td>
-            <td>{{variant.rank_score}}</td>
-            <td>
-            {% if variant.manual_rank %}
-              <span class="badge badge-pill badge-secondary" title="Manual rank">{{ manual_rank_options[variant.manual_rank]['label'] }}</span>
-            {% endif %}
-            {% if variant.cancer_tier %}
-              <span class="badge badge-pill badge-secondary" title="Tier">{{ cancer_rank_options[variant.cancer_tier]['label'] }}</span>
-            {% endif %}
-            {% if not (variant.manual_rank or variant.cancer_tier) %}
-              -
-            {% endif %}
-            </td>
-            <td>
-              <span class="float-left">
-                {% for model in variant.genetic_models|sort %}
-                  <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
-                {% else %}
-                  <span class="badge badge-warning">No models followed</span>
-                {% endfor %}
-              </span>
-            </td>
-            <td>
-              {% if variant.acmg_classification %}
-                <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['code'] }}</span>
-              {% else %}
-                -
-              {% endif %}
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table id="panel-table" class="table table-sm" style="background-color: transparent">
-        <thead>
-          <tr>
-            <th>Affected gene(s)</th>
-            <th>Description</th>
-            <th>Region annotation</th>
-            <th>Transcript - HGVS - Protein</th>
-            <th>OMIM phenotypes [inheritance]</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for gene in variant.genes %}
-            <tr>
-              <td>
-                <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
-                {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-                </a>
-              </td>
-              <td>{{gene.description|title}}</td>
-              <td>{{gene.region_annotation}}</td>
-              <td>
-                {% set n_primary_transcripts = [] %}
-                <ul>
-                {% for transcript in gene.primary_transcripts %}
-                  {% do n_primary_transcripts.append(gene.primary_transcripts|length) %}
-                  {% if loop.index <= 5 or transcript.is_canonical %} <!--Do not print too many transcript, but include the canonical-->
-                    <li>{{transcript.refseq_id}} - {{ (transcript.coding_sequence_name or '')|truncate(20, True) }} - {{ (transcript.protein_sequence_name or '')|url_decode }}
-                    {% if transcript.is_canonical %}
-                      <span class="badge badge-pill badge-secondary" title="canonical">C</span>
-                    {% endif %}
-                    </li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-                {% if n_primary_transcripts|sum > 5 %}
-                .. other transcripts available for this variant are not shown.<br><br>
-                {% endif %}
-              </td>
-              <td>
-                <ul>
-                {% for disease_term in gene.disease_terms %}
-                  <li>{{ disease_term.description }}&nbsp;{{ disease_term.inheritance }}</li>
-                {% endfor %}
-                </ul>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-
-      {% if variant.comments.count() %}
-        <br>
-        <table id="panel-table" class="table table-sm" style="background-color: transparent">
-          <thead>
-            <tr>
-              <td colspan=3><strong>Variant-related comments</strong></td>
-            </tr>
-          </thead>
-          <tbody>
-            {% for comment in variant.comments %}
-              <tr>
-                <td width="20%">{{comment.created_at.strftime('%Y-%m-%d')}}</td>
-                <td width="20%">{{comment.user_name}}:</td>
-                <td><strong>{{ comment.content }}</strong></td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
-    </div>
-  </div>
-</div>
-{% endmacro %}
-
-{% macro sv_variant_content(variant,index) %} <!--The entire description of a structural variant, dynamic contentc -->
 <div class="card" style="border-width: 5px;">
   <div class="card-header">
+    <div class="row d-flex align-items-center">
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
     &nbsp;<span class="badge badge-pill badge-warning">SV</span>
+    </div>
+    {% if variant.get('phenotypes') %}
+      <div class="row mt-3">
+        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+          OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
+          HPO terms:&nbsp;
+          {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
+            {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
+          {%- endfor -%}
+        </h6>
+      </div>
+    {% endif %}
   </div>
   <div class="card-body">
     <table id="panel-table" class="table table-sm" style="background-color: transparent">

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -111,13 +111,15 @@
 	                <tr {% if ind.phenotype == 2 %} class="table-danger" {% endif %}>
 	                  <td>{{ ind.display_name }}</td>
 	                  <td>
-                      {% if ind.sex_human in ['female','male'] %}
-                        <i class="fa fa-{{ind.sex_human}}" aria-hidden="true"></i>
+                      {% if ind.sex_human == 'female' %}
+                        F
+                      {% elif ind.sex_human == 'male' %}
+                        M
                       {% else %}
                         n.a.
                       {% endif %}
 	                    {% if ind.confirmed_sex %}
-	                      <i class="fa fa-check"></i>
+	                      <span class="badge badge-pill badge-sm badge-light">V</span>
 	                    {% endif %}
 	                  </td>
 	                  <td>
@@ -132,9 +134,9 @@
 	                  <td>{{ ind.predicted_ancestry or 'N/A' }}</td>
 	                  <td>
 	                    {% if ind.confirmed_parent == True %}
-	                      <i class="fa fa-check"></i>
+	                      <span class="badge badge-pill badge-sm badge-light">V</span>
 	                    {% elif ind.confirmed_parent == False %}
-	                      <i class="fa fa-exclamation-circle"></i>
+	                      <span class="badge badge-pill badge-sm badge-danger">!</span>
 	                    {% else %}
 	                      N/A
 	                    {% endif %}


### PR DESCRIPTION
fix #1587

**How to test**:
1. Mark one or more variants (SNVs, SVs) as partial causatives
1. Go to general report and check they're shown on it (also relative HPO and OMIM terms)
1. Make sure that also the PDF report is correct.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
