### PR TITLE
fix #1690: unique ACMG map for all causatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cases activate when STR variants are viewed
 - Always calculate code coverage
 - Pinned/Classification/comments in all types of variants pages
+- ACMG classification not showing for some causatives
+
 
 ### Changed
 - Renamed `requests` file to `scout_requests`

--- a/scout/server/blueprints/cases/templates/cases/causatives.html
+++ b/scout/server/blueprints/cases/templates/cases/causatives.html
@@ -34,7 +34,6 @@
 </li>
 {% endblock %}
 {% block content_main %}
-
 <div class="card mt-3">
   <div class="card-body">
       <table id="causatives_table" class="table display table-sm" cellspacing="0" width="100%">
@@ -98,7 +97,7 @@
               <a href="#" data-toggle="tooltip" title="ACMG classification assigned by Scout users (not Clinvar)"
                 style="text-decoration: none; color: #000;">ACMG:
                 {% if 'acmg_classification' in variant %}
-                <span class="badge badge-{{variant.acmg_classification.color}}">{{variant.acmg_classification.short}}</span>
+                <span class="badge badge-{{acmg_map[variant.acmg_classification].color}}">{{acmg_map[variant.acmg_classification].short}}</span>
                 {% else %}
                 -
                 {% endif %}

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -517,15 +517,13 @@ def causatives(institute_id):
             case_obj = all_cases[variant_obj["case_id"]]
 
         if variant_obj["variant_id"] not in all_variants:
-            # capture ACMG classification for this variant
-            if isinstance(variant_obj.get("acmg_classification"), int):
-                acmg_code = ACMG_MAP[variant_obj["acmg_classification"]]
-                variant_obj["acmg_classification"] = ACMG_COMPLETE_MAP[acmg_code]
-
             all_variants[variant_obj["variant_id"]] = []
+            
         all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
 
-    return dict(institute=institute_obj, variant_groups=all_variants)
+    acmg_map = { key:ACMG_COMPLETE_MAP[value] for key,value in ACMG_MAP.items() }
+
+    return dict(institute=institute_obj, variant_groups=all_variants, acmg_map=acmg_map)
 
 
 @cases_bp.route("/<institute_id>/gene_variants", methods=["GET", "POST"])

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -518,10 +518,10 @@ def causatives(institute_id):
 
         if variant_obj["variant_id"] not in all_variants:
             all_variants[variant_obj["variant_id"]] = []
-            
+
         all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
 
-    acmg_map = { key:ACMG_COMPLETE_MAP[value] for key,value in ACMG_MAP.items() }
+    acmg_map = {key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()}
 
     return dict(institute=institute_obj, variant_groups=all_variants, acmg_map=acmg_map)
 


### PR DESCRIPTION
fix #1690

**How to test**:
1. Install this branch on scout stage and go to causatives page of one institute
1. Make sure that each causative has an acmg classification missing (-) or a value (P, LP, VUS, LB, B)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
