### PR TITLE
Fix first str variant button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Cancer case HPO panel variants link
 - Fix so that some drop downs have correct size
+- First IGV button in str variants page
 
 ### Changed
 - Renamed `requests` file to `scout_requests`

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -95,7 +95,7 @@
                   <input type="hidden" name="start" value="{{variant.position - 50}}">
                   <input type="hidden" name="stop" value="{{variant.position + 50}}">
                   <input type="hidden" name="center_guide" value="T">
-                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit" formmethod="post" formaction="{{ url_for('alignviewers.igv') }}">IGV viewer</button>
+                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit">IGV viewer</button>
                 </form>
               {% endif %}
             </td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -31,86 +31,88 @@
 {% endblock %}
 
 {% block content_main %}
-<div class="card mt-3">
-  <table class="table table-bordered table-hover">
-    <thead>
-      <tr>
-        <th style="width:8%" title="Index">Index</th>
-        <th style="width:8%" title="Repeat ID">Repeat locus</th>
-        <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
-        <th style="width:8%" title="ALT">Estimated size</th>
-        <th style="width:8%" title="ReferenceSize">Reference size</th>
-        <th style="width:10%" title="Status">Status</th>
-        <th style="width:8%" title="Max normal">Max normal</th>
-        <th style="width:8%" title="Min pathologic">Min pathologic</th>
-        <th style="width:14%" title="GT">Genotype</th>
-        <th style="width:6%" title="Chromosome">Chr.</th>
-        <th style="width:10%" title="Position">Position</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% set ns = namespace(allele0='') %}
-      {% for variant in variants %}
-        {% if variant.chromosome + variant.position|string != ns.allele0 %}
-          <tr style="height:10px;"></tr>
-        {% endif %}
-        {% set ns.allele0 = variant.chromosome + variant.position|string %}
-        {% if variant.dismiss_variant %}
-            <tr class="dismiss">
-        {% elif variant.str_status == 'normal' %}
-            <tr class="bg-success">
-        {% elif variant.str_status == 'full_mutation' %}
-            <tr class="bg-danger">
-        {% elif variant.str_status == 'pre_mutation' %}
-            <tr class="bg-warning">
-        {% else %}
-            <tr>
-        {% endif %}
-          <td>{{ cell_rank(variant) }}</td>
-          <td>{{ variant.str_repid }}</td>
-          <td class="text-right">{{ variant.str_ru }}</td>
-          <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
-          <td class="text-right">{{ variant.str_ref }}</td>
-          <td>{{ variant.str_status }}</td>
-          <td>{{ variant.str_normal_max }}</td>
-          <td>{{ variant.str_pathologic_min }}</td>
-          <td>{% for sample in variant.samples %}
-                {% if sample.genotype_call != "./." %}
-                  <div class="float-left">{{ sample.display_name }}</div>
-                  <div class="float-right">{{ sample.genotype_call }}</div><br>
-                {% endif %}
-              {% endfor %}
-          </td>
-          <td>{{ variant.chromosome }}</td>
-          <td>
-            {{ variant.position }}
-            {% if case.bam_files %}
-              <form role="form" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
-                <input type="hidden" name="sample" value="{{case.sample_names|join(',')}}">
-                <input type="hidden" name="build" value="{{case.genome_build}}">
-                <input type="hidden" name="bam" value="{{case.bam_files|join(',')}}">
-                <input type="hidden" name="bai" value="{{case.bai_files|join(',')}}">
-                <input type="hidden" name="contig" value="{{variant.chromosome}}">
-                <input type="hidden" name="start" value="{{variant.position - 50}}">
-                <input type="hidden" name="stop" value="{{variant.position + 50}}">
-                <input type="hidden" name="center_guide" value="T">
-                <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit">IGV viewer</button>
-              </form>
-            {% endif %}
-          </td>
-      </tr>
-      {% else %}
+<form>
+  <div class="card mt-3">
+    <table class="table table-bordered table-hover">
+      <thead>
         <tr>
