### PR TITLE
Swap ref/alt to alt/ref reads in cancer variants page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Bug in variant.gene when gene has no HGVS description
 - SV variant links now take you to the SV variant page again
+- cancer variants show correct alt/ref reads mirroring alt frequency now 
 
 ### Changed
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -156,7 +156,7 @@
   {% if 'alt_freq' in allele %}
     {{ (allele.alt_freq * 100)|round(2)  }}%
     <br>
-    <small class="text-muted">{{ allele.alt_depth }} / {{ allele.ref_depth }}</small>
+    <small class="text-muted">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
   {% else %}
     <span class="text-muted">N/A</span>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -159,7 +159,7 @@
     <span class="text-muted">N/A</span>
   {% endif %}
   <br>
-  <small class="text-muted">{{ allele.ref_depth }} / {{ allele.alt_depth }}</small>
+  <small class="text-muted">{{ allele.alt_depth } / allele.ref_depth }}}</small>
 {% endmacro %}
 
 {% block scripts %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -159,7 +159,7 @@
     <span class="text-muted">N/A</span>
   {% endif %}
   <br>
-  <small class="text-muted">{{ allele.alt_depth } / allele.ref_depth }}}</small>
+  <small class="text-muted">{{ allele.alt_depth }} / {{allele.ref_depth }}</small>
 {% endmacro %}
 
 {% block scripts %}


### PR DESCRIPTION
So it mirrors the actual alt allele frequency

**How to test**:
1. Install it and check that on variants page it is reported the right info

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
