### PR TITLE
Calculate correct translocation lengths

### DIFF
--- a/scout/parse/variant/coordinates.py
+++ b/scout/parse/variant/coordinates.py
@@ -1,4 +1,6 @@
-from scout.constants import CYTOBANDS, BND_ALT_PATTERN, CHR_PATTERN
+"""Code to parse variant coordinates"""
+
+from scout.constants import BND_ALT_PATTERN, CHR_PATTERN, CYTOBANDS
 
 
 def get_cytoband_coordinates(chrom, pos):
@@ -13,110 +15,93 @@ def get_cytoband_coordinates(chrom, pos):
     """
     coordinate = ""
 
-    if chrom in CYTOBANDS:
-        for interval in CYTOBANDS[chrom][pos]:
-            coordinate = interval.data
+    if chrom not in CYTOBANDS:
+        return coordinate
+
+    for interval in CYTOBANDS[chrom][pos]:
+        coordinate = interval.data
 
     return coordinate
 
 
-def get_sub_category(alt_len, ref_len, category, svtype=None):
-    """Get the subcategory for a VCF variant
-
-    The sub categories are:
-        'snv', 'indel', 'del', 'ins', 'dup', 'bnd', 'inv'
+def sv_length(pos, end, chrom, end_chrom, svlen=None):
+    """Return the length of a structural variant
 
     Args:
-        alt_len(int)
-        ref_len(int)
-        category(str)
-        svtype(str)
+        pos(int)
+        end(int)
+        chrom(str)
+        end_chrom(str)
+        svlen(int)
 
     Returns:
-        subcategory(str)
+        length(int)
     """
-    subcategory = ""
+    if chrom != end_chrom:
+        return int(10e10)
+    if svlen:
+        return abs(int(svlen))
+    # Some software does not give a length but they give END
+    if not end:
+        return -1
 
-    if category in ("snv", "indel", "cancer"):
-        if ref_len == alt_len:
-            subcategory = "snv"
-        else:
-            subcategory = "indel"
-    elif category in ("sv", "cancer_sv"):
-        subcategory = svtype
+    if end == pos:
+        return -1
 
-    return subcategory
-
-
-def get_length(alt_len, ref_len, category, pos, end, svtype=None, svlen=None):
-    """Return the length of a variant
-
-    Args:
-        alt_len(int)
-        ref_len(int)
-        category(str)
-        svtype(str)
-        svlen(int)
-    """
-    # -1 would indicate uncertain length
-    length = -1
-    if category in ("snv", "indel", "cancer"):
-        if ref_len == alt_len:
-            length = alt_len
-        else:
-            length = abs(ref_len - alt_len)
-
-    elif category in ("sv", "cancer_sv"):
-        if svtype == "bnd":
-            length = int(10e10)
-        else:
-            if svlen:
-                length = abs(int(svlen))
-            # Some software does not give a length but they give END
-            elif end:
-                if end != pos:
-                    length = end - pos
-    return length
+    return end - pos
 
 
-def get_end(pos, alt, category, snvend=None, svend=None, svlen=None):
-    """Return the end coordinate for a variant
+def sv_end(pos, alt, svend=None, svlen=None):
+    """Return the end coordinate for a structural variant
+    The END field from INFO usually works fine, although for some cases like insertions the callers
+     set end to same as pos. In those cases we can hope that there is a svlen...
+
+    Translocations needs their own treatment as usual
 
     Args:
         pos(int)
         alt(str)
