### PR TITLE
Ci/fix tidy

### DIFF
--- a/.gitlint.yaml
+++ b/.gitlint.yaml
@@ -223,25 +223,6 @@ ini:
 
 # HTML
 # Sample output:
-# line 2 column 1 - Warning: missing </h2> before </h3>
-tidy:
-  extensions:
-    - .html
-  command: tidy-wrapper.sh
-  requirements:
-    - tidy
-    - remove_template.py
-    - grep
-  arguments:
-    - -qe
-    - --drop-empty-elements
-    - "false"
-  installation: Visit https://w3c.github.io/tidy-html5/
-  filter: >-
-    ^line (?P<line>{lines}) column (?P<column>\d+) -
-    (?P<severity>[^:]+): (?P<message>.+)
-
-# Sample output:
 # 1:10: Error: Javascript ...
 html_lint:
   extensions:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,66 +5,70 @@ env: TRAVIS=1
 
 jobs:
     include:
-        - name: "Package install"
-          if: type = pull_request
-          install: python setup.py install
-          script: true
-
-        - name: "Production dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install .
-          script: pip check
-
-        - name: "Development dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install -r requirements.txt -r requirements-dev.txt .
-          script: pip check
-
-        - name: "Tests"
-          if: type = pull_request
-          services: mongodb
-          install:
-              - pip install cython
-              - pip install . -r requirements-dev.txt
-          script: py.test -rxs tests/
-
-        - name: "Tests & Coverage"
-          if: NOT type = pull_request
-          services: mongodb
-          install:
-              - pip install cython
-              - pip install -r requirements-dev.txt -e .
-          script: py.test --cov=scout -rxs tests/
-          after_success: coveralls
-
-        - name: "Code formatting"
-          if: type = pull_request
-          install: pip install black
-          script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
-
-        - name: "Pylint score"
-          if: type = pull_request
-          install: pip install pylint
-          script:
-              - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
-              - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
-              - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
-              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/after_files.txt) > $TRAVIS_HOME/pylint_after_output.txt
-              - git checkout $TRAVIS_BRANCH
-              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
-              - >-
-                grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
-                grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
-                (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
+#        - name: "Package install"
+#          if: type = pull_request
+#          install: python setup.py install
+#          script: true
+#
+#        - name: "Production dependencies"
+#          if: type = pull_request
+#          install:
+#              - pip install cython
+#              - pip install .
+#          script: pip check
+#
+#        - name: "Development dependencies"
+#          if: type = pull_request
+#          install:
+#              - pip install cython
+#              - pip install -r requirements.txt -r requirements-dev.txt .
+#          script: pip check
+#
+#        - name: "Tests"
+#          if: type = pull_request
+#          services: mongodb
+#          install:
+#              - pip install cython
+#              - pip install . -r requirements-dev.txt
+#          script: py.test -rxs tests/
+#
+#        - name: "Tests & Coverage"
+#          if: NOT type = pull_request
+#          services: mongodb
+#          install:
+#              - pip install cython
+#              - pip install -r requirements-dev.txt -e .
+#          script: py.test --cov=scout -rxs tests/
+#          after_success: coveralls
+#
+#        - name: "Code formatting"
+#          if: type = pull_request
+#          install: pip install black
+#          script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
+#
+#        - name: "Pylint score"
+#          if: type = pull_request
+#          install: pip install pylint
+#          script:
+#              - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
+#              - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
+#              - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
+#              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/after_files.txt) > $TRAVIS_HOME/pylint_after_output.txt
+#              - git checkout $TRAVIS_BRANCH
+#              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
+#              - >-
+#                grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
+#                grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
+#                (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
 
         - name: "Linting"
-          if: type = pull_request
+          #if: type = pull_request
           install: pip install git-lint pylint pycodestyle yamllint docutils html-linter tidy
-          script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+          script:
+              - which tidy
+              - remove_template.py
+              - which grep
+              - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,6 @@ env: TRAVIS=1
 
 jobs:
     include:
-        - name: "Package install"
-          if: type = pull_request
-          install: python setup.py install
-          script: pip check
-
-        - name: "Production dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install .
-          script: pip check
-
-        - name: "Development dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install . -r requirements-dev.txt
-          script: pip check
-
         - name: "Tests"
           if: type = pull_request
           services: mongodb
@@ -40,6 +21,25 @@ jobs:
               - pip install -r requirements-dev.txt -e .
           script: py.test --cov=scout -rxs tests/
           after_success: coveralls
+
+        - name: "Package Install"
+          if: type = pull_request
+          install: python setup.py install
+          script: pip check
+
+        - name: "Production Dependencies"
+          if: type = pull_request
+          install:
+              - pip install cython
+              - pip install .
+          script: pip check
+
+        - name: "Development Dependencies"
+          if: type = pull_request
+          install:
+              - pip install cython
+              - pip install . -r requirements-dev.txt
+          script: pip check
 
         - name: "PEP8 Compliance"
           if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,67 +5,66 @@ env: TRAVIS=1
 
 jobs:
     include:
-#        - name: "Package install"
-#          if: type = pull_request
-#          install: python setup.py install
-#          script: true
-#
-#        - name: "Production dependencies"
-#          if: type = pull_request
-#          install:
-#              - pip install cython
-#              - pip install .
-#          script: pip check
-#
-#        - name: "Development dependencies"
-#          if: type = pull_request
-#          install:
-#              - pip install cython
-#              - pip install -r requirements.txt -r requirements-dev.txt .
-#          script: pip check
-#
-#        - name: "Tests"
-#          if: type = pull_request
-#          services: mongodb
-#          install:
-#              - pip install cython
-#              - pip install . -r requirements-dev.txt
-#          script: py.test -rxs tests/
-#
-#        - name: "Tests & Coverage"
-#          if: NOT type = pull_request
-#          services: mongodb
-#          install:
-#              - pip install cython
-#              - pip install -r requirements-dev.txt -e .
-#          script: py.test --cov=scout -rxs tests/
-#          after_success: coveralls
-#
-#        - name: "Code formatting"
-#          if: type = pull_request
-#          install: pip install black
-#          script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
-#
-#        - name: "Pylint score"
-#          if: type = pull_request
-#          install: pip install pylint
-#          script:
-#              - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
-#              - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
-#              - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
-#              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/after_files.txt) > $TRAVIS_HOME/pylint_after_output.txt
-#              - git checkout $TRAVIS_BRANCH
-#              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
-#              - >-
-#                grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
-#                grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
-#                (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
+        - name: "Package install"
+          if: type = pull_request
+          install: python setup.py install
+          script: pip check
 
-        - name: "Linting"
-          #if: type = pull_request
-          install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
+        - name: "Production dependencies"
+          if: type = pull_request
+          install:
+              - pip install cython
+              - pip install .
+          script: pip check
+
+        - name: "Development dependencies"
+          if: type = pull_request
+          install:
+              - pip install cython
+              - pip install . -r requirements-dev.txt
+          script: pip check
+
+        - name: "Tests"
+          if: type = pull_request
+          services: mongodb
+          install:
+              - pip install cython
+              - pip install . -r requirements-dev.txt
+          script: py.test -rxs tests/
+
+        - name: "Tests & Coverage"
+          if: NOT type = pull_request
+          services: mongodb
+          install:
+              - pip install cython
+              - pip install -r requirements-dev.txt -e .
+          script: py.test --cov=scout -rxs tests/
+          after_success: coveralls
+
+        - name: "PEP8 Compliance"
+          if: type = pull_request
+          install: pip install black
+          script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
+
+        - name: "Code Quality Score"
+          if: type = pull_request
+          install: pip install pylint
           script:
-              - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+              - grep -r -E "pylint. {0,1}disable\=" .; if [ $? -eq 0 ]; then echo "Can not run pylint scoring with any pylint warnings disabled, please remove them and try again" && false; else true; fi
+              - (git --no-pager diff --name-only --diff-filter=M $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/before_files.txt
+              - (git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" || echo "$(basename "$PWD")") > $TRAVIS_HOME/after_files.txt
+              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/after_files.txt) > $TRAVIS_HOME/pylint_after_output.txt
+              - git checkout $TRAVIS_BRANCH
+              - pylint --rcfile=.configs/pylintrc --jobs=0 --exit-zero $(< $TRAVIS_HOME/before_files.txt) > $TRAVIS_HOME/pylint_before_output.txt
+              - >-
+                grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
+                grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
+                (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
+
+        - name: "Lint Free"
+          if: type = pull_request
+          install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
+          script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,9 @@ jobs:
 
         - name: "Linting"
           #if: type = pull_request
-          install: pip install git-lint pylint pycodestyle yamllint docutils html-linter tidy
+          install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
           script:
-              - pip show tidy
-              - remove_template.py
-              - tidy-wrapper.sh
-              - which grep
               - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
-              - tidy
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,10 +65,12 @@ jobs:
           #if: type = pull_request
           install: pip install git-lint pylint pycodestyle yamllint docutils html-linter tidy
           script:
-              - which tidy
+              - pip show tidy
               - remove_template.py
+              - tidy-wrapper.sh
               - which grep
               - git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+              - tidy
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
           install: pip install black
           script: git --no-pager diff --name-only --diff-filter=AM $TRAVIS_COMMIT_RANGE | grep -F ".py" | xargs black --check
 
-        - name: "Code Quality Score"
+        - name: "Pylint Rating"
           if: type = pull_request
           install: pip install pylint
           script:
@@ -59,12 +59,12 @@ jobs:
               - >-
                 grep -F "/10, -" $TRAVIS_HOME/pylint_before_output.txt ||
                 grep -F "/10, +0.00" $TRAVIS_HOME/pylint_before_output.txt ||
-                (echo "pylint score decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
+                (echo "pylint rating decreased, please try again after fixing some lint issues." && cat $TRAVIS_HOME/pylint_after_output.txt && false)
 
         - name: "Lint Free"
           if: type = pull_request
           install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
-          script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint
+          script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint || (echo "Linting issues found, please try again after fixing the above lint issues." && false)
 
 notifications:
     email: false

--- a/scout/demo/delivery_report.html
+++ b/scout/demo/delivery_report.html
@@ -1,6 +1,3 @@
-
-
-
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/scout/demo/delivery_report.html
+++ b/scout/demo/delivery_report.html
@@ -1,3 +1,4 @@
+
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/scout/demo/delivery_report.html
+++ b/scout/demo/delivery_report.html
@@ -1,5 +1,6 @@
 
 
+
 <html lang="en">
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
This PR fixes linting of html-files on travis. Resolves #1627. Removes dependency on tidy since it is a bit tricky to install on travis 

**How to test**:
1. Open Travis PR-check
1. open the "Lint Free" job

**Expected outcome**:
- [x] The linter should OK the delivery-report.html without suggesting to install tidy.
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @dnil
- [x] tests executed by @patrikgrenfeldt 

