### PR TITLE
Cytoband Search for Cancer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+- Filter cancer on cytoband coordinates
 - Show dismiss reasons in a badge with hover for clinical variants
 - Show an ellipsis if 10 cases or more to display with loqusdb matches
 - A new blog post for version 4.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
-- Filter cancer on cytoband coordinates
+- Filter cancer variants on cytoband coordinates
 - Show dismiss reasons in a badge with hover for clinical variants
 - Show an ellipsis if 10 cases or more to display with loqusdb matches
 - A new blog post for version 4.17

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -532,7 +532,7 @@ def upload_panel(store, institute_id, case_name, stream):
 def populate_filters_form(store, institute_obj, case_obj, user_obj, category, request_form):
     # Update filter settings if Clinical Filter was requested
     clinical_filter_panels = []
-
+    LOG.debug("populate_filters_form(...)")
     default_panels = []
     for panel in case_obj["panels"]:
         if panel.get("is_default"):
@@ -627,9 +627,12 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
     if request_obj.method == "GET":
         form = SvFiltersForm(request_obj.args)
         form.variant_type.data = request_obj.args.get("variant_type", "clinical")
+        LOG.debug("CHROM.DATA: {}".format(request_obj.args.get("chrom", None)))
         form.chrom.data = request_obj.args.get("chrom", None)
 
     else:  # POST
+        LOG.debug("populate filter!")
+
         form = populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request_obj.form
         )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -469,7 +469,6 @@ def cancer_variants(store, institute_id, case_name, form, page=1):
     variant_count = variants_query.count()
     more_variants = True if variant_count > (skip_count + per_page) else False
     variant_res = variants_query.skip(skip_count).limit(per_page)
-    LOG.debug("cancer_variants -form: {}".format(form))
     data = dict(
         page=page,
         more_variants=more_variants,
@@ -533,9 +532,6 @@ def upload_panel(store, institute_id, case_name, stream):
 def populate_filters_form(store, institute_obj, case_obj, user_obj, category, request_form):
     # Update filter settings if Clinical Filter was requested
     clinical_filter_panels = []
-    LOG.debug("populate_filters_form(...)")
-    LOG.debug("request_form: {}".format(request_form))
-    LOG.debug("category: {}".format(category))
 
     default_panels = []
     for panel in case_obj["panels"]:
@@ -607,7 +603,7 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
         form = FiltersFormClass(request_form)
     else:
         form = FiltersFormClass(request_form)
-    LOG.debug("populate, chrom: {}".format(form.chrom))
+
     return form
 
 
@@ -631,12 +627,9 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
     if request_obj.method == "GET":
         form = SvFiltersForm(request_obj.args)
         form.variant_type.data = request_obj.args.get("variant_type", "clinical")
-        LOG.debug("CHROM.DATA: {}".format(request_obj.args.get("chrom", None)))
         form.chrom.data = request_obj.args.get("chrom", None)
 
     else:  # POST
-        LOG.debug("populate filter!")
-
         form = populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request_obj.form
         )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -469,6 +469,7 @@ def cancer_variants(store, institute_id, case_name, form, page=1):
     variant_count = variants_query.count()
     more_variants = True if variant_count > (skip_count + per_page) else False
     variant_res = variants_query.skip(skip_count).limit(per_page)
