### PR TITLE
Loqus version req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds CLI command to update individual alignments path
 - Update HPO terms using downloaded definitions files
 - Option to use alternative flask config when running `scout serve`
+- Requirement to use loqusdb >= 2.5 if integrated
 
 ### Fixed
 - Do not display Pedigree panel in cancer view

--- a/README.md
+++ b/README.md
@@ -90,11 +90,20 @@ scout load case scout/demo/643594.config.yaml
 
 ## Integration with chanjo for coverage report visualization
 
-Scout may be configured to visualize coverage reports produced by [Chanjo][chanjo]. Instructions on how to enable this feature can be found in the document [chanjo_coverage_integration](docs/admin-guide/chanjo_coverage_integration.md).
+Scout may be configured to visualize coverage reports produced by [Chanjo][chanjo]. Instructions on
+how to enable this feature can be found in the document [chanjo_coverage_integration][chanjo-scout].
+
+## Integration with loqusdb for integrating local variant frequencies
+
+Scout may be configured to visualize local variant frequencies monitored by [Loqusdb][loqusdb].
+Instructions on how to enable this feature can be found in the document
+[loqusdb integration][loqusdb-scout].
 
 ## Server setup
 
-Scout needs a server config to know which databases to connect to etc. Depending on which information you provide you activate different parts of the interface automatically, including user authentication, coverage, and local observations.
+Scout needs a server config to know which databases to connect to etc. Depending on which
+information you provide you activate different parts of the interface automatically,
+including user authentication, coverage, and local observations.
 
 This is an example of the config file:
 
@@ -149,10 +158,13 @@ scout --flask-config config.py serve
 
 ### Hosting a production server
 
-When running the server in production you will likely want to use a proper Python server solution such as Gunicorn. This is also how we can multiprocess the server and use encrypted HTTPS connections.
+When running the server in production you will likely want to use a proper Python server solution
+such as Gunicorn.
+This is also how we can multiprocess the server and use encrypted HTTPS connections.
 
 ```bash
-SCOUT_CONFIG=./config.py gunicorn --workers 4 --bind 0.0.0.0:8080 --access-logfile - --error-logfile - --keyfile /tmp/myserver.key --certfile /tmp/server.crt wsgi_gunicorn:app
+SCOUT_CONFIG=./config.py gunicorn --workers 4 --bind 0.0.0.0:8080 --access-logfile - --error-logfile
+ - --keyfile /tmp/myserver.key --certfile /tmp/server.crt wsgi_gunicorn:app
 ```
 
 > The `wsgi_gunicorn.py` file is included in the repo and configures Flask to work with Gunicorn.
@@ -160,9 +172,13 @@ SCOUT_CONFIG=./config.py gunicorn --workers 4 --bind 0.0.0.0:8080 --access-logfi
 
 ### Integration with MatchMaker Exchange
 
