### PR TITLE
Remove users as case assignees when their account is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 - Export dynamic HPO gene list from case page
+- Remove users as case assignees when their account is deleted
 
 ### Fixed
 - Handle the ProxyFix ModuleNotFoundError when Werkzeug installed version is >1.0

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -76,6 +76,7 @@ class CaseHandler(object):
         name_query=None,
         yield_query=False,
         within_days=None,
+        assignee=None,
     ):
         """Fetches all cases from the backend.
 
@@ -97,6 +98,7 @@ class CaseHandler(object):
             yield_query(bool): If true, only return mongo query dict for use in
                                 compound querying.
             within_days(int): timespan (in days) for latest event on case
+            assignee(str): email of an assignee
 
         Returns:
             Cases ordered by date.
@@ -149,6 +151,9 @@ class CaseHandler(object):
 
         if cohort:
             query["cohorts"] = {"$exists": True, "$ne": []}
+
+        if assignee:
+            query["assignees"] = {"$in": [assignee]}
 
         if name_query:
             name_value = name_query.split(":")[

--- a/scout/adapter/mongo/user.py
+++ b/scout/adapter/mongo/user.py
@@ -102,6 +102,5 @@ class UserHandler(object):
 
         """
         LOG.info("Deleting user %s", email)
-        user_obj = self.user_collection.delete_one({"email": email})
-
-        return user_obj
+        result = self.user_collection.delete_one({"email": email})
+        return result

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -26,28 +26,6 @@ def panel(panel_id, version):
         adapter.delete_panel(panel_obj)
 
 
-# @click.command('users', short_help='Display users')
-# @click.pass_context
-# def users(context):
-#     """Show all users in the database"""
-#     LOG.info("Running scout view users")
-#     adapter = context.obj['adapter']
-#
-#     ## TODO add a User interface to the adapter
-#     for user_obj in User.objects():
-#         click.echo(user_obj['name'])
-#
-# @click.command('institutes', short_help='Display institutes')
-# @click.pass_context
-# def institutes(context):
-#     """Show all institutes in the database"""
-#     LOG.info("Running scout view institutes")
-#     adapter = context.obj['adapter']
-#
-#     for institute_obj in adapter.institutes():
-#         click.echo(institute_obj['internal_id'])
-
-
 @click.command("index", short_help="Delete all indexes")
 @with_appcontext
 def index():
@@ -79,9 +57,9 @@ def user(mail):
     # remove this user as assignee from any case where it is found
     assigned_cases = adapter.cases(assignee=mail)
     updated_cases = 0
-    for case_obj in assigned_cases:
-        institute_obj = adapter.institute(case_obj["owner"])
-        with current_app.test_request_context("/cases"):
+    with current_app.test_request_context("/cases"):
+        for case_obj in assigned_cases:
+            institute_obj = adapter.institute(case_obj["owner"])
             link = url_for(
                 "cases.case", institute_id=institute_obj["_id"], case_name=case_obj["display_name"]
             )

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -65,7 +65,7 @@ def user(mail):
             )
             if adapter.unassign(institute_obj, case_obj, user_obj, link, True):
                 updated_cases += 1
-    click.echo(f"User was removed as assignee from {updated_cases} cases.")
+    click.echo(f"User was removed as assignee from {updated_cases} case(s).")
 
 
 @click.command("genes", short_help="Delete genes")


### PR DESCRIPTION
fix #1933 

When the user delete cli command is used it first deletes the user and then it removes it from any case where it is found as case assignee.

**How to test (local implementation of scout is fine)**:
1. setup a demo instance of scout with `scout setup demo`.
1. launch the server and go to the demo case page.
1. Assign yourself to the case.
1. Stop the server and run the following command from the cli: `scout --demo delete user -m clark.kent@mail.com`

**Expected outcome**:
The functionality should be working:
- it should say that the user was deleted
- it should say that the user was deleted as assignee from one case

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by ML
- [x] tests executed by CR, ML
