### PR TITLE
Reuse variant events (pinned/classif/comments) in all variants pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cancer case activates on SNV variants
 - Cases activate when STR variants are viewed
 - Always calculate code coverage
+- Pinned/Classification/comments in all types of variants pages
 
 ### Changed
 - Renamed `requests` file to `scout_requests`

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -6,8 +6,6 @@
 {% from "cases/phenotype.html" import cohort_panel, diagnosis_phenotypes, diagnosis_genes, phenotype_groups_panel, phenotype_terms_panel, phenotypes_panel %}
 {% from "cases/gene_panel.html" import genepanels_table, hpo_genelist_panel %}
 {% from "cases/case_ideograms.html" import case_ideograms %}
-{% from "variants/utils.html" import tier_cell %}
-
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }}
@@ -62,7 +60,7 @@
 
       <div class="row ">
           <div class="col-xs-12 col-md-6">{{ causatives_list(causatives, institute, case) }}</div>
-          <div class="col-xs-12 col-md-6">{{ suspects_list(suspects, institute, case) }}</div>
+          <div class="col-xs-12 col-md-6">{{ suspects_list(suspects, institute, case, manual_rank_options) }}</div>
       </div>
 
       <div class="row">

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -108,7 +108,7 @@
     <div class="card-body">
       <ul class="list-group">
         {% for hpo_term in case.phenotype_groups %}
-          {{ hpo_group_item(hpo_term) }}
+          {{ hpo_group_item(hpo_term, institute) }}
         {% else %}
           <li class="list-group-item">No HPO groups added yet.</li>
         {% endfor %}
@@ -156,7 +156,7 @@
   </div>
 {% endmacro %}
 
-{% macro hpo_group_item(hpo_term) %}
+{% macro hpo_group_item(hpo_term, institute) %}
   <li class="list-group-item">
     <div class="row d-flex justify-content-between">
       <div class="flex-fill">

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -108,7 +108,7 @@
     <div class="card-body">
       <ul class="list-group">
         {% for hpo_term in case.phenotype_groups %}
-          {{ hpo_group_item(hpo_term, institute) }}
+          {{ hpo_group_item(hpo_term, case, institute) }}
         {% else %}
           <li class="list-group-item">No HPO groups added yet.</li>
         {% endfor %}
@@ -156,7 +156,7 @@
   </div>
 {% endmacro %}
 
-{% macro hpo_group_item(hpo_term, institute) %}
+{% macro hpo_group_item(hpo_term, case, institute) %}
   <li class="list-group-item">
     <div class="row d-flex justify-content-between">
       <div class="flex-fill">

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -20,7 +20,7 @@
                                       variant_id=variant._id) }}">
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
-                      {{ display_genes.append(gene.hgnc_symbol + gene.hgvs_identifier or "") }}
+                      {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier or "") }}
                     {% endfor %}
                     {{ display_genes|join(", ") }}
 		             {% else %}
