### PR TITLE
introduced clinvar SNVs track for IGV, both genome builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+- ClinVar SNVs track in IGV
 
 ### Fixed
 - Bug when adding a new gene to a panel

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -60,17 +60,6 @@
                           maxRows: "{{clinvar_snvs.maxRows}}",
                       },
                       {
-                          name: "{{ clinvar_cnvs.name }}",
-                          type: "{{ clinvar_cnvs.type }}",
-                          format: "{{ clinvar_cnvs.format }}",
-                          sourceType: "{{ clinvar_cnvs.sourceType }}",
-                          url: "{{ clinvar_cnvs.url|replace('%2F','/') }}",
-                          displayMode: "{{ clinvar_cnvs.displayMode }}",
-                          order: Number.MIN_VALUE,
-                          height: "{{clinvar_cnvs.height}}",
-                          maxRows: "{{clinvar_cnvs.maxRows}}",
-                      },
-                      {
                           name: "{{ genes_track.name }}",
                           type: "{{ genes_track.type }}",
                           format: "{{ genes_track.format }}",

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -56,7 +56,8 @@
                           url: "{{ clinvar_snvs.url|replace('%2F','/') }}",
                           displayMode: "{{ clinvar_snvs.displayMode }}",
                           order: Number.MIN_VALUE,
-                          height: "{{clinvar_snvs.height}}"
+                          height: "{{clinvar_snvs.height}}",
+                          maxRows: "{{clinvar_snvs.maxRows}}",
                       },
                       {
                           name: "{{ clinvar_cnvs.name }}",
@@ -66,18 +67,19 @@
                           url: "{{ clinvar_cnvs.url|replace('%2F','/') }}",
                           displayMode: "{{ clinvar_cnvs.displayMode }}",
                           order: Number.MIN_VALUE,
-                          height: "{{clinvar_cnvs.height}}"
+                          height: "{{clinvar_cnvs.height}}",
+                          maxRows: "{{clinvar_cnvs.maxRows}}",
                       },
                       {
-                            name: "{{ genes_track.name }}",
-                            type: "{{ genes_track.type }}",
-                            format: "{{ genes_track.format }}",
-                            sourceType: "{{ genes_track.sourceType }}",
-                            url: "{{ genes_track.url|replace('%2F','/') }}",
-                            indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
-                            displayMode: "{{ genes_track.displayMode }}",
-                            order: Number.MIN_VALUE,
-                            visibilityWindow: 300000000,
+                          name: "{{ genes_track.name }}",
+                          type: "{{ genes_track.type }}",
+                          format: "{{ genes_track.format }}",
+                          sourceType: "{{ genes_track.sourceType }}",
+                          url: "{{ genes_track.url|replace('%2F','/') }}",
+                          indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
+                          displayMode: "{{ genes_track.displayMode }}",
+                          order: Number.MIN_VALUE,
+                          visibilityWindow: 300000000,
                       },
                       {% for wtrack in rhocall_wig_tracks %}
                       {

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -69,6 +69,16 @@
                           order: Number.MIN_VALUE,
                           visibilityWindow: 300000000
                       },