-Starting from release 4.4, Scout offers integration for patient data sharing via MatchMaker Exchange. General info about MatchMaker and patient matching could be found in [this paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6016856/).
-For a technical guideline of our implementation of MatchMaker Exchange at Clinical Genomics and its integration with Scout follow this [link](docs/admin-guide/matchmaker_exchange_integration.md).
-A user-oriented guide describing how to share case and variant data to MatchMaker using Scout can be found [here](docs/user-guide/cases.md#matchmaker-exchange-integration).
+Starting from release 4.4, Scout offers integration for patient data sharing via MatchMaker
+Exchange.
+General info about MatchMaker and patient matching could be found in [this paper][matchmaker-pub].
+For a technical guideline of our implementation of MatchMaker Exchange at Clinical Genomics and its
+integration with Scout check scouts [matchmaker docs][matchmaker-scout].
+A user-oriented guide describing how to share case and variant data to MatchMaker using Scout can
+be found [here][matchmaker-scout-sharing].
 
 
 ## Example of analysis config
@@ -172,13 +188,22 @@ TODO.
 
 ### Contributing to Scout
 
-If you want to contribute and make Scout better, you help is very appreciated! Bug reports or feature requests are really helpful and can be submitted via github issues.
-Feel free to open a pull request to add a new functionality or fixing a bug, we welcome any help, regardless of the amount of code provided or your skills as a programmer.
-More info on how to contribute to the project and a description of the Scout branching workflow can be found [here](CONTRIBUTING.md).
+If you want to contribute and make Scout better, you help is very appreciated! Bug reports or
+feature requests are really helpful and can be submitted via github issues.
+Feel free to open a pull request to add a new functionality or fixing a bug, we welcome any help,
+regardless of the amount of code provided or your skills as a programmer.
+More info on how to contribute to the project and a description of the Scout branching workflow can
+be found in [CONTRIBUTING](CONTRIBUTING.md).
 
 
 
 [chanjo]: https://github.com/Clinical-Genomics/chanjo
+[chanjo-scout]: docs/admin-guide/chanjo_coverage_integration.md
+[loqusdb]: https://github.com/moonso/loqusdb
+[loqusdb-scout]: docs/admin-guide/loqusdb_integration.md
+[matchmaker-pub]: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6016856/
+[matchmaker-scout]: docs/admin-guide/matchmaker_exchange_integration.md
+[matchmaker-scout-sharing]: docs/user-guide/cases.md#matchmaker-exchange-integration
 [travis-img]: https://img.shields.io/travis/Clinical-Genomics/scout/develop.svg?style=flat-square
 [travis-url]: https://travis-ci.org/Clinical-Genomics/scout
 [pypi-img]: https://img.shields.io/pypi/v/scout-browser.svg?style=flat-square

--- a/docs/admin-guide/loqusdb_integration.md
+++ b/docs/admin-guide/loqusdb_integration.md
@@ -1,6 +1,6 @@
 # Loqusdb integration
 
-[Loqusdb][loqus] is a tool to keep track of local observation of genomic variants. Local frequencies/observations has been shown to add value to the analysis of genomic data both for rare disease and cancer. Scout integrates with loqusdb by fetching data from a given instance of loqusdb via the CLI.
+[Loqusdb][loqus] is a tool to keep track of local observation of genomic variants. Local frequencies/observations has been shown to add value to the analysis of genomic data both for rare disease and cancer. Scout integrates with loqusdb by fetching data from a given instance of loqusdb via the CLI. Please note that loqusdb version >= 2.5 needs to be installed.
 
 ## Setup
 

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -56,22 +56,30 @@ def get_app(ctx):
     if options.params.get("demo"):
         cli_config["demo"] = "scout-demo"
 
-    app = create_app(
-        config=dict(
-            MONGO_DBNAME=cli_config.get("demo")
-            or options.params.get("mongodb")
-            or cli_config.get("mongodb")
-            or "scout",
-            MONGO_HOST=options.params.get("host")
-            or cli_config.get("host")
-            or "localhost",
-            MONGO_PORT=options.params.get("port") or cli_config.get("port") or 27017,
-            MONGO_USERNAME=options.params.get("username") or cli_config.get("username"),
-            MONGO_PASSWORD=options.params.get("password") or cli_config.get("password"),
-            OMIM_API_KEY=cli_config.get("omim_api_key"),
-        ),
-        config_file=flask_conf,
-    )
+    try:
+        app = create_app(
+            config=dict(
+                MONGO_DBNAME=cli_config.get("demo")
+                or options.params.get("mongodb")
+                or cli_config.get("mongodb")
+                or "scout",
+                MONGO_HOST=options.params.get("host")
+                or cli_config.get("host")
+                or "localhost",
+                MONGO_PORT=options.params.get("port")
+                or cli_config.get("port")
+                or 27017,
+                MONGO_USERNAME=options.params.get("username")
+                or cli_config.get("username"),
+                MONGO_PASSWORD=options.params.get("password")
+                or cli_config.get("password"),
+                OMIM_API_KEY=cli_config.get("omim_api_key"),
+            ),
+            config_file=flask_conf,
+        )
+    except SyntaxError as err:
+        LOG.error(err)
+        raise click.Abort
     return app
 
 

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -76,7 +76,7 @@ class LoqusDB:
         """Check if a compatible version is used"""
         if not self.version >= 2.5:
             LOG.info("Please update your loqusdb version to >=2.5")
-            raise SyntaxError("Only compatible with loausdb version >= 2.5")
+            raise SyntaxError("Only compatible with loqusdb version >= 2.5")
 
     @staticmethod
     def set_coordinates(variant_info):

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -50,10 +50,8 @@ class LoqusDB:
         )
 
         self.base_call = [self.loqusdb_binary]
