### PR TITLE
Take care of empty bam paths values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Discrepancy between the manual disease transcripts and those in database in gene-edit page
 - ACMG classification not showing for some causatives
 - Fix bug which caused IGV.js to use hg19 reference files for hg38 data
+- Bug when multiple bam files sources with non-null values are available
 
 ### Changed
 - Renamed `requests` file to `scout_requests`

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -286,9 +286,12 @@ def parse_individual(sample):
     ind_info["predicted_ancestry"] = sample.get("predicted_ancestry")
 
     # IGV files these can be bam or cram format
-    ind_info["bam_file"] = sample.get(
-        "bam_path", sample.get("bam_file", sample.get("alignment_path"))
-    )
+    bam_path_options = ["bam_path", "bam_file", "alignment_path"]
+    for option in bam_path_options:
+        if sample.get(option) and not sample.get(option).strip() == "":
+            ind_info["bam_file"] = sample[option]
+            break
+
     ind_info["rhocall_bed"] = sample.get("rhocall_bed", sample.get("rhocall_bed"))
     ind_info["rhocall_wig"] = sample.get("rhocall_wig", sample.get("rhocall_wig"))
     ind_info["tiddit_coverage_wig"] = sample.get(


### PR DESCRIPTION
This is an urgent bug fix

The current master branch doesn't handle well when both these keys are present in case config file:
1. An empty `bam_path`
1. A valid `alignment_path`

**How to test**:
1. Install it on hasta stage and upload a case with the above configuration
1. Make sure that the correct bam path is passed along and saved in the database.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MM
- [x] tests executed by HS