@@ -150,7 +150,7 @@
                                         variant_id=variant._id) }}">
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
-                        {{ display_genes.append(gene.hgnc_symbol + gene.hgvs_identifier or "") }}
+                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                       {% endfor %}
                       {{ display_genes|join(", ") }}
                   {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -150,7 +150,7 @@
                                         variant_id=variant._id) }}">
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
-                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier or "") }}
                       {% endfor %}
                       {{ display_genes|join(", ") }}
                   {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -1,4 +1,6 @@
 
+{% from "variants/utils.html" import tier_cell %}
+
 {% macro causatives_list(causatives, institute, case) %}
   <div class="card panel-default">
     <div data-toggle='tooltip' class="panel-heading" title="Displays all variants that have been marked causative for this case">
@@ -126,7 +128,7 @@
   </div>
 {% endmacro %}
 
-{% macro suspects_list(suspects, institute, case) %}
+{% macro suspects_list(suspects, institute, case, manual_rank_options) %}
   <div class="card panel-default">
     <div data-toggle='tooltip' class="panel-heading panel-heading-secondary"
          title="Displays all variants that has been pinned for this case">

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -21,9 +21,9 @@
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
                       {% if 'hgvs_identifier' in gene %}
-                        {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                       {% else %}
-                        {{ display_genes.append(gene.hgnc_symbol) }}
+                        {{ "" if display_genes.append(gene.hgnc_symbol) }}
                       {% endif %}
                     {% endfor %}
                     {{ display_genes|join(", ") }}
@@ -155,9 +155,9 @@
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
                         {% if 'hgvs_identifier' in gene %}
-                          {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+                          {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                         {% else %}
-                          {{ display_genes.append(gene.hgnc_symbol) }}
+                          {{ "" if display_genes.append(gene.hgnc_symbol) }}
                         {% endif %}
                       {% endfor %}
                       {{ display_genes|join(", ") }}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -1,5 +1,4 @@
 {% from "variants/utils.html" import tier_cell %}
-{% from "variants/utils.html" import tier_cell %}
 
 {% macro causatives_list(causatives, partial_causatives, institute, case) %}
   <div class="card panel-default">

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -21,7 +21,7 @@
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
                       {% if 'hgvs_identifier' in gene %}
-                        {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier }}
+                        {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                       {% else %}
                         {{ display_genes.append(gene.hgnc_symbol) }}
                       {% endif %}
@@ -155,7 +155,7 @@
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
                         {% if 'hgvs_identifier' in gene %}
-                          {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier }}
+                          {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                         {% else %}
                           {{ display_genes.append(gene.hgnc_symbol) }}
                         {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -150,7 +150,7 @@
                                         variant_id=variant._id) }}">
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
-                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+                        {{ display_genes.append(gene.hgnc_symbol + gene.hgvs_identifier or "") }}
                       {% endfor %}
                       {{ display_genes|join(", ") }}
                   {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -20,7 +20,7 @@
                                       variant_id=variant._id) }}">
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
-                      {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+                      {{ display_genes.append(gene.hgnc_symbol + gene.hgvs_identifier or "") }}
                     {% endfor %}
                     {{ display_genes|join(", ") }}
 		             {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -20,7 +20,11 @@
                                       variant_id=variant._id) }}">
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
-                      {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier or "") }}
+                      {% if 'hgvs_identifier' in gene %}
+                        {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier }}
+                      {% else %}
+                        {{ display_genes.append(gene.hgnc_symbol) }}
+                      {% endif %}
                     {% endfor %}
                     {{ display_genes|join(", ") }}
 		             {% else %}
@@ -150,7 +154,11 @@
                                         variant_id=variant._id) }}">
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
-                        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier or "") }}
+                        {% if 'hgvs_identifier' in gene %}
+                          {{ display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier }}
+                        {% else %}
+                          {{ display_genes.append(gene.hgnc_symbol) }}
+                        {% endif %}
                       {% endfor %}
                       {{ display_genes|join(", ") }}
                   {% else %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -101,7 +101,7 @@
                     <label class="ml-3">Dismiss variant</label>
                     <div class="row">
                       <div class="col-8 d-flex">
-                          <select multiple class="ml-3 selectpicker" title="Select categories..." name="dismiss_variant" id="dismiss_variant" >
+                          <select multiple class="ml-3 selectpicker" title="Select categories..." name="dismiss_variant" id="dismiss_variant" data-width="100%">
                           {% for rank, data in dismiss_variant_options.items() %}
                             <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
                               {{ data.label }}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -1,6 +1,7 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_panel, pedigree_panel %}
 {% from "variants/utils.html" import modal_causative %}
+{% from "variant/variant_details.html" import old_observations %}
 {% from "variant/utils.html" import rankscore_panel, overlapping_panel, genes_panel, transcripts_panel, sv_alignments, pin_button, causative_button %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes, genemodels_panel %}
 {% from "variant/variant_details.html" import gtcall_panel, frequencies, observations_panel %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import sv_filters %}
