### PR TITLE
Fix #1673

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cases activate when STR variants are viewed
 - Always calculate code coverage
 - Pinned/Classification/comments in all types of variants pages
+- Null values for panel's custom_inheritance_models
+- Discrepancy between the manual disease transcripts and those in database in gene-edit page
 
 ### Changed
 - Renamed `requests` file to `scout_requests`

--- a/scout/server/blueprints/panels/forms.py
+++ b/scout/server/blueprints/panels/forms.py
@@ -12,6 +12,10 @@ class PanelGeneForm(FlaskForm):
     reduced_penetrance = BooleanField()
     mosaicism = BooleanField()
     database_entry_version = TextField()
-    inheritance_models = SelectMultipleField("Standard inheritance models",choices=GENE_CUSTOM_INHERITANCE_MODELS)
-    custom_inheritance_models = TextField("Other non-standard inheritance models (free text, comma separated)")
+    inheritance_models = SelectMultipleField(
+        "Standard inheritance models", choices=GENE_CUSTOM_INHERITANCE_MODELS
+    )
+    custom_inheritance_models = TextField(
+        "Other non-standard inheritance models (free text, comma separated)"
+    )
     comment = TextField()

--- a/scout/server/blueprints/panels/forms.py
+++ b/scout/server/blueprints/panels/forms.py
@@ -12,6 +12,6 @@ class PanelGeneForm(FlaskForm):
     reduced_penetrance = BooleanField()
     mosaicism = BooleanField()
     database_entry_version = TextField()
-    inheritance_models = SelectMultipleField(choices=GENE_CUSTOM_INHERITANCE_MODELS)
-    custom_inheritance_models = TextField("Other inheritance models (comma separated)")
+    inheritance_models = SelectMultipleField("Standard inheritance models",choices=GENE_CUSTOM_INHERITANCE_MODELS)
+    custom_inheritance_models = TextField("Other non-standard inheritance models (free text, comma separated)")
     comment = TextField()

--- a/scout/server/blueprints/panels/templates/panels/gene-edit.html
+++ b/scout/server/blueprints/panels/templates/panels/gene-edit.html
@@ -38,8 +38,7 @@
           <div class="form-group">
             <div class="row">
               <div class="col-md-4">
-                {{ form.inheritance_models.label(class="control-label") }}
-                (OMIM: {{ gene.inheritance_models|join(', ') if gene.inheritance_models else 'unknown' }})
+                {{ form.inheritance_models.label(class="control-label") }}<br>
                 {{ form.inheritance_models(class="selectpicker") }}
               </div>
               <div class="col-md-4">
@@ -52,7 +51,7 @@
                 {{ form.database_entry_version(class="form-control") }}
               </div>
             </div>
-            <div class="row">
+            <div class="row mt-3">
               <div class="col-md-12">
                 {{ form.comment.label(class="control-label") }}
                 {{ form.comment(class="form-control") }}

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -130,7 +130,11 @@
               <td>{{ 'Yes' if gene.reduced_penetrance }}</td>
               <td>{{ 'Yes' if gene.mosaicism }}</td>
               <td>{{ gene.database_entry_version }}</td>
-              <td>{{ (gene.inheritance_models|list + gene.custom_inheritance_models|list)|join(', ') }}</td>
+              {% if gene.custom_inheritance_models|list != [''] %}
+                <td>{{ (gene.inheritance_models|list + gene.custom_inheritance_models|list)|join(', ') }}</td>
+              {% else %}
+                <td>{{ gene.inheritance_models|list }}</td>
+              {% endif %}
               <td>{{ gene.comment }}</td>
               <td>
                 {% if not panel.is_archived %}

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -201,7 +201,7 @@ def gene_edit(panel_id, hgnc_id):
             refseq_id = transcript.get("refseq_id")
             transcript_choices.append((refseq_id, refseq_id))
 
-    # collect even refseq version provided by user for this transcript (might be an older one)
+    # collect even refseq version provided by user for this transcript (might have a version)
     if panel_obj.get('genes'):
         genes_dict = { gene_obj["symbol"]:gene_obj for gene_obj in panel_obj['genes'] }
         gene_obj = genes_dict.get(hgnc_gene['hgnc_symbol'])

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -105,7 +105,6 @@ def panel(panel_id):
     """Display (and add pending updates to) a specific gene panel."""
     panel_obj = store.gene_panel(panel_id) or store.panel(panel_id)
 
-    flash("HERE")
     if request.method == "POST":
         if request.form.get("update_description"):
             panel_obj["description"] = request.form["panel_description"]

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -189,6 +189,7 @@ def panel_export(panel_id):
 @templated("panels/gene-edit.html")
 def gene_edit(panel_id, hgnc_id):
     """Edit additional information about a panel gene."""
+
     panel_obj = store.panel(panel_id)
     hgnc_gene = store.hgnc_gene(hgnc_id)
     panel_gene = controllers.existing_gene(store, panel_obj, hgnc_id)
@@ -205,7 +206,7 @@ def gene_edit(panel_id, hgnc_id):
         info_data = form.data.copy()
         if "csrf_token" in info_data:
             del info_data["csrf_token"]
-        if "custom_inheritance_models" in info_data:
+        if info_data["custom_inheritance_models"] != "":
             info_data["custom_inheritance_models"] = info_data[
                 "custom_inheritance_models"
             ].split(",")
