### PR TITLE
Run pip checks on github actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install cython
+        pip install numpy
         pip install -e .
         pip check
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,7 +27,7 @@ jobs:
       uses: wbari/start-mongoDB@v0.2
       with:
         mongoDBVersion: ${{ matrix.mongodb-version}}
-    
+
     - name: Production Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,13 +27,18 @@ jobs:
       uses: wbari/start-mongoDB@v0.2
       with:
         mongoDBVersion: ${{ matrix.mongodb-version}}
-
-    - name: Install dependencies
+    
+    - name: Production Dependencies
       run: |
         python -m pip install --upgrade pip
         pip install cython
-        pip install numpy
-        pip install -r requirements-dev.txt -e .
+        pip install -e .
+        pip check
+
+    - name: Development Dependencies
+      run: |
+        pip install -r requirements-dev.txt
+        pip check
 
     - name: Lint with flake8
       run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,6 @@ env: TRAVIS=1
 jobs:
     include:
 
-        - name: "Production Dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install .
-          script: pip check
-
-        - name: "Development Dependencies"
-          if: type = pull_request
-          install:
-              - pip install cython
-              - pip install . -r requirements-dev.txt
-          script: pip check
-
         - name: "PEP8 Compliance"
           if: type = pull_request
           install: pip install black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved code that sends requests to the external APIs
 - Updates ranges for user ranks to fit todays usage
 - Run coveralls on github actions instead of travis
+- Run pip checks on github actions instead of coveralls
 
 
 ## [4.13.1]


### PR DESCRIPTION
This PR changes so that pip checks are executed in GitHub Actions instead of travis

**Expected outcome**:
pip checks should be run on GitHub Actions

**Review:**
- [x] code approved by CR
- [x] tests executed by GitHub Actions
