### PR TITLE
Round Allele and Normal Frequency to Two Decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Renamed `requests` file to `scout_requests`
-
+- Cancer variant view shows two, instead of four, decimals for allele and normal
 
 ## [4.11.1]
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -154,7 +154,7 @@
 
 {% macro allele_cell(allele) %}
   {% if 'alt_freq' in allele %}
-    {{ (allele.alt_freq * 100)|round(4)  }}%
+    {{ (allele.alt_freq * 100)|round(2)  }}%
   {% else %}
     <span class="text-muted">N/A</span>
   {% endif %}


### PR DESCRIPTION
Show two instead of four decimals for Allele and Normal frequency
in cancer view.

This PR adds a functionality or fixes a bug.

As from discussion here:
https://github.com/Clinical-Genomics/scout/issues/1629#event-3009077515

**How to test**:
1. how to install it

Clone and install Scout from `QoL-cancer_variant_view_200214`. Setup demo or preferred configuration showing cancer variants such as `cancer.load_config.yaml`


1. how to test it, possibly with real cases/data

Go to `Clinical Cancer Variants Page`in Scout.

**Expected outcome**:
At the most two decimals are shown, instead of four, for Allele and Normal in Scout's cancer view. For example:

![Screenshot 2020-02-14 at 15 52 17](https://user-images.githubusercontent.com/1150065/74541632-40b10400-4f42-11ea-877c-37e6b515fac9.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "merge and deploy" approved by
