### PR TITLE
added default gene panel for non-cancer structural variant view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
+
+### Added
+- Default gene-panel in non-cancer structural view in url
+
 ### Added
 - COSMIC badge shown in cancer variants
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -164,13 +164,12 @@ def register_filters(app):
         """Decode a string with encoded hex values."""
         return unquote(string)
 
-
     @app.template_filter()
     def cosmic_prefix(cosmicId):
         """ If cosmicId is an integer, add 'COSM' as prefix
             otherwise return unchanged """
         if isinstance(cosmicId, int):
-            return "COSM"+str(cosmicId)
+            return "COSM" + str(cosmicId)
         return cosmicId
 
 

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -35,7 +35,7 @@
         {{ variant.variant_type|capitalize }} cancer structural variants
       </a>
     {% else %}
-      <a class="nav-link text-nowrap" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
+      <a class="nav-link text-nowrap" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
         {{ variant.variant_type|capitalize }} structural variants
       </a>
     {% endif %}

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -300,7 +300,7 @@ def parse_variant(
     variant_obj["length"] = {100000000000: "inf", -1: "n.d."}.get(variant_length, variant_length)
     if not "end_chrom" in variant_obj:
         variant_obj["end_chrom"] = variant_obj["chromosome"]
-    variant_obj['cosmic_link'] = cosmic_link(variant_obj)
+    variant_obj["cosmic_link"] = cosmic_link(variant_obj)
     return variant_obj
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

**How to test**:
1. In a sample with default gene-panel, select a variant in structural view, then click on "Clinical Structural variants", the default gene-panel should not be lost.

**Expected outcome**:
The functionality should be working
![default_gene_panel](https://user-images.githubusercontent.com/44899319/82880202-6042ca00-9f3e-11ea-8915-5679ca1d8f29.png)


**Review:**
- [x] code approved by
- [x] tests executed by