+{% from "variants/utils.html" import sv_filters,cell_rank %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -174,39 +174,6 @@
     </div>
 {% endmacro %}
 
-{% macro cell_rank(variant) %}
-  <a class="variants-row-item flex-small layout"
-     href="{{ url_for('variant.sv_variant', institute_id=institute._id,
-                      case_name=case.display_name, variant_id=variant._id) }}">
-    {{ variant.variant_rank }}
-  </a>
-  {% set comment_count = variant.comments.count() %}
-  {% if variant.manual_rank %}
-    <span class="badge pull-right" title="Manual rank">{{ variant.manual_rank }}</span>
-  {% endif %}
-
-  {% if comment_count > 0 %}
-    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
-    <a href="#"
-      class="badge badge-secondary"
-      style="color:white;"
-      data-toggle="popover"
-      data-placement="right"
-      data-html="true"
-      data-trigger="hover click"
-      data-content="<small>{{ comments_content }}</small>">
-      {{ comment_count }}
-      <i class="fa fa-comment"></i>
-      {% if 'GLOBAL' in comments_content %}
-        <i class="fa fa-globe" aria-hidden="true"></i>
-      {% endif %}
-    </a>
-  {% endif %}
-  {% if variant._id in case.suspects %}
-    <i class="fa fa-map-pin"></i>
-  {% endif %}
-{% endmacro %}
-
 {% macro variant_row(variant) %}
   {% if variant.dismiss_variant %}
   <tr class="dismiss">
@@ -214,7 +181,7 @@
   <tr>
   {% endif %}
     <td>
-      {{ cell_rank(variant) }}
+      {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
     <td>{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
@@ -285,13 +252,16 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
   <script>
+    $('select[multiple]').selectpicker({
+      width: '100%'
+    });
     $(function () {
+      $('[data-toggle="tooltip"]').tooltip();
       $('[data-toggle="popover"]').popover({
+        sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
         container: 'body',
-      });
-
-      $('select[multiple]').selectpicker({
-        width: '100%'
       });
     })
   </script>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -68,7 +68,7 @@
           {% else %}
             <tr>
           {% endif %}
-              <td class="text-left">{{cell_rank(variant, institute, case, form)}}</td>
+              <td class="text-left">{{cell_rank(variant, institute, case, form, manual_rank_options)}}</td>
             <td>
               <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
                                   variant_id=variant._id, cancer='yes') }}">

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -165,11 +165,16 @@
 {% block scripts %}
   {{ super() }}
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
   <script>
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();
-      $('select[multiple]').multiselect({
-        buttonWidth: '100%'
+      $('[data-toggle="popover"]').popover({
+        sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
+        container: 'body',
       });
     })
   </script>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
-{% from "variants/utils.html" import cancer_filters, tier_cell %}
+{% from "variants/utils.html" import cancer_filters, tier_cell, cell_rank %}
 
 
 {% block title %}
@@ -68,7 +68,7 @@
           {% else %}
             <tr>
           {% endif %}
-              <td>{{ variant.variant_rank }}</td>
+              <td class="text-left">{{cell_rank(variant, institute, case, form)}}</td>
             <td>
               <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
                                   variant_id=variant._id, cancer='yes') }}">

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -1,6 +1,7 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 {% from "utils.html" import comments_table %}
+{% from "variants/utils.html" import cell_rank %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - STR variants
@@ -67,7 +68,7 @@
 	        {% else %}
 	            <tr>
 	        {% endif %}
-            <td>{{ cell_rank(variant) }}</td>
+            <td>{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
             <td>{{ variant.str_repid }}</td>
 	          <td class="text-right">{{ variant.str_ru }}</td>
             <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
@@ -115,36 +116,6 @@
 </form>
 {% endblock %}
 
-{% macro cell_rank(variant) %}
-  <a class="variants-row-item flex-small layout"
-     href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
-                      variant_id=variant._id, str='yes') }}">
-    {{ variant.variant_rank }}
-  </a>
-  {% set comment_count = variant.comments.count() %}
-  {% if variant.manual_rank %}
-    <span class="badge float-right" title="Manual rank">{{ variant.manual_rank }}</span>
-  {% endif %}
-  {% if comment_count > 0 %}
-    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
-    <a href="#"
-       class="badge float-right"
-       data-toggle="popover"
-       data-placement="right"
-       data-html="true"
-       data-trigger="hover click"
-       data-content="{{ comments_content }}"
-       title=""
-       >
-      {{ comment_count }}
-      <i class="fa fa-comment"></i>
-      {% if 'GLOBAL' in comments_content %}
-        <i class="fa fa-globe" aria-hidden="true"></i>
-      {% endif %}
-    </a>
-  {% endif %}
-{% endmacro %}
-
 {% macro footer() %}
   <div class="container-fluid">
     <div class="form-group text-center">
