### PR TITLE
Fix collaborate twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Bug in clinVar form when variant has no gene
+- Bug when sharing cases with the same institute twice
 
 ### Changed
 

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -328,7 +328,7 @@ class CaseEventHandler(object):
             updated_case
         """
         if collaborator_id in case.get("collaborators", []):
-            raise ValueError("new customer is already a collaborator")
+            raise ValueError(f"{collaborator_id} is already a collaborator.")
 
         self.create_event(
             institute=institute,

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -251,8 +251,8 @@
     <div class="form-group">
       <form action="{{ url_for('cases.share', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
         <div class="input-group">
-          <select class="form-control" name="collaborator">
-            <option class="placeholder" selected disabled value="">Select institute</option>
+          <select class="form-control form-control-sm" name="collaborator">
+            <option selected disabled value="">Select institute</option>
             {% for collab_id, collab_name in collaborators %}
               <option value="{{ collab_id }}">{{ collab_name }}</option>
             {% endfor %}
@@ -268,7 +268,7 @@
     <form method="POST" action="{{ url_for('cases.share', institute_id=institute._id, case_name=case.display_name) }}">
       <input type="hidden" name="revoke" />
       <div class="input-group">
-        <select class="form-control sm" name="collaborator">
+        <select class="form-control form-control-sm" name="collaborator">
           <option>Institute</option>
           {% for collab_id, collab_name in case.o_collaborators %}
             <option value="{{ collab_id }}">{{ collab_name }}</option>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -1169,10 +1169,13 @@ def share(institute_id, case_name):
     revoke_access = "revoke" in request.form
     link = url_for(".case", institute_id=institute_id, case_name=case_name)
 
-    if revoke_access:
-        store.unshare(institute_obj, case_obj, collaborator_id, user_obj, link)
-    else:
-        store.share(institute_obj, case_obj, collaborator_id, user_obj, link)
+    try:
+        if revoke_access:
+            store.unshare(institute_obj, case_obj, collaborator_id, user_obj, link)
+        else:
+            store.share(institute_obj, case_obj, collaborator_id, user_obj, link)
+    except ValueError as ex:
+        flash(str(ex), "warning")
 
     return redirect(request.referrer)
 


### PR DESCRIPTION
Bug fix #1910 

**How to test**:
1. To reproduce the bug on a local instance:
1. Add a new institute using the cli command:
`scout --demo load institute -i cust001 -d cust001`
1. Launch the server:
`scout --demo serve`
1. Change the cust000 institute server settings including cust001 in the list of institutes selectable for case sharing, see at the bottom of this pic:
![image](https://user-images.githubusercontent.com/28093618/81643902-f0edb600-9426-11ea-8252-4fc9d4198dd1.png)

1. Go to the case page and note that cust001 appears in the list of the institutes to share the case with:
![image](https://user-images.githubusercontent.com/28093618/81644113-6d809480-9427-11ea-8231-5da59d622f63.png)

1. Share the case with cust001
1. Share the case with cust001, again. This will trigger the bug.

1. Checkout to this branch and the repeated sharing will only flash an error message, instead of crashing the app.
1. Also "unsharing" the case will not cause any error
1. HTML selects of this branch will look smaller and fit better the sidebar

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR and DN