-        category(str)
-        snvend(str)
         svend(int)
         svlen(int)
 
     Returns:
         end(int)
     """
-    # If nothing is known we set end to be same as start
-    end = pos
-    # If variant is snv or indel we know that cyvcf2 can handle end pos
-    if category in ("snv", "indel", "cancer"):
-        end = snvend
+    end = svend
 
-    # With SVs we have to be a bit more careful
-    elif category in ("sv", "cancer_sv"):
-        # The END field from INFO usually works fine
-        end = svend
+    if ":" in alt:
+        match = BND_ALT_PATTERN.match(alt)
+        if match:
+            end = int(match.group(2))
 
-        # For some cases like insertions the callers set end to same as pos
-        # In those cases we can hope that there is a svlen...
-        if svend == pos:
-            if svlen:
-                end = pos + svlen
-        # If variant is 'BND' they have ':' in alt field
-        # Information about other end is in the alt field
-        if ":" in alt:
-            match = BND_ALT_PATTERN.match(alt)
-            if match:
-                end = int(match.group(2))
+    if svend == pos:
+        if svlen:
+            end = pos + svlen
 
     return end
+
+
+def get_end_chrom(alt, chrom):
+    """Return the end chromosome for a tranlocation
+
+    Args:
+        alt(str)
+        chrom(str)
+
+    Returns:
+        end_chrom(str)
+    """
+    end_chrom = chrom
+    if ":" not in alt:
+        return end_chrom
+
+    match = BND_ALT_PATTERN.match(alt)
+    # BND will often be translocations between different chromosomes
+    if match:
+        other_chrom = match.group(1)
+        match = CHR_PATTERN.match(other_chrom)
+        end_chrom = match.group(2)
+    return end_chrom
 
 
 def parse_coordinates(variant, category):
@@ -138,8 +123,6 @@ def parse_coordinates(variant, category):
             'cytoband_end':<str>,
         }
     """
-    ref = variant.REF
-
     if variant.ALT:
         alt = variant.ALT[0]
     if category == "str" and not variant.ALT:
@@ -147,49 +130,50 @@ def parse_coordinates(variant, category):
 
     chrom_match = CHR_PATTERN.match(variant.CHROM)
     chrom = chrom_match.group(2)
-
-    svtype = variant.INFO.get("SVTYPE")
-    if svtype:
-        svtype = svtype.lower()
-
-    mate_id = variant.INFO.get("MATEID")
-
-    svlen = variant.INFO.get("SVLEN")
-
-    svend = variant.INFO.get("END")
-    snvend = int(variant.end)
+    end_chrom = chrom
 
     position = int(variant.POS)
 
-    ref_len = len(ref)
+    ref_len = len(variant.REF)
     alt_len = len(alt)
 
-    sub_category = get_sub_category(alt_len, ref_len, category, svtype)
-    end = get_end(position, alt, category, snvend, svend)
+    if category in {"sv", "cancer_sv"}:
+        svtype = variant.INFO.get("SVTYPE")
+        if svtype:
+            svtype = svtype.lower()
+        sub_category = svtype
+        if sub_category == "bnd":
+            end_chrom = get_end_chrom(alt, chrom)
+        end = sv_end(
+            pos=position,
+            alt=alt,
+            svend=variant.INFO.get("END"),
+            svlen=variant.INFO.get("SVLEN"),
+        )
+        length = sv_length(
+            pos=position,
+            end=end,
+            chrom=chrom,
+            end_chrom=end_chrom,
+            svlen=variant.INFO.get("SVLEN"),
+        )
 
-    length = get_length(alt_len, ref_len, category, position, end, svtype, svlen)
-    end_chrom = chrom
-
-    if sub_category == "bnd":
-        if ":" in alt:
-            match = BND_ALT_PATTERN.match(alt)
-            # BND will often be translocations between different chromosomes
-            if match:
-                other_chrom = match.group(1)
-                match = CHR_PATTERN.match(other_chrom)
-                end_chrom = match.group(2)
-
-    cytoband_start = get_cytoband_coordinates(chrom, position)
-    cytoband_end = get_cytoband_coordinates(end_chrom, end)
+    else:
+        sub_category = "snv"
+        end = int(variant.end)
+        length = alt_len
+        if ref_len != alt_len:
+            sub_category = "indel"
+            abs(ref_len - alt_len)
 
     coordinates = {
         "position": position,
         "end": end,
         "length": length,
         "sub_category": sub_category,
-        "mate_id": mate_id,
-        "cytoband_start": cytoband_start,
-        "cytoband_end": cytoband_end,
+        "mate_id": variant.INFO.get("MATEID"),
+        "cytoband_start": get_cytoband_coordinates(chrom, position),
+        "cytoband_end": get_cytoband_coordinates(end_chrom, end),
         "end_chrom": end_chrom,
     }
 

