### PR TITLE
Fix code for when a new gene is added (and not edited) in a panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+
 ### Fixed
+- Bug when adding a new gene to a panel
+
 ### Changed
+
 
 ## [4.12.4]
 

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -205,9 +205,10 @@ def gene_edit(panel_id, hgnc_id):
     if panel_obj.get('genes'):
         genes_dict = { gene_obj["symbol"]:gene_obj for gene_obj in panel_obj['genes'] }
         gene_obj = genes_dict.get(hgnc_gene['hgnc_symbol'])
-        for transcript in gene_obj.get("disease_associated_transcripts", []):
-            if (transcript,transcript) not in transcript_choices:
-                transcript_choices.append((transcript,transcript))
+        if gene_obj:
+            for transcript in gene_obj.get("disease_associated_transcripts", []):
+                if (transcript,transcript) not in transcript_choices:
+                    transcript_choices.append((transcript,transcript))
 
     form.disease_associated_transcripts.choices = transcript_choices
     if form.validate_on_submit():


### PR DESCRIPTION
fix #1750. 


**How to test**:
1. From a local instance of Scout (master branch), go to a gene panel and remove a gene using the red delete button (remember which gene!)
1. Try to add the gene again using the form above: 
![image](https://user-images.githubusercontent.com/28093618/75140802-ece7ad00-56ef-11ea-974e-73ca3aacc6ba.png)
1. Make sure that when you apply the pending action of adding the gene the app crashes.
1. Checkout to this branch and make sure that the gene can be added normally.
1. Test also the option to modify a gene and not add it

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
