### PR TITLE
update igv.js to the newest version (2.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Better handling of delivery reports for rerun cases
 
 ### Changed
+- Updated the version of igv.js to 2.5.4
 
 
 ## [4.15.1]

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -25,7 +25,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-     <script type="text/javascript" src="https://igv.org/web/snapshot/dist/igv.js"></script>
+     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/igv@2.5.4/dist/igv.min.js"></script>
 </head>
 <body>
 <div class="container-fluid" id="igvDiv" style="padding:5px; border:1px solid lightgray"></div>


### PR DESCRIPTION
igv.js has released a bug fixed version containing the fix to our bigBed bug (I've done a nice assonance here!). The bug in question is the one in #1793

Our current master is using a patched version of igv.js at the moment (the version they use for developing in between official releases), so it would be nice to use the current version instead.

**How to test**:
1. Install this branch on clinical-db scout stage
1. make sure that bigBed tracks (for instance clinVar CNVs) are displayed correctly

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
