### PR TITLE
Fix coordinates filter bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Restored missing recent delivery reports
 - Fixed style and links to other reports in case side panel
 - Deleting cases using display_name and institute not deleting its variants
+- Fixed bug that caused coordinates filter to override other filters
 
 ### Changed
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -268,7 +268,7 @@ class QueryHandler(object):
 
         # if chromosome coordinates exist in query, add them as first element of the mongo_query['$and']
         if coordinate_query:
-            if mongo_query.get("query") or mongo_query.get("$and"):
+            if mongo_query.get("$and"):
                 mongo_query["$and"] = coordinate_query + mongo_query["$and"]
             else:
                 mongo_query["$and"] = coordinate_query

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -268,7 +268,7 @@ class QueryHandler(object):
 
         # if chromosome coordinates exist in query, add them as first element of the mongo_query['$and']
         if coordinate_query:
-            if mongo_query.get("query"):
+            if mongo_query.get("query") or mongo_query.get("$and"):
                 mongo_query["$and"] = coordinate_query + mongo_query["$and"]
             else:
                 mongo_query["$and"] = coordinate_query


### PR DESCRIPTION
This PR fixes a bug causing the coordinates filter to override all other filters.

In SVfilters, if you select these filters: SVtype=DEL, Chromosome 3. This will show all variants on chr3 reagardless of SVtype. The query looks like this:
```
mongo query: {'case_id': 'xxx', 'category': 'sv', 'variant_type': 'clinical', '$and': [{'$or': [{'chromosome': '3'}, {'end_chrom': '3'}]}]}
```

This will fix that and make the query look like this:
```
mongo query: {'case_id': 'xxx', 'category': 'sv', 'variant_type': 'clinical', '$and': [{'$or': [{'chromosome': '3'}, {'end_chrom': '3'}]}, {'sub_category': {'$in': ['del']}}]}
```

I think this was caused by a typo where `if mongo_query.get("query"):` should have been `if mongo_query.get("$and"):`, but I don't understand the query building well enough to remove the old check so I just added an `and`.

