### PR TITLE
Revert CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. These users will be requested for
-# review when someone opens a pull request.
-*   @dnil @moonso @northwestwitch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adds possibility to add "lims_id" to cases. Currently only stored in database, not shown anywhere
 - Adds verification comment box to SVs (previously only available for small variants)
 - Scrollable pedigree panel
-- List of codeowners
 
 ### Fixed
 - Error caused by changes in WTForm (new release 2.3.x)


### PR DESCRIPTION
This PR reverts the use of CODEOWNERS until we have use for it. Up until today, we have been fine with write permissions and requiring reviews from one other contributor.

**Review:**
- [x] code approved by CR

