### PR TITLE
Handle the ProxyFix ModuleNotFoundError when Werkzeug installed version is >1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
+
 ### Added
 ### Fixed
+- Handle the ProxyFix ModuleNotFoundError when Werkzeug installed version is >1.0
+
 ### Changed
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,7 +70,7 @@ nav:
       - Whats new in 4.0?: 'blog/new-4.0.0.md'
       - Whats new in 4.7?: 'blog/new-4.7.3.md'
       - Whats new in 4.17?: 'blog/new-4.17.md'
-      - Whats new in 4.17?: 'blog/new-4.18.md'
+      - Whats new in 4.18?: 'blog/new-4.18.md'
 
   - About:
       -Glossary: 'GLOSSARY.md'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-Mail
 Flask-WeasyPrint
 coloredlogs
 query_phenomizer
-Flask-Babel
+Flask-Babel>=1.0.0 # Avoid errors with Werkzeug >=1.0.0
 livereload
 python-dateutil
 pymongo<3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Flask-Mail
 Flask-WeasyPrint
 coloredlogs
 query_phenomizer
-Flask-Babel>=1.0.0 # Avoid errors with Werkzeug >=1.0.0
+Flask-Babel
 livereload
 python-dateutil
 pymongo<3.7

--- a/scout/server/auto.py
+++ b/scout/server/auto.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
 
-from werkzeug.contrib.fixers import ProxyFix
+try:
+    from werkzeug.contrib.fixers import ProxyFix
+except ModuleNotFoundError:
+    # Werkzeug >1.0 moved the library to middleware : https://github.com/pallets/werkzeug/issues/1477
+    from werkzeug.middleware.proxy_fix import ProxyFix
 
 from .app import create_app
 


### PR DESCRIPTION
Fix #1970

**How to test**:
1. Go to the Scout test real environment on clinical-db stage and update the Werkzeug module with the following command:
`pip install Werkzeug -U`. Running `pip freeze` should show that the installed version of the library is >= 1.0.

1. Restart Scout with the supervisor command and note that the server can't be started (because of #1970).

1. Install this branch and  restart the server. This time the server should be up and running

1. ** Don't forget to reinstall the old library of Werkzeug (0.16) before leaving the test environment, since other software might be using it as well**

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
