### PR TITLE
Calculate coverage for PR CI but not for push CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
           script: py.test -rxs tests/
 
         - name: "Tests & Coverage"
-          if: NOT type = pull_request
+          if: NOT type = push
           services: mongodb
           install:
               - pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env: TRAVIS=1
 jobs:
     include:
         - name: "Tests"
-          if: type = pull_request
+          if: type = push
           services: mongodb
           install:
               - pip install cython

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Slightly darker page background
 - Fixed an issued with parsed conservation values from CSQ
-
+- Coverage calculated on Pull Request commits instead of last push commit
 
 ## [4.10.1]
 


### PR DESCRIPTION
This PR fixes erroneous coverage calculation on CI by moving it from the push CI to the PR CI

**How to test**:
1. open the push check

**Expected outcome**:
- [x] No coverage check

**How to test**:
1. open the PR check

**Expected outcome**:
- [x] coverage check

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by @patrikgrenfeldt 
- [ ] "merge and deploy" approved by
