### PR TITLE
Step Age as Integer Not Float

### DIFF
--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -100,7 +100,7 @@
                   <i class="fa fa-check"></i>
                 {% endif %}
               </td>
-              <td><input name="age_{{ind.individual_id}}" type="number" step="0.1" min="0"
+              <td><input name="age_{{ind.individual_id}}" type="number" step="1" min="0"
                   class="form-control col-8" value="{{ind.age}}"></td>
               <td>{{ ind.phenotype_human }}</td>
               <td>{{ ind.analysis_type|upper }}</td>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Age step as whole integers, not in 0.1 steps.

**How to test**:
1. how to test it, possibly with real cases/data

Go to 'Case' page. Increase/decrease age of sample individual -this is now done in whole steps. 


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.



![Screenshot 2020-07-10 at 13 55 08](https://user-images.githubusercontent.com/1150065/87151960-170fc500-c2b5-11ea-9627-092e38e0e6ba.png)


**Review:**
- [ ] code approved by
- [ ] tests executed by
