### PR TITLE
Bugfix other causatives case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - COSMIC stub URL changed to https://cancer.sanger.ac.uk/cosmic/search?q= instead.
 - Updated to a version of IGV where bigBed tracks are visualized correctly  
 - Clinvar submission files are named according to the content (variant_data and case_data)
+- Always show causatives from other cases in case overview
 
 ### Changed
 - Runs all CI checks in github actions

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -52,7 +52,7 @@
         <div class="col-sm-12">{{ variants_buttons() }}</div>
       </div>
 
-      {% if other_causatives|length > 1%}
+      {% if other_causatives|length > 0%}
         <div class="row ">
           <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
         </div>


### PR DESCRIPTION
This PR fixes a bug which caused causatives from other cases to show up only if there were at least **two** of them.