### PR TITLE
Add custom annotations back in for SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix so that new cosmic identifier (COSV) is also acceptable #1304
 - Fixed COSMIC tag in INFO (outside of CSQ) to be parses as well with `&` splitter.
 - COSMIC stub URL changed to https://cancer.sanger.ac.uk/cosmic/search?q= instead.
+- Re-add "custom annotations" for SV variants
 
 ### Changed
 - Runs all CI checks in github actions

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -225,6 +225,15 @@
           <div>Type</div><div class="float-right">{{ variant.sub_category|upper }}</div>
         </div>
       </li>
+      {% if variant.custom %}
+        {% for pair in variant.custom %}
+        <li class="list-group-item">
+          <div class="row d-flex justify-content-between">
+            <div>{{pair[0]}}</div><div class="float-right">{{pair[1]}}</div>
+          </div>
+        </li>
+        {% endfor %}
+      {% endif %}
       {% if variant._id in case.suspects and not variant.clinvar_clinsig %}
         <a href="{{ url_for('variant.clinvar', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" class="btn btn-default form-control" target="_blank">Submit to ClinVar</a>
       {% endif %}


### PR DESCRIPTION
This commit https://github.com/Clinical-Genomics/scout/commit/e5468f439ee9c89fe68280ebb3cffe76611a53d7 accidentally (?) removed the "custom annotations" from the SV-variant template.

This PR adds them back in. I realize we're the only ones using these, but they don't affect anything if you're not using them.

