### PR TITLE
Show Internal ID and Add Internal ID to CGH-Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 
 ### Added
+- Show internal ID for case
+- Add internal ID for downloaded CGH files
 - Export dynamic HPO gene list from case page
 - Remove users as case assignees when their account is deleted
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -45,7 +45,9 @@
 <div class="container_spaced">
   <div class="card">
     <h4 class="card-header">Case: {{case.display_name}}</h4>
-      <p class="card-title {% if case.status == 'solved' %} bg-success {% elif case.status == 'archived' %} bg-danger-light {% endif %}">status: <strong>{{case.status}}</strong></p>
+    <p class="card-title {% if case.status == 'solved' %} bg-success {% elif case.status == 'archived' %} bg-danger-light {% endif %}">Status: <strong>{{case.status}}</strong>
+      <br>
+      Internal ID: <strong>{{case._id}}</strong></p>
     <div class="card-body">
 
       <div class="row text-center"> <!-- variants buttons -->

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -936,7 +936,7 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     outdir = os.path.abspath(os.path.dirname(vcf2cytosure))
     filename = os.path.basename(vcf2cytosure)
-    attachment_filename = display_name+"."+case_obj['_id']+".vcf2cytosure.cgh"
+    attachment_filename = display_name + "." + case_obj["_id"] + ".vcf2cytosure.cgh"
     LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
     return send_from_directory(
         outdir, filename, attachment_filename=attachment_filename, as_attachment=True

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -936,7 +936,7 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     outdir = os.path.abspath(os.path.dirname(vcf2cytosure))
     filename = os.path.basename(vcf2cytosure)
-    attachment_filename = display_name + "." + case_obj["_id"] + ".vcf2cytosure.cgh"
+    attachment_filename = ".".join([ display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh" ])
     LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
     return send_from_directory(
         outdir, filename, attachment_filename=attachment_filename, as_attachment=True

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -936,7 +936,9 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     outdir = os.path.abspath(os.path.dirname(vcf2cytosure))
     filename = os.path.basename(vcf2cytosure)
-    attachment_filename = ".".join([ display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh" ])
+    attachment_filename = ".".join(
+        [display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh"]
+    )
     LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
     return send_from_directory(
         outdir, filename, attachment_filename=attachment_filename, as_attachment=True

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -933,14 +933,11 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     (display_name, vcf2cytosure) = controllers.vcf2cytosure(
         store, institute_id, case_name, individual_id
     )
-
+    institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     outdir = os.path.abspath(os.path.dirname(vcf2cytosure))
     filename = os.path.basename(vcf2cytosure)
-
-    LOG.debug("Attempt to deliver file {0} from dir {1}".format(filename, outdir))
-
-    attachment_filename = display_name + ".vcf2cytosure.cgh"
-
+    attachment_filename = display_name+"."+case_obj['_id']+".vcf2cytosure.cgh"
+    LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
     return send_from_directory(
         outdir, filename, attachment_filename=attachment_filename, as_attachment=True
     )


### PR DESCRIPTION
Ref: #1686

This PR adds a functionality or fixes a bug.

**How to test**:
1. how to test it, possibly with real cases/data

Install `feature-#1686_show_internal_name-200707`.
a. Go to Case page:
-Internal ID should show
b. Download CGH
-File name should be <case-id>.<internal-id>.vcf2cytosure.cgh


**Expected outcome**:
The functionality should be working

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/1150065/86771567-c39e3c80-c052-11ea-9336-27bd3981d116.png">

**Review:**
- [ ] code approved by
- [ ] tests executed by
