### PR TITLE
Run coveralls from github actions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source=scout
+omit=tests/*, setup.py

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -41,8 +41,9 @@ jobs:
         # stop the build if there are Python syntax errors or undefined names
         flake8 scout/ --count --select=E9,F63,F7,F82 --show-source --statistics
 
-    - name: Test with pytest
+    - name: Test with pytest & Coveralls
       run: |
-        py.test -rxs tests/
+        pytest --cov=./
+        coveralls
       env:
         GITHUB: 1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,3 +47,4 @@ jobs:
         coveralls
       env:
         GITHUB: 1
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ pytest.ini
 *.sublime-*
 dev/
 .vagrant/
-.coverage*
 htmlcov/
 provision/roles/
 .env

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ env: TRAVIS=1
 
 jobs:
     include:
-        - name: "Tests & Coverage"
-          services: mongodb
-          install:
-              - pip install cython
-              - pip install -r requirements-dev.txt -e .
-          script: py.test --cov=scout -rxs tests/
-          after_success: coveralls
+        # - name: "Tests & Coverage"
+        #   services: mongodb
+        #   install:
+        #       - pip install cython
+        #       - pip install -r requirements-dev.txt -e .
+        #   script: py.test --cov=scout -rxs tests/
+        #   after_success: coveralls
 
         - name: "Production Dependencies"
           if: type = pull_request

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,6 @@ env: TRAVIS=1
 
 jobs:
     include:
-        # - name: "Tests & Coverage"
-        #   services: mongodb
-        #   install:
-        #       - pip install cython
-        #       - pip install -r requirements-dev.txt -e .
-        #   script: py.test --cov=scout -rxs tests/
-        #   after_success: coveralls
 
         - name: "Production Dependencies"
           if: type = pull_request

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Improved code that sends requests to the external APIs
 - Updates ranges for user ranks to fit todays usage
+- Run coveralls on github actions instead of travis
 
 
 ## [4.13.1]


### PR DESCRIPTION
This PR switch from using travis to GitHub Actions for coveralls


**Expected outcome**:
Coveralls should be run from GitHub Actions 

**Review:**
- [x] code approved by CR

