### PR TITLE
Add COSMIC Badge (revisited)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- COSMIC badge shown in cancer variants
 
 ### Fixed
 - Bug in clinVar form when variant has no gene

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -169,6 +169,15 @@ def register_filters(app):
         return unquote(string)
 
 
+    @app.template_filter()
+    def cosmic_prefix(cosmicId):
+        """ If cosmicId is an integer, add 'COSM' as prefix
+            otherwise return unchanged """
+        if isinstance(cosmicId, int):
+            return "COSM"+str(cosmicId)
+        return cosmicId
+
+
 def configure_email_logging(app):
     """Setup logging of error/exceptions to email."""
     import logging

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -31,7 +31,7 @@ from scout.constants.variants_export import EXPORT_HEADER, VERIFIED_VARIANTS_HEA
 from scout.export.variant import export_verified_variants
 from scout.server.blueprints.genes.controllers import gene
 from scout.server.blueprints.variant.utils import predictions
-from scout.server.links import add_gene_links, add_tx_links, ensembl
+from scout.server.links import add_gene_links, add_tx_links, ensembl, cosmic_link
 from scout.server.utils import (
     case_append_alignments,
     institute_and_case,
@@ -320,7 +320,7 @@ def parse_variant(
     )
     if not "end_chrom" in variant_obj:
         variant_obj["end_chrom"] = variant_obj["chromosome"]
-
+    variant_obj['cosmic_link'] = cosmic_link(variant_obj)
     return variant_obj
 
 

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -95,7 +95,7 @@
     {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency else '~' }}
   </div>
   {% if variant.cosmic_ids %}
-  <span  class="badge badge-dark" target="_blank">Cosmic</span>
+  <span  class="badge badge-dark" target="_blank">COSMIC</span>
   <br>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -83,7 +83,7 @@
         <strong>Local (arch.)</strong>: {{ variant.local_obs_old or 0 }} obs.
       </div>
       {% if variant.cosmic_ids %}
-      <strong>CosmicIDs</strong>:
+      <strong>COSMIC obs. </strong>:
       <div>
         {% for cosmicID in variant.cosmic_ids %}
         {{cosmicID|cosmic_prefix}}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -82,8 +82,20 @@
       <div>
         <strong>Local (arch.)</strong>: {{ variant.local_obs_old or 0 }} obs.
       </div>
+      {% if variant.cosmic_ids %}
+      <strong>CosmicIDs</strong>:
+      <div>
+        {% for cosmicID in variant.cosmic_ids %}
+        {{cosmicID|cosmic_prefix}}
+        {% endfor %}
+      </div>
+      {% endif %}
     </div>
   ">
     {{ variant.gnomad_frequency|human_decimal if variant.gnomad_frequency else '~' }}
   </div>
+  {% if variant.cosmic_ids %}
+  <span  class="badge badge-dark" target="_blank">Cosmic</span>
+  <br>
+  {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -83,12 +83,7 @@
         <strong>Local (arch.)</strong>: {{ variant.local_obs_old or 0 }} obs.
       </div>
       {% if variant.cosmic_ids %}
-      <strong>COSMIC obs. </strong>:
-      <div>
-        {% for cosmicID in variant.cosmic_ids %}
-        {{cosmicID|cosmic_prefix}}
-        {% endfor %}
-      </div>
+      <strong>COSMIC</strong>: {{variant.cosmic_ids|count}} obs
       {% endif %}
     </div>
   ">

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -383,7 +383,7 @@ def cosmic_link(variant_obj):
         variant_obj(scout.models.Variant)
 
     Returns:
-        url_template(str): Link to COSMIIC database if cosmic id is present
+        url_template(str): Link to COSMIC database if cosmic id is present
     """
 
     cosmic_ids = variant_obj.get("cosmic_ids")


### PR DESCRIPTION
This PR adds a functionality.

1. In Scout's cancer view, if cosmic ID exists, add a badge "Cosmic". 
2. Hoover over will show IDs No links.

No extras, no links :)


Ref: https://github.com/Clinical-Genomics/scout/issues/1629
Ref: Old pr #1867 

**How to test**:
1. how to test it, possibly with real cases/data

Install and run Scout in cancer view. 


**Expected outcome**:
1. If a variant has a Cosmic ID, a badge is shown in Exac-column.
2. Mouse hoover over will show details, among those Cosmic ID:s.


<img width="1177" alt="Screenshot 2020-05-25 at 09 58 59" src="https://user-images.githubusercontent.com/1150065/82791749-944eba00-9e6e-11ea-83c4-a78fe07be352.png">


<img width="1177" alt="Screenshot 2020-05-25 at 10 09 42" src="https://user-images.githubusercontent.com/1150065/82792628-f52ac200-9e6f-11ea-95c5-cf8cc79434c9.png">

**Review:**
- [X] code approved by @hassanfa 
- [X] tests executed by @mikaell 
