### PR TITLE
Delete case and variants when using delete command with case display_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+
 ### Fixed
+- Deleting cases using display_name and institute not deleting its variants
+
 ### Changed
 
 ## [4.12.4]

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -478,10 +478,11 @@ class CaseHandler(object):
 
         return self.case_collection.find({"individuals.disply_name": ind_id})
 
-    def delete_case(self, case_id):
+    def delete_case(self, case_id=None, institute_id=None, display_name=None):
         """Delete a single case from database
 
         Args:
+            institute_id(str)
             case_id(str)
 
         Returns:
@@ -491,7 +492,13 @@ class CaseHandler(object):
         if case_id:
             query["_id"] = case_id
             LOG.info("Deleting case %s", case_id)
-        
+        else:
+            if not (institute_id and display_name):
+                raise ValueError("Have to provide both institute_id and display_name")
+            LOG.info("Deleting case %s institute %s", display_name, institute_id)
+            query["owner"] = institute_id
+            query["display_name"] = display_name
+
         result = self.case_collection.delete_one(query)
         return result
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -478,11 +478,10 @@ class CaseHandler(object):
 
         return self.case_collection.find({"individuals.disply_name": ind_id})
 
-    def delete_case(self, case_id=None, institute_id=None, display_name=None):
+    def delete_case(self, case_id):
         """Delete a single case from database
 
         Args:
-            institute_id(str)
             case_id(str)
 
         Returns:
@@ -492,13 +491,7 @@ class CaseHandler(object):
         if case_id:
             query["_id"] = case_id
             LOG.info("Deleting case %s", case_id)
-        else:
-            if not (institute_id and display_name):
-                raise ValueError("Have to provide both institute_id and display_name")
-            LOG.info("Deleting case %s institute %s", display_name, institute_id)
-            query["owner"] = institute_id
-            query["display_name"] = display_name
-
+        
         result = self.case_collection.delete_one(query)
         return result
 

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -133,9 +133,8 @@ def case(institute, case_id, display_name):
     LOG.info("Running deleting case {0}".format(case_id))
     case = adapter.delete_case(case_id=case_obj["_id"])
 
-    if case.deleted_count == 1:
-        adapter.delete_variants(case_id=case_obj["_id"], variant_type="clinical")
-        adapter.delete_variants(case_id=case_obj["_id"], variant_type="research")
+    adapter.delete_variants(case_id=case_obj["_id"], variant_type="clinical")
+    adapter.delete_variants(case_id=case_obj["_id"], variant_type="research")
 
 
 # @click.command('diseases', short_help='Display all diseases')

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -125,7 +125,9 @@ def case(institute, case_id, display_name):
         case_obj = adapter.case(case_id=case_id)
 
     if not case_obj:
-        click.echo("Coudn't find any case in database matching the provided parameters.")
+        click.echo(
+            "Coudn't find any case in database matching the provided parameters."
+        )
         raise click.Abort()
 
     LOG.info("Running deleting case {0}".format(case_id))

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -120,6 +120,8 @@ def case(institute, case_id, display_name):
                 "deleted with flag '-i/--institute'."
             )
             raise click.Abort()
+        case_obj = adapter.case(display_name=display_name, institute_id=institute)
+    else:
         case_obj = adapter.case(case_id=case_id)
 
     if not case_obj:
@@ -130,12 +132,11 @@ def case(institute, case_id, display_name):
     case = adapter.delete_case(case_id=case_obj["_id"])
 
     if case.deleted_count == 1:
-        adapter.delete_variants(case_id=case_id, variant_type="clinical")
-        adapter.delete_variants(case_id=case_id, variant_type="research")
+        adapter.delete_variants(case_id=case_obj["_id"], variant_type="clinical")
+        adapter.delete_variants(case_id=case_obj["_id"], variant_type="research")
     else:
         LOG.warning("Case does not exist in database")
         raise click.Abort()