-          <td colspan="9">
-            No matching variants
-          </td>
+          <th style="width:8%" title="Index">Index</th>
+          <th style="width:8%" title="Repeat ID">Repeat locus</th>
+          <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
+          <th style="width:8%" title="ALT">Estimated size</th>
+          <th style="width:8%" title="ReferenceSize">Reference size</th>
+          <th style="width:10%" title="Status">Status</th>
+          <th style="width:8%" title="Max normal">Max normal</th>
+          <th style="width:8%" title="Min pathologic">Min pathologic</th>
+          <th style="width:14%" title="GT">Genotype</th>
+          <th style="width:6%" title="Chromosome">Chr.</th>
+          <th style="width:10%" title="Position">Position</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
-<br>
-{{ footer() }}
+      </thead>
+      <tbody>
+        {% set ns = namespace(allele0='') %}
+        {% for variant in variants %}
+          {% if variant.chromosome + variant.position|string != ns.allele0 %}
+            <tr style="height:10px;"></tr>
+          {% endif %}
+          {% set ns.allele0 = variant.chromosome + variant.position|string %}
+          {% if variant.dismiss_variant %}
+              <tr class="dismiss">
+          {% elif variant.str_status == 'normal' %}
+              <tr class="bg-success">
+          {% elif variant.str_status == 'full_mutation' %}
+              <tr class="bg-danger">
+          {% elif variant.str_status == 'pre_mutation' %}
+              <tr class="bg-warning">
+	        {% else %}
+	            <tr>
+	        {% endif %}
+            <td>{{ cell_rank(variant) }}</td>
+            <td>{{ variant.str_repid }}</td>
+	          <td class="text-right">{{ variant.str_ru }}</td>
+            <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
+            <td class="text-right">{{ variant.str_ref }}</td>
+            <td>{{ variant.str_status }}</td>
+            <td>{{ variant.str_normal_max }}</td>
+            <td>{{ variant.str_pathologic_min }}</td>
+            <td>{% for sample in variant.samples %}
+                  {% if sample.genotype_call != "./." %}
+                    <div class="float-left">{{ sample.display_name }}</div>
+                    <div class="float-right">{{ sample.genotype_call }}</div><br>
+                  {% endif %}
+                {% endfor %}
+            </td>
+            <td>{{ variant.chromosome }}</td>
+            <td>
+              {{ variant.position }}
+              {% if case.bam_files %}
+                <form name="form_{{variant._id}}" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
+                  <input type="hidden" name="sample" value="{{case.sample_names|join(',')}}">
+                  <input type="hidden" name="build" value="{{case.genome_build}}">
+                  <input type="hidden" name="bam" value="{{case.bam_files|join(',')}}">
+                  <input type="hidden" name="bai" value="{{case.bai_files|join(',')}}">
+                  <input type="hidden" name="contig" value="{{variant.chromosome}}">
+                  <input type="hidden" name="start" value="{{variant.position - 50}}">
+                  <input type="hidden" name="stop" value="{{variant.position + 50}}">
+                  <input type="hidden" name="center_guide" value="T">
+                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit" formmethod="post" formaction="{{ url_for('alignviewers.igv') }}">IGV viewer</button>
+                </form>
+              {% endif %}
+            </td>
+        </tr>
+        {% else %}
+          <tr>
+            <td colspan="9">
+              No matching variants
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <br>
+  {{ footer() }}
+</form>
 {% endblock %}
 
 {% macro cell_rank(variant) %}
@@ -144,6 +146,7 @@
 {% endmacro %}
 
 {% macro footer() %}
+<form>
   <div class="container-fluid">
     <div class="form-group text-center">
       {% if more_variants %}
@@ -167,6 +170,7 @@
       {% endif %}
     </div>
   </div>