-        print(self.version)
         if self.loqusdb_config:
             self.base_call.extend(["--config", self.loqusdb_config])
-        self.version_check()
 
     def init_app(self, app):
         """Initialize from Flask."""

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -50,8 +50,10 @@ class LoqusDB:
         )
 
         self.base_call = [self.loqusdb_binary]
+        print(self.version)
         if self.loqusdb_config:
             self.base_call.extend(["--config", self.loqusdb_config])
+        self.version_check()
 
     def init_app(self, app):
         """Initialize from Flask."""
@@ -70,6 +72,13 @@ class LoqusDB:
         self.version = app.config["LOQUSDB_SETTINGS"].get("version")
         if not self.version:
             self.version = self.get_version()
+        self.version_check()
+
+    def version_check(self):
+        """Check if a compatible version is used"""
+        if not self.version >= 2.5:
+            LOG.info("Please update your loqusdb version to >=2.5")
+            raise SyntaxError("Only compatible with loausdb version >= 2.5")
 
     @staticmethod
     def set_coordinates(variant_info):

--- a/tests/server/extensions/conftest.py
+++ b/tests/server/extensions/conftest.py
@@ -3,42 +3,43 @@ import pytest
 
 from scout.server.extensions.loqus_extension import LoqusDB
 
-# @pytest.fixture(name="loqus_exe")
-# def fixture_loqus_exe():
-#     """Return the path to a loqus executable"""
-#     return "a/path/to/loqusdb"
-#
-#
-# @pytest.fixture(name="loqus_config")
-# def fixture_loqus_config():
-#     """Return the path to a loqus config"""
-#     return "configs/loqus-config.yaml"
-#
-#
-# @pytest.fixture(name="loqus_version")
-# def fixture_loqus_version():
-#     """Return a loqus version"""
-#     return 2.5
-#
-#
-# @pytest.fixture(name="app_config")
-# def fixture_app_config(loqus_exe, loqus_config, loqus_version):
-#     """Return a dictionary with loqus configs"""
-#     _configs = {
-#         "LOQUSDB_SETTINGS": {
-#             "binary_path": loqus_exe,
-#             "version": loqus_version,
-#             "config_path": loqus_config,
-#         }
-#     }
-#
-#     return _configs
-#
-#
-# @pytest.fixture(name="loqus_extension")
-# def fixture_loqus_extension(loqus_exe, loqus_config, loqus_version):
-#     """Return a loqusdb extension"""
-#     loqus_obj = LoqusDB(
-#         loqusdb_binary=loqus_exe, loqusdb_config=loqus_config, version=loqus_version
-#     )
-#     return loqus_obj
+
+@pytest.fixture(name="loqus_exe")
+def fixture_loqus_exe():
+    """Return the path to a loqus executable"""
+    return "a/path/to/loqusdb"
+
+
+@pytest.fixture(name="loqus_version")
+def fixture_loqus_version():
+    """Return a loqus version"""
+    return 2.5
+
+
+@pytest.fixture(name="loqus_config")
+def fixture_loqus_config():
+    """Return the path to a loqus config"""
+    return "configs/loqus-config.yaml"
+
+
+@pytest.fixture(name="app_config")
+def fixture_app_config(loqus_exe, loqus_config, loqus_version):
+    """Return a dictionary with loqus configs"""
+    _configs = {
+        "LOQUSDB_SETTINGS": {
+            "binary_path": loqus_exe,
+            "version": loqus_version,
+            "config_path": loqus_config,
+        }
+    }
+
+    return _configs
+
+
+@pytest.fixture(name="loqus_extension")
+def fixture_loqus_extension(loqus_exe, loqus_config, loqus_version):
+    """Return a loqusdb extension"""
+    loqus_obj = LoqusDB(
+        loqusdb_binary=loqus_exe, loqusdb_config=loqus_config, version=loqus_version
+    )
+    return loqus_obj

--- a/tests/server/extensions/conftest.py
+++ b/tests/server/extensions/conftest.py
@@ -3,43 +3,42 @@ import pytest
 
 from scout.server.extensions.loqus_extension import LoqusDB
 
