### PR TITLE
Fix issue with maintainerless panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Small fixes to clinVar submission form
+- Gene panel page crash when panel has no maintainers
 
 ### Changed
 

--- a/scout/commands/update/panel.py
+++ b/scout/commands/update/panel.py
@@ -73,7 +73,7 @@ def panel(
 
             raise click.Abort()
 
-        new_maintainer = panel_obj.get("maintainer", [])
+        new_maintainer = panel_obj.get("maintainer") or []
         if add_maintainer in new_maintainer:
             LOG.warning("User %s already in maintainer list.", add_maintainer)
             raise click.Abort()
@@ -81,7 +81,7 @@ def panel(
         new_maintainer.append(add_maintainer)
 
     if revoke_maintainer:
-        current_maintainers = panel_obj.get("maintainer", [])
+        current_maintainers = panel_obj.get("maintainer") or []
         try:
             current_maintainers.remove(revoke_maintainer)
             new_maintainer = current_maintainers

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -19,14 +19,17 @@ def panel(store, panel_obj):
     full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])
     panel_obj["name_and_version"] = full_name
 
-    panel_obj["maintainer_names"] = [
-        maintainer_obj.get("name")
-        for maintainer_obj in (
-            store.user(user_id=maintainer_id)
-            for maintainer_id in panel_obj.get("maintainer")
-        )
-        if maintainer_obj is not None
-    ]
+    if panel_obj.get("maintainer") is None:
+        panel_obj["maintainer_names"] = []
+    else:
+        panel_obj["maintainer_names"] = [
+            maintainer_obj.get("name")
+            for maintainer_obj in (
+                store.user(user_id=maintainer_id)
+                for maintainer_id in panel_obj.get("maintainer")
+            )
+            if maintainer_obj is not None
+        ]
 
     return dict(panel=panel_obj)
 

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -24,8 +24,7 @@ def panel(store, panel_obj):
     panel_obj["maintainer_names"] = [
         maintainer_obj.get("name")
         for maintainer_obj in (
-            store.user(user_id=maintainer_id)
-            for maintainer_id in maintainers
+            store.user(user_id=maintainer_id) for maintainer_id in maintainers
         )
         if maintainer_obj is not None
     ]

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -19,17 +19,14 @@ def panel(store, panel_obj):
     full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])
     panel_obj["name_and_version"] = full_name
 
-    if panel_obj.get("maintainer") is None:
-        panel_obj["maintainer_names"] = []
-    else:
-        panel_obj["maintainer_names"] = [
-            maintainer_obj.get("name")
-            for maintainer_obj in (
-                store.user(user_id=maintainer_id)
-                for maintainer_id in panel_obj.get("maintainer")
-            )
-            if maintainer_obj is not None
-        ]
+    panel_obj["maintainer_names"] = [
+        maintainer_obj.get("name")
+        for maintainer_obj in (
+            store.user(user_id=maintainer_id)
+            for maintainer_id in panel_obj.get("maintainer", [])
+        )
+        if maintainer_obj is not None
+    ]
 
     return dict(panel=panel_obj)
 

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -19,11 +19,13 @@ def panel(store, panel_obj):
     full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])
     panel_obj["name_and_version"] = full_name
 
+    maintainers = panel_obj.get("maintainer") or []
+
     panel_obj["maintainer_names"] = [
         maintainer_obj.get("name")
         for maintainer_obj in (
             store.user(user_id=maintainer_id)
-            for maintainer_id in panel_obj.get("maintainer", [])
+            for maintainer_id in maintainers
         )
         if maintainer_obj is not None
     ]


### PR DESCRIPTION
This PR fixes a bug

**How to test**:
1. on a scout db with panel obj without even empty maintainer fields, visit panel pages
2. Just to be sure, again test updating maintainer for the same maintainer field lacking panel obj

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

<img width="816" alt="Screenshot 2020-04-06 at 12 55 59" src="https://user-images.githubusercontent.com/758570/78551437-04917580-7806-11ea-8fea-41d4918ec979.png">

<img width="1022" alt="Screenshot 2020-04-06 at 12 51 21" src="https://user-images.githubusercontent.com/758570/78551115-787f4e00-7805-11ea-840b-05f2c9232fe4.png">

<img width="361" alt="Screenshot 2020-04-06 at 12 51 42" src="https://user-images.githubusercontent.com/758570/78551123-7b7a3e80-7805-11ea-9a50-4386800f9e78.png">

**Review:**
- [ ] code approved by
- [ ] tests executed by