@@ -173,12 +144,15 @@
 
 {% block scripts %}
   {{ super() }}
-
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script>
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();
       $('[data-toggle="popover"]').popover({
+        sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
         container: 'body',
       });
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -232,14 +232,17 @@
       return true;
     }
 
-    $('[data-toggle="tooltip"]').tooltip();
-    $(function () {
-      $('[data-toggle="popover"]').popover({
-        container: 'body',
-      });
+    $('select[multiple]').selectpicker({
+      width: '100%'
+    });
 
-      $('select[multiple]').selectpicker({
-        width: '100%'
+    $(function () {
+      $('[data-toggle="tooltip"]').tooltip();
+      $('[data-toggle="popover"]').popover({
+        sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
+        container: 'body',
       });
     })
   </script>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import sv_filters %}
+{% from "variants/utils.html" import sv_filters, cell_rank %}
 {% from "variants/components.html" import frequency_cell_general %}
 
 {% block title %}
@@ -84,49 +84,6 @@
 </form>
 {% endblock %}
 
-{% macro cell_rank(variant) %}
-  <a
-     href="{{ url_for('variant.sv_variant', institute_id=institute._id,
-                      case_name=case.display_name, variant_id=variant._id) }}">
-    {{ variant.variant_rank }}
-  </a>
-  {% set comment_count = variant.comments.count() %}
-  {% if variant.manual_rank %}
-    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right" title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">{{  manual_rank_options[variant.manual_rank]['label'] }}</span>
-  {% endif %}
-
-  {% if comment_count > 0 %}
-    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
-    <a href="#"
-      class="badge badge-secondary"
-      style="color:white;"
-      data-toggle="popover"
-      data-placement="right"
-      data-html="true"
-      data-trigger="hover click"
-      data-content="<small>{{ comments_content }}</small>">
-      {{ comment_count }}
-      <i class="fa fa-comment"></i>
-      {% if 'GLOBAL' in comments_content %}
-        <i class="fa fa-globe" aria-hidden="true"></i>
-      {% endif %}
-    </a>
-  {% endif %}
-  {% if variant._id in case.suspects %}
-    <i class="fa fa-map-pin"></i>
-  {% endif %}
-  {% if form.variant_type.data == 'research' %}
-    {% if variant.clinical_assessments %}
-      {% for assessment in variant.clinical_assessments %}
-        <span class="badge badge-secondary" data-toggle="tooltip" data-placement="right"
-            title="{{ assessment.title }}">
-            {{ assessment.label }}</span>
-      {% endfor %}
-    {% endif %}
-  {% endif %}
-
-{% endmacro %}
-
 {% macro variant_row(variant) %}
   {% if variant.dismiss_variant %}
   <tr class="dismiss">
@@ -134,7 +91,7 @@
   <tr>
   {% endif %}
     <td class="text-left">