-
-@pytest.fixture(name="loqus_exe")
-def fixture_loqus_exe():
-    """Return the path to a loqus executable"""
-    return "a/path/to/loqusdb"
-
-
-@pytest.fixture(name="loqus_config")
-def fixture_loqus_config():
-    """Return the path to a loqus config"""
-    return "configs/loqus-config.yaml"
-
-
-@pytest.fixture(name="loqus_version")
-def fixture_loqus_version():
-    """Return a loqus version"""
-    return 2.5
-
-
-@pytest.fixture(name="app_config")
-def fixture_app_config(loqus_exe, loqus_config, loqus_version):
-    """Return a dictionary with loqus configs"""
-    _configs = {
-        "LOQUSDB_SETTINGS": {
-            "binary_path": loqus_exe,
-            "version": loqus_version,
-            "config_path": loqus_config,
-        }
-    }
-
-    return _configs
-
-
-@pytest.fixture(name="loqus_extension")
-def fixture_loqus_extension(loqus_exe, loqus_config, loqus_version):
-    """Return a loqusdb extension"""
-    loqus_obj = LoqusDB(
-        loqusdb_binary=loqus_exe, loqusdb_config=loqus_config, version=loqus_version
-    )
-    return loqus_obj
+# @pytest.fixture(name="loqus_exe")
+# def fixture_loqus_exe():
+#     """Return the path to a loqus executable"""
+#     return "a/path/to/loqusdb"
+#
+#
+# @pytest.fixture(name="loqus_config")
+# def fixture_loqus_config():
+#     """Return the path to a loqus config"""
+#     return "configs/loqus-config.yaml"
+#
+#
+# @pytest.fixture(name="loqus_version")
+# def fixture_loqus_version():
+#     """Return a loqus version"""
+#     return 2.5
+#
+#
+# @pytest.fixture(name="app_config")
+# def fixture_app_config(loqus_exe, loqus_config, loqus_version):
+#     """Return a dictionary with loqus configs"""
+#     _configs = {
+#         "LOQUSDB_SETTINGS": {
+#             "binary_path": loqus_exe,
+#             "version": loqus_version,
+#             "config_path": loqus_config,
+#         }
+#     }
+#
+#     return _configs
+#
+#
+# @pytest.fixture(name="loqus_extension")
+# def fixture_loqus_extension(loqus_exe, loqus_config, loqus_version):
+#     """Return a loqusdb extension"""
+#     loqus_obj = LoqusDB(
+#         loqusdb_binary=loqus_exe, loqusdb_config=loqus_config, version=loqus_version
+#     )
+#     return loqus_obj

--- a/tests/server/extensions/test_loqusdb_extension.py
+++ b/tests/server/extensions/test_loqusdb_extension.py
@@ -2,6 +2,8 @@
 
 import subprocess
 
+import pytest
+
 from scout.server.extensions.loqus_extension import LoqusDB
 
 
@@ -25,86 +27,85 @@ def test_set_coordinates_no_variant_type():
     assert var["length"] == length
 
 