+</form>
 {% endmacro %}
 
 {% block scripts %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -31,89 +31,86 @@
 {% endblock %}
 
 {% block content_main %}
-<form>
-  <div class="card mt-3">
-    <table class="table table-bordered table-hover">
-      <thead>
-        <tr>
-          <th style="width:8%" title="Index">Index</th>
-          <th style="width:8%" title="Repeat ID">Repeat locus</th>
-          <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
-          <th style="width:8%" title="ALT">Estimated size</th>
-          <th style="width:8%" title="ReferenceSize">Reference size</th>
-          <th style="width:10%" title="Status">Status</th>
-          <th style="width:8%" title="Max normal">Max normal</th>
-          <th style="width:8%" title="Min pathologic">Min pathologic</th>
-          <th style="width:14%" title="GT">Genotype</th>
-          <th style="width:6%" title="Chromosome">Chr.</th>
-          <th style="width:10%" title="Position">Position</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% set ns = namespace(allele0='') %}
-        {% for variant in variants %}
-          {% if variant.chromosome + variant.position|string != ns.allele0 %}
-            <tr style="height:10px;"></tr>
-          {% endif %}
-          {% set ns.allele0 = variant.chromosome + variant.position|string %}
-          {% if variant.dismiss_variant %}
-              <tr class="dismiss">
-          {% elif variant.str_status == 'normal' %}
-              <tr class="bg-success">
-          {% elif variant.str_status == 'full_mutation' %}
-              <tr class="bg-danger">
-          {% elif variant.str_status == 'pre_mutation' %}
-              <tr class="bg-warning">
-	        {% else %}
-	            <tr>
-	        {% endif %}
-            <td>{{ cell_rank(variant) }}</td>
-            <td>{{ variant.str_repid }}</td>
-	          <td class="text-right">{{ variant.str_ru }}</td>
-            <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
-            <td class="text-right">{{ variant.str_ref }}</td>
-            <td>{{ variant.str_status }}</td>
-            <td>{{ variant.str_normal_max }}</td>
-            <td>{{ variant.str_pathologic_min }}</td>
-            <td>{% for sample in variant.samples %}
-                  {% if sample.genotype_call != "./." %}
-                    <div class="float-left">{{ sample.display_name }}</div>
-                    <div class="float-right">{{ sample.genotype_call }}</div><br>
-                  {% endif %}
-                {% endfor %}
-            </td>
-            <td>{{ variant.chromosome }}</td>
-            <td>
-              {{ variant.position }}
-              {% if case.bam_files %}
-                <form name="form_{{variant._id}}" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
-                  <input type="hidden" name="sample" value="{{case.sample_names|join(',')}}">
-                  <input type="hidden" name="build" value="{{case.genome_build}}">
-                  <input type="hidden" name="bam" value="{{case.bam_files|join(',')}}">
-                  <input type="hidden" name="bai" value="{{case.bai_files|join(',')}}">
-                  <input type="hidden" name="contig" value="{{variant.chromosome}}">
-                  <input type="hidden" name="start" value="{{variant.position - 50}}">
-                  <input type="hidden" name="stop" value="{{variant.position + 50}}">
-                  <input type="hidden" name="center_guide" value="T">
-                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit" formmethod="post"
-                    formaction="{{ url_for('alignviewers.igv') }}">IGV viewer</button>
-                </form>
-              {% endif %}
-            </td>
-        </tr>
+<div class="card mt-3">
+  <table class="table table-bordered table-hover">
+    <thead>
+      <tr>
+        <th style="width:8%" title="Index">Index</th>
+        <th style="width:8%" title="Repeat ID">Repeat locus</th>
+        <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
+        <th style="width:8%" title="ALT">Estimated size</th>
+        <th style="width:8%" title="ReferenceSize">Reference size</th>
+        <th style="width:10%" title="Status">Status</th>
+        <th style="width:8%" title="Max normal">Max normal</th>
+        <th style="width:8%" title="Min pathologic">Min pathologic</th>
+        <th style="width:14%" title="GT">Genotype</th>
+        <th style="width:6%" title="Chromosome">Chr.</th>
+        <th style="width:10%" title="Position">Position</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% set ns = namespace(allele0='') %}
+      {% for variant in variants %}
+        {% if variant.chromosome + variant.position|string != ns.allele0 %}
+          <tr style="height:10px;"></tr>
+        {% endif %}
+        {% set ns.allele0 = variant.chromosome + variant.position|string %}
+        {% if variant.dismiss_variant %}
+            <tr class="dismiss">
+        {% elif variant.str_status == 'normal' %}
+            <tr class="bg-success">
+        {% elif variant.str_status == 'full_mutation' %}
+            <tr class="bg-danger">
+        {% elif variant.str_status == 'pre_mutation' %}
+            <tr class="bg-warning">
         {% else %}