-      {{ cell_rank(variant) }}
+      {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
     <td class="text-right">{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1,4 +1,5 @@
 {% import "bootstrap/wtf.html" as wtf %}
+{% from "utils.html" import comments_table %}
 
 {% macro compounds_table(institute, case, compounds) %}
   <table class='table table-condensed table-bordered table-sm'>
@@ -545,4 +546,66 @@
       title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">
       {{ manual_rank_options[variant.manual_rank].label }}</span>
   {% endif %}
+{% endmacro %}
+
+{% macro cell_rank(variant, institute, case, form) %}
+  <a class="variants-row-item flex-small layout"
+     href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
+                      variant_id=variant._id) }}">
+    {{ variant.variant_rank }}&nbsp;
+  </a>
+  {% set comment_count = variant.comments.count() %}
+
+  {% if variant.acmg_classification %}
+    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right" title="ACMG: {{ variant.acmg_classification.label }}">
+      {{ variant.acmg_classification.short }}
+    </span>
+  {% endif %}
+  {% if variant.manual_rank %}
+    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right"
+        title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">
+        {{ manual_rank_options[variant.manual_rank].label }}</span>
+  {% endif %}
+  {% if variant.evaluations %}
+    {% for evaluation in (variant.evaluations or []) %}
+      <span class="badge badge-secondary" style="margin-left:1px" data-toggle="tooltip" data-placement="right"
+      title="Previously classified as {{ evaluation.classification.label }}">
+      {{ evaluation.classification.short }}
+      </span>
+    {% endfor %}
+  {% endif %}
+  {% if form.variant_type.data == 'research' %}
+    {% if variant.clinical_assessments %}
+      {% for assessment in variant.clinical_assessments %}
+        <span class="badge badge-secondary" data-toggle="tooltip" data-placement="right"
+            title="{{ assessment.title }}">
+            {{ assessment.label }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endif %}
+
+  {% if comment_count > 0 %}
+    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
+    <a href="#"
+       class="badge badge-info"
+       data-toggle="popover"
+       data-placement="right"
+       data-html="true"
+       data-trigger="hover click"
+       data-content="{{ comments_content }}"
+       title=""
+       style="color:white;"
+       >
+      {{ comment_count }}
+      <i class="fa fa-comment"></i>
+      {% if 'GLOBAL' in comments_content %}
+        <i class="fa fa-globe" aria-hidden="true"></i>
+      {% endif %}
+    </a>
+  {% endif %}
+
+  {% if variant._id in case.suspects %}
+    <i class="fa fa-map-pin"></i>
+  {% endif %}
+
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -548,7 +548,7 @@
   {% endif %}
 {% endmacro %}
 
-{% macro cell_rank(variant, institute, case, form) %}
+{% macro cell_rank(variant, institute, case, form, manual_rank_options) %}
   <a class="variants-row-item flex-small layout"
      href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
                       variant_id=variant._id) }}">

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -70,7 +70,7 @@
               {% else %}
                 <tr>
               {% endif %}
