### PR TITLE
Name clinvar submission files according to their type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed COSMIC tag in INFO (outside of CSQ) to be parses as well with `&` splitter.
 - COSMIC stub URL changed to https://cancer.sanger.ac.uk/cosmic/search?q= instead.
 - Updated to a version of IGV where bigBed tracks are visualized correctly  
+- Clinvar submission files are named according to the content (variant_data and case_data)
 
 ### Changed
 - Runs all CI checks in github actions

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -230,21 +230,12 @@ def clinvar_submissions(institute_id):
                 csv_header = [
                     '"' + str(x) + '"' for x in csv_header
                 ]  # quote columns in header for csv rendering
-
+                download_day = str(datetime.datetime.now().strftime("%Y-%m-%d"))
                 headers = Headers()
                 headers.add(
                     "Content-Disposition",
                     "attachment",
-                    filename="".join(
-                        [
-                            clinvar_subm_id,
-                            "_",
-                            csv_type,
-                            "_",
-                            str(datetime.datetime.now().strftime("%Y-%m-%d")),
-                            ".csv",
-                        ]
-                    ),
+                    filename = f"{clinvar_subm_id}_{csv_type}_{download_day}.csv"
                 )
                 return Response(
                     generate_csv(",".join(csv_header), csv_lines),

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -120,7 +120,7 @@ def cases(institute_id):
         skip_assigned=skip_assigned,
         is_research=is_research,
         query=query,
-        **data
+        **data,
     )
 
 
@@ -139,7 +139,7 @@ def case(institute_id, case_name):
         case=case_obj,
         mme_nodes=current_app.mme_nodes,
         tissue_types=SAMPLE_SOURCE,
-        **data
+        **data,
     )
 
 
@@ -235,7 +235,7 @@ def clinvar_submissions(institute_id):
                 headers.add(
                     "Content-Disposition",
                     "attachment",
-                    filename = f"{clinvar_subm_id}_{csv_type}_{download_day}.csv"
+                    filename=f"{clinvar_subm_id}_{csv_type}_{download_day}.csv",
                 )
                 return Response(
                     generate_csv(",".join(csv_header), csv_lines),
@@ -692,7 +692,7 @@ def pdf_case_report(institute_id, case_name):
         institute=institute_obj,
         case=case_obj,
         format="pdf",
-        **data
+        **data,
     )
     return render_pdf(
         HTML(string=html_report),

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -235,14 +235,16 @@ def clinvar_submissions(institute_id):
                 headers.add(
                     "Content-Disposition",
                     "attachment",
-                    filename="".join([
-                        clinvar_subm_id,
-                        "_",
-                        csv_type,
-                        "_",
-                        str(datetime.datetime.now().strftime("%Y-%m-%d")),
-                        ".csv"
-                    ])
+                    filename="".join(
+                        [
+                            clinvar_subm_id,
+                            "_",
+                            csv_type,
+                            "_",
+                            str(datetime.datetime.now().strftime("%Y-%m-%d")),
+                            ".csv",
+                        ]
+                    ),
                 )
                 return Response(
                     generate_csv(",".join(csv_header), csv_lines),

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -214,8 +214,7 @@ def clinvar_submissions(institute_id):
                 )
                 return redirect(request.referrer)
 
-            csv_type = ""
-            csv_type = request.form.get("csv_type")
+            csv_type = request.form.get("csv_type", "")
 
             submission_objs = store.clinvar_objs(
                 submission_id=submission_id, key_id=csv_type
@@ -236,10 +235,14 @@ def clinvar_submissions(institute_id):
                 headers.add(
                     "Content-Disposition",
                     "attachment",
-                    filename=clinvar_subm_id
-                    + "_"
-                    + str(datetime.datetime.now().strftime("%Y-%m-%d"))
-                    + ".csv",
+                    filename="".join([
+                        clinvar_subm_id,
+                        "_",
+                        csv_type,
+                        "_",
+                        str(datetime.datetime.now().strftime("%Y-%m-%d")),
+                        ".csv"
+                    ])
                 )
                 return Response(
                     generate_csv(",".join(csv_header), csv_lines),


### PR DESCRIPTION
Fix #1835.
In the current situation whenever a clinvar submission object is created, then the downloadable files have the same name. This PR fixes that and adds the type of file (case_data, variant_data) to the downloadable file names.


**How to test**:
1. Install the branch on a local instance of Scout.
1. Assign an HPO phenotype to the demo case
1. Pin a variant
1. Create a clinvar submission object and download the associated files

**Expected outcome**:
1. The 2 downloaded files should have different names. 

**Review:**
- [x] code approved by PG
- [x] tests executed by CR