+                      {
+                          name: "{{ clinvar_cnvs.name }}",
+                          type: "{{ clinvar_cnvs.type }}",
+                          format: "{{ clinvar_cnvs.format }}",
+                          sourceType: "{{ clinvar_cnvs.sourceType }}",
+                          url: "{{ clinvar_cnvs.url|replace('%2F','/') }}",
+                          displayMode: "{{ clinvar_cnvs.displayMode }}",
+                          order: Number.MIN_VALUE,
+                          visibilityWindow: 300000000
+                      },
                       {% for wtrack in rhocall_wig_tracks %}
                       {
                         type: "wig",

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -57,7 +57,7 @@
                             indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
                             displayMode: "{{ genes_track.displayMode }}",
                             order: Number.MIN_VALUE,
-                            visibilityWindow: 300000000
+                            visibilityWindow: 300000000,
                       },
                       {
                           name: "{{ clinvar_snvs.name }}",
@@ -67,7 +67,7 @@
                           url: "{{ clinvar_snvs.url|replace('%2F','/') }}",
                           displayMode: "{{ clinvar_snvs.displayMode }}",
                           order: Number.MIN_VALUE,
-                          visibilityWindow: 300000000
+                          height: "{{clinvar_snvs.height}}"
                       },
                       {
                           name: "{{ clinvar_cnvs.name }}",
@@ -77,7 +77,7 @@
                           url: "{{ clinvar_cnvs.url|replace('%2F','/') }}",
                           displayMode: "{{ clinvar_cnvs.displayMode }}",
                           order: Number.MIN_VALUE,
-                          visibilityWindow: 300000000
+                          height: "{{clinvar_cnvs.height}}"
                       },
                       {% for wtrack in rhocall_wig_tracks %}
                       {

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -49,17 +49,6 @@
                     locus: "{{locus}}",
                     tracks: [
                       {
-                            name: "{{ genes_track.name }}",
-                            type: "{{ genes_track.type }}",
-                            format: "{{ genes_track.format }}",
-                            sourceType: "{{ genes_track.sourceType }}",
-                            url: "{{ genes_track.url|replace('%2F','/') }}",
-                            indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
-                            displayMode: "{{ genes_track.displayMode }}",
-                            order: Number.MIN_VALUE,
-                            visibilityWindow: 300000000,
-                      },
-                      {
                           name: "{{ clinvar_snvs.name }}",
                           type: "{{ clinvar_snvs.type }}",
                           format: "{{ clinvar_snvs.format }}",
@@ -78,6 +67,17 @@
                           displayMode: "{{ clinvar_cnvs.displayMode }}",
                           order: Number.MIN_VALUE,
                           height: "{{clinvar_cnvs.height}}"
+                      },
+                      {
+                            name: "{{ genes_track.name }}",
+                            type: "{{ genes_track.type }}",
+                            format: "{{ genes_track.format }}",
+                            sourceType: "{{ genes_track.sourceType }}",
+                            url: "{{ genes_track.url|replace('%2F','/') }}",
+                            indexURL: "{{ genes_track.indexURL|replace('%2F','/') }}",
+                            displayMode: "{{ genes_track.displayMode }}",
+                            order: Number.MIN_VALUE,
+                            visibilityWindow: 300000000,
                       },
                       {% for wtrack in rhocall_wig_tracks %}
                       {

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -59,6 +59,16 @@
                             order: Number.MIN_VALUE,
                             visibilityWindow: 300000000
                       },
+                      {
+                          name: "{{ clinvar_snvs.name }}",
+                          type: "{{ clinvar_snvs.type }}",
+                          format: "{{ clinvar_snvs.format }}",
+                          sourceType: "{{ clinvar_snvs.sourceType }}",
+                          url: "{{ clinvar_snvs.url|replace('%2F','/') }}",
+                          displayMode: "{{ clinvar_snvs.displayMode }}",
+                          order: Number.MIN_VALUE,
+                          visibilityWindow: 300000000
+                      },
                       {% for wtrack in rhocall_wig_tracks %}
                       {
                         type: "wig",

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -110,6 +110,9 @@ def igv():
     gene_track_format = ""
     gene_track_URL = ""
     gene_track_indexURL = ""
+    clinvar_snvs_url = ""
+    clinvar_cnvs_url = ""
+    clinvar_track_format = "bigBed"
 
     if chromosome_build in ["GRCh38", "38"] or chrom == "M":
         fastaURL = (
@@ -120,6 +123,8 @@ def igv():
         gene_track_format = "gtf"
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
+        clinvar_snvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
+        clinvar_cnvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb"
 
     else:
         fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"
@@ -128,6 +133,7 @@ def igv():
         gene_track_format = "bed"
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi"
+        clinvar_snvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
 
     display_obj["reference_track"] = {
         "fastaURL": fastaURL,
@@ -145,6 +151,14 @@ def igv():
         "displayMode": "EXPANDED",
     }
 
+    display_obj["clinvar_snvs"] = {
+        "name": "Clinvar SNVs",
+        "type": "annotation",
+        "format": clinvar_track_format,
+        "sourceType": "file",
+        "url": clinvar_snvs_url,
+        "displayMode": "COLLAPSED",
+    }
     # Init upcoming igv-tracks
     sample_tracks = []
     upd_regions_bed_tracks = []

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -153,23 +153,25 @@ def igv():
     }
 
     display_obj["clinvar_snvs"] = {
-        "name": "Clinvar SNVs",
+        "name": "ClinVar",
         "type": "annotation",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_snvs_url,
         "displayMode": "COLLAPSED",
+        "height": 150,
     }
 
     display_obj["clinvar_cnvs"] = {
-        "name": "Clinvar CNVs",
+        "name": "ClinVar CNVs",
         "type": "annotation",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_cnvs_url,
         "displayMode": "COLLAPSED",
+        "height": 150,
     }
-    
+
     # Init upcoming igv-tracks
     sample_tracks = []
     upd_regions_bed_tracks = []

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -158,7 +158,7 @@ def igv():
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_snvs_url,
-        "displayMode": "COLLAPSED",
+        "displayMode": "EXPANDED",
         "height": 150,
     }
 
@@ -168,7 +168,7 @@ def igv():
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_cnvs_url,
-        "displayMode": "COLLAPSED",
+        "displayMode": "EXPANDED",
         "height": 150,
     }
 

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -122,7 +122,7 @@ def igv():
         gene_track_format = "gtf"
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
-        clinvar_snvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
+        clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
 
     else:
         fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"
@@ -131,7 +131,7 @@ def igv():
         gene_track_format = "bed"
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi"
-        clinvar_snvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
+        clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
 
     display_obj["reference_track"] = {
         "fastaURL": fastaURL,

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -154,7 +154,7 @@ def igv():
 
     display_obj["clinvar_snvs"] = {
         "name": "ClinVar",
-        "type": "bigBed",
+        "type": "annotation",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_snvs_url,
@@ -165,7 +165,7 @@ def igv():
 
     display_obj["clinvar_cnvs"] = {
         "name": "ClinVar CNVs",
-        "type": "bigBed",
+        "type": "annotation",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_cnvs_url,

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -111,6 +111,7 @@ def igv():
     gene_track_URL = ""
     gene_track_indexURL = ""
     clinvar_snvs_url = ""
+    clinvar_cnvs_url = ""
     clinvar_track_format = "bigBed"
 
     if chromosome_build in ["GRCh38", "38"] or chrom == "M":
@@ -123,6 +124,7 @@ def igv():
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
         clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
+        clinvar_cnvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb "
 
     else:
         fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"
@@ -132,6 +134,7 @@ def igv():
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi"
         clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
+        clinvar_cnvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarCnv.bb"
 
     display_obj["reference_track"] = {
         "fastaURL": fastaURL,
@@ -157,6 +160,16 @@ def igv():
         "url": clinvar_snvs_url,
         "displayMode": "COLLAPSED",
     }
+
+    display_obj["clinvar_cnvs"] = {
+        "name": "Clinvar CNVs",
+        "type": "annotation",
+        "format": clinvar_track_format,
+        "sourceType": "file",
+        "url": clinvar_cnvs_url,
+        "displayMode": "COLLAPSED",
+    }
+    
     # Init upcoming igv-tracks
     sample_tracks = []
     upd_regions_bed_tracks = []

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -111,8 +111,7 @@ def igv():
     gene_track_URL = ""
     gene_track_indexURL = ""
     clinvar_snvs_url = ""
-    clinvar_cnvs_url = ""
-    clinvar_track_format = "bigbed"
+    clinvar_track_format = "bigBed"
 
     if chromosome_build in ["GRCh38", "38"] or chrom == "M":
         fastaURL = (
@@ -124,7 +123,6 @@ def igv():
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
         clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
-        clinvar_cnvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb "
 
     else:
         fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"
@@ -134,7 +132,6 @@ def igv():
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi"
         clinvar_snvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
-        clinvar_cnvs_url = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarCnv.bb"
 
     display_obj["reference_track"] = {
         "fastaURL": fastaURL,
@@ -161,17 +158,6 @@ def igv():
         "displayMode": "EXPANDED",
         "maxRows": 50,
         "height": 100,
-    }
-
-    display_obj["clinvar_cnvs"] = {
-        "name": "ClinVar CNVs",
-        "type": "annotation",
-        "format": clinvar_track_format,
-        "sourceType": "file",
-        "url": clinvar_cnvs_url,
-        "displayMode": "EXPANDED",
-        "maxRows": 500,
-        "height": 250,
     }
 
     # Init upcoming igv-tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -111,7 +111,6 @@ def igv():
     gene_track_URL = ""
     gene_track_indexURL = ""
     clinvar_snvs_url = ""
-    clinvar_cnvs_url = ""
     clinvar_track_format = "bigBed"
 
     if chromosome_build in ["GRCh38", "38"] or chrom == "M":
@@ -124,7 +123,6 @@ def igv():
         gene_track_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
         gene_track_indexURL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
         clinvar_snvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
-        clinvar_cnvs_url = "http://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb"
 
     else:
         fastaURL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/hg19.fasta"

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -154,7 +154,7 @@ def igv():
 
     display_obj["clinvar_snvs"] = {
         "name": "ClinVar",
-        "type": "annotation",
+        "type": "bigBed",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_snvs_url,
@@ -165,7 +165,7 @@ def igv():
 
     display_obj["clinvar_cnvs"] = {
         "name": "ClinVar CNVs",
-        "type": "annotation",
+        "type": "bigBed",
         "format": clinvar_track_format,
         "sourceType": "file",
         "url": clinvar_cnvs_url,

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -159,7 +159,8 @@ def igv():
         "sourceType": "file",
         "url": clinvar_snvs_url,
         "displayMode": "EXPANDED",
-        "height": 150,
+        "maxRows": 50,
+        "height": 100,
     }
 
     display_obj["clinvar_cnvs"] = {
@@ -169,7 +170,8 @@ def igv():
         "sourceType": "file",
         "url": clinvar_cnvs_url,
         "displayMode": "EXPANDED",
-        "height": 150,
+        "maxRows": 500,
+        "height": 250,
     }
 
     # Init upcoming igv-tracks

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -112,7 +112,7 @@ def igv():
     gene_track_indexURL = ""
     clinvar_snvs_url = ""
     clinvar_cnvs_url = ""
-    clinvar_track_format = "bigBed"
+    clinvar_track_format = "bigbed"
 
     if chromosome_build in ["GRCh38", "38"] or chrom == "M":
         fastaURL = (


### PR DESCRIPTION
This PR adds a Clinvar IGV track on top of the gene track (fix : #1660)
![image](https://user-images.githubusercontent.com/28093618/75243408-2391f600-57ca-11ea-9dda-f5b353c28aa0.png)

For more reference about where I took the track and color codes: https://genome-euro.ucsc.edu/cgi-bin/hgTrackUi?hgsid=234574442_yPXTIamdZkAXX0L6DUZZmsPXEy7H&c=chr21&g=clinvar

Clinvar files are updated every month so it would be nice to use their track!

**How to test**:
1. Install this branch on stage and check some variants' alignments  (example case: http://scout-stage.scilifelab.se/cust000/lovedmarlin)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by CR, DN, MM