-          <tr>
-            <td colspan="9">
-              No matching variants
-            </td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  <br>
-  {{ footer() }}
-</form>
+            <tr>
+        {% endif %}
+          <td>{{ cell_rank(variant) }}</td>
+          <td>{{ variant.str_repid }}</td>
+          <td class="text-right">{{ variant.str_ru }}</td>
+          <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
+          <td class="text-right">{{ variant.str_ref }}</td>
+          <td>{{ variant.str_status }}</td>
+          <td>{{ variant.str_normal_max }}</td>
+          <td>{{ variant.str_pathologic_min }}</td>
+          <td>{% for sample in variant.samples %}
+                {% if sample.genotype_call != "./." %}
+                  <div class="float-left">{{ sample.display_name }}</div>
+                  <div class="float-right">{{ sample.genotype_call }}</div><br>
+                {% endif %}
+              {% endfor %}
+          </td>
+          <td>{{ variant.chromosome }}</td>
+          <td>
+            {{ variant.position }}
+            {% if case.bam_files %}
+              <form role="form" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
+                <input type="hidden" name="sample" value="{{case.sample_names|join(',')}}">
+                <input type="hidden" name="build" value="{{case.genome_build}}">
+                <input type="hidden" name="bam" value="{{case.bam_files|join(',')}}">
+                <input type="hidden" name="bai" value="{{case.bai_files|join(',')}}">
+                <input type="hidden" name="contig" value="{{variant.chromosome}}">
+                <input type="hidden" name="start" value="{{variant.position - 50}}">
+                <input type="hidden" name="stop" value="{{variant.position + 50}}">
+                <input type="hidden" name="center_guide" value="T">
+                <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit">IGV viewer</button>
+              </form>
+            {% endif %}
+          </td>
+      </tr>
+      {% else %}
+        <tr>
+          <td colspan="9">
+            No matching variants
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<br>
+{{ footer() }}
 {% endblock %}
 
 {% macro cell_rank(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -86,7 +86,7 @@
             <td>
               {{ variant.position }}
               {% if case.bam_files %}
-                <form role="form" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
+                <form name="form_{{variant._id}}" action="{{ url_for('alignviewers.igv') }}" target="_blank" method="POST">
                   <input type="hidden" name="sample" value="{{case.sample_names|join(',')}}">
                   <input type="hidden" name="build" value="{{case.genome_build}}">
                   <input type="hidden" name="bam" value="{{case.bam_files|join(',')}}">
@@ -95,7 +95,8 @@
                   <input type="hidden" name="start" value="{{variant.position - 50}}">
                   <input type="hidden" name="stop" value="{{variant.position + 50}}">
                   <input type="hidden" name="center_guide" value="T">
-                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit">IGV viewer</button>
+                  <button class="btn btn-outline-secondary btn-sm" name="align" value="bam" type="submit" formmethod="post"
+                    formaction="{{ url_for('alignviewers.igv') }}">IGV viewer</button>
                 </form>
               {% endif %}
             </td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -31,7 +31,6 @@
 {% endblock %}
 
 {% block content_main %}
-<form>
   <div class="card mt-3">
     <table class="table table-bordered table-hover">
       <thead>
@@ -112,7 +111,6 @@
   </div>
   <br>
   {{ footer() }}
-</form>
 {% endblock %}
 
 {% macro cell_rank(variant) %}


### PR DESCRIPTION
Bug fix #1698

Make it sure that the form action is the IGV view and the method is POST. Add this to the buttons as well so that the first one behaves as it should. Don't ask me why but this is working!

**How to test on a local branch**:
- Modify the load config file `scout/demo/643594.config.yaml` by adding the field: 
```
bam_path : scout/demo/reduced_mt.bam 
```
to each of the 3 samples of the case. (*Doesn't matter that it's not the correct bam file, it does the trick to display the buttons and triggers the igv view anyway).

-  Upload the case with the command:
``` 
scout --demo upload path_to_the_above_demo_config-file
``` 
- From master branch, go to the str variants page of the case and make sure that the first button doesn't work (doesn't open a new igv window)
- Switch to this branch and make sure the igv button if the first str variant works (opens the IGV browser)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
