### PR TITLE
Make matchmaker results scrollable 1654

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Updated the documentation on how to create a new software release
 - Genome build-aware cytobands coordinates
+- Styling update of the Matchmaker card
 
 
 ## [4.19]

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -272,15 +272,15 @@
                 <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Match against&nbsp;<span class="caret"></span>
                 </button>
-                <ul class="dropdown-menu">
-                  <li><a href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='internal') }}">Scout patients in MatchMaker</a></li>
+                <div class="dropdown-menu">
+                  <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='internal') }}">Scout patients in MatchMaker</a></li>
                   {% if mme_nodes|length >1 %}
-                    <li><a href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='external') }}">All external nodes</a></li>
+                    <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='external') }}">All external nodes</a></li>
                   {% endif %}
                   {% for node in mme_nodes %}
-                    <li><a href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target=node.id) }}">{{node.description}}</a></li>
+                    <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target=node.id) }}">{{node.description}}</a></li>
                   {% endfor %}
-                </ul>
+                </div>
               </div>
               <a class="btn btn-outline-secondary" href="#mme_form" data-toggle="collapse">Modify submission</a>
             </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -262,28 +262,22 @@
 <div class="card panel-default">
     <div class="panel-heading">Matching patients</div>
     <div class="card-body">
-      {% if case.mme_submission %} <!-- case was aready submitted to MatchMaker -->
+      {% if case.mme_submission %} <!-- case was already submitted to MatchMaker -->
         <p>This case is in MatchMaker!</p>
         <p>
-          <div class="text-center">
-            <div class="btn-group" role="group" aria-label="...">
-              <a href="{{url_for('cases.matchmaker_matches', institute_id=institute._id, case_name=case.display_name)}}" class="btn btn-outline-secondary" role="button">Matches</a>
-              <div class="btn-group">
-                <button type="button" class="btn btn-outline-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Match against&nbsp;<span class="caret"></span>
-                </button>
-                <div class="dropdown-menu">
-                  <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='internal') }}">Scout patients in MatchMaker</a></li>
-                  {% if mme_nodes|length >1 %}
-                    <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='external') }}">All external nodes</a></li>
-                  {% endif %}
-                  {% for node in mme_nodes %}
-                    <a class="dropdown-item" href="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target=node.id) }}">{{node.description}}</a></li>
-                  {% endfor %}
-                </div>
-              </div>
-              <a class="btn btn-outline-secondary" href="#mme_form" data-toggle="collapse">Modify submission</a>
-            </div>
+          <div class="text-center matchmaker-grid">
+              <select class="custom-select matchmaker-grid-item1" onchange="window.open(this.value,'_self');">
+                   <option selected>Match against</option>
+                    <option value="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='internal') }}">Scout patients in MatchMaker</option>
+                    {% if mme_nodes|length >1 %}
+                    <option value="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target='external') }}">All external nodes</option>
+                    {% endif %}
+                    {% for node in mme_nodes %}
+                    <option value="{{ url_for('cases.matchmaker_match', institute_id=institute._id, case_name=case.display_name, target=node.id) }}">{{node.description}}</option>
+                 {% endfor %}
+              </select>
+              <a href="{{url_for('cases.matchmaker_matches', institute_id=institute._id, case_name=case.display_name)}}" class="btn btn-outline-secondary matchmaker-grid-item2" role="button">Matches</a>
+              <a class="btn btn-outline-secondary matchmaker-grid-item3" href="#mme_form" data-toggle="collapse">Modify submission</a>
           </div>
         </p>
       {% else %} <!-- display option to submit case to MatchMaker -->
@@ -430,7 +424,6 @@
         });
 </script>
 
-
 <script>
 $(function () {
 
@@ -507,6 +500,32 @@ $('[data-toggle=sidebar-collapse]').click(function() {
   SidebarCollapse();
 });
 </script>
+
+<style>
+/*Matchmaker card styling*/
+.matchmaker-grid {
+  display: grid;
+  grid-gap: 15px;
+  grid-template-columns: auto auto;
+  grid-template-rows: auto auto;
+}
+
+.matchmaker-grid-item1 {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.matchmaker-grid-item2 {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.matchmaker-grid-item3 {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+</style>
 
 {% if case.chromograph_prefixes %}
   {{ case_ideograms(institute, case) }}


### PR DESCRIPTION
This PR changes the style of the Matchmaker card
Now it looks like this:
![Aug-10-2020 15-06-29after](https://user-images.githubusercontent.com/6919697/89788563-a4963d00-db1f-11ea-8e70-b24a039cdfb5.gif)

**How to test**:
On stage this repo in scout-staging, and pick a case with a match in Matchmaker like 
https://scout-stage.scilifelab.se/cust101/A1383
Check out the matchmaker card

**Expected outcome**:
The functionality should be working

**Review:**
- [ x ] code approved by
- [ x  ] tests executed by
