### PR TITLE
Fix cancer variants HPO panel link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
 ### Fixed
-
+- Cancer case HPO panel variants link
 
 ## [4.11.1]
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -138,21 +138,17 @@
   </div>
 </div>
 {% if case.is_research%}
-  {% if case.track=="cancer" %}
-    <div class="form-group">
-      <div class="btn-group">
-        <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
-        <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
-      </div>
+  <div class="form-group">
+    <div class="btn-group">
+    {% if case.track=="cancer" %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+    {% else %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+    {% endif %}
     </div>
-  {% else %}
-    <div class="form-group">
-      <div class="btn-group">
-        <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
-        <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
-      </div>
-    </div>
-  {% endif %}
+  </div>
 {% endif %}
 {% endmacro %}
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -904,12 +904,21 @@
             Use HPO list for clinical filter</div>
         </div>
         <div>
-          <a class="btn btn-outline-secondary form-control"
-            href="{{ url_for('variants.variants', institute_id=institute._id,
-                             case_name=case.display_name, variant_type='clinical',
-                             gene_panels=['hpo']) }}">
-             Clinical HPO SNV variants
-           </a>
+          {% if case.track == 'cancer' %}
+            <a class="btn btn-outline-secondary form-control"
+              href="{{ url_for('variants.cancer_variants', institute_id=institute._id,
+                               case_name=case.display_name, variant_type='clinical',
+                               gene_panels=['hpo']) }}">
+               Clinical HPO SNV variants
+             </a>
+          {% else %}
+            <a class="btn btn-outline-secondary form-control"
+              href="{{ url_for('variants.variants', institute_id=institute._id,
+                               case_name=case.display_name, variant_type='clinical',
+                               gene_panels=['hpo']) }}">
+               Clinical HPO SNV variants
+             </a>
+           {% endif %}
         </div>
       </div>
     {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -137,13 +137,22 @@
 
   </div>
 </div>
-{% if case.is_research and not case.track=="cancer" %}
-  <div class="form-group">
-    <div class="btn-group">
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+{% if case.is_research%}
+  {% if case.track=="cancer" %}
+    <div class="form-group">
+      <div class="btn-group">
+        <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
+        <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+      </div>
     </div>
-  </div>
+  {% else %}
+    <div class="form-group">
+      <div class="btn-group">
+        <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
+        <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+      </div>
+    </div>
+  {% endif %}
 {% endif %}
 {% endmacro %}
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -137,7 +137,7 @@
 
   </div>
 </div>
-{% if case.is_research %}
+{% if case.is_research and not case.track=="cancer" %}
   <div class="form-group">
     <div class="btn-group">
       <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>


### PR DESCRIPTION
This PR fixes the link that from a cancer case leads to variants hitting genes in the HPO panel. (fix #1611).

Current behavior:
1. When an HPO panel is created the link to `Clinical HPO SNV variants` :

![image](https://user-images.githubusercontent.com/28093618/73737467-fb6f2400-4742-11ea-8b9c-35aab1a8b277.png)

1. This link opens the NON-CANCER variants page

**How to test**:
1. On a local implementation of Scout load a demo cancer case: 
`scout --demo load case scout/demo/cancer.load_config.yaml`

1. Generate an HPO panel on a case page using a random HPO term. 
1. Check that the button to `Clinical HPO SNV variants` opens the "Clinical Cancer Variants" page.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