-# def test_set_coordinates_ins():
-#     """Test update coordinates when hidden insertion"""
-#     # GIVEN a variant with some coordinates
-#     pos = 10
-#     end = 10
-#     length = 10
-#     var_type = "INS"
-#     var = {
-#         "_id": "1_10_INS",
-#         "pos": pos,
-#         "end": end,
-#         "length": length,
-#         "variant_type": var_type,
-#     }
-#     # WHEN setting the coordinates
-#     LoqusDB.set_coordinates(var)
-#     # THEN assert that end coordinate is updated
-#     assert var["pos"] == pos
-#     assert var["end"] == end + length
-#     assert var["length"] == length
-#
-#
-# def test_set_coordinates_unknown_ins():
-#     """Test update coordinates when insertion length is unknown"""
-#     # GIVEN a variant with some coordinates
-#     pos = 10
-#     end = 10
-#     length = -1
-#     var_type = "INS"
-#     var = {
-#         "_id": "1_10_INS",
-#         "pos": pos,
-#         "end": end,
-#         "length": length,
-#         "variant_type": var_type,
-#     }
-#     # WHEN setting the coordinates
-#     LoqusDB.set_coordinates(var)
-#     # THEN assert that end coordinate is updated
-#     assert var["pos"] == pos
-#     assert var["end"] == end
-#     assert var["length"] == length
-#
-#
-# def test_loqusdb_variant(mocker, loqus_extension):
-#     """Test to fetch a variant from loqusdb"""
-#     # GIVEN a return value from loqusdb
-#     return_value = (
-#         b'{"homozygote": 0, "hemizygote": 0, "observations": 1, "chrom": "1", "start": '
-#         b'235918688, "end": 235918693, "ref": "CAAAAG", "alt": "C", "families": ["643594"],'
-#         b' "total": 3}'
-#     )
-#     mocker.patch.object(subprocess, "check_output")
-#     subprocess.check_output.return_value = return_value
-#     # WHEN fetching the variant info
-#     var_info = loqus_extension.get_variant({"_id": "a variant"})
-#
-#     # THEN assert the info was parsed correct
-#     assert var_info["total"] == 3
-#
-#
-# def test_loqusdb_cases(mocker, loqus_extension):
-#     """Test the case count function in loqus extension"""
-#     # GIVEN a return value from loqusdb
-#     nr_cases = 15
-#     return_value = b"%d" % nr_cases
-#     mocker.patch.object(subprocess, "check_output")
-#     subprocess.check_output.return_value = return_value
-#     # WHEN fetching the number of cases
-#     res = loqus_extension.case_count()
-#     # THEN assert the output is parsed correct
-#     assert res == nr_cases
-#
-#
-# def test_loqusdb_wrong_version(mocker):
-#     """Test to instantiate a loqus extension whe version is to low"""
-#     # GIVEN a loqusdb version < 2.5
-#     mocker.patch.object(LoqusDB, "get_version")
-#     LoqusDB.get_version.return_value = 1.0
-#     # WHEN instantiating an adapter
-#     with pytest.raises(SyntaxError):
-#         # THEN assert a syntax error is raised since version is wrong
-#         LoqusDB()
+def test_set_coordinates_ins():
+    """Test update coordinates when hidden insertion"""
+    # GIVEN a variant with some coordinates
+    pos = 10
+    end = 10
+    length = 10
+    var_type = "INS"
+    var = {
+        "_id": "1_10_INS",
+        "pos": pos,
+        "end": end,
+        "length": length,
+        "variant_type": var_type,
+    }
+    # WHEN setting the coordinates
+    LoqusDB.set_coordinates(var)
+    # THEN assert that end coordinate is updated
+    assert var["pos"] == pos
+    assert var["end"] == end + length
+    assert var["length"] == length
+
+
+def test_set_coordinates_unknown_ins():
+    """Test update coordinates when insertion length is unknown"""
+    # GIVEN a variant with some coordinates
+    pos = 10
+    end = 10
+    length = -1
+    var_type = "INS"
+    var = {
+        "_id": "1_10_INS",
+        "pos": pos,
+        "end": end,
+        "length": length,
+        "variant_type": var_type,
+    }
+    # WHEN setting the coordinates
+    LoqusDB.set_coordinates(var)
+    # THEN assert that end coordinate is updated
+    assert var["pos"] == pos
+    assert var["end"] == end
+    assert var["length"] == length
+
+
+def test_loqusdb_variant(mocker, loqus_extension):
+    """Test to fetch a variant from loqusdb"""
+    # GIVEN a return value from loqusdb
+    return_value = (
+        b'{"homozygote": 0, "hemizygote": 0, "observations": 1, "chrom": "1", "start": '
+        b'235918688, "end": 235918693, "ref": "CAAAAG", "alt": "C", "families": ["643594"],'
+        b' "total": 3}'
+    )
+    mocker.patch.object(subprocess, "check_output")
+    subprocess.check_output.return_value = return_value
+    # WHEN fetching the variant info
+    var_info = loqus_extension.get_variant({"_id": "a variant"})
+
+    # THEN assert the info was parsed correct
+    assert var_info["total"] == 3
+
+
+def test_loqusdb_cases(mocker, loqus_extension):
+    """Test the case count function in loqus extension"""
+    # GIVEN a return value from loqusdb
+    nr_cases = 15
+    return_value = b"%d" % nr_cases
+    mocker.patch.object(subprocess, "check_output")
+    subprocess.check_output.return_value = return_value
+    # WHEN fetching the number of cases
+    res = loqus_extension.case_count()
+    # THEN assert the output is parsed correct
+    assert res == nr_cases
+
+
+def test_loqusdb_wrong_version(loqus_exe):
+    """Test to instantiate a loqus extension whe version is to low"""
+    # GIVEN a loqusdb version < 2.5
+    loqus_extension = LoqusDB(loqusdb_binary=loqus_exe, version=1.0)
+    # WHEN instantiating an adapter
+    with pytest.raises(SyntaxError):
+        # THEN assert a syntax error is raised since version is wrong
+        loqus_extension.version_check()