--- a/tests/parse/conftest.py
+++ b/tests/parse/conftest.py
@@ -1,4 +1,95 @@
+"""Fixtures for coordinates"""
+
 import pytest
+
+
+class CyvcfVariant:
+    """Mock a cyvcf variant
+
+    Default is to return a variant with three individuals high genotype
+    quality.
+    """
+
+    def __init__(self,):
+        self._chrom = "1"
+        self._position = 80000
+        self._reference = "A"
+        self._alternative = "C"
+        self._end = None
+        self.var_type = "snv"
+        self.INFO = {}
+
+    @property
+    def gt_quals(self):
+        """Get the genotype qualities"""
+        return [60, 60, 60]
+
+    @property
+    def gt_types(self):
+        """Get the genotypes"""
+        return [1, 1, 0]
+
+    @property
+    def CHROM(self):
+        """Get the chrom"""
+        return self._chrom
+
+    @CHROM.setter
+    def CHROM(self, value):
+        """Set the chromosome"""
+        self._chrom = value
+
+    @property
+    def POS(self):
+        """Get the pos"""
+        return self._position
+
+    @POS.setter
+    def POS(self, value):
+        """Set the pos"""
+        self._position = value
+
+    @property
+    def REF(self):
+        """Get the reference"""
+        return self._reference
+
+    @REF.setter
+    def REF(self, value):
+        """Set the reference"""
+        self._reference = value
+
+    @property
+    def ALT(self):
+        """Get the alternative"""
+        return [self._alternative]
+
+    @ALT.setter
+    def ALT(self, value):
+        """Set the alternative"""
+        self._alternative = value
+
+    @property
+    def end(self):
+        """Get the end"""
+        return self._end or self._position
+
+    @end.setter
+    def end(self, value):
+        """Set the end"""
+        self._end = value
+
+    def __repr__(self):
+        return (
+            f"CyvcfVariant:CHROM:{self._chrom},REF:{self._reference},ALT:{self._alternative},POS:"
+            f"{self._position},end:{self._end},INFO:{self.INFO}"
+        )
+
+
+@pytest.fixture
+def mock_variant():
+    """Return a mocked cyvcf2 variant"""
+    return CyvcfVariant()
 
 
 @pytest.fixture

--- a/tests/parse/test_parse_coordinates.py
+++ b/tests/parse/test_parse_coordinates.py
@@ -1,70 +1,54 @@
-from scout.parse.variant.coordinates import (
-    get_cytoband_coordinates,
-    get_sub_category,
-    get_length,
-    get_end,
-    parse_coordinates,
-)
+"""Tests to parse coordinates"""
+
+from scout.parse.variant.coordinates import (get_cytoband_coordinates,
+                                             parse_coordinates, sv_end,
+                                             sv_length)
 
 
-class CyvcfVariant(object):
-    """Mock a cyvcf variant
-    
-    Default is to return a variant with three individuals high genotype 
-    quality.
-    """
+def test_parse_coordinates_snv(mock_variant):
+    """Test to parse the coordinates for a simple snv"""
+    # GIVEN a cyvcf2 variant
+    variant = mock_variant
 
-    def __init__(
-        self,
-        chrom="1",
-        pos=80000,
-        ref="A",
-        alt="C",
-        end=None,
-        gt_quals=[60, 60, 60],
-        gt_types=[1, 1, 0],
-        var_type="snv",
-        info_dict={},
-    ):
-        super(CyvcfVariant, self).__init__()
-        self.CHROM = chrom
-        self.POS = pos
-        self.REF = ref
-        self.ALT = [alt]
-        self.end = end or pos
-        self.gt_quals = gt_quals
-        self.gt_types = gt_types
-        self.var_type = var_type
-        self.INFO = info_dict
-
-
-def test_parse_coordinates_snv():
-    variant = CyvcfVariant()
-
+    # WHEN parsing the coordinate info
     coordinates = parse_coordinates(variant, "snv")
 
