### PR TITLE
Add VAF filter in cancer SNV variants filter form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - COSMIC badge shown in cancer variants
 - Default gene-panel in non-cancer structural view in url
 - Filter SNVs and SVs by cytoband coordinates
-- Filter cancer SNV variants by tumor allele frequency
+- Filter cancer SNV variants by alt allele frequency in tumor
 
 ### Fixed
 - Bug in clinVar form when variant has no gene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - COSMIC badge shown in cancer variants
 - Default gene-panel in non-cancer structural view in url
 - Filter SNVs and SVs by cytoband coordinates
+- Filter cancer SNV variants by tumor allele frequency
 
 ### Fixed
 - Bug in clinVar form when variant has no gene

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -106,6 +106,7 @@ class QueryHandler(object):
                 'clingen_ngi': int,
                 'cadd_score': float,
                 'cadd_inclusive": boolean,
+                'vaf_frequency': float,
                 'genetic_models': list(str),
                 'hgnc_symbols': list,
                 'region_annotations': list,
@@ -188,7 +189,7 @@ class QueryHandler(object):
         primary_terms = False
 
         # gnomad_frequency, local_obs, clingen_ngi, swegen, spidex_human, cadd_score, genetic_models, mvl_tag
-        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency
+        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency, vaf_frequency
         secondary_terms = False
 
         # check if any of the primary criteria was specified in the query
@@ -209,7 +210,6 @@ class QueryHandler(object):
         # such as a Pathogenic ClinSig.
         if secondary_terms is True:
             secondary_filter = self.secondary_query(query, mongo_query)
-
             # If there are no primary criteria given, all secondary criteria are added as a
             # top level '$and' to the query.
             if primary_terms is False:
@@ -585,6 +585,13 @@ class QueryHandler(object):
                 mongo_secondary_query.append(
                     {"normal.alt_freq": {"$lt": float(query.get("control_frequency"))}}
                 )
+
+            if criterion == "vaf_frequency":
+                LOG.debug("add minimum VAF filter")
+                mongo_secondary_query.append(
+                    {"tumor.alt_freq": {"$gt": float(query.get("vaf_frequency"))}}
+                )
+
 
             if criterion == "mvl_tag":
                 LOG.debug("add managed variant list filter")

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -106,7 +106,7 @@ class QueryHandler(object):
                 'clingen_ngi': int,
                 'cadd_score': float,
                 'cadd_inclusive": boolean,
-                'vaf_frequency': float,
+                'tumor_frequency': float,
                 'genetic_models': list(str),
                 'hgnc_symbols': list,
                 'region_annotations': list,
@@ -189,7 +189,7 @@ class QueryHandler(object):
         primary_terms = False
 
         # gnomad_frequency, local_obs, clingen_ngi, swegen, spidex_human, cadd_score, genetic_models, mvl_tag
-        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency, vaf_frequency
+        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency, tumor_frequency
         secondary_terms = False
 
         # check if any of the primary criteria was specified in the query
@@ -586,10 +586,10 @@ class QueryHandler(object):
                     {"normal.alt_freq": {"$lt": float(query.get("control_frequency"))}}
                 )
 
-            if criterion == "vaf_frequency":
+            if criterion == "tumor_frequency":
                 LOG.debug("add minimum VAF filter")
                 mongo_secondary_query.append(
-                    {"tumor.alt_freq": {"$gt": float(query.get("vaf_frequency"))}}
+                    {"tumor.alt_freq": {"$gt": float(query.get("tumor_frequency"))}}
                 )
 
             if criterion == "mvl_tag":

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -43,5 +43,5 @@ SECONDARY_CRITERIA = [
     "alt_count",
     "control_frequency",
     "mvl_tag",
-    "vaf_frequency",
+    "tumor_frequency",
 ]

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -43,4 +43,5 @@ SECONDARY_CRITERIA = [
     "alt_count",
     "control_frequency",
     "mvl_tag",
+    "vaf_frequency"
 ]

--- a/scout/server/blueprints/institutes/templates/overview/institute.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute.html
@@ -26,7 +26,7 @@
 {% block content_main %}
 <form  action="{{ url_for('overview.institute', institute_id=institute._id) }}" method="POST"
   accept-charset="utf-8" id="institute_form">
-{{ form.csrf_token() }}
+{{ form.csrf_token }}
 <div class="container">
   <div class="display:block">
     <!-- institute settings panel -->

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -92,7 +92,7 @@ class VariantFiltersForm(FlaskForm):
 
     gnomad_frequency = BetterDecimalField("gnomadAF", places=2, validators=[validators.Optional()])
 