--- a/tests/server/extensions/test_loqusdb_extension.py
+++ b/tests/server/extensions/test_loqusdb_extension.py
@@ -25,75 +25,86 @@ def test_set_coordinates_no_variant_type():
     assert var["length"] == length
 
 
-def test_set_coordinates_ins():
-    """Test update coordinates when hidden insertion"""
-    # GIVEN a variant with some coordinates
-    pos = 10
-    end = 10
-    length = 10
-    var_type = "INS"
-    var = {
-        "_id": "1_10_INS",
-        "pos": pos,
-        "end": end,
-        "length": length,
-        "variant_type": var_type,
-    }
-    # WHEN setting the coordinates
-    LoqusDB.set_coordinates(var)
-    # THEN assert that end coordinate is updated
-    assert var["pos"] == pos
-    assert var["end"] == end + length
-    assert var["length"] == length
-
-
-def test_set_coordinates_unknown_ins():
-    """Test update coordinates when insertion length is unknown"""
-    # GIVEN a variant with some coordinates
-    pos = 10
-    end = 10
-    length = -1
-    var_type = "INS"
-    var = {
-        "_id": "1_10_INS",
-        "pos": pos,
-        "end": end,
-        "length": length,
-        "variant_type": var_type,
-    }
-    # WHEN setting the coordinates
-    LoqusDB.set_coordinates(var)
-    # THEN assert that end coordinate is updated
-    assert var["pos"] == pos
-    assert var["end"] == end
-    assert var["length"] == length
-
-
-def test_loqusdb_variant(mocker, loqus_extension):
-    """Test to fetch a variant from loqusdb"""
-    # GIVEN a return value from loqusdb
-    return_value = (
-        b'{"homozygote": 0, "hemizygote": 0, "observations": 1, "chrom": "1", "start": '
-        b'235918688, "end": 235918693, "ref": "CAAAAG", "alt": "C", "families": ["643594"],'
-        b' "total": 3}'
-    )
-    mocker.patch.object(subprocess, "check_output")
-    subprocess.check_output.return_value = return_value
-    # WHEN fetching the variant info
-    var_info = loqus_extension.get_variant({"_id": "a variant"})
-
-    # THEN assert the info was parsed correct
-    assert var_info["total"] == 3
-
-
-def test_loqusdb_cases(mocker, loqus_extension):
-    """Test the case count function in loqus extension"""
-    # GIVEN a return value from loqusdb
-    nr_cases = 15
-    return_value = b"%d" % nr_cases
-    mocker.patch.object(subprocess, "check_output")
-    subprocess.check_output.return_value = return_value
-    # WHEN fetching the number of cases
-    res = loqus_extension.case_count()
-    # THEN assert the output is parsed correct
-    assert res == nr_cases
+# def test_set_coordinates_ins():
+#     """Test update coordinates when hidden insertion"""
+#     # GIVEN a variant with some coordinates
+#     pos = 10
+#     end = 10
+#     length = 10
+#     var_type = "INS"
+#     var = {
+#         "_id": "1_10_INS",
+#         "pos": pos,
+#         "end": end,
+#         "length": length,
+#         "variant_type": var_type,
+#     }
+#     # WHEN setting the coordinates
+#     LoqusDB.set_coordinates(var)
+#     # THEN assert that end coordinate is updated
+#     assert var["pos"] == pos
+#     assert var["end"] == end + length
+#     assert var["length"] == length
+#
+#
+# def test_set_coordinates_unknown_ins():
+#     """Test update coordinates when insertion length is unknown"""
+#     # GIVEN a variant with some coordinates
+#     pos = 10
+#     end = 10
+#     length = -1
+#     var_type = "INS"
+#     var = {
+#         "_id": "1_10_INS",
+#         "pos": pos,
+#         "end": end,
+#         "length": length,
+#         "variant_type": var_type,
+#     }
+#     # WHEN setting the coordinates
+#     LoqusDB.set_coordinates(var)
+#     # THEN assert that end coordinate is updated
+#     assert var["pos"] == pos
+#     assert var["end"] == end
+#     assert var["length"] == length
+#
+#
+# def test_loqusdb_variant(mocker, loqus_extension):
+#     """Test to fetch a variant from loqusdb"""
+#     # GIVEN a return value from loqusdb
+#     return_value = (
+#         b'{"homozygote": 0, "hemizygote": 0, "observations": 1, "chrom": "1", "start": '
+#         b'235918688, "end": 235918693, "ref": "CAAAAG", "alt": "C", "families": ["643594"],'
+#         b' "total": 3}'
+#     )
+#     mocker.patch.object(subprocess, "check_output")
+#     subprocess.check_output.return_value = return_value
+#     # WHEN fetching the variant info
+#     var_info = loqus_extension.get_variant({"_id": "a variant"})
+#
+#     # THEN assert the info was parsed correct
+#     assert var_info["total"] == 3
+#
+#
+# def test_loqusdb_cases(mocker, loqus_extension):
+#     """Test the case count function in loqus extension"""
+#     # GIVEN a return value from loqusdb
+#     nr_cases = 15
+#     return_value = b"%d" % nr_cases
+#     mocker.patch.object(subprocess, "check_output")
+#     subprocess.check_output.return_value = return_value
+#     # WHEN fetching the number of cases
+#     res = loqus_extension.case_count()
+#     # THEN assert the output is parsed correct
+#     assert res == nr_cases
+#
+#
+# def test_loqusdb_wrong_version(mocker):
+#     """Test to instantiate a loqus extension whe version is to low"""
+#     # GIVEN a loqusdb version < 2.5
+#     mocker.patch.object(LoqusDB, "get_version")
+#     LoqusDB.get_version.return_value = 1.0
+#     # WHEN instantiating an adapter
+#     with pytest.raises(SyntaxError):
+#         # THEN assert a syntax error is raised since version is wrong
+#         LoqusDB()

