### PR TITLE
Bugfix Flask Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds verification comment box to SVs (previously only available for small variants)
 
 ### Fixed
+- Pytest bug when Flask version < 1.1.0
+
 ### Changed
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 BeautifulSoup4
 werkzeug<1.0 # This can be removed when switching from Flask-OAuthlib
-Flask>=0.10
+Flask>=1.1.0
 Flask-DebugToolbar
 Flask-Bootstrap
 path.py


### PR DESCRIPTION
When running Pytest, Flask encountered a AttributeError, fixed from Flask 1.1.0 and upwards.
Bug related to Flask and POP 302 import hooks (not familiar enough with Pythons low level import handling to know the details).

This PR adds a functionality or fixes a bug.


**How to test**:
1. how to test it

Install old Flask ` pip install Flask=1.0.3`.

Go to top Scout folder and run `pytest`. This will fail.


![image](https://user-images.githubusercontent.com/1150065/80217204-9e975180-863f-11ea-98e0-05ab3dbd8c1b.png)



**Expected outcome**:
Apply this patch. Run `pip install -r requirments.txt`. This will upgrade Flask. Go to top Scout folder and run `pytest`. This should succeed.


**Review:**
- [ ] code approved by
- [ ] tests executed by




Example of Failing Pytest
-------------------------
```
tests/server/blueprints/cases/test_cases_views.py::test_case_synopsis ^C^C

2020-04-24 15:14:10 mikaellmbp conftest[44194] INFO Deleting database
2020-04-24 15:14:10 mikaellmbp conftest[44194] INFO Database deleted
2020-04-24 15:14:10 mikaellmbp conftest[44194] INFO Time to run test:0:00:01.356301


================================================================================= FAILURES =================================================================================
___________________________________________________________________ test_case_controller_rank_model_link ___________________________________________________________________

adapter = <scout.adapter.mongo.base.MongoAdapter object at 0x11981da20>
institute_obj = {'internal_id': 'cust000', '_id': 'cust000', 'display_name': 'test_institute', 'sanger_recipients': ['john@doe.com', '...00), 'updated_at': datetime.datetime(2020, 4, 24, 15, 13, 52, 779000), 'coverage_cutoff': 10, 'frequency_cutoff': 0.01}
dummy_case = {'_id': ObjectId('5ea2e610711c13aca27732f5'), 'case_id': '1', 'individuals': [{'analysis_type': 'wgs', 'individual_id': 'ind1', 'phenotype': 2, 'sex': 1}], 'owner': 'cust000', ...}

    def test_case_controller_rank_model_link(adapter, institute_obj, dummy_case):
        # GIVEN an adapter with a case
        dummy_case["rank_model_version"] = "1.3"
        adapter.case_collection.insert_one(dummy_case)
        adapter.institute_collection.insert_one(institute_obj)
        fetched_case = adapter.case_collection.find_one()
>       app = Flask(__name__)

tests/server/blueprints/cases/test_cases_controllers.py:87:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/app.py:381: in __init__
    instance_path = self.auto_find_instance_path()
/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/app.py:678: in auto_find_instance_path
    prefix, package_path = find_package(self.import_name)
/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/helpers.py:826: in find_package
    loader, root_mod_name):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

loader = <_pytest.assertion.rewrite.AssertionRewritingHook object at 0x108c009b0>, mod_name = 'test_cases_controllers'

    def _matching_loader_thinks_module_is_package(loader, mod_name):
        """Given the loader that loaded a module and the module this function
        attempts to figure out if the given module is actually a package.
        """
        # If the loader can tell us if something is a package, we can
        # directly ask the loader.
        if hasattr(loader, 'is_package'):
            return loader.is_package(mod_name)
        # importlib's namespace loaders do not have this functionality but
        # all the modules it loads are packages, so we can take advantage of
        # this information.
        elif (loader.__class__.__module__ == '_frozen_importlib' and
              loader.__class__.__name__ == 'NamespaceLoader'):
            return True
        # Otherwise we need to fail with an error that explains what went
        # wrong.
        raise AttributeError(
            ('%s.is_package() method is missing but is required by Flask of '
             'PEP 302 import hooks.  If you do not use import hooks and '
             'you encounter this error please file a bug against Flask.') %
>           loader.__class__.__name__)
E       AttributeError: AssertionRewritingHook.is_package() method is missing but is required by Flask of PEP 302 import hooks.  If you do not use import hooks and you encounter this error please file a bug against Flask.

/miniconda3/envs/python3.6/lib/python3.6/site-packages/flask/helpers.py:789: AttributeError
```
