### PR TITLE
Arrange cards using card-columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Fix the link to Ensembl for SV variants when genome build 38.
+- Arrange information in columns on variant page
 
 ### Changed
 - Runs all CI checks in github actions

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -79,12 +79,12 @@
     </div>
 
     <div class="card-columns">
+      {{ omim_phenotypes(variant) }}
+      {{ genemodels_panel(variant) }}
       {{ inheritance_panel(variant) }}
         {% if variant.azlength %}
           {{ autozygosity_panel(variant) }}
         {% endif %}
-      {{ genemodels_panel(variant) }}
-      {{ omim_phenotypes(variant) }}
       {{ frequencies(variant) }}
       {% if config['LOQUSDB_SETTINGS'] %}
         {{ observations_panel(variant, observations, case) }}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -78,30 +78,21 @@
       </div>
     </div>
 
-    <div class="row">
-      <div class="col-sm-4">
-        <div class="col-sm-12">{{ inheritance_panel(variant) }}</div>
+    <div class="card-columns">
+      {{ inheritance_panel(variant) }}
         {% if variant.azlength %}
-          <div class="col-sm-12">{{ autozygosity_panel(variant) }}</div>
+          {{ autozygosity_panel(variant) }}
         {% endif %}
-      </div>
-      <div class="col-sm-4">{{ genemodels_panel(variant) }}</div>
-      <div class="col-sm-4">{{ omim_phenotypes(variant) }}</div>
-    </div>
-
-    <div class="row">
-      <div class="col">{{ frequencies(variant) }}</div>
-        {% if config['LOQUSDB_SETTINGS'] %}
-          <div class="col">{{ observations_panel(variant, observations, case) }}</div>
-        {% endif %}
-        <div class="col">{{ old_observations(variant) }}</div>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="col">{{ severity_list(variant) }}</div>
-      <div class="col">{{ conservations(variant) }}</div>
-      <div class="col">{{ mappability(variant) }}</div>
+      {{ genemodels_panel(variant) }}
+      {{ omim_phenotypes(variant) }}
+      {{ frequencies(variant) }}
+      {% if config['LOQUSDB_SETTINGS'] %}
+        {{ observations_panel(variant, observations, case) }}
+      {% endif %}
+      {{ old_observations(variant) }}
+      {{ severity_list(variant) }}
+      {{ conservations(variant) }}
+      {{ mappability(variant) }}
     </div>
 
     <div class="row">

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -229,7 +229,7 @@
           </li>
         {% else %}
           <li class="list-group-item">
-            <p class="card-text">    -</p>
+            <p class="card-text">-</p>
           </li>
         {% endif %}
       </ul>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -222,11 +222,17 @@
     {% endfor %}
     {% set superdups_fracmatches = superdups_fracmatches|sort %}
     <div class="panel-body">
-      {% if superdups_fracmatches %}
-        <span>mapping to {{superdups_fracmatches|length}} segm. dups. (min matching:{{ superdups_fracmatches|first|float|round(3) }}, max matching:{{ superdups_fracmatches|last|float|round(3) }})</span>
-      {% else %}
-        <p class="card-text">-</p>
-      {% endif %}
+      <ul class="list-group">
+        {% if superdups_fracmatches %}
+          <li class="list-group-item">
+            <span>mapping to {{superdups_fracmatches|length}} segm. dups. (min matching:{{ superdups_fracmatches|first|float|round(3) }}, max matching:{{ superdups_fracmatches|last|float|round(3) }})</span>
+          </li>
+        {% else %}
+          <li class="list-group-item">
+            <p class="card-text">    -</p>
+          </li>
+        {% endif %}
+      </ul>
     </div>
   </div>
 {% endmacro %}


### PR DESCRIPTION
This PR rearranges the cards on variant page

**Prepare for test**:
1. On stage
1. Open a variant, looks something like this:

![Skärmavbild 2020-03-25 kl  13 34 01](https://user-images.githubusercontent.com/405278/77537147-e179d400-6e9d-11ea-985c-3f4093238c62.png)

Frequencies in one row, gene models in one etc.

**How to test**:
1. Install on clinical-db stage
1. Refresh the variant from above

**Expected outcome**:
Models should be in one column, frequencies in one and severity/conservation in one

![Skärmavbild 2020-03-26 kl  10 50 16](https://user-images.githubusercontent.com/405278/77633350-a041fc80-6f4f-11ea-8f6b-c046a32646f4.png)


**Review:**
- [x] code approved by @northwestwitch 
- [X] tests executed by @moonso 
