### PR TITLE
Variant frequency loop fix in 2 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+
 ### Fixed
+- Case report when causative or pinned SVs have non null allele frequencies
+
 ### Changed
 
 ## [4.12.2]

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -987,7 +987,7 @@
               <th colspan=2>Frequencies</th>
             </thead>
             <tbody>
-              {% for freq_name, value in variant.frequencies %}
+              {% for freq_name, value, link in variant.frequencies %}
                 <tr>
                   <td>{{ freq_name }}</td>
                   <td>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -40,7 +40,7 @@
 {% macro frequency_cell_general(variant) %}
   <div data-toggle="tooltip" data-placement="left" data-html="true" title="
       <div class='text-left'>
-        {% for freq_name, value in variant.frequencies %}
+        {% for freq_name, value, link in variant.frequencies %}
           <div>
             <strong>freq_name</strong>: {{ value|human_decimal}}
           </div>


### PR DESCRIPTION
fix #1737 and fixes another minor potential bug in variants components.html template.

Something must have changed in the code where variant frequencies are collected and now it's a list of tuples with 3 elements each, and not 2, as before.

**How to test**:
1. Install branch on stage 
1. Go to case https://scout-stage.scilifelab.se/cust000/15026-mip7 (which has a general report not working with current master branch) and the report should work. Check also PDF report

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
