### PR TITLE
Layout fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Included Font Awesome availability in general report
 - Fixed missing path import by importing pathlib.Path
 - Hadle index inconsistencies in the update index functions
+- Fixed layout problems
 
 
 ## [4.9.0]

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -65,8 +65,8 @@
           </div>
         {% endif %}
       </div>
-      <div class="col-md-2 col-sm-2">
-      <select name="institute" id="institute" onchange="this.form.submit()">
+      <div class="col-md-4 col-sm-2">
+      <select name="institute" class="form-control" id="institute" onchange="this.form.submit()">
         {% for inst in institutes %}
           {% if inst.display_name == 'All institutes' and query and not current_user.is_admin %}
             <option value="{{ inst._id }}" disabled>{{ inst.display_name }}</option>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -63,14 +63,10 @@
             </li>
 
             <div class="list-group-item">
-              Gene panels
-              <ul class="list-inline float-right list-scroll">
-                {% for panel_id in variant.panels %}
-                  <li>
-                    <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>
-                  </li>
-                {% endfor %}
-              </ul>
+              <strong>Gene panels:</strong><br>
+              {% for panel_id in variant.panels %}
+                <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>&nbsp;&nbsp;
+              {% endfor %}
             </div>
             <div class="list-group mt-3">
               <div>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -318,14 +318,10 @@
       </div>
       <ul class="list-group">
         <div class="list-group-item">
-          <strong>Gene panels</strong>
-          <ul class="list-inline float-right">
-            {% for panel_id in variant.panels %}
-              <li>
-                  <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>
-              </li>
-            {% endfor %}
-          </ul>
+          <strong>Gene panels:</strong><br>
+          {% for panel_id in variant.panels %}
+            <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>&nbsp;&nbsp;
+          {% endfor %}
         </div>
       </ul>
       <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
@@ -554,7 +550,7 @@
 	</tbody>
       </table>
       {% endif %}
-      
+
     </div> <!-- end of card body -->
   </div> <!--  end of card div -->
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -22,7 +22,7 @@
         {% endif %}
       </div>"
         href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
-      </a>
+      </a>&nbsp;&nbsp;
     {% endfor %}
     {% if variant.panels|count > 0 %}
         <a

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -166,7 +166,7 @@
             {{ variant.hgnc_symbols[:2]|join(', ') }} [...] {{ variant.hgnc_symbols[-2:]|join(', ') }}
           {% else %}
             {% for symbol in variant.hgnc_symbols %}
-              <div>{{ symbol }}</div>
+              <div>{{ symbol }}</div>&nbsp;&nbsp;
             {% endfor %}
           {% endif %}
         </div>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -55,7 +55,7 @@
               <th style="width:8%" title="Rank position">Rank </th>
               <th style="width:8%" title="Rank score">Score</th>
               <th style="width:8%" title="Chromosome">Chr.</th>
-              <th style="width:8%" title="HGNC symbols" >Gene</th>
+              <th style="width:8%" title="HGNC symbols">Gene</th>
               <th style="width:8%" title="Poulation frequency">PopFreq</th>
               <th style="width:8%" title="CADD score">CADD</th>
               <th style="width:8%" title="Gene region annotation">Gene annotation</th>


### PR DESCRIPTION
final fix #1497
**Introduced fixes:**
- [ ] Select style in dashboard page:

Master looks like this:
![image](https://user-images.githubusercontent.com/28093618/70914033-7c4d5180-2017-11ea-9dd2-52390f22dafa.png)

After this fix:
![image](https://user-images.githubusercontent.com/28093618/70914014-6e97cc00-2017-11ea-86d8-86caebbe0c8c.png)

-------------------

- [ ] Gene panel style on variahttps://scout-stage.scilifelab.se/cust003/94/5d0e8f66a544daeb748fb3049b745046nts (snvs & svs) page:
Master looks like this ()

![image](https://user-images.githubusercontent.com/28093618/70915093-853f2280-2019-11ea-8137-82d05ba8de8a.png)

After installing this branch:

![image](https://user-images.githubusercontent.com/28093618/70915920-0ea32480-201b-11ea-81b7-3217491cb282.png)

-------------------

- [ ] Add space between genes in variants page. In this case for example: https://scout-stage.scilifelab.se/cust003/14001/variants?variant_type=clinical&gene_panels=IEM#collapseFilters

Master looks like this:
![image](https://user-images.githubusercontent.com/28093618/70914417-4066bc00-2018-11ea-8b50-af76505610d2.png)

After installing this branch:

![image](https://user-images.githubusercontent.com/28093618/70916045-45793a80-201b-11ea-86d0-3138cfe6844a.png)

-------------------

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
