### PR TITLE
Fix "download everything" command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Apply default gene panel on return to cancer variantS from variant view
 - Revert to certificate checking when asking for Chanjo reports
+- "scout download everything" command failing while downloading HPO terms
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Apply default gene panel on return to cancer variantS from variant view
 - Revert to certificate checking when asking for Chanjo reports
-- "scout download everything" command failing while downloading HPO terms
+- `scout download everything` command failing while downloading HPO terms
 
 ### Changed
 

--- a/scout/commands/download/everything.py
+++ b/scout/commands/download/everything.py
@@ -6,14 +6,13 @@ import pathlib
 
 import click
 
-from .ensembl import print_ensembl
-from .exac import print_exac
-from .hgnc import print_hgnc
-from .hpo import print_hpo
-from .omim import print_omim
+from .ensembl import ensembl
+from .exac import exac
+from .hgnc import hgnc
+from .hpo import hpo
+from .omim import omim
 
 LOG = logging.getLogger(__name__)
-
 
 @click.command("everything", help="Download all necessary resources for scout")
 @click.option("--api-key", help="Specify the api key")
@@ -21,23 +20,19 @@ LOG = logging.getLogger(__name__)
 @click.option("--skip-tx", is_flag=True, help="Only download ensembl genes, skip transcripts")
 @click.option("--exons", is_flag=True, help="If ensembl exons should be downloaded")
 @click.option("--build", type=click.Choice(["37", "38"]), help="If only one build should be used")
-def everything(out_dir, api_key, skip_tx, exons, build):
+@click.pass_context
+def everything(ctx, out_dir, api_key, skip_tx, exons, build):
     """Download all necessary resources for scout"""
     out_dir = pathlib.Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    if not api_key:
+    if api_key is None:
         LOG.warning("No OMIM api key provided, skipping OMIM")
+        ctx.invoke(hpo, out_dir=out_dir, terms=True, genes=True)
     else:
-        print_omim(out_dir, api_key)
-    print_exac(out_dir)
-    print_hpo(out_dir)
-    print_hgnc(out_dir)
+        ctx.invoke(omim, out_dir=out_dir, api_key=api_key)
+        ctx.invoke(hpo, out_dir=out_dir, terms=True, genes=True, disease=True)
 
-    print_ensembl(out_dir, "genes", build)
-
-    if not skip_tx:
-        print_ensembl(out_dir, "transcripts", build)
-
-    if exons:
-        print_ensembl(out_dir, "exons", build)
+    ctx.invoke(exac, out_dir=out_dir)
+    ctx.invoke(hgnc, out_dir=out_dir)
+    ctx.invoke(ensembl, out_dir=out_dir, skip_tx=skip_tx, exons=exons, build=build)

--- a/scout/commands/download/everything.py
+++ b/scout/commands/download/everything.py
@@ -28,11 +28,10 @@ def everything(ctx, out_dir, api_key, skip_tx, exons, build):
 
     if api_key is None:
         LOG.warning("No OMIM api key provided, skipping OMIM")
-        ctx.invoke(hpo, out_dir=out_dir, terms=True, genes=True)
     else:
         ctx.invoke(omim, out_dir=out_dir, api_key=api_key)
-        ctx.invoke(hpo, out_dir=out_dir, terms=True, genes=True, disease=True)
 
+    ctx.invoke(hpo, out_dir=out_dir)
     ctx.invoke(exac, out_dir=out_dir)
     ctx.invoke(hgnc, out_dir=out_dir)
     ctx.invoke(ensembl, out_dir=out_dir, skip_tx=skip_tx, exons=exons, build=build)


### PR DESCRIPTION
Fix #1957

**How to test**:
1. check that on master branch the `scout download everything` command fails
1. Checkout to this branch and run
- `scout (--demo) download everything`
- `scout (--demo) download everything --api-key a-valid-key`

**Expected outcome**:
The functionality should be working and download all the expected files.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by CR
