### PR TITLE
Gnomad link hg38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved code that sends requests to the external APIs
 - Updates ranges for user ranks to fit todays usage
 - Run coveralls on github actions instead of travis
+- For hg38 cases, change gnomAD link to point to version 3.0 (which is hg38 based)
 
 
 ## [4.13.1]

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -97,7 +97,7 @@ def variant(
     variant_type = variant_type or variant_obj.get("category", "snv")
     variant_id = variant_obj["variant_id"]
 
-    genome_build = case_obj.get("genome_build", "37")
+    genome_build = str( case_obj.get("genome_build", "37") )
     if genome_build not in ["37", "38"]:
         genome_build = "37"
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -340,7 +340,7 @@ def gnomad_link(variant_obj, build=37):
     else:
         url_template = (
             "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
-            "{this[position]}-{this[reference]}-{this[alternative]}?hej="+str(build)
+            "{this[position]}-{this[reference]}-{this[alternative]}"
         )
 
     return url_template.format(this=variant_obj)

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -286,7 +286,7 @@ def get_variant_links(variant_obj, build=None):
     links = dict(
         thousandg_link=thousandg_link(variant_obj, build),
         exac_link=exac_link(variant_obj),
-        gnomad_link=gnomad_link(variant_obj),
+        gnomad_link=gnomad_link(variant_obj, build),
         swegen_link=swegen_link(variant_obj),
         cosmic_link=cosmic_link(variant_obj),
         beacon_link=beacon_link(variant_obj, build),
@@ -329,12 +329,20 @@ def exac_link(variant_obj):
     return url_template.format(this=variant_obj)
 
 
-def gnomad_link(variant_obj):
+def gnomad_link(variant_obj, build=37):
     """Compose link to gnomAD website."""
-    url_template = (
-        "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
-        "{this[position]}-{this[reference]}-{this[alternative]}"
-    )
+
+    if build == 38:
+        url_template = (
+            "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
+            "{this[position]}-{this[reference]}-{this[alternative]}?dataset=gnomad_r3"
+        )
+    else:
+        url_template = (
+            "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
+            "{this[position]}-{this[reference]}-{this[alternative]}?hej="+str(build)
+        )
+
     return url_template.format(this=variant_obj)
 
 


### PR DESCRIPTION
Yet another hg19/hg38 fix.

For hg38 cases, link to gnomAD 3.0 (which is hg38 based) instead of the default (currently 2.1.1, which is hg19 based).

Also fixes a related typecasting bug that I have a feeling that I've fixed before. Maybe in another function.