-    filters = SelectField(choices=[], validators=[validators.Optional()])
+    filters = NonValidatingSelectMultipleField(choices=[], validators=[validators.Optional()])
     filter_display_name = StringField(default="")
     save_filter = SubmitField(label="Save filter")
     load_filter = SubmitField(label="Load filter")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -125,7 +125,7 @@ class CancerFiltersForm(VariantFiltersForm):
     depth = IntegerField("Depth >", validators=[validators.Optional()])
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField(
-        "Control freq. <", places=2, validators=[validators.Optional()]
+        "Normal freq. <", places=2, validators=[validators.Optional()]
     )
     tumor_frequency = BetterDecimalField("Tumor alt AF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -127,7 +127,7 @@ class CancerFiltersForm(VariantFiltersForm):
     control_frequency = BetterDecimalField(
         "Control freq. <", places=2, validators=[validators.Optional()]
     )
-    vaf_frequency = BetterDecimalField("Tumor AF >", places=2, validators=[validators.Optional()])
+    tumor_frequency = BetterDecimalField("Tumor AF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")
 
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -127,7 +127,7 @@ class CancerFiltersForm(VariantFiltersForm):
     control_frequency = BetterDecimalField(
         "Control freq. <", places=2, validators=[validators.Optional()]
     )
-    vaf_frequency = BetterDecimalField("VAF >", places=2, validators=[validators.Optional()])
+    vaf_frequency = BetterDecimalField("Tumor AF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")
 
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -123,11 +123,11 @@ class CancerFiltersForm(VariantFiltersForm):
     """Base filters for CancerFiltersForm - extends VariantsFiltersForm"""
 
     depth = IntegerField("Depth >", validators=[validators.Optional()])
-    alt_count = IntegerField("Min alt count >", validators=[validators.Optional()])
+    alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField(
         "Control freq. <", places=2, validators=[validators.Optional()]
     )
-    tumor_frequency = BetterDecimalField("Tumor AF >", places=2, validators=[validators.Optional()])
+    tumor_frequency = BetterDecimalField("Tumor alt AF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")
 
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -45,6 +45,12 @@ class NonValidatingSelectMultipleField(SelectMultipleField):
     def pre_validate(self, form):
         pass
 
+class NonValidatingSelectField(SelectField):
+    """Necessary to skip validation of dynamic selects in form"""
+
+    def pre_validate(self, form):
+        pass
+
 
 class TagListField(Field):
     widget = TextInput()
@@ -92,7 +98,7 @@ class VariantFiltersForm(FlaskForm):
 
     gnomad_frequency = BetterDecimalField("gnomadAF", places=2, validators=[validators.Optional()])
 
-    filters = NonValidatingSelectMultipleField(choices=[], validators=[validators.Optional()])
+    filters = NonValidatingSelectField(choices=[], validators=[validators.Optional()])
     filter_display_name = StringField(default="")
     save_filter = SubmitField(label="Save filter")
     load_filter = SubmitField(label="Load filter")
@@ -125,7 +131,7 @@ class CancerFiltersForm(VariantFiltersForm):
     depth = IntegerField("Depth >", validators=[validators.Optional()])
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField(
-        "Normal freq. <", places=2, validators=[validators.Optional()]
+        "Normal alt AF <", places=2, validators=[validators.Optional()]
     )
     tumor_frequency = BetterDecimalField("Tumor alt AF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -118,6 +118,7 @@ class CancerFiltersForm(VariantFiltersForm):
     depth = IntegerField("Depth >")
     alt_count = IntegerField("Min alt count >")
     control_frequency = BetterDecimalField("Control freq. <", places=2)
+    vaf_frequency = BetterDecimalField("VAF >", places=2)
     mvl_tag = BooleanField("In Managed Variant List")
 
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -39,6 +39,12 @@ SV_TYPE_CHOICES = [(term, term.replace("_", " ").upper()) for term in SV_TYPES]
 SPIDEX_CHOICES = [(term, term.replace("_", " ")) for term in SPIDEX_LEVELS]
 
 
+class NonValidatingSelectMultipleField(SelectMultipleField):
+    """Necessary to skip validation of dynamic multiple selects in form"""
+
+    def pre_validate(self, form):
+        pass
+
 class TagListField(Field):
     widget = TextInput()
 
@@ -72,7 +78,7 @@ class BetterDecimalField(DecimalField):
 class VariantFiltersForm(FlaskForm):
     variant_type = HiddenField(default="clinical")
 
-    gene_panels = SelectMultipleField(choices=[])
+    gene_panels = NonValidatingSelectMultipleField(choices=[])
     hgnc_symbols = TagListField("HGNC Symbols/Ids (case sensitive)")
 
     region_annotations = SelectMultipleField(choices=REGION_ANNOTATIONS)
@@ -81,7 +87,7 @@ class VariantFiltersForm(FlaskForm):
 
     cadd_score = BetterDecimalField("CADD", places=2, validators=[validators.Optional()])
     cadd_inclusive = BooleanField("CADD inclusive")
-    clinsig = SelectMultipleField("CLINSIG", choices=CLINSIG_OPTIONS)
+    clinsig = NonValidatingSelectMultipleField("CLINSIG", choices=CLINSIG_OPTIONS)
 
     gnomad_frequency = BetterDecimalField("gnomadAF", places=2, validators=[validators.Optional()])
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -79,13 +79,13 @@ class VariantFiltersForm(FlaskForm):
     functional_annotations = SelectMultipleField(choices=FUNC_ANNOTATIONS)
     genetic_models = SelectMultipleField(choices=GENETIC_MODELS)
 
-    cadd_score = BetterDecimalField("CADD", places=2)
+    cadd_score = BetterDecimalField("CADD", places=2, validators=[validators.Optional()])
     cadd_inclusive = BooleanField("CADD inclusive")
     clinsig = SelectMultipleField("CLINSIG", choices=CLINSIG_OPTIONS)
 
-    gnomad_frequency = BetterDecimalField("gnomadAF", places=2)
+    gnomad_frequency = BetterDecimalField("gnomadAF", places=2, validators=[validators.Optional()])
 
-    filters = SelectField(choices=[])
+    filters = SelectField(choices=[], validators=[validators.Optional()])
     filter_display_name = StringField(default="")
     save_filter = SubmitField(label="Save filter")
     load_filter = SubmitField(label="Load filter")
@@ -115,10 +115,10 @@ class FiltersForm(VariantFiltersForm):
 class CancerFiltersForm(VariantFiltersForm):
     """Base filters for CancerFiltersForm - extends VariantsFiltersForm"""
 
-    depth = IntegerField("Depth >")
-    alt_count = IntegerField("Min alt count >")
-    control_frequency = BetterDecimalField("Control freq. <", places=2)
-    vaf_frequency = BetterDecimalField("VAF >", places=2)
+    depth = IntegerField("Depth >", validators=[validators.Optional()])
+    alt_count = IntegerField("Min alt count >", validators=[validators.Optional()])
+    control_frequency = BetterDecimalField("Control freq. <", places=2, validators=[validators.Optional()])
+    vaf_frequency = BetterDecimalField("VAF >", places=2, validators=[validators.Optional()])
     mvl_tag = BooleanField("In Managed Variant List")
 
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -39,7 +39,7 @@
       <div class="card-header">
         <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">Filters</a></strong>
       </div>
-      <div class="card-body panel-collapse collapse" id="collapseFilters">
+      <div class="card-body panel-collapse collapse {{ "show" if request.args.get("expand_search") }}" id="collapseFilters" >
           {{ cancer_filters(form, institute, case) }}
       </div>
     </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -438,11 +438,11 @@
           {{ form.depth.label(class="control-label") }}
           {{ form.depth(class="form-control") }}
         </div>
-        <div class="col-2">
+        <div class="col-1">
           {{ form.alt_count.label(class="control-label") }}
           {{ form.alt_count(class="form-control") }}
         </div>
-        <div class="col-1">
+        <div class="col-2">
           {{ form.tumor_frequency.label(class="control-label") }}
           {{ form.tumor_frequency(class="form-control") }}
         </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -435,16 +435,16 @@
           {{ form.gnomad_frequency(class="form-control") }}
         </div>
         <div class="col-1">
-          {{ form.vaf_frequency.label(class="control-label") }}
-          {{ form.vaf_frequency(class="form-control") }}
-        </div>
-        <div class="col-1">
           {{ form.depth.label(class="control-label") }}
           {{ form.depth(class="form-control") }}
         </div>
         <div class="col-2">
           {{ form.alt_count.label(class="control-label") }}
           {{ form.alt_count(class="form-control") }}
+        </div>
+        <div class="col-1">
+          {{ form.vaf_frequency.label(class="control-label") }}
+          {{ form.vaf_frequency(class="form-control") }}
         </div>
         <div class="col-2">
           {{ form.control_frequency.label(class="control-label") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -443,8 +443,8 @@
           {{ form.alt_count(class="form-control") }}
         </div>
         <div class="col-1">
-          {{ form.vaf_frequency.label(class="control-label") }}
-          {{ form.vaf_frequency(class="form-control") }}
+          {{ form.tumor_frequency.label(class="control-label") }}
+          {{ form.tumor_frequency(class="form-control") }}
         </div>
         <div class="col-2">
           {{ form.control_frequency.label(class="control-label") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -426,13 +426,17 @@
           {{ form.cadd_score.label(class="control-label") }}
           {{ form.cadd_score(class="form-control") }}
         </div>
-        <div class="col-2">
+        <div class="col-1">
           {{ form.cadd_inclusive.label(class="control-label", data_toggle="tooltip", data_placement="top", title="Include empty CADD") }}
           <div>{{ form.cadd_inclusive() }}</div>
         </div>
         <div class="col-1">
           {{ form.gnomad_frequency.label(class="control-label") }}
           {{ form.gnomad_frequency(class="form-control") }}
+        </div>
+        <div class="col-1">
+          {{ form.vaf_frequency.label(class="control-label") }}
+          {{ form.vaf_frequency(class="form-control") }}
         </div>
         <div class="col-1">
           {{ form.depth.label(class="control-label") }}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -54,7 +54,7 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
-        # If special filter buttons were selected:
+        # If special filter were selected:
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
@@ -250,10 +250,20 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
-        page = int(request.form.get("page", 1))
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
+        if form.validate_on_submit() is False:
+            # Flash a message with errors
+            for field, err_list in form.errors.items():
+                for err in err_list:
+                    flash(f"{field} --> {err}", "warning")
+            # And do not submit the form
+            return redirect(
+                url_for(".cancer_variants", institute_id=institute_id, case_name=case_name, expand_search=True),
+            )
+        page = int(request.form.get("page", 1))
+
     else:
         page = int(request.args.get("page", 1))
         form = CancerFiltersForm(request.args)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -250,6 +250,7 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
+        flash(f"HI BITCHES:{request.form}")
         page = int(request.form.get("page", 1))
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -250,7 +250,6 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
-        flash(request.form)
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -250,6 +250,7 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
+        flash(request.form)
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -250,7 +250,6 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
-        flash(f"HI BITCHES:{request.form}")
         page = int(request.form.get("page", 1))
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -257,7 +257,7 @@ def cancer_variants(institute_id, case_name):
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:
-                    flash(f"Conteint of field '{field}' has not a valid format", "warning")
+                    flash(f"Content of field '{field}' has not a valid format", "warning")
             # And do not submit the form
             return redirect(
                 url_for(

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -54,7 +54,6 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
-        # If special filter were selected:
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -257,7 +257,7 @@ def cancer_variants(institute_id, case_name):
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:
-                    flash(f"{field} --> {err}", "warning")
+                    flash(f"Conteint of field '{field}' has not a valid format", "warning")
             # And do not submit the form
             return redirect(
                 url_for(

--- a/tests/server/blueprints/institutes/test_institutes_views.py
+++ b/tests/server/blueprints/institutes/test_institutes_views.py
@@ -20,14 +20,8 @@ def test_overview(app, user_obj, institute_obj):
         assert resp.status_code == 200
 
 
-def test_institute(app, user_obj, institute_obj, monkeypatch):
+def test_institute(app, user_obj, institute_obj):
     """Test function that creates institute update form and updates an institute"""
-
-    # monkeypatching form validation is easier than haldling a missing csfr token
-    def mock_validate_form(*args, **kwargs):
-        return True
-
-    monkeypatch.setattr(form, "validate_on_submit", mock_validate_form)
 
     # insert 2 mock HPO terms in database, for later use
     mock_disease_terms = [

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -272,7 +272,7 @@ def test_filter_cancer_variants_by_vaf(app, institute_obj, case_obj):
 
         # When a POST request filter with VAF > than the VAF in test_var is sent to the page
         form_data = {
-            "vaf_frequency": 0.5,
+            "tumor_frequency": 0.5,
         }
         resp = client.post(
             url_for(

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -84,6 +84,7 @@ def app(real_database_name, real_variant_database, user_obj):
             MONGO_DBNAME=real_database_name,
             DEBUG_TB_ENABLED=False,
             LOGIN_DISABLED=True,
+            WTF_CSRF_ENABLED=False
         )
     )
 


### PR DESCRIPTION
Fix #1922

- Adds a field to filter variants with Tumor AF > than a certain floating point value
- Validates the whole filter on submission. So when some weird parameter is submitted, the search is not performed and an error will be flashed instead

![image](https://user-images.githubusercontent.com/28093618/83235250-e145cf80-a191-11ea-8dd8-0babf24423db.png)


**How to test**:
1. Install the branch on Scout stage
1. Go to a cancer case
1. Filter for variants with VAF > than a custom number (try with numbers like 0.25 or 0,25)
1. Try to fill in the form with wrong input for the fields

**Expected outcome**:
The functionality should be working:
1. VAF filter should work (compare with VAF for the returned variants)
1. Form validation errors should be returned when the occur

**Review:**
- [x] code approved by dNil
- [x] tests executed by @hassanfa 
