### PR TITLE
Add verification comment box also for SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds possibility to add "lims_id" to cases. Currently only stored in database, not shown anywhere
+- Adds verification comment box to SVs (previously only available for small variants)
 
 ### Fixed
 ### Changed

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -373,6 +373,9 @@
     <strong>Ordered by</strong>:
     {{ current_user.name }}
   </div>
+  <div class="list-group-item">
+    Comment: <input type="text" size=45 name="verification_comment">
+  </div>
 </ul>
 {% endmacro %}
 


### PR DESCRIPTION
This small PR adds the verification email comment box that was available for small variants also to SVs. Only changes the template, since the backend functionality is shared with SNVs.

I have tested this, and it works as intented for me. 