@@ -215,7 +216,7 @@ def gene_edit(panel_id, hgnc_id):
 
     if panel_gene:
         form.custom_inheritance_models.data = ", ".join(
-            panel_gene.get("custom_inheritance_models", [])
+            panel_gene.get("custom_inheritance_models", None)
         )
         for field_key in [
             "disease_associated_transcripts",

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -99,6 +99,7 @@ def panels():
         institutes=institutes,
     )
 
+
 @panels_bp.route("/panels/<panel_id>", methods=["GET", "POST"])
 @templated("panels/panel.html")
 def panel(panel_id):

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -202,10 +202,19 @@ def gene_edit(panel_id, hgnc_id):
             refseq_id = transcript.get("refseq_id")
             transcript_choices.append((refseq_id, refseq_id))
 
-            # collect available refseq version for this transcript
+            # collect latest refseq version for this transcript
             refseq_id_version = fetch_refseq_version(refseq_id)
             if refseq_id_version:
                 transcript_choices.append((refseq_id_version, refseq_id_version))
+
+    # collect even refseq version provided by user for this transcript (might be an older one)
+    if panel_obj.get("gene_objects"):
+        gene_obj = panel_obj["gene_objects"].get(hgnc_gene['hgnc_symbol'])
+        if gene_obj:
+            for transcript in gene_obj.get("disease_associated_transcripts", []):
+                if (transcript,transcript) not in transcript_choices:
+                    transcript_choices.append((transcript,transcript))
+
 
     form.disease_associated_transcripts.choices = transcript_choices
     if form.validate_on_submit():

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -8,7 +8,6 @@ from flask_login import current_user
 
 from scout.server.extensions import store
 from scout.server.utils import templated, user_institutes
-from scout.utils.scout_requests import fetch_refseq_version
 from .forms import PanelGeneForm
 from . import controllers
 
@@ -202,19 +201,13 @@ def gene_edit(panel_id, hgnc_id):
             refseq_id = transcript.get("refseq_id")
             transcript_choices.append((refseq_id, refseq_id))
 
-            # collect latest refseq version for this transcript
-            refseq_id_version = fetch_refseq_version(refseq_id)
-            if refseq_id_version:
-                transcript_choices.append((refseq_id_version, refseq_id_version))
-
     # collect even refseq version provided by user for this transcript (might be an older one)
-    if panel_obj.get("gene_objects"):
-        gene_obj = panel_obj["gene_objects"].get(hgnc_gene['hgnc_symbol'])
-        if gene_obj:
-            for transcript in gene_obj.get("disease_associated_transcripts", []):
-                if (transcript,transcript) not in transcript_choices:
-                    transcript_choices.append((transcript,transcript))
-
+    if panel_obj.get('genes'):
+        genes_dict = { gene_obj["symbol"]:gene_obj for gene_obj in panel_obj['genes'] }
+        gene_obj = genes_dict.get(hgnc_gene['hgnc_symbol'])
+        for transcript in gene_obj.get("disease_associated_transcripts", []):
+            if (transcript,transcript) not in transcript_choices:
+                transcript_choices.append((transcript,transcript))
 
     form.disease_associated_transcripts.choices = transcript_choices
     if form.validate_on_submit():

--- a/tests/server/blueprints/panels/test_panels_views.py
+++ b/tests/server/blueprints/panels/test_panels_views.py
@@ -131,3 +131,22 @@ def test_panel_export(client, real_panel_database):
     resp = client.get(url_for("panels.panel_export", panel_id=panel_obj["_id"]))
     # THEN it should display the panel with all the genes
     assert resp.status_code == 200
+
+
+def test_gene_edit(client, real_panel_database):
+    """Test interface that allows gene panel editing, GET method"""
+    adapter = real_panel_database
+
+    # GIVEN a panel in the database
+    panel_obj = adapter.gene_panels()[0]
+
+    # WITH at least a gene
+    gene = panel_obj["genes"][0]
+    assert gene
+
+    # WHEN accessing the panel gene_edit view
+    resp = client.get(
+        url_for("panels.gene_edit", panel_id=panel_obj["_id"], hgnc_id=gene["hgnc_id"])
+    )
+    # THEN it should return a valid page
+    assert resp.status_code == 200


### PR DESCRIPTION
fix #1673

This PR fixes 3 small things:
- [x] avoid empty lists caused by None values in Other inheritance models, which causes an addition of a comma to the list of the inheritance models in the panel view:
 
![image](https://user-images.githubusercontent.com/28093618/74643289-c3b9a080-5174-11ea-9383-7655775b115f.png)

- [x] More user friendly and self explanatory `Inheritance Models` and `Other inheritance models` labels on gene-edit view

- [x]  There is a discrepancy between the disease transcripts provided manually which may contain transcript version, example:
![image](https://user-images.githubusercontent.com/28093618/74646494-41cc7600-517a-11ea-8085-621fc49865a5.png)

And those collected from the database (which don't have version). When editing the gene the transcripts in the dropdown don't contain the version and for this reason the transcript is not recognized and not pre-selected:
![image](https://user-images.githubusercontent.com/28093618/74647174-7e4ca180-517b-11ea-802f-3c2116cedf11.png)

This PR adds the option to add either the refseq version (custom) with the version or the one without:



**How to test**:
1. Install the branch on stage and try to modify a gene panel according to the examples above
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
