### PR TITLE
fix #1881

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Adds possibility to add "lims_id" to cases. Currently only stored in database, not shown anywhere
+- Adds verification comment box to SVs (previously only available for small variants)
 
 ### Fixed
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Error caused by changes in WTForm (new release 2.3.x)
+- Bug in OMIM case page form, causing the page to crash when a string was provided instead of a numerical OMIM id
 
 ### Changed
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -759,6 +759,7 @@ def case_diagnosis(institute_id, case_name):
     omim_obj = store.disease_term(omim_id.strip())
     if not omim_obj:
         flash("Couldn't find any disease term with id: {}".format(omim_id), "warning")
+        return redirect(request.referrer)
 
     remove = True if request.args.get("remove") == "yes" else False
     store.diagnose(

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -373,6 +373,9 @@
     <strong>Ordered by</strong>:
     {{ current_user.name }}
   </div>
+  <div class="list-group-item">
+    Comment: <input type="text" size=45 name="verification_comment">
+  </div>
 </ul>
 {% endmacro %}
 


### PR DESCRIPTION
Fixes a bug that happens whenever one writer a random string in one of the 2 omim forms on the case page (add/remove a disease, or add/remove a disease gene).
Fix #1881 

**How to test**:
1. Test it on stage or on a local instance of scout, after updating the disease with this command:
`scout updated diseases --api-key blabla`
1. On master branch, observe that if you don't use the form field autocomplete that suggests you the disease after you type the first 3 chars in the input field (or if you don't provide a valid numeric omim id) the form crashes on submit.
1. Switch to this branch and make sure that if you repeat the same actions you get a flash error message instead, and the page doesn't crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
