### PR TITLE
Fix pin cancer var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - SV variant links now take you to the SV variant page again
 - Cancer variant view has cleaner table data entries for "N/A" data
 - cancer variants show correct alt/ref reads mirroring alt frequency now
+- Pinned variant case level display hotfix for cancer and str - more on this later
 
 ### Changed
 

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -22,10 +22,17 @@
                     {% for gene in variant.genes %}
                       {% if gene.hgvs_identifier %}
                         {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
-                      {% else %}
-                        {{ "" if display_genes.append(gene.hgnc_symbol) }}
+                      {% elif gene.hgnc_symbol %}
+                          {{ "" if display_genes.append(gene.hgnc_symbol) }}
+                      {% elif gene.hgvs_identifier and gene.hgnc_id %}
+                          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier) }}
                       {% endif %}
                     {% endfor %}
+
+                    {% if not display_genes %}
+                        {{ "" if display_genes.append( variant.simple_id ) }}
+                    {% endif %}
+
                     {{ display_genes|join(", ") }}
 		             {% else %}
         		      <a href="{{ url_for('variant.sv_variant',
@@ -166,7 +173,7 @@
                       {% if not display_genes %}
                           {{ "" if display_genes.append( variant.simple_id ) }}
                       {% endif %}
-                      
+
                       {{ display_genes|join(", ") }}
 
                   {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -147,20 +147,23 @@
                 <div class="form-group row justify-content-between align-items-center">
                 <div class="ml-3">
                   <i class="fa fa-bookmark"></i>
-                  {% if variant.category == "snv" %}
+                  {% if variant.category in ("snv", "cancer", "str") %}
                     <a href="{{ url_for('variant.variant',
                                         institute_id=variant.institute,
                                         case_name=case.display_name,
                                         variant_id=variant._id) }}">
                       {% set display_genes = [] %}
                       {% for gene in variant.genes %}
-                        {% if gene.hgvs_identifier %}
+                        {% if gene.hgvs_identifier and gene.hgnc_symbol %}
                           {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
-                        {% else %}
+                        {% elif gene.hgnc_symbol %}
                           {{ "" if display_genes.append(gene.hgnc_symbol) }}
+                        {% elif gene.hgvs_identifier and gene.hgnc_id %}
+                          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier) }}
                         {% endif %}
                       {% endfor %}
                       {{ display_genes|join(", ") }}
+
                   {% else %}
                     <a href="{{ url_for('variant.sv_variant',
                                               institute_id=variant.institute,

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -162,6 +162,11 @@
                           {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier) }}
                         {% endif %}
                       {% endfor %}
+
+                      {% if not display_genes %}
+                          {{ "" if display_genes.append( variant.simple_id ) }}
+                      {% endif %}
+                      
                       {{ display_genes|join(", ") }}
 
                   {% else %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -13,14 +13,14 @@
             <div class="row align-items-between align-items-center">
               <div class="col-10">
                 <i class="fa fa-check-circle-o"></i>
-		            {% if variant.category == "snv" %}
+		            {% if variant.category in ("snv", "cancer", "str") %}
                   <a href="{{ url_for('variant.variant',
                                       institute_id=variant.institute,
                                       case_name=case.display_name,
                                       variant_id=variant._id) }}">
                     {% set display_genes = [] %}
                     {% for gene in variant.genes %}
-                      {% if gene.hgvs_identifier %}
+                      {% if gene.hgvs_identifier and gene.hgnc_symbol  %}
                         {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
                       {% elif gene.hgnc_symbol %}
                           {{ "" if display_genes.append(gene.hgnc_symbol) }}


### PR DESCRIPTION
A patch over the cancer pinned variant hgvs view. Appears some details on the genes there (and for STRs) is missing. We should return to this, but this at least just doesn't leave an empty field for pinned variants.

<img width="344" alt="Screenshot 2020-02-20 at 12 48 27" src="https://user-images.githubusercontent.com/758570/74931501-016e3180-53e0-11ea-95b5-0d4f18bcf8c2.png">

<img width="512" alt="Screenshot 2020-02-20 at 12 48 17" src="https://user-images.githubusercontent.com/758570/74931495-ffa46e00-53df-11ea-8b7e-286809e5bd17.png">


**How to test**:
1. Pin a variant of each type (cancer, cancer_sv, str, snv. sv) and make sure they render reasonably on the case page.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by