-
 
 # @click.command('diseases', short_help='Display all diseases')
 # @click.pass_context

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -107,6 +107,8 @@ def exons(build):
 def case(institute, case_id, display_name):
     """Delete a case and it's variants from the database"""
     adapter = store
+    case_obj = None
+
     if not (case_id or display_name):
         click.echo("Please specify what case to delete")
         raise click.Abort()
@@ -118,11 +120,14 @@ def case(institute, case_id, display_name):
                 "deleted with flag '-i/--institute'."
             )
             raise click.Abort()
+        case_obj = adapter.case(case_id=case_id)
+
+    if not case_obj:
+        click.echo("Coudn't find any case in database matching the provided parameters.")
+        raise click.Abort()
 
     LOG.info("Running deleting case {0}".format(case_id))
-    case = adapter.delete_case(
-        case_id=case_id, institute_id=institute, display_name=display_name
-    )
+    case = adapter.delete_case(case_id=case_obj["_id"])
 
     if case.deleted_count == 1:
         adapter.delete_variants(case_id=case_id, variant_type="clinical")

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -134,9 +134,7 @@ def case(institute, case_id, display_name):
     if case.deleted_count == 1:
         adapter.delete_variants(case_id=case_obj["_id"], variant_type="clinical")
         adapter.delete_variants(case_id=case_obj["_id"], variant_type="research")
-    else:
-        LOG.warning("Case does not exist in database")
-        raise click.Abort()
+
 
 # @click.command('diseases', short_help='Display all diseases')
 # @click.pass_context

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -351,15 +351,26 @@ def test_get_non_existing_case(adapter, case_obj):
     assert result is None
 
 
-def test_delete_case(adapter, case_obj):
+def test_delete_case_by_id(adapter, case_obj):
     # GIVEN an empty database (no cases)
     assert adapter.case_collection.find_one() is None
     adapter.case_collection.insert_one(case_obj)
-    assert adapter.case_collection.find_one()
-    logger.info("Testing to delete case")
 
-    # WHEN deleting a case from the database
+    # WHEN deleting a case from the database using case _id
     result = adapter.delete_case(case_id=case_obj["_id"])
+    # THEN there should be no cases left in the database
+    assert sum(1 for i in adapter.cases()) == 0
+
+
+def test_delete_case_by_display_name(adapter, case_obj):
+    # GIVEN an empty database (no cases)
+    assert adapter.case_collection.find_one() is None
+    adapter.case_collection.insert_one(case_obj)
+
+    # WHEN deleting a case from the database using display_name
+    result = adapter.delete_case(
+        institute_id=case_obj["owner"], display_name=case_obj["display_name"]
+    )
     # THEN there should be no cases left in the database
     assert sum(1 for i in adapter.cases()) == 0
 

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -283,7 +283,7 @@ def test_delete_case_wrong_id(empty_mock_app, case_obj):
     )
 
     ## THEN assert the correct information is communicated
-    assert "Case does not exist in database" in result.output
+    assert "Coudn't find any case in database matching the provided parameters" in result.output
     ## THEN assert the cli exits with error
     assert result.exit_code == 1
     ## THEN assert there is a case left

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -283,7 +283,10 @@ def test_delete_case_wrong_id(empty_mock_app, case_obj):
     )
 
     ## THEN assert the correct information is communicated
-    assert "Coudn't find any case in database matching the provided parameters" in result.output
+    assert (
+        "Coudn't find any case in database matching the provided parameters"
+        in result.output
+    )
     ## THEN assert the cli exits with error
     assert result.exit_code == 1
     ## THEN assert there is a case left


### PR DESCRIPTION
Fix #1709

**How to test**:
1. Delete using case ID should remove case and variants:
`scout setup demo`
`scout --demo --loglevel DEBUG delete case -c internal_id`

1. Delete using display_nave and institute should remove case and variants:
`scout setup demo`
`scout --demo --loglevel DEBUG delete case -i cust000 -d 643594`


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