-                <td class="text-left">{{ cell_rank(variant, institute, case, form) }}</td>
+                <td class="text-left">{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
                 <td class="text-right">{{ variant.rank_score|int }}</td>
                 <td>{{ variant.chromosome }}</td>
                 <td>{{ gene_cell(variant) }}</td>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -1,6 +1,5 @@
 {% extends "layout_bs4.html" %}
-{% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import compounds_table, svs_table, snv_filters %}
+{% from "variants/utils.html" import compounds_table, svs_table, snv_filters, cell_rank %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 
 {% block title %}
@@ -71,7 +70,7 @@
               {% else %}
                 <tr>
               {% endif %}
-                <td class="text-left">{{ cell_rank(variant) }}</td>
+                <td class="text-left">{{ cell_rank(variant, institute, case, form) }}</td>
                 <td class="text-right">{{ variant.rank_score|int }}</td>
                 <td>{{ variant.chromosome }}</td>
                 <td>{{ gene_cell(variant) }}</td>
@@ -105,67 +104,7 @@
   </form>
 {% endblock %}
 
-{% macro cell_rank(variant) %}
-  <a class="variants-row-item flex-small layout"
-     href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
-                      variant_id=variant._id) }}">
-    {{ variant.variant_rank }}&nbsp;
-  </a>
-  {% set comment_count = variant.comments.count() %}
-
-  {% if variant.acmg_classification %}
-    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right" title="ACMG: {{ variant.acmg_classification.label }}">
-      {{ variant.acmg_classification.short }}
-    </span>
-  {% endif %}
-  {% if variant.manual_rank %}
-    <span class="badge badge-primary" data-toggle="tooltip" data-placement="right"
-        title="Manual rank: {{ manual_rank_options[variant.manual_rank].description }}">
-        {{ manual_rank_options[variant.manual_rank].label }}</span>
-  {% endif %}
-  {% if variant.evaluations %}
-    {% for evaluation in (variant.evaluations or []) %}
-      <span class="badge badge-secondary" style="margin-left:1px" data-toggle="tooltip" data-placement="right"
-      title="Previously classified as {{ evaluation.classification.label }}">
-      {{ evaluation.classification.short }}
-      </span>
-    {% endfor %}
-  {% endif %}
-  {% if form.variant_type.data == 'research' %}
-    {% if variant.clinical_assessments %}
-      {% for assessment in variant.clinical_assessments %}
-        <span class="badge badge-secondary" data-toggle="tooltip" data-placement="right"
-            title="{{ assessment.title }}">
-            {{ assessment.label }}</span>
-      {% endfor %}
-    {% endif %}
-  {% endif %}
-
-  {% if comment_count > 0 %}
-    {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
-    <a href="#"
-       class="badge badge-info"
-       data-toggle="popover"
-       data-placement="right"
-       data-html="true"
-       data-trigger="hover click"
-       data-content="{{ comments_content }}"
-       title=""
-       style="color:white;"
-       >
-      {{ comment_count }}
-      <i class="fa fa-comment"></i>
-      {% if 'GLOBAL' in comments_content %}
-        <i class="fa fa-globe" aria-hidden="true"></i>
-      {% endif %}
-    </a>
-  {% endif %}
-
-  {% if variant._id in case.suspects %}
-    <i class="fa fa-map-pin"></i>
-  {% endif %}
-
-{% endmacro %}
+{{ cell_rank(variant) }}
 
 {% macro cell_cadd(variant) %}
   <div data-toggle="tooltip" data-placement="left" data-html="true" title="

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -104,8 +104,6 @@
   </form>
 {% endblock %}
 
-{{ cell_rank(variant) }}
-
 {% macro cell_cadd(variant) %}
   <div data-toggle="tooltip" data-placement="left" data-html="true" title="
     <div class='text-left'>

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -203,6 +203,7 @@ def str_variants(institute_id, case_name):
         institute=institute_obj,
         case=case_obj,
         variant_type=variant_type,
+        manual_rank_options=MANUAL_RANK_OPTIONS,
         form=form,
         page=page,
         **data


### PR DESCRIPTION
Fixes also missing info in cancer variants and cancer sv variants pages (fix #1680)
Fixes also: 
- a bug affecting case page for cases with pinned or causative variants in genes without hgvs_identifier. Example: https://scout-stage.scilifelab.se/cust000/620573fam30M
- a bug in case page due to missing parameters in hpo_group_item macro
- a bug caused by missing old_observation import in sv variant page

**How to test**:
1. Open a **snv variant from a non-cancer case** and pin it, add an ACMG classification, comment it globally and locally
1. Open a **structural variant from a non-cancer case** and pin it, add an ACMG classification, comment it globally and locally
1. Open a **str variant from a non-cancer case** and pin it, add an ACMG classification, comment it globally and locally
1. Open a **snv variant from a cancer case** and pin it, add an ACMG classification, comment it globally and locally
1. Open a **structural variant from a cancer case** and pin it, add an ACMG classification, comment it globally and locally

**Expected outcome**:
- [x] non-cancer variants page should show pinned, comments and classification info in the rank cell.
- [x] non-cancer SV variants page should show pinned, comments and classification info in the rank cell.
- [x] non-cancer strs variants page should show pinned, comments and classification info in the rank cell.
- [x] cancer variants page should show pinned, comments and classification info in the rank cell.
- [x] cancer SV variants page should show pinned, comments and classification info in the rank cell.

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
