### PR TITLE
Alamut link hg38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Error caused by changes in WTForm (new release 2.3.x)
 - Bug in OMIM case page form, causing the page to crash when a string was provided instead of a numerical OMIM id
+- Fix Alamut link to work properly on hg38
 
 ### Changed
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -312,7 +312,7 @@ def get_variant_links(variant_obj, build=None):
         cosmic_link=cosmic_link(variant_obj),
         beacon_link=beacon_link(variant_obj, build),
         ucsc_link=ucsc_link(variant_obj, build),
-        alamut_link=alamut_link(variant_obj),
+        alamut_link=alamut_link(variant_obj, build),
         spidex_human=spidex_human(variant_obj),
     )
     return links
@@ -436,12 +436,19 @@ def ucsc_link(variant_obj, build=None):
     return url_template.format(this=variant_obj)
 
 
-def alamut_link(variant_obj):
+def alamut_link(variant_obj, build=None):
+    build = build or 37
+
+    build_str = ""
+    if build == 38:
+        build_str = "(GRCh38)"
+
     url_template = (
-        "http://localhost:10000/show?request={this[chromosome]}:"
+        "http://localhost:10000/show?request={this[chromosome]}{build_str}:"
         "{this[position]}{this[reference]}>{this[alternative]}"
     )
-    return url_template.format(this=variant_obj)
+
+    return url_template.format(this=variant_obj, build_str = build_str)
 
 
 def spidex_human(variant_obj):

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -448,7 +448,7 @@ def alamut_link(variant_obj, build=None):
         "{this[position]}{this[reference]}>{this[alternative]}"
     )
 
-    return url_template.format(this=variant_obj, build_str = build_str)
+    return url_template.format(this=variant_obj, build_str=build_str)
 
 
 def spidex_human(variant_obj):


### PR DESCRIPTION
This PR fixes the Alamut link for hg38. 

When linking to a specific genome build in Alamut, the link must contain a query like this (GRCh37 is default if nothing is given):

```
3(GRCh38):g.37020386A>G
```

This has been tested and works properly on our setup (with Alamut 2.11), both for GRCh37 and 38.