### PR TITLE
Export clinVar "assertion method citation" in downloaded clinVar variants file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show an ellipsis if 10 cases or more to display with loqusdb matches
 - A new blog post for version 4.17
 - Tooltip to better describe Tumor and Normal columns in cancer variants
+- Default export of `Assertion method citation` to clinVar variants submission file
 
 ### Fixed
 - Apply default gene panel on return to cancer variantS from variant view

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -28,6 +28,7 @@ CLINVAR_HEADER = {
     "last_evaluated": "Date last evaluated",
     "variant_comment": "Comment on variant",
     "assertion_method": "Assertion method",
+    "assertion_method_cit": "Assertion method citation",
     "inheritance_mode": "Mode of inheritance",
     "clinsig_cit": "Clinical significance citations",
     "clinsig_comment": "Comment on clinical significance",

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -448,9 +448,9 @@
                         <td><input type="text" name="assertion_method@{{pinned._id}}" placeholder="optional (Submitter's or other publication)" size="40" value="ACMG Guidelines, 2015"></td>
                       </tr>
                       <tr>
-                        <td>Assertion citation</td>
+                        <td>Assertion method citation</td>
                         <td>
-                          <textarea name="assertion_method_cit@{{pinned._id}}" placeholder="(optional)" rows="3" cols="40">doi: 10.1038/gim.2015.30</textarea>
+                          <textarea name="assertion_method_cit@{{pinned._id}}" placeholder="(optional)" rows="3" cols="40">PMID:25741868</textarea>
                         </td>
                       </tr>
                       <tr>


### PR DESCRIPTION
Fix #1902.
Save "Assertion method citation" to clinVar export form:

![image](https://user-images.githubusercontent.com/28093618/84016357-78263f00-a97d-11ea-85f5-fab8b02b19dd.png)

And make it exportable in the relative downloadable submission file:

![image](https://user-images.githubusercontent.com/28093618/84016541-b885bd00-a97d-11ea-97f8-bd048af47c7d.png)


And the downloadable file:
![image](https://user-images.githubusercontent.com/28093618/84016735-fbe02b80-a97d-11ea-8eab-722edfe63e70.png)


**How to test**:
1. Assign a phenotype (OMIM or HPO) to a case and pin one of its variants
1. Go to the variants and click on the "Submit to ClinVar" button. Follow the procedure to save the submission and make sure that the "Assertion method citation" is present in the variants file downloadable from the submission object (button `Download variants file`)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
