### PR TITLE
Avoid flashing popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Alternative key `GNOMADAF_popmax` for Gnomad popmax allele frequency
 - Automatic suggestions on how to improve the code on Pull Requests
 - Parse GERP, phastCons and phyloP annotations from vep annotated CSQ fields
-
+- Avoid flickering comment popovers in variant list
 
 ### Fixed
 

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -131,7 +131,8 @@ table.dataTable {margin-bottom: 0rem}
 }
 
 .popover {
-	max-width: none;
+    max-width: none;
+    pointer-events: none;
 }
 
 .popover-content > table {


### PR DESCRIPTION
The comment popover:
![image](https://user-images.githubusercontent.com/11991860/72623549-9f845d00-3945-11ea-8a3f-9d407d2091ce.png)

...is flickering wildly and is unreadable for long comments (if wider than the browser window I think). This has been the case since the BS4 update.

This simple CSS change fixes it. And as far as I can see it doesn't have any other side effects.