### PR TITLE
Fix remove causative variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Bug in clinVar form when variant has no gene
 - Bug when sharing cases with the same institute twice
+- Page crashing when removing causative variant tag
 
 ### Changed
 

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -459,6 +459,7 @@ class VariantEventHandler(object):
             updated_case(dict)
 
         """
+        LOG.info("--------------------------------->{partial_causatives}")
         display_name = variant["display_name"]
         LOG.info(
             "Remove variant {0} as partially causative in case {1}".format(
@@ -468,6 +469,7 @@ class VariantEventHandler(object):
 
         # update partial_causative field of this case
         partial_causatives = case.get("partial_causatives") or {}
+        LOG.info(f"--------------------------------->{partial_causatives}")
         del partial_causatives[variant["_id"]]
 
         updated_case = self.case_collection.find_one_and_update(

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -459,7 +459,6 @@ class VariantEventHandler(object):
             updated_case(dict)
 
         """
-        LOG.info("--------------------------------->{partial_causatives}")
         display_name = variant["display_name"]
         LOG.info(
             "Remove variant {0} as partially causative in case {1}".format(
@@ -469,7 +468,8 @@ class VariantEventHandler(object):
 
         # update partial_causative field of this case
         partial_causatives = case.get("partial_causatives") or {}
-        LOG.info(f"--------------------------------->{partial_causatives}")
+        if variant["_id"] not in partial_causatives:
+            return case
         del partial_causatives[variant["_id"]]
 
         updated_case = self.case_collection.find_one_and_update(

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -1088,7 +1088,7 @@ def mark_causative(institute_id, case_name, variant_id, partial_causative=False)
         else:
             store.mark_causative(institute_obj, case_obj, user_obj, link, variant_obj)
     elif request.form["action"] == "DELETE":
-        if partial_causative:
+        if partial_causative == "True":
             store.unmark_partial_causative(
                 institute_obj, case_obj, user_obj, link, variant_obj
             )
@@ -1097,7 +1097,7 @@ def mark_causative(institute_id, case_name, variant_id, partial_causative=False)
 
     # send the user back to the case that was marked as solved
     case_url = url_for(".case", institute_id=institute_id, case_name=case_name)
-    return redirect(case_url)
+    return redirect(request.referrer)
 
 
 @cases_bp.route("/<institute_id>/<case_name>/check-case", methods=["POST"])


### PR DESCRIPTION
bug fix #1912

**How to test**:
1. Use a local instance of Scout
1. Mark a variant as causative
1. Assign an HPO phenotype to the case and mark another variant as partial causative for that specific phenotype
1. Make sure that removing causative works
1. Make sure that removing partial causative works

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
