### PR TITLE
Avoid server error on variant page when VCF file is not available

### DIFF
--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -667,7 +667,12 @@ class VariantHandler(VariantLoader):
         if not variant_file:
             raise SyntaxError("Vcf file does not seem to exist")
 
-        vcf_obj = VCF(variant_file)
+        try:
+            vcf_obj = VCF(variant_file)
+        except:
+            LOG.error("Cannot read VCF: {0}".format(variant_file))
+            return None
+
         region = ""
 
         if gene_obj:


### PR DESCRIPTION
This PR fixes a bug which causes a server error when trying to view a variant overview page (both for SNVs and SVs) while the VCF file is not currently accessible. 

I think this bug has been present since this commit https://github.com/Clinical-Genomics/scout/commit/2769b285354790077aa86e692e25b9cf9c41be29#diff-48cf522b95b5383c87a80b36ce46df9cL106 fixed the typo of "crom" to "chrom" in scout/server/utils.py, making the code work as intended, and thereby ironically causing this bug.