### PR TITLE
Side panel fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Bug when adding a new gene to a panel
+- Restored missing recent delivery reports
+- Fixed style and links to other reports in case side panel
 
 ### Changed
 

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -66,12 +66,12 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">Coverage</span>
-            <form method="POST" id="coverage_html" target="_blank" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
+            <form method="POST" id="coverage_html" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
               <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
               <a href="javascript:;" onclick="document.getElementById('coverage_html').submit();" target="_blank">
                 <i class="fa fa-link"></i></a>
             </form>
-            <form method="POST" id="coverage_pdf" target="_blank" action="{{ url_for('report.pdf', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
+            <form method="POST" id="coverage_pdf" action="{{ url_for('report.pdf', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
               <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
               <a href="javascript:;" onclick="document.getElementById('coverage_pdf').submit();" target="_blank">
                 <i class="fa fa-file-pdf-o"></i></a>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -66,14 +66,14 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">Coverage</span>
-            <form method="POST" id="coverage_html" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
+            <form method="POST" id="coverage_html" target="_blank" action="{{ url_for('report.report', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
               <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
-              <a href="javascript:;" onclick="document.getElementById('coverage_html').submit();" target="_blank">
+              <a href="javascript:;" onclick="document.getElementById('coverage_html').submit();">
                 <i class="fa fa-link"></i></a>
             </form>
-            <form method="POST" id="coverage_pdf" action="{{ url_for('report.pdf', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
+            <form method="POST" id="coverage_pdf" target="_blank" action="{{ url_for('report.pdf', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
               <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
-              <a href="javascript:;" onclick="document.getElementById('coverage_pdf').submit();" target="_blank">
+              <a href="javascript:;" onclick="document.getElementById('coverage_pdf').submit();">
                 <i class="fa fa-file-pdf-o"></i></a>
             </form>
         </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -53,10 +53,14 @@
       </div>
     </div>
     {% if case.multiqc %}
-      <a href="{{ url_for('cases.multiqc', institute_id=institute._id,
-                          case_name=case.display_name) }}" class="list-group-item list-group-item-action bg-dark text-white">
-          <span class="menu-collapsed">MultiQC</span>
-      </a>
+      <div href="#" class="bg-dark list-group-item text-white">
+        <div class="d-flex flex-row flex-fill bd-highlight">
+          <span class="menu-collapsed ml-2">MultiQC</span>
+          <a href="{{ url_for('cases.multiqc', institute_id=institute._id,
+                              case_name=case.display_name) }}" target="_blank">
+                              <i class="fa fa-link"></i></a>
+        </div>
+      </div>
     {% endif %}
     {% if config.SQLALCHEMY_DATABASE_URI %}
       <div href="#" class="bg-dark list-group-item text-white">

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -101,6 +101,15 @@
           </div>
         {% endif %}
       {% endfor %}
+    {% elif case.delivery_report %}
+      <div href="#" class="bg-dark list-group-item text-white">
+        <div class="d-flex flex-row flex-fill bd-highlight"></span>
+          <span class="menu-collapsed ml-2">Delivery ({{case.analysis_date.date()}})
+            <a href="{{ 'cases.delivery_report', institute_id=institute._id,
+                              case_name=case.display_name }}" target="_blank"><i class="fa fa-link"></i></a>
+            <a href="{{ url_for('cases.delivery_report', institute_id=institute._id,
+                              case_name=case.display_name, format='pdf') }}"><i class="fa fa-file-pdf-o"></i></a>
+      </div>
     {% endif %}
 </div>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -109,6 +109,7 @@
                               case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
             <a href="{{ url_for('cases.delivery_report', institute_id=institute._id,
                               case_name=case.display_name, format='pdf') }}"><i class="fa fa-file-pdf-o"></i></a>
+        </div>
       </div>
     {% endif %}
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -105,8 +105,8 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight"></span>
           <span class="menu-collapsed ml-2">Delivery ({{case.analysis_date.date()}})
-            <a href="{{ 'cases.delivery_report', institute_id=institute._id,
-                              case_name=case.display_name }}" target="_blank"><i class="fa fa-link"></i></a>
+            <a href="{{ url_for('cases.delivery_report', institute_id=institute._id,
+                              case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
             <a href="{{ url_for('cases.delivery_report', institute_id=institute._id,
                               case_name=case.display_name, format='pdf') }}"><i class="fa fa-file-pdf-o"></i></a>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -71,11 +71,6 @@
               <a href="javascript:;" onclick="document.getElementById('coverage_html').submit();">
                 <i class="fa fa-link"></i></a>
             </form>
-            <form method="POST" id="coverage_pdf" target="_blank" action="{{ url_for('report.pdf', sample_id=case.individual_ids, level=institute.coverage_cutoff, panel_name=case.panel_names|join(', ')) }}">
-              <input type="hidden" name="gene_ids" value="{{ case.default_genes|join(',') }}"></input>
-              <a href="javascript:;" onclick="document.getElementById('coverage_pdf').submit();">
-                <i class="fa fa-file-pdf-o"></i></a>
-            </form>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
Fix #1745

**How to test**:
1. Install on stage and check that all the points in #1745 are OK for a recent case having those reports available

**Expected outcome**:
The functionality should be working:
- [x] Recent delivery reports are missing. Tested with https://scout-stage.scilifelab.se/cust000/643594-300M, before (master doesn't show report)
- [x] MultiQC's link should look like the other report links (same icon and it should open a new browser tab)
- [x] Tried to fix a solution to the blank download PDF coverage report, nothing worked so I decided to remove the option. PDF report creation from the HTML one works anyway, so users can use that button instead!
- [x] Coverage HTML link opens 2 tabs instead of one
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by CR
