### PR TITLE
Feature filter on chr 200603

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show an ellipsis if 10 cases or more to display with loqusdb matches
 - A new blog post for version 4.17
 - Tooltip to better describe Tumor and Normal columns in cancer variants
-- Filter on chromosome start/end in Cancer View
+- Filter cancer SNVs and SVs by chromosome coordinates
 
 ### Fixed
 - Apply default gene panel on return to cancer variantS from variant view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
-- A new blog post for version 4.17
 
+- A new blog post for version 4.17
+- Filter on chromosome start/end in Cancer View
+	
 ### Fixed
 ### Changed
 
@@ -27,6 +29,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Filter SNVs and SVs by cytoband coordinates
 - Filter cancer SNV variants by alt allele frequency in tumor
 - Correct genome build in UCSC link from structural variant page
+
+
 
 ### Fixed
 - Bug in clinVar form when variant has no gene

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -118,7 +118,6 @@ class FiltersForm(VariantFiltersForm):
     clinsig_confident_always_returned = BooleanField("CLINSIG Confident")
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
-    chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     cytoband_start = SelectField("Cytoband start", choices=[])
     cytoband_end = SelectField("Cytoband end", choices=[])
     local_obs = IntegerField("Local obs. (archive)")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,7 +105,7 @@ class VariantFiltersForm(FlaskForm):
     load_filter = SubmitField(label="Load filter")
     delete_filter = SubmitField(label="Delete filter")
 
-    chrom = TextField("Chromosome", [validators.Optional()])
+    chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     start = IntegerField("Start position", [validators.Optional()])
     end = IntegerField("End position", [validators.Optional()])
 
@@ -121,8 +121,6 @@ class FiltersForm(VariantFiltersForm):
     chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     cytoband_start = SelectField("Cytoband start", choices=[])
     cytoband_end = SelectField("Cytoband end", choices=[])
-    start = IntegerField("Start position", [validators.Optional()])
-    end = IntegerField("End position", [validators.Optional()])
     local_obs = IntegerField("Local obs. (archive)")
 
     filter_variants = SubmitField(label="Filter variants")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,6 +105,10 @@ class VariantFiltersForm(FlaskForm):
     load_filter = SubmitField(label="Load filter")
     delete_filter = SubmitField(label="Delete filter")
 
+    chrom = TextField("Chromosome", [validators.Optional()])
+    start = IntegerField("Start position", [validators.Optional()])
+    end = IntegerField("End position", [validators.Optional()])
+
 
 class FiltersForm(VariantFiltersForm):
     """Base FiltersForm for SNVs - extends VariantFiltersForm."""
@@ -161,11 +165,8 @@ class SvFiltersForm(VariantFiltersForm):
     clingen_ngi = IntegerField("ClinGen NGI obs")
     swegen = IntegerField("SweGen obs")
 
-    chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     cytoband_start = SelectField("Cytoband start", choices=[])
     cytoband_end = SelectField("Cytoband end", choices=[])
-    start = IntegerField("Start position", [validators.Optional()])
-    end = IntegerField("End position", [validators.Optional()])
 
     filter_variants = SubmitField(label="Filter variants")
     clinical_filter = SubmitField(label="Clinical filter")

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -453,12 +453,26 @@
       </div>
     </div>
     <div class="form-group">
-      <div class="row">
-
-            </div>
+      <div class="row"></div>
     </div>
-    <br>
-    <div class="form-group">
+    <div class="form-group" id="start_end_filter">
+      <div class="row justify-content-between" style="margin-top:20px;">
+        <div class="col-1">
+          {{ wtf.form_field(form.chrom) }}
+        </div>
+        <div class="col-2">
+          {{ wtf.form_field(form.start) }}
+        </div>
+        <div class="col-2">
+          {{ wtf.form_field(form.end) }}
+        </div>
+        <div class="col">
+        </div>
+
+      </div>
+    </div>
+
+    <div class="form-group" id="buttons">
       <div class="row">
         <div class="col-3">
           <button class="btn btn-primary form-control">Filter variants</button>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -452,9 +452,6 @@
         </div>
       </div>
     </div>
-    <div class="form-group">
-      <div class="row"></div>
-    </div>
     <div class="form-group" id="start_end_filter">
       <div class="row justify-content-between" style="margin-top:20px;">
         <div class="col-1">


### PR DESCRIPTION
This PR adds functionality to filter cancer variants on chromosome, start/end in cancer view.

Ref #1926 -customer request.

The functionality is like filtering on the ordinary SNVs/Indels and uses the same backend.


**How to test**:
1. how to test it, possibly with real cases/data
Install `featuer-filter_on_chr-200603` (typo!).

Go to cancer variants, select filter and enter a chromosome, start and end. 



**Expected outcome**:
All matching variants will be shown.

![Screenshot 2020-06-03 at 14 44 55](https://user-images.githubusercontent.com/1150065/83639823-8a823080-a5ab-11ea-87dd-223b9de5617b.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
