### PR TITLE
display locus name on str variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+- Display locus name on STR variant page
 
 ### Fixed
 

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -290,6 +290,14 @@
               <span class="float-right"><strong>{{ variant.reference }} → {{ variant.alternative }}</strong></span>
             </td>
           </tr>
+          {% if variant.str_repid %}
+          <tr>
+            <td colspan="2">
+              Repeat locus
+              <span><strong>{{variant.str_repid}}</strong></span>
+            </td>
+          </tr>
+          {% endif %}
         </tbody>
       </table>
       <div class="table-responsive">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -278,7 +278,7 @@
           <tr>
             <td>
               Position
-              <span class="float-right">
+              <span>
                 <strong>{{ variant.chromosome }}:<span class="text-muted">{{ variant.position }}</span></strong>
                 {% if variant.is_par %}
                   <span class="badge badge-info">PAR</span>
@@ -287,7 +287,7 @@
             </td>
             <td>
               Change
-              <span class="float-right"><strong>{{ variant.reference }} → {{ variant.alternative }}</strong></span>
+              <span><strong>{{ variant.reference }} → {{ variant.alternative }}</strong></span>
             </td>
           </tr>
           {% if variant.str_repid %}


### PR DESCRIPTION
fix #1601

**How to test**:
1. Install the branch on a local instance of scout
1. Open a str variant page and note that the repeat locus name is present:

![image](https://user-images.githubusercontent.com/28093618/71660478-79f33300-2d4b-11ea-8847-ab0861856dac.png)



**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
