### PR TITLE
fix #1880 (WTForm validation error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds verification comment box to SVs (previously only available for small variants)
 
 ### Fixed
+- Error caused by changes in WTForm (new release 2.3.x)
+
 ### Changed
 
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -100,8 +100,8 @@ class FiltersForm(VariantFiltersForm):
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
     chrom = TextField("Chromosome", [validators.Optional()])
-    start = IntegerField("Start position", [validators.Optional(), IntegerField])
-    end = IntegerField("End position", [validators.Optional(), IntegerField])
+    start = IntegerField("Start position", [validators.Optional()])
+    end = IntegerField("End position", [validators.Optional()])
     local_obs = IntegerField("Local obs. (archive)")
 
     filter_variants = SubmitField(label="Filter variants")
@@ -140,8 +140,8 @@ class SvFiltersForm(VariantFiltersForm):
     swegen = IntegerField("SweGen obs")
 
     chrom = TextField("Chromosome", [validators.Optional()])
-    start = IntegerField("Start position", [validators.Optional(), IntegerField])
-    end = IntegerField("End position", [validators.Optional(), IntegerField])
+    start = IntegerField("Start position", [validators.Optional()])
+    end = IntegerField("End position", [validators.Optional()])
 
     filter_variants = SubmitField(label="Filter variants")
     clinical_filter = SubmitField(label="Clinical filter")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -43,8 +43,7 @@ class TagListField(Field):
     def _value(self):
         if self.data:
             return ", ".join(self.data)
-        else:
-            return ""
+        return ""
 
     def process_formdata(self, valuelist):
         if valuelist:


### PR DESCRIPTION
Bug fix #1880 .

A bunch of things happened in the latest WTForm releases (release + bugfix release): https://wtforms.readthedocs.io/en/2.3.x/changes/#version-2-3-1

**How to test**:
1. On a local instance of scout make sure that all the pages that contain a form validation work (variants of any type, edit institute page)

**Expected outcome**:
The pages mentioned above should work, and scout tests as well.

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
