### PR TITLE
4 improvements to clinvar submissions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+- Display gene names in clinVar submissions page
+
 ### Fixed
+- Small fixes to clinVar submission form
+
 ### Changed
+
 
 ## [4.15]
 

--- a/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
+++ b/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
@@ -113,6 +113,7 @@
                 <th>Type</th>
                 <th>Case</th>
                 <th>Refseq</th>
+                <th>Gene</th>
                 <th>HGVS</th>
                 <th>Significance</th>
                 <th></th>
@@ -141,6 +142,7 @@
                   </td>
                   <td>{{subm_variant.case_id}}</td>
                   <td>{{subm_variant.ref_seq or '-'}}</td>
+                  <td>{{subm_variant.gene_symbol or '-'}}</td>
                   <td>{{subm_variant.hgvs or '-'}}</td>
                   <td>{{subm_variant.clinsig}}</td>
                   <td><button type="submit" name="delete_variant" value="{{subm_variant._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash-o fa-lg" aria-hidden="true"></span></button></td>

--- a/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
+++ b/scout/server/blueprints/cases/templates/cases/clinvar_submissions.html
@@ -255,5 +255,4 @@
       });
   });
 </script>
-
 {% endblock %}

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -235,11 +235,10 @@
                         </select>
                       </td>
                     </tr>
-                    {% if pinned.dbsnp_id and pinned.category == 'snv'%}
-                    {% set dbsnp_id = pinned.dbsnp_id.split(':')[0] %} <!-- sometimes snps look like this rs65544478:some_stuff -->
+                    {% if pinned.category == 'snv'%}
                       <tr>
                         <td>var. identifier</td>
-                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{dbsnp_id}}" size=14 pattern="rs[0-9]+"></td>
+                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{ pinned.dbsnp_id.split(':')[0] if pinned.dbsnp_id else ''}}" size=14 pattern="rs[0-9]+"></td>
                       </tr>
                     {% endif %}
                     <tr>

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -584,6 +584,7 @@
                                       <option value="homozygote" {%if sample.genotype_call == '1/1' %} selected {%endif%}>homozygote</option>
                                       <option value="compound heterozygote" {%if sample.genotype_call != '1/1'%} selected {%endif%}>compound heterozygote</option>
                                       <option value="single heterozygote">single heterozygote</option>
+                                      <option value="">leave blank</option>
                                     </select>
                                   {% endif %}
                                 {% endfor %}


### PR DESCRIPTION
fix #1850 (dbsnp ids containing rsnumber:something)
fix #1851 (option to leave zygosity empty)
fix #1853 (display dbsnp box even if variant doesn't have associated dbsnp id)
fix  #1837 (display gene in clinVar submissions page)

**How to test**:
1. Install the branch on a local instance of Scout
1. Assign a HPO phenotype to the case
1. Pin a snv variant (POT1 works perfectly)
1. From the variant page click on "Submit to clinVar"
1. Check the zygosity option in the casedata (checkbox "Submit case data for this variant") has the new option "leave blank"
1. Change the dbsnp_id for this variant in the database to "rs116916706:blabla" and check that the clinVar form shows only "rs116916706".
1. Remove completely the dbsnp_id field from the database and make sure that it still shows up in the clinVar form (blank value). Add a random value to the box.
1. Make sure the value is saved when you save the submission.
1. Make sure that no value is saved for the zygosity when it is set to "leave blank"
1. Make sure that genes are displayed in the clinvar submissions page (if available):

![image](https://user-images.githubusercontent.com/28093618/78469457-cde22f00-7721-11ea-979b-9020451b5512.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