+    LOG.debug("cancer_variants -form: {}".format(form))
     data = dict(
         page=page,
         more_variants=more_variants,
@@ -603,7 +604,7 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
         form = FiltersFormClass(request_form)
     else:
         form = FiltersFormClass(request_form)
-
+    LOG.debug("populate, chrom: {}".format(form.chrom))
     return form
 
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -534,6 +534,9 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
     # Update filter settings if Clinical Filter was requested
     clinical_filter_panels = []
     LOG.debug("populate_filters_form(...)")
+    LOG.debug("request_form: {}".format(request_form))
+    LOG.debug("category: {}".format(category))
+
     default_panels = []
     for panel in case_obj["panels"]:
         if panel.get("is_default"):

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -108,6 +108,8 @@ class VariantFiltersForm(FlaskForm):
     chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     start = IntegerField("Start position", [validators.Optional()])
     end = IntegerField("End position", [validators.Optional()])
+    cytoband_start = SelectField("Cytoband start", choices=[])
+    cytoband_end = SelectField("Cytoband end", choices=[])
 
 
 class FiltersForm(VariantFiltersForm):
@@ -118,8 +120,6 @@ class FiltersForm(VariantFiltersForm):
     clinsig_confident_always_returned = BooleanField("CLINSIG Confident")
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
-    cytoband_start = SelectField("Cytoband start", choices=[])
-    cytoband_end = SelectField("Cytoband end", choices=[])
     local_obs = IntegerField("Local obs. (archive)")
 
     filter_variants = SubmitField(label="Filter variants")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -108,8 +108,8 @@ class VariantFiltersForm(FlaskForm):
     chrom = SelectField("Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS)
     start = IntegerField("Start position", [validators.Optional()])
     end = IntegerField("End position", [validators.Optional()])
-    cytoband_start = SelectField("Cytoband start", choices=[])
-    cytoband_end = SelectField("Cytoband end", choices=[])
+    cytoband_start = NonValidatingSelectField("Cytoband start", choices=[])
+    cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
 
 
 class FiltersForm(VariantFiltersForm):

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -129,7 +129,7 @@ class FiltersForm(VariantFiltersForm):
 
 class CancerFiltersForm(VariantFiltersForm):
     """Base filters for CancerFiltersForm - extends VariantsFiltersForm"""
-
+    filter_variants = SubmitField(label="Filter variants")
     depth = IntegerField("Depth >", validators=[validators.Optional()])
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField(

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -110,7 +110,7 @@ class VariantFiltersForm(FlaskForm):
     end = IntegerField("End position", [validators.Optional()])
     cytoband_start = NonValidatingSelectField("Cytoband start", choices=[])
     cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
-
+    filter_variants = SubmitField(label="Filter variants")
 
 class FiltersForm(VariantFiltersForm):
     """Base FiltersForm for SNVs - extends VariantFiltersForm."""
@@ -121,8 +121,6 @@ class FiltersForm(VariantFiltersForm):
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
     local_obs = IntegerField("Local obs. (archive)")
-
-    filter_variants = SubmitField(label="Filter variants")
     clinical_filter = SubmitField(label="Clinical filter")
     export = SubmitField(label="Filter and export")
 
@@ -130,7 +128,6 @@ class FiltersForm(VariantFiltersForm):
 class CancerFiltersForm(VariantFiltersForm):
     """Base filters for CancerFiltersForm - extends VariantsFiltersForm"""
 
-    filter_variants = SubmitField(label="Filter variants")
     depth = IntegerField("Depth >", validators=[validators.Optional()])
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField(
@@ -146,7 +143,6 @@ class StrFiltersForm(FlaskForm):
     """docstring for StrFiltersForm"""
 
     variant_type = HiddenField(default="clinical")
-
     chrom = TextField("Chromosome")
     gene_panels = SelectMultipleField(choices=[])
     repids = TagListField()
@@ -158,14 +154,9 @@ class SvFiltersForm(VariantFiltersForm):
     size = TextField("Length")
     size_shorter = BooleanField("Length shorter than")
     svtype = SelectMultipleField("SVType", choices=SV_TYPE_CHOICES)
-
     decipher = BooleanField("Decipher")
     clingen_ngi = IntegerField("ClinGen NGI obs")
     swegen = IntegerField("SweGen obs")
 
-    cytoband_start = SelectField("Cytoband start", choices=[])
-    cytoband_end = SelectField("Cytoband end", choices=[])
-
-    filter_variants = SubmitField(label="Filter variants")
     clinical_filter = SubmitField(label="Clinical filter")
     export = SubmitField(label="Filter and export")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -112,6 +112,7 @@ class VariantFiltersForm(FlaskForm):
     cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
     filter_variants = SubmitField(label="Filter variants")
 
+
 class FiltersForm(VariantFiltersForm):
     """Base FiltersForm for SNVs - extends VariantFiltersForm."""
 

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -1,11 +1,16 @@
 function populateCytobands(cytobands){
   var chrom = document.forms["filters_form"].elements["chrom"].value;
-
+    console.log("chrom:")
+    console.log(chrom)
+    console.log("cytobands:")
+    console.log(cytobands)
   if(chrom===""){
+      console.log("chrom='' -> start to '' ")
     startElem.value = "";
     endElem.value = "";
     return //only reset cytoband select element
   }
+
 
   var chrom_cytobands = cytobands[chrom]["cytobands"]; // chromosome-specific cytobands
 
@@ -49,6 +54,7 @@ function populateCytobands(cytobands){
 }
 
 function populateStart(){
+    console.log("populateStart()")
   startElem.value = cytoStart.options[cytoStart.selectedIndex].value
 }
 

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -1,13 +1,6 @@
 function populateCytobands(cytobands){
-    var chrom = document.forms["filters_form"].elements["chrom"].value;
-    console.log("chrom:")
-    console.log(chrom)
-    console.log("cytobands:")
-    console.log(cytobands)
-    console.log("forms:")
-    console.log(document.forms)
+  var chrom = document.forms["filters_form"].elements["chrom"].value;
   if(chrom===""){
-      console.log("chrom='' -> start to '' ")
     startElem.value = "";
     endElem.value = "";
     return //only reset cytoband select element
@@ -56,7 +49,6 @@ function populateCytobands(cytobands){
 }
 
 function populateStart(){
-    console.log("populateStart()")
   startElem.value = cytoStart.options[cytoStart.selectedIndex].value
 }
 

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -48,10 +48,51 @@ function populateCytobands(cytobands){
   }
 }
 
-function populateStart(){
-  startElem.value = cytoStart.options[cytoStart.selectedIndex].value
+
+
+// ValidateForm()
+// Controll user input fields (start, end) in varaint filter.
+//
+function validateForm(){
+    var start = document.forms["filters_form"].elements["start"].value
+    var end = document.forms["filters_form"].elements["end"].value
+    if(start || end){
+        if(!chrom){
+            alert("Chromosome field is required");
+            return false;
+        }
+        else if( !start || !end){
+            alert("Both start and end coordinates are required");
+            return false;
+        }
+        else if( (isNaN(start) || isNaN(end)) || Number(end)<Number(start) ){
+            alert("Coordinate field not valid");
+            return false;
+        }
+    }
+    return true;
 }
 
-function populateEnd(){
-  endElem.value = cytoEnd.options[cytoEnd.selectedIndex].value
+
+// syncSearchConstraints(selectorId:HTML-selector, textId:HTML-textfield)
+//
+// Initialize and synchronize 'startelem' and 'cyto_start', used for setting
+// contrsaints when searching variants in cytoband.
+function initSearchConstraints(selectorId, textId){
+    console.log("init cytoband search: selector and text")
+    selectorId.addEventListener("change", function() {
+        if(selectorId.options[selectorId.selectedIndex].value === ""){
+            textId.value = "";
+            return
+        }
+        // populate textfield
+        textId.value = selectorId.options[selectorId.selectedIndex].value
+    });
 }
+
+
+
+
+
+
+

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -1,9 +1,11 @@
 function populateCytobands(cytobands){
-  var chrom = document.forms["filters_form"].elements["chrom"].value;
+    var chrom = document.forms["filters_form"].elements["chrom"].value;
     console.log("chrom:")
     console.log(chrom)
     console.log("cytobands:")
     console.log(cytobands)
+    console.log("forms:")
+    console.log(document.forms)
   if(chrom===""){
       console.log("chrom='' -> start to '' ")
     startElem.value = "";

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -251,7 +251,27 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
-  <script>
+  <script src="{{ url_for('variants.static', filename='form_scripts.js') }}"></script>
+  <script type="text/javascript">
+
+    var startElem = document.getElementById("start");
+    var endElem = document.getElementById("end");
+
+    var chromSel = document.getElementById("chrom");
+    chromSel.addEventListener("change", function() {
+      populateCytobands({{cytobands|safe}});
+    });
+
+    var cytoStart = document.getElementById("cytoband_start");
+    initSearchConstraints(cytoStart, startElem)
+
+    var cytoEnd = document.getElementById("cytoband_end");
+    initSearchConstraints(cytoEnd, endElem)
+
+    window.onload=function() {
+        populateCytobands({{cytobands|safe}});
+    }
+
     $('select[multiple]').selectpicker({
       width: '100%'
     });

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -180,25 +180,10 @@
     });
 
     var cytoStart = document.getElementById("cytoband_start");
-
-    cytoStart.addEventListener("change", function() {
-        if(cytoStart.options[cytoStart.selectedIndex].value === ""){
-            console.log("start empty")
-            startElem.value = "";
-            return
-        }
-        populateStart();
-    });
+    initSearchConstraints(cytoStart, startElem)
 
     var cytoEnd = document.getElementById("cytoband_end");
-
-    cytoEnd.addEventListener("change", function() {
-        if(cytoEnd.options[cytoEnd.selectedIndex].value === ""){
-            endElem.value = "";
-            return
-        }
-        populateEnd();
-    });
+    initSearchConstraints(cytoEnd, endElem)
 
 
     $('select[multiple]').selectpicker({
@@ -208,27 +193,6 @@
 
     window.onload=function() {
         populateCytobands({{cytobands|safe}});
-    }
-
-
-    function validateForm(){
-      var start = document.forms["filters_form"].elements["start"].value
-      var end = document.forms["filters_form"].elements["end"].value
-      if(start || end){
-        if(!chrom){
-          alert("Chromosome field is required");
-          return false;
-        }
-        else if( !start || !end){
-          alert("Both start and end coordinates are required");
-          return false;
-        }
-        else if( (isNaN(start) || isNaN(end)) || Number(end)<Number(start) ){
-          alert("Coordinate field not valid");
-          return false;
-        }
-      }
-      return true;
     }
 
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -200,16 +200,18 @@
         populateEnd();
     });
 
+
+    $('select[multiple]').selectpicker({
+      width: '100%'
+    });
+
+    
+    window.onload=function() {
+        populateCytobands({{cytobands|safe}});
+    }
+
+
     function validateForm(){
-      var valid_chroms = [];
-      i = 1;
-      while(valid_chroms.push(i++) <22){};
-      valid_chroms.push("X","Y","MT");
-      var chrom = document.forms["filters_form"].elements["chrom"].value;
-      if(chrom && !valid_chroms.map(String).includes(chrom)){
-        alert("Chromosome field is not valid. Accepted values are: "+valid_chroms)
-        return false
-      }        
       var start = document.forms["filters_form"].elements["start"].value
       var end = document.forms["filters_form"].elements["end"].value
       if(start || end){
@@ -221,25 +223,18 @@
           alert("Both start and end coordinates are required");
           return false;
         }
-        else if( (isNaN(start) || isNaN(end)) || Number(end)<number(start) ){
+        else if( (isNaN(start) || isNaN(end)) || Number(end)<Number(start) ){
           alert("Coordinate field not valid");
           return false;
         }
       }
       return true;
     }
-    
 
     $('select[multiple]').selectpicker({
       width: '100%'
     });
 
-    
-    window.onload=function() {
-        populateCytobands({{cytobands|safe}});
-    }
-
-    
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();
       $('[data-toggle="popover"]').popover({

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -205,7 +205,7 @@
       width: '100%'
     });
 
-    
+
     window.onload=function() {
         populateCytobands({{cytobands|safe}});
     }
@@ -231,9 +231,6 @@
       return true;
     }
 
-    $('select[multiple]').selectpicker({
-      width: '100%'
-    });
 
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -167,7 +167,79 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
-  <script>
+
+  <script src="{{ url_for('variants.static', filename='form_scripts.js') }}"></script>
+  <script type="text/javascript">
+
+    var startElem = document.getElementById("start");
+    var endElem = document.getElementById("end");
+
+    var chromSel = document.getElementById("chrom");
+    chromSel.addEventListener("change", function() {
+        populateCytobands({{cytobands|safe}});
+    });
+
+    var cytoStart = document.getElementById("cytoband_start");
+
+    cytoStart.addEventListener("change", function() {
+        if(cytoStart.options[cytoStart.selectedIndex].value === ""){
+            console.log("start empty")
+            startElem.value = "";
+            return
+        }
+        populateStart();
+    });
+
+    var cytoEnd = document.getElementById("cytoband_end");
+
+    cytoEnd.addEventListener("change", function() {
+        if(cytoEnd.options[cytoEnd.selectedIndex].value === ""){
+            endElem.value = "";
+            return
+        }
+        populateEnd();
+    });
+
+    function validateForm(){
+      var valid_chroms = [];
+      i = 1;
+      while(valid_chroms.push(i++) <22){};
+      valid_chroms.push("X","Y","MT");
+      var chrom = document.forms["filters_form"].elements["chrom"].value;
+      if(chrom && !valid_chroms.map(String).includes(chrom)){
+        alert("Chromosome field is not valid. Accepted values are: "+valid_chroms)
+        return false
+      }        
+      var start = document.forms["filters_form"].elements["start"].value
+      var end = document.forms["filters_form"].elements["end"].value
+      if(start || end){
+        if(!chrom){
+          alert("Chromosome field is required");
+          return false;
+        }
+        else if( !start || !end){
+          alert("Both start and end coordinates are required");
+          return false;
+        }
+        else if( (isNaN(start) || isNaN(end)) || Number(end)<number(start) ){
+          alert("Coordinate field not valid");
+          return false;
+        }
+      }
+      return true;
+    }
+    
+
+    $('select[multiple]').selectpicker({
+      width: '100%'
+    });
+
+    
+    window.onload=function() {
+        populateCytobands({{cytobands|safe}});
+    }
+
+    
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();
       $('[data-toggle="popover"]').popover({

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -190,34 +190,6 @@
     });
 
 
-    function validateForm(){
-        var valid_chroms = [];
-        i = 1;
-        while(valid_chroms.push(i++) <22){};
-        valid_chroms.push("X","Y","MT");
-        var chrom = document.forms["filters_form"].elements["chrom"].value;
-        if(chrom && !valid_chroms.map(String).includes(chrom)){
-            alert("Chromosome field is not valid. Accepted values are: "+valid_chroms)
-            return false
-        }
-        var start = document.forms["filters_form"].elements["start"].value
-        var end = document.forms["filters_form"].elements["end"].value
-        if(start || end){
-            if(!chrom){
-                alert("Chromosome field is required");
-                return false;
-            }
-            else if( !start || !end){
-                alert("Both start and end coordinates are required");
-                return false;
-            }
-            else if( (isNaN(start) || isNaN(end)) || end<start ){
-                alert("Coordinate field not valid");
-                return false;
-            }
-        }
-        return true;
-    }
 
     $('select[multiple]').selectpicker({
         width: '100%'

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -185,7 +185,6 @@
         populateCytobands({{cytobands|safe}});
     }
 
-    <script>
     $(function () {
         $('[data-toggle="tooltip"]').tooltip();
         $('[data-toggle="popover"]').popover({

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -169,7 +169,7 @@
     chromSel.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
     });
-    
+
     var cytoStart = document.getElementById("cytoband_start");
 
     cytoStart.addEventListener("change", function() {
@@ -191,40 +191,40 @@
 
 
     function validateForm(){
-      var valid_chroms = [];
-      i = 1;
-      while(valid_chroms.push(i++) <22){};
-      valid_chroms.push("X","Y","MT");
-      var chrom = document.forms["filters_form"].elements["chrom"].value;
-      if(chrom && !valid_chroms.map(String).includes(chrom)){
-        alert("Chromosome field is not valid. Accepted values are: "+valid_chroms)
-        return false
-      }
-      var start = document.forms["filters_form"].elements["start"].value
-      var end = document.forms["filters_form"].elements["end"].value
-      if(start || end){
-        if(!chrom){
-          alert("Chromosome field is required");
-          return false;
+        var valid_chroms = [];
+        i = 1;
+        while(valid_chroms.push(i++) <22){};
+        valid_chroms.push("X","Y","MT");
+        var chrom = document.forms["filters_form"].elements["chrom"].value;
+        if(chrom && !valid_chroms.map(String).includes(chrom)){
+            alert("Chromosome field is not valid. Accepted values are: "+valid_chroms)
+            return false
         }
-        else if( !start || !end){
-          alert("Both start and end coordinates are required");
-          return false;
+        var start = document.forms["filters_form"].elements["start"].value
+        var end = document.forms["filters_form"].elements["end"].value
+        if(start || end){
+            if(!chrom){
+                alert("Chromosome field is required");
+                return false;
+            }
+            else if( !start || !end){
+                alert("Both start and end coordinates are required");
+                return false;
+            }
+            else if( (isNaN(start) || isNaN(end)) || end<start ){
+                alert("Coordinate field not valid");
+                return false;
+            }
         }
-        else if( (isNaN(start) || isNaN(end)) || end<start ){
-          alert("Coordinate field not valid");
-          return false;
-        }
-      }
-      return true;
+        return true;
     }
 
     $('select[multiple]').selectpicker({
-      width: '100%'
+        width: '100%'
     });
 
     window.onload=function() {
-      populateCytobands({{cytobands|safe}});
+        populateCytobands({{cytobands|safe}});
     }
 
     <script>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -171,24 +171,10 @@
     });
 
     var cytoStart = document.getElementById("cytoband_start");
-
-    cytoStart.addEventListener("change", function() {
-      if(cytoStart.options[cytoStart.selectedIndex].value === ""){
-        startElem.value = "";
-        return
-      }
-      populateStart();
-    });
+    initSearchConstraints(cytoStart, startElem)
 
     var cytoEnd = document.getElementById("cytoband_end");
-    cytoEnd.addEventListener("change", function() {
-      if(cytoEnd.options[cytoEnd.selectedIndex].value === ""){
-        endElem.value = "";
-        return
-      }
-      populateEnd();
-    });
-
+    initSearchConstraints(cytoEnd, endElem)
 
 
     $('select[multiple]').selectpicker({

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -169,7 +169,7 @@
     chromSel.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
     });
-
+    
     var cytoStart = document.getElementById("cytoband_start");
 
     cytoStart.addEventListener("change", function() {
@@ -189,10 +189,6 @@
       populateEnd();
     });
 
-
-    window.onload=function() {
-      populateCytobands({{cytobands|safe}});
-    }
 
     function validateForm(){
       var valid_chroms = [];
@@ -227,14 +223,19 @@
       width: '100%'
     });
 
+    window.onload=function() {
+      populateCytobands({{cytobands|safe}});
+    }
+
+    <script>
     $(function () {
-      $('[data-toggle="tooltip"]').tooltip();
-      $('[data-toggle="popover"]').popover({
-        sanitizeFn: function (content) {
-          return DOMPurify.sanitize(content)
-        },
-        container: 'body',
-      });
+        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-toggle="popover"]').popover({
+            sanitizeFn: function (content) {
+                return DOMPurify.sanitize(content)
+            },
+            container: 'body',
+        });
     })
   </script>
 {% endblock %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -454,23 +454,30 @@
     </div>
     <div class="form-group" id="chromosome_search">
       <div class="row" style="margin-top:20px;">
-        <div class="col-1">
+        <div class="col-1" style="margin-right:3em">
           {{ wtf.form_field(form.chrom) }}
         </div>
+        <div class="col-3" style="margin-right:3em">
+          <div class="row">
+            <div class="col-6" style="margin-right-xl">
+              {{ wtf.form_field(form.start) }}
+            </div>
+            <div class="col-6">
+              {{ wtf.form_field(form.end) }}
+            </div>
+          </div>
+        </div>
+        <div class="col-3">        
+          <div class="row">
+            <div class="col-6">
+              {{ wtf.form_field(form.cytoband_start) }}
+            </div>
+            <div class="col-6">
+              {{ wtf.form_field(form.cytoband_end) }}
+            </div>
+          </div>
+        </div>
         <div class="col-1" id="create_space"></div>
-        <div class="col-1" style="margin-right-xl">
-          {{ wtf.form_field(form.start) }}
-        </div>
-        <div class="col-1">
-          {{ wtf.form_field(form.end) }}
-        </div>
-        <div class="col-1" id="create_space"></div>
-        <div class="col-2">
-          {{ wtf.form_field(form.cytoband_start) }}
-        </div>
-        <div class="col-2">
-          {{ wtf.form_field(form.cytoband_end) }}
-        </div>
 
       </div>
     </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -457,25 +457,19 @@
         <div class="col-1" style="margin-right:3em">
           {{ wtf.form_field(form.chrom) }}
         </div>
-        <div class="col-3" style="margin-right:3em">
-          <div class="row">
-            <div class="col-6" style="margin-right-xl">
+
+        <div class="col-1">
               {{ wtf.form_field(form.start) }}
-            </div>
-            <div class="col-6">
-              {{ wtf.form_field(form.end) }}
-            </div>
-          </div>
         </div>
-        <div class="col-4">        
-          <div class="row">
-            <div class="col-6">
-              {{ wtf.form_field(form.cytoband_start) }}
-            </div>
-            <div class="col-6">
-              {{ wtf.form_field(form.cytoband_end) }}
-            </div>
-          </div>
+        <div class="col-1" style="margin-right:3em">
+          {{ wtf.form_field(form.end) }}
+        </div>
+
+        <div class="col-2">        
+          {{ wtf.form_field(form.cytoband_start) }}
+        </div>
+        <div class="col-2">
+          {{ wtf.form_field(form.cytoband_end) }}
         </div>
       </div>
     </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -458,21 +458,23 @@
           {{ wtf.form_field(form.chrom) }}
         </div>
 
-        <div class="col-1">
-              {{ wtf.form_field(form.start) }}
+        <div class="col-md-2 col-lg-2 col-xl-1">
+          {{ wtf.form_field(form.start) }}
         </div>
-        <div class="col-1" style="margin-right:3em">
+        <div class="col-md-2 col-lg-2 col-xl-1" style="margin-right:3em">
           {{ wtf.form_field(form.end) }}
         </div>
 
-        <div class="col-2">        
+        <div class="col-md-3 col-lg-3 col-xl-2">
           {{ wtf.form_field(form.cytoband_start) }}
         </div>
-        <div class="col-2">
+        <div class="col-md-3 col-lg-3 col-xl-2">
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
+        <div class="col-md-1 col-lg-1 col-xl-5" id="empty_space"></div>
       </div>
     </div>
+
     <div class="form-group" id="buttons">
       <div class="row">
         <div class="col-3">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -467,7 +467,7 @@
             </div>
           </div>
         </div>
-        <div class="col-3">        
+        <div class="col-4">        
           <div class="row">
             <div class="col-6">
               {{ wtf.form_field(form.cytoband_start) }}
@@ -477,8 +477,6 @@
             </div>
           </div>
         </div>
-        <div class="col-1" id="create_space"></div>
-
       </div>
     </div>
     <div class="form-group" id="buttons">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -452,23 +452,28 @@
         </div>
       </div>
     </div>
-    <div class="form-group" id="start_end_filter">
-      <div class="row justify-content-between" style="margin-top:20px;">
+    <div class="form-group" id="chromosome_search">
+      <div class="row" style="margin-top:20px;">
         <div class="col-1">
           {{ wtf.form_field(form.chrom) }}
         </div>
-        <div class="col-2">
+        <div class="col-1" id="create_space"></div>
+        <div class="col-1" style="margin-right-xl">
           {{ wtf.form_field(form.start) }}
         </div>
-        <div class="col-2">
+        <div class="col-1">
           {{ wtf.form_field(form.end) }}
         </div>
-        <div class="col">
+        <div class="col-1" id="create_space"></div>
+        <div class="col-2">
+          {{ wtf.form_field(form.cytoband_start) }}
+        </div>
+        <div class="col-2">
+          {{ wtf.form_field(form.cytoband_end) }}
         </div>
 
       </div>
     </div>
-
     <div class="form-group" id="buttons">
       <div class="row">
         <div class="col-3">

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -177,48 +177,17 @@
     });
 
     var cytoStart = document.getElementById("cytoband_start");
-
-    cytoStart.addEventListener("change", function() {
-      if(cytoStart.options[cytoStart.selectedIndex].value === ""){
-        startElem.value = "";
-        return
-      }
-      populateStart();
-    });
-
+    initSearchConstraints(cytoStart, startElem)
+    
     var cytoEnd = document.getElementById("cytoband_end");
-    cytoEnd.addEventListener("change", function() {
-      if(cytoEnd.options[cytoEnd.selectedIndex].value === ""){
-        endElem.value = "";
-        return
-      }
-      populateEnd();
-    });
+    initSearchConstraints(cytoEnd, endElem)
+
+
 
     window.onload=function() {
       populateCytobands({{cytobands|safe}});
     }
-
-    function validateForm(){
-      var start = document.forms["filters_form"].elements["start"].value
-      var end = document.forms["filters_form"].elements["end"].value
-      if(start || end){
-        if(!chrom){
-          alert("Chromosome field is required");
-          return false;
-        }
-        else if( !start || !end){
-          alert("Both start and end coordinates are required");
-          return false;
-        }
-        else if( (isNaN(start) || isNaN(end)) || Number(end)<Number(start) ){
-          alert("Coordinate field not valid");
-          return false;
-        }
-      }
-      return true;
-    }
-
+    
     $('select[multiple]').selectpicker({
       width: '100%'
     });

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -54,11 +54,15 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
+        LOG.debug("variants/POST")
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
+        LOG.debug(" POST VARIANTSform = controllers.populate_sv_filters_form(..): {}".format(form))
     else:
+        LOG.debug("variants(else:)")
         form = FiltersForm(request.args)
+        LOG.debug("GET VARIANTSform = controllers.populate_sv_filters_form(..): {}".format(form))
         # set form variant data type the first time around
         form.variant_type.data = variant_type
         form.chrom.data = request.args.get("chrom", None)
@@ -215,9 +219,9 @@ def sv_variants(institute_id, case_name):
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
-
     form = controllers.populate_sv_filters_form(store, institute_obj, case_obj, category, request)
     cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
+    LOG.debug("form = controllers.populate_sv_filters_form(..): {}".form)
 
     variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
     # if variants should be exported
@@ -249,9 +253,12 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
+        LOG.debug("cancer/POST")
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
+        LOG.debug(" POST form = controllers.populate_sv_filters_form(..): {}".format(form))
+
         if form.validate_on_submit() is False:
             # Flash a message with errors
             for field, err_list in form.errors.items():
@@ -269,8 +276,10 @@ def cancer_variants(institute_id, case_name):
         page = int(request.form.get("page", 1))
 
     else:
+        LOG.debug("GET, no form")
         page = int(request.args.get("page", 1))
         form = CancerFiltersForm(request.args)
+        form.chrom.data = request.args.get("chrom", None)
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
@@ -287,8 +296,11 @@ def cancer_variants(institute_id, case_name):
     form.gene_panels.choices = panel_choices
 
     variant_type = request.args.get("variant_type", "clinical")
+    LOG.debug("cancer_variants -form: {}".format(form))
     data = controllers.cancer_variants(store, institute_id, case_name, form, page=page)
-    return dict(variant_type=variant_type, **data)
+    cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
+    LOG.debug("cancer_variants HTML")
+    return dict(variant_type=variant_type, cytobands=cytobands, **data)
 
 
 @variants_bp.route("/<institute_id>/<case_name>/cancer/sv-variants", methods=["GET", "POST"])

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -54,15 +54,11 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
-        LOG.debug("variants/POST")
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
-        LOG.debug(" POST VARIANTSform = controllers.populate_sv_filters_form(..): {}".format(form))
     else:
-        LOG.debug("variants(else:)")
         form = FiltersForm(request.args)
-        LOG.debug("GET VARIANTSform = controllers.populate_sv_filters_form(..): {}".format(form))
         # set form variant data type the first time around
         form.variant_type.data = variant_type
         form.chrom.data = request.args.get("chrom", None)
@@ -221,7 +217,6 @@ def sv_variants(institute_id, case_name):
     controllers.activate_case(store, institute_obj, case_obj, current_user)
     form = controllers.populate_sv_filters_form(store, institute_obj, case_obj, category, request)
     cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
-    LOG.debug("form = controllers.populate_sv_filters_form(..): {}".form)
 
     variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
     # if variants should be exported
@@ -254,20 +249,16 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
-        LOG.debug("variants/cancer-variant/POST")
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
-        LOG.debug("POST form = controllers.populate_sv_filters_form(..): {}".format(form))
 
         if form.validate_on_submit() is False:
             # Flash a message with errors
-            LOG.debug("Validate is False")
             for field, err_list in form.errors.items():
                 for err in err_list:
                     flash(f"Content of field '{field}' has not a valid format", "warning")
             # And do not submit the form
-            LOG.debug("Redirect")
             return redirect(
                 url_for(
                     ".cancer_variants",
@@ -279,7 +270,6 @@ def cancer_variants(institute_id, case_name):
         page = int(request.form.get("page", 1))
 
     else:
-        LOG.debug("variants/cancer-variant/GET")
         page = int(request.args.get("page", 1))
         form = CancerFiltersForm(request.args)
         form.chrom.data = request.args.get("chrom", None)
@@ -299,10 +289,8 @@ def cancer_variants(institute_id, case_name):
     form.gene_panels.choices = panel_choices
 
     variant_type = request.args.get("variant_type", "clinical")
-    LOG.debug("cancer_variants -form: {}".format(form))
     data = controllers.cancer_variants(store, institute_id, case_name, form, page=page)
     cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
-    LOG.debug("cancer_variants HTML")
     return dict(variant_type=variant_type, cytobands=cytobands, **data)
 
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -251,20 +251,23 @@ def cancer_variants(institute_id, case_name):
 
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
 
+
     user_obj = store.user(current_user.email)
     if request.method == "POST":
-        LOG.debug("cancer/POST")
+        LOG.debug("variants/cancer-variant/POST")
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
-        LOG.debug(" POST form = controllers.populate_sv_filters_form(..): {}".format(form))
+        LOG.debug("POST form = controllers.populate_sv_filters_form(..): {}".format(form))
 
         if form.validate_on_submit() is False:
             # Flash a message with errors
+            LOG.debug("Validate is False")
             for field, err_list in form.errors.items():
                 for err in err_list:
                     flash(f"Content of field '{field}' has not a valid format", "warning")
             # And do not submit the form
+            LOG.debug("Redirect")
             return redirect(
                 url_for(
                     ".cancer_variants",
@@ -276,7 +279,7 @@ def cancer_variants(institute_id, case_name):
         page = int(request.form.get("page", 1))
 
     else:
-        LOG.debug("GET, no form")
+        LOG.debug("variants/cancer-variant/GET")
         page = int(request.args.get("page", 1))
         form = CancerFiltersForm(request.args)
         form.chrom.data = request.args.get("chrom", None)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -312,6 +312,8 @@ def cancer_sv_variants(institute_id, case_name):
 
     form = controllers.populate_sv_filters_form(store, institute_obj, case_obj, category, request)
 
+    cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
+
     variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
     # if variants should be exported
     if request.form.get("export"):
@@ -327,6 +329,7 @@ def cancer_sv_variants(institute_id, case_name):
         severe_so_terms=SEVERE_SO_TERMS,
         cancer_tier_options=CANCER_TIER_OPTIONS,
         manual_rank_options=MANUAL_RANK_OPTIONS,
+        cytobands=cytobands,
         page=page,
         **data,
     )


### PR DESCRIPTION
Adds support for cytoband search in cancer variants.

This is a copy of  #1390, but for Scout Cancer.

![Screenshot 2020-06-10 at 15 29 34](https://user-images.githubusercontent.com/1150065/84273670-3b9a4500-ab2f-11ea-8538-44ed21cba134.png)
The cytoband start and end selects are dynamic and their content depends on the selected chromosome. Once a cytoband start is selected it updates the start coordinate in the filters form. End coordinate works in the same way


**How to test**:
1. Cytobands collection can be populated in 2 ways:
 - `scout setup demo` or `scout setup`
 - `scout load cytobands` (--build to specify which build, otherwise both builds are used) 
2. After populating the cytobands collection in a local instance of Scout, go to the demo case, variants page. Use the cytoband start and end selects to filter variants
3.  Go to the structural variants page. Use the cytoband start and end selects to filter variants.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