-    assert coordinates["position"] == variant.POS
-
-
-def test_parse_coordinates_indel():
-    variant = CyvcfVariant(alt="ACCC", end=80003)
-
-    coordinates = parse_coordinates(variant, "snv")
-
+    # THEN assert that they are correctly parsed
     assert coordinates["position"] == variant.POS
     assert coordinates["end"] == variant.end
-
-
-def test_parse_coordinates_translocation():
-    info_dict = {"SVTYPE": "BND"}
-    variant = CyvcfVariant(
-        ref="N",
-        alt="N[hs37d5:12060532[",
-        pos=724779,
-        end=724779,
-        var_type="sv",
-        info_dict=info_dict,
+    assert coordinates["length"] == len(variant.ALT)
+    assert coordinates["sub_category"] == "snv"
+    assert coordinates["mate_id"] is None
+    assert (
+        coordinates["cytoband_start"]
+        == coordinates["cytoband_end"]
+        == get_cytoband_coordinates(variant.CHROM, variant.POS)
     )
+    assert coordinates["end_chrom"] == variant.CHROM
+
+
+def test_parse_coordinates_indel(mock_variant):
+    """Test to parse the coordinates for an indel"""
+    mock_variant.ALT = "ACCC"
+    mock_variant.end = 80003
+    variant = mock_variant
+
+    coordinates = parse_coordinates(variant, "snv")
+    assert coordinates["position"] == variant.POS
+    assert coordinates["end"] == variant.end
+    assert coordinates["sub_category"] == "indel"
+    assert coordinates["length"] == len(variant.ALT[0])
+
+
+def test_parse_coordinates_translocation(mock_variant):
+    """Test to parse the coordinates for a translocation"""
+    mock_variant.INFO = {"SVTYPE": "BND"}
+    mock_variant.REF = "N"
+    mock_variant.ALT = "N[hs37d5:12060532["
+    mock_variant.POS = 724779
+    mock_variant.end = 724779
+    mock_variant.var_type = "sv"
+    variant = mock_variant
 
     coordinates = parse_coordinates(variant, "sv")
 
@@ -75,16 +59,34 @@ def test_parse_coordinates_translocation():
     assert coordinates["sub_category"] == "bnd"
 
 
-def test_parse_coordinates_translocation_2():
-    info_dict = {"SVTYPE": "BND"}
-    variant = CyvcfVariant(
-        ref="N",
-        alt="N[GL000232.1:25141[",
-        pos=724779,
-        end=724779,
-        var_type="sv",
-        info_dict=info_dict,
-    )
+def test_parse_coordinates_translocation_same_chrom(mock_variant):
+    """Test to parse the coordinates for a translocation on the same chromosome"""
+    mock_variant.INFO = {"SVTYPE": "BND"}
+    mock_variant.REF = "N"
+    mock_variant.ALT = "N[1:12060532["
+    mock_variant.POS = 724779
+    mock_variant.end = 724779
+    mock_variant.var_type = "sv"
+    variant = mock_variant
+
+    coordinates = parse_coordinates(variant, "sv")
+
+    assert coordinates["position"] == variant.POS
+    assert coordinates["end"] == 12060532
+    assert coordinates["end_chrom"] == "1"
+    assert coordinates["length"] == coordinates["end"] - coordinates["position"]
+    assert coordinates["sub_category"] == "bnd"
+
+
+def test_parse_coordinates_translocation_2(mock_variant):
+    """Test to parse the coordinates for a translocation"""
+    mock_variant.INFO = {"SVTYPE": "BND"}
+    mock_variant.REF = "N"
+    mock_variant.ALT = "N[GL000232.1:25141["
+    mock_variant.POS = 724779
+    mock_variant.end = 724779
+    mock_variant.var_type = "sv"
+    variant = mock_variant
 
     coordinates = parse_coordinates(variant, "sv")
 
@@ -95,164 +97,98 @@ def test_parse_coordinates_translocation_2():
     assert coordinates["sub_category"] == "bnd"
 
 
-###### parse subcategory #######
-def test_get_subcategory_snv():
-    alt_len = 1
-    ref_len = 1
-    category = "snv"
-    svtype = None
-
-    sub_category = get_sub_category(alt_len, ref_len, category, svtype)
-
-    assert sub_category == "snv"
-
-
-def test_get_subcategory_indel():
-    alt_len = 1
-    ref_len = 3
-    category = "snv"
-    svtype = None
-
-    sub_category = get_sub_category(alt_len, ref_len, category, svtype)
-
-    assert sub_category == "indel"
-
-
-###### parse length #######
-
-# get_length(alt_len, ref_len, category, pos, end, svtype=None, svlen=None)
-def test_get_length_snv():
-    alt_len = 1
-    ref_len = 1
-    category = "snv"
-    pos = end = 879537
-
-    length = get_length(alt_len, ref_len, category, pos, end)
-
-    assert length == 1
-
-
-def test_get_length_indel():
-    alt_len = 3
-    ref_len = 1
-    category = "snv"
-    pos = end = 879537
-
-    length = get_length(alt_len, ref_len, category, pos, end)
-
-    assert length == 2
+# parse length #
 
 
 def test_get_sv_length_small_ins():
-    ## GIVEN an insertion with whole sequence in alt field
-    alt_len = 296
-    ref_len = 1
-    category = "sv"
+    """Test to get the length for a small insertion"""
+    # GIVEN an insertion with whole sequence in alt field
     # Pos and end is same for insertions
     pos = end = 144343218
-    svtype = "ins"
     svlen = 296
+    chrom = end_chrom = "1"
 
-    ## WHEN parsing the length
-    length = get_length(alt_len, ref_len, category, pos, end, svtype, svlen)
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
 
-    ## THEN assert that the length is correct
+    # THEN assert that the length is correct
     assert length == 296
 
 
 def test_get_sv_length_large_ins_no_length():
-    ## GIVEN an imprecise insertion
-    alt_len = 5
-    ref_len = 1
-    category = "sv"
+    """Test to get the length for a small insertion wihtout length"""
+    # GIVEN an imprecise insertion
     # Pos and end is same for insertions
     pos = end = 133920667
-    svtype = "ins"
     svlen = None
+    chrom = end_chrom = "1"
 
-    ## WHEN parsing the length
-    length = get_length(alt_len, ref_len, category, pos, end, svtype, svlen)
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
 
-    ## THEN assert that the length is correct
+    # THEN assert that the length is correct
     assert length == -1
 
 
 def test_get_sv_length_translocation():
-    ## GIVEN an translocation
-    alt_len = 16
-    ref_len = 1
-    category = "sv"
+    """Test to get the length for a translocation on different chromosomes"""
+    # GIVEN an translocation with different start and end chromosomes
     pos = 726044
     end = None
-    svtype = "bnd"
     svlen = None
+    chrom = "1"
+    end_chrom = "10"
 
-    ## WHEN parsing the length
-    length = get_length(alt_len, ref_len, category, pos, end, svtype, svlen)
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
 
-    ## THEN assert that the length is correct
+    # THEN assert that the length is "infinite"
     assert length == 10e10
 
 
+def test_get_sv_length_translocation_same_chrom():
+    """Test to get the length for a translocation on different chromosomes"""
+    # GIVEN an translocation with different start and end chromosomes
+    pos = 726044
+    end = 16457990
+    svlen = None
+    chrom = end_chrom = "1"
+
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
+
+    # THEN assert that the length is "infinite"
+    assert length == end - pos
+
+
 def test_get_sv_length_cnvnator_del():
-    ## GIVEN an cnvnator type deletion
-    alt_len = 5
-    ref_len = 1
-    category = "sv"
+    """Test to get the length cnvnator formated deletion"""
+    # GIVEN an cnvnator type deletion
     pos = 1
     end = 10000
-    svtype = "del"
     svlen = -10000
+    chrom = end_chrom = "1"
 
-    ## WHEN parsing the length
-    length = get_length(alt_len, ref_len, category, pos, end, svtype, svlen)
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
 
-    ## THEN assert that the length is correct
+    # THEN assert that the length is correct
     assert length == 10000
 
 
 def test_get_sv_length_del_no_length():
-    ## GIVEN an deletion without len
-    alt_len = 5
-    ref_len = 1
-    category = "sv"
+    """Test to get the length for a deletion without length"""
+    # GIVEN an deletion without len
     pos = 869314
     end = 870246
-    svtype = "del"
     svlen = None
+    chrom = end_chrom = "1"
 
-    ## WHEN parsing the length
-    length = get_length(alt_len, ref_len, category, pos, end, svtype, svlen)
+    # WHEN parsing the length
+    length = sv_length(pos, end, chrom, end_chrom, svlen)
 
-    ## THEN assert that the length is correct
+    # THEN assert that the length is correct
     assert length == end - pos
-
-
-###### parse end #######
-# get_end(pos, alt, category, snvend, svend, svlen)
-
-# snv/indels are easy since cyvcf2 are parsing the end for us
-
-
-def test_get_end_snv():
-    alt = "T"
-    category = "snv"
-    pos = snvend = 879537
-
-    end = get_end(pos, alt, category, snvend, svend=None, svlen=None)
-
-    assert end == snvend
-
-
-def test_get_end_indel():
-    alt = "C"
-    category = "indel"
-    pos = 302253
-    snvend = 302265
-
-    end = get_end(pos, alt, category, snvend, svend=None, svlen=None)
-
-    assert end == snvend
 
 
 # SVs are much harder since there are a lot of corner cases
@@ -261,41 +197,29 @@ def test_get_end_indel():
 
 
 def test_get_end_tiddit_translocation():
-    ## GIVEN a translocation
-    alt = "N[hs37d5:12060532["
-    category = "sv"
+    """Test to get the end position for a translocation in tiddit format"""
+    # GIVEN a translocation
+    _end = 12060532
+    alt = f"N[hs37d5:{_end}["
     pos = 724779
 
-    ## WHEN parsing the end coordinate
-    end = get_end(pos, alt, category, snvend=None, svend=None, svlen=None)
+    # WHEN parsing the end coordinate
+    end = sv_end(pos, alt, svend=None, svlen=None)
 
-    ## THEN assert that the end is the same as en coordinate described in alt field
-    assert end == 12060532
-
-
-def test_get_end_tiddit_translocation():
-    ## GIVEN a translocation
-    alt = "N[hs37d5:12060532["
-    category = "sv"
-    pos = 724779
-
-    ## WHEN parsing the end coordinate
-    end = get_end(pos, alt, category, snvend=None, svend=None, svlen=None)
-
-    ## THEN assert that the end is the same as en coordinate described in alt field
-    assert end == 12060532
+    # THEN assert that the end is the same as en coordinate described in alt field
+    assert end == _end
 
 
 def test_get_end_deletion():
-    ## GIVEN a translocation
+    """Test to get the end position for a SV deletion"""
+    # GIVEN a translocation
     alt = "<DEL>"
-    category = "sv"
     pos = 869314
     svend = 870246
     svlen = None
 
-    ## WHEN parsing the end coordinate
-    end = get_end(pos, alt, category, snvend=None, svend=svend, svlen=svlen)
+    # WHEN parsing the end coordinate
+    end = sv_end(pos, alt, svend, svlen)
 
-    ## THEN assert that the end is the same as en coordinate described in alt field
+    # THEN assert that the end is the same as en coordinate described in alt field
     assert end == svend


### PR DESCRIPTION
This PR adds the functionality to calculate end position for translocations when break points are on the same chromosome

**How to test**:
1. Tests are automated

**Expected outcome**:
Scout will now display the correct length for translocations

**Review:**
- [x] code approved by
- [x] tests executed by @moonso 
