### PR TITLE
Upload coverage on master an push CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
           install:
               - pip install cython
               - pip install -r requirements-dev.txt -e .
-          script: py.test --cov=scout -rxs tests/commands/
+          script: py.test --cov=scout -rxs tests/
           after_success: coveralls
 
         - name: "Package Install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env: TRAVIS=1
 jobs:
     include:
         - name: "Tests"
-          if: type = push
+          if: type = pull_request
           services: mongodb
           install:
               - pip install cython
@@ -14,7 +14,7 @@ jobs:
           script: py.test -rxs tests/
 
         - name: "Tests & Coverage"
-          if: NOT type = push
+          if: NOT type = pull_request
           services: mongodb
           install:
               - pip install cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
           install:
               - pip install cython
               - pip install -r requirements-dev.txt -e .
-          script: py.test --cov=scout -rxs tests/
+          script: py.test --cov=scout -rxs tests/commands/
           after_success: coveralls
 
         - name: "Package Install"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Slightly darker page background
 - Fixed an issued with parsed conservation values from CSQ
-- Coverage calculated on Pull Request commits instead of last push commit
 - Clinvar submissions accessible to all users of an institute
-- Header toolbar when on Clinvar page now shows institute name correctly 
+- Header toolbar when on Clinvar page now shows institute name correctly
 - Case should not always inactivate upon update
 - Show dismissed snv cancer variants as grey on the cancer variants page
 - Improved style of mappability link and local observations on variant page


### PR DESCRIPTION
This PR fixes the issue with coverage reports missing on PRs (fix #1666)

**How to test**:
1. Open this PR on Github
1. Commit some changes that reduces the amount of code covered
1. Revert those changes

**Expected outcome**:
- [x] The build should fail due to decreased coverage
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by Travis CI

This is a patch/fix