### PR TITLE
Add black as optional pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
 
         - name: "Lint Free"
           if: type = pull_request
-          install: pip install git-lint pylint pycodestyle yamllint docutils html-linter
+          install: pip install -r requirements-dev.txt
           script: git reset --soft ${TRAVIS_COMMIT_RANGE%...*} && git lint || (echo "Linting issues found, please try again after fixing the above lint issues." && false)
 
     allow_failures:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid flickering comment popovers in variant list
 - Parse REVEL score from vep annotated CSQ fields
 - Allow users to modify general institute settings
-
+- Optionally format code automatically on commit
 
 ### Fixed
 - Slightly darker page background

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,20 +29,22 @@ own feature branch, based on an updated master branch.
 
 1. Please try to name your PR with dashes as separator like `adds-supertrack-to-igv`
 1. We have a pull request template to help you defining the proposed changes/fixes and how to test
-    the code.
-1. If the pull request adds functionality the docs should be updated.
+    the code
+1. If the pull request adds functionality the docs should be updated
 1. Don't forget to update the CHANGELOG.md document
-1. The PR is automatically built and tested on Travis-CI.
-Please know that we appreciate your work even if Travis suggests changes.
+1. The PR is automatically built and tested on [Travis-CI][travis-ci]. Please know that we appreciate your work even if Travis suggests changes
+    1. _PEP8 Compliance_: [Black][black] is a tool to make code [PEP8][pep8] compliant. Black is run on the code and reports if it would make changes to the code to make it compliant with its formatting rules. To get automatic formatting of your code with Black to PEP8 you can install [pre-commit][pre-commit] with `pre-commit install`
+    1. _Pylint Rating_: Pylint is a tool that can suggest changes that would improve maintainability and readability. This tool checks if the new code is at least as well structured as the previous version and suggests improvements otherwise. This check will turn green when the code is at least as well structured as the previous version
+    1. _Lint Free_: Checks line lengths and suggest other code cleanliness improvements
 
 ### Coding standards
 
 - We try to follow [PEP8][pep8] with an line length of 100
-- To get [pre-commit][pre-commit] formatting of code with [Black][black] to PEP8 do `pre-commit install`
-- Always include docstrings to explain functions/classes.
-- All code has to work for python versions > 3.6.
+- Always include docstrings to explain functions/classes
+- All code has to work for python 3.6+
 
 [release_flow]: https://www.nebbiatech.com/2019/03/15/git-branching-strategies-which-one-should-i-pick/
 [pep8]: https://www.python.org/dev/peps/pep-0008/
 [black]: https://github.com/psf/black
 [pre-commit]: https://pre-commit.com/
+[travis-ci]: https://travis-ci.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,11 @@ Please know that we appreciate your work even if Travis suggests changes.
 ### Coding standards
 
 - We try to follow [PEP8][pep8] with an line length of 100
+- To get [pre-commit][pre-commit] formatting of code with [Black][black] to PEP8 do `pre-commit install`
 - Always include docstrings to explain functions/classes.
 - All code has to work for python versions > 3.6.
 
 [release_flow]: https://www.nebbiatech.com/2019/03/15/git-branching-strategies-which-one-should-i-pick/
 [pep8]: https://www.python.org/dev/peps/pep-0008/
+[black]: https://github.com/psf/black
+[pre-commit]: https://pre-commit.com/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,16 @@ invoke
 # docs
 mkdocs
 mkdocs-material
+
+# PEP8 Compliance
+black
+
+# Pylint Rating
+pylint
+
+# Lint Free
+git-lint
+pycodestyle
+yamllint
+docutils
+html-linter

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,7 @@ black
 
 # Pylint Rating
 pylint
+six>=1.12                   # due to astroid 2.3.3 needed by pylint
 
 # Lint Free
 git-lint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ mkdocs
 mkdocs-material
 
 # PEP8 Compliance
+pre-commit
 black
 
 # Pylint Rating


### PR DESCRIPTION
This PR adds optional automatic Black as pre-commit event

**How to test**:
install scout locally including dev-requirements
* run pre-commit install
* make a non PEP8 change to a .py file 
* commit

**Expected outcome**:
The file should be pep8 formatted auto by Black
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @northwestwitch 
- [x] tests executed by @patrikgrenfeldt 
- [x] "merge and deploy" approved @northwestwitch 
