### PR TITLE
Turn tumor and normal allele frequencies to decimal and add tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 ### Changed
-- Turn tumor and normal allele frequencies to decimal numbers in tumor variants page
+- Turn tumor and normal allelic fraction to decimal numbers in tumor variants page
 
 ## [4.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show an ellipsis if 10 cases or more to display with loqusdb matches
 - Apply default gene panel on return to cancer variantS from variant view
 - A new blog post for version 4.17
+- Tooltip to better describe Tumor and Normal columns in cancer variants
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - A new blog post for version 4.17
 
 ### Fixed
-### Changed
 
+### Changed
+- Turn tumor and normal allele frequencies to decimal numbers in tumor variants page
 
 ## [4.17.1]
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -57,8 +57,8 @@
               <th>ExAC</th>
               <th>Type</th>
               <th>Consequence</th>
-              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. allele frequency">Tumor</th>
-              <th data-toggle="tooltip" data-placement="top" title="Normal alt. allele frequency">Normal</th>
+              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. allele frequency. &#013; Alt. allele count | Ref allele count">Tumor</th>
+              <th data-toggle="tooltip" data-placement="top" title="Normal alt. allele frequency. &#013; Alt. allele count | Ref. allele count">Normal</th>
             </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -57,8 +57,8 @@
               <th>ExAC</th>
               <th>Type</th>
               <th>Consequence</th>
-              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. allele frequency. &#013; Alt. allele count | Ref allele count">Tumor</th>
-              <th data-toggle="tooltip" data-placement="top" title="Normal alt. allele frequency. &#013; Alt. allele count | Ref. allele count">Normal</th>
+              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
+              <th data-toggle="tooltip" data-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
             </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -57,8 +57,8 @@
               <th>ExAC</th>
               <th>Type</th>
               <th>Consequence</th>
-              <th>Tumor</th>
-              <th>Normal</th>
+              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. allele frequency">Tumor</th>
+              <th data-toggle="tooltip" data-placement="top" title="Normal alt. allele frequency">Normal</th>
             </tr>
       </thead>
       <tbody>
@@ -154,7 +154,7 @@
 
 {% macro allele_cell(allele) %}
   {% if 'alt_freq' in allele %}
-    {{ (allele.alt_freq * 100)|round(2)  }}%
+    {{ allele.alt_freq|round(4)  }}
     <br>
     <small class="text-muted">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
   {% else %}


### PR DESCRIPTION
Fix #1941  and fix #1940

I've turned the Tumor and Normal alt allele frequency fields to decimal numbers, instead of %, to be consistent with the population frequencies. This way is also consistent with the numbers expected in the filters form above.

So this:
![image](https://user-images.githubusercontent.com/28093618/83847814-2ecfb880-a70d-11ea-9e91-169ede985a52.png)



Becomes this:
![image](https://user-images.githubusercontent.com/28093618/83847765-19f32500-a70d-11ea-912c-c8a28ae75ac3.png)

I've also added a tooltip when you hover on "Tumor" and "Normal", to explain what these numbers are. Example:

![image](https://user-images.githubusercontent.com/28093618/83849572-e82f8d80-a70f-11ea-8d62-7a2f668cca1f.png)

Do we need to explain a bit more?

**How to test**:
1. Install the branch on Scout stage (or use a local instance with a cancer case loaded) and go to cancer SNV variantS page.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [ ] tests executed by
