### PR TITLE
Fix #1638. Allow travis fails on code quality advisory jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,5 +66,10 @@ jobs:
           install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
           script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint || (echo "Linting issues found, please try again after fixing the above lint issues." && false)
 
+    allow_failures:
+      - name: "Lint Free"
+      - name: "PEP8 Compliance"
+      - name: "Pylint Rating"
+
 notifications:
     email: false


### PR DESCRIPTION
**How to test**:
Lint, Lint score and PEP8 rests on travis should be advisory / discretional. Fix #1638.

**Expected outcome**:
The functionality should be working

**Review:**
- [x] code approved by CR
- [x] tests executed by @ ehr Travis