--- a/tests/server/extensions/test_loqusdb_extension_init.py
+++ b/tests/server/extensions/test_loqusdb_extension_init.py
@@ -1,6 +1,7 @@
 """Tests for loqusdb extension"""
 import subprocess
 
+import pytest
 from flask import Flask
 
 from scout.server.extensions.loqus_extension import LoqusDB
@@ -88,6 +89,19 @@ def test_init_loqusextension_init_app_no_version(mocker, loqus_exe, loqus_versio
         assert loqus_obj.version == loqus_version
         # THEN assert that there is no config
         assert loqus_obj.loqusdb_config is None
+
+
+def test_init_loqusextension_init_app_wrong_version(loqus_exe):
+    """Test a init a loqus extension object with flask app"""
+    # GIVEN a loqusdb binary
+    configs = {"LOQUSDB_SETTINGS": {"binary_path": loqus_exe, "version": 1.0}}
+    # WHEN initialising a loqusdb extension with init app
+    app = Flask(__name__)
+    loqus_obj = LoqusDB()
+    with pytest.raises(SyntaxError):
+        with app.app_context():
+            app.config = configs
+            loqus_obj.init_app(app)
 
 
 def test_init_loqusextension_init_app_with_config(loqus_exe, loqus_config):


### PR DESCRIPTION
This PR adds a requirement on loqusdb to use `version >= 2.5`

**How to test**:
1. Install on local machine 
1. Create a loqusdb environment with a loqusdb version <= 2.5
1. Start the server

**Expected outcome**:
Scout should exit gracefully and tell what was the problem
![Skärmavbild 2020-03-19 kl  10 15 37](https://user-images.githubusercontent.com/405278/77050815-986fde80-69ca-11ea-9493-da3470df060a.png)


**Review:**
- [ ] code approved by
- [x] tests executed by @moonso 
