### PR TITLE
Scroll pedigree - Fix #1818

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Adds possibility to add "lims_id" to cases. Currently only stored in database, not shown anywhere
 - Adds verification comment box to SVs (previously only available for small variants)
+- Scrollable pedigree panel
 
 ### Fixed
 - Error caused by changes in WTForm (new release 2.3.x)

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -120,7 +120,9 @@
         <p>Single sample case: {{ case.individuals.0.display_name }}</p>
       {% else %}
         <div class="d-flex justify-content-center align-items-center" >
+          <object>
         {{ case.madeline_info|safe }}
+          </object>
         </div>
       {% endif %}
       </div>


### PR DESCRIPTION
This PR embeds the pedigree svgs in the pedigree panel as scrollable objects. This is a simple workaround to the issues in #1818 without committing to more arcane viewBox javascripting.

**How to test**:
1. look at a pedigree and shrink the view until it is obvious the pedigree can scroll

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

<img width="215" alt="Screenshot 2020-04-27 at 09 10 22" src="https://user-images.githubusercontent.com/758570/80344037-332fc880-8867-11ea-8126-3b93404e1fad.png">


**Review:**
- [ ] code approved by
- [x] tests executed by DN
