### PR TITLE
Add peddy info (ancestry, sex check, parenthood) to demo case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 - Bug occurring when rerun is requested twice
+- Peddy info fields in the demo config file
 
 ### Changed
 - Updated the documentation on how to create a new software release

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -44,8 +44,8 @@ vcf_cancer_research: str(optional)
 madeline: str(optional)
 
 peddy_ped: str(optional)
-peddy_ped_check: str(optional)
-peddy_sex_check: str(optional)
+peddy_check: str(optional)
+peddy_sex: str(optional)
 
 multiqc: str(optional)
 
@@ -97,8 +97,8 @@ Let's go through each field:
 - **vcf_cancer_research**
 - **madeline** path to a madeline pedigree file in xml format
 - **peddy_ped** path to a [peddy][peddy] ped file with an analysis of the pedigree based on variant information
-- **peddy_ped_check** path to a [peddy][peddy] ped check file
-- **peddy_sex_check** path to a [peddy][peddy] ped check file
+- **peddy_check** path to a [peddy][peddy] ped check file
+- **peddy_sex** path to a [peddy][peddy] ped check file
 - **multiqc** path to a [multiqc][multiqc] report with arbitrary information
 - **default_gene_panels** list of default gene panels. Variants from the genes in the gene panels specified will be shown when opening the case in scout
 - **gene_panels** list of gene panels. This will specify what panels the case has been run with

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -98,7 +98,7 @@ Let's go through each field:
 - **madeline** path to a madeline pedigree file in xml format
 - **peddy_ped** path to a [peddy][peddy] ped file with an analysis of the pedigree based on variant information
 - **peddy_check** path to a [peddy][peddy] ped check file
-- **peddy_sex** path to a [peddy][peddy] ped check file
+- **peddy_sex** path to a [peddy][peddy] ped sex check file
 - **multiqc** path to a [multiqc][multiqc] report with arbitrary information
 - **default_gene_panels** list of default gene panels. Variants from the genes in the gene panels specified will be shown when opening the case in scout
 - **gene_panels** list of gene panels. This will specify what panels the case has been run with

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -54,8 +54,8 @@ vcf_sv_research: scout/demo/643594.research.SV.vcf.gz
 madeline: scout/demo/madeline.xml
 
 peddy_ped: scout/demo/643594.peddy.ped
-peddy_ped_check: scout/demo/643594.ped_check.csv
-peddy_sex_check: scout/demo/643594.sex_check.csv
+peddy_check: scout/demo/643594.ped_check.csv
+peddy_sex: scout/demo/643594.sex_check.csv
 
 delivery_report: scout/demo/delivery_report.html
 

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -23,6 +23,7 @@ from scout.resources import cytoband_files
 from scout.load import load_hgnc_genes, load_hpo, load_transcripts, load_cytobands
 
 # Resources
+from scout.parse.case import add_peddy_information
 from scout.parse.panel import parse_gene_panel
 from scout.utils.handle import get_file_handle
 from scout.utils.scout_requests import (
@@ -189,6 +190,7 @@ def setup_scout(
 
         case_handle = get_file_handle(load_path)
         case_data = yaml.load(case_handle, Loader=yaml.FullLoader)
+        add_peddy_information(case_data)
 
         adapter.load_case(case_data)
 

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -23,7 +23,7 @@ from scout.resources import cytoband_files
 from scout.load import load_hgnc_genes, load_hpo, load_transcripts, load_cytobands
 
 # Resources
-from scout.parse.case import add_peddy_information, parse_case_data
+from scout.parse.case import parse_case_data
 from scout.parse.panel import parse_gene_panel
 from scout.utils.handle import get_file_handle
 from scout.utils.scout_requests import (

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -23,7 +23,7 @@ from scout.resources import cytoband_files
 from scout.load import load_hgnc_genes, load_hpo, load_transcripts, load_cytobands
 
 # Resources
-from scout.parse.case import add_peddy_information
+from scout.parse.case import add_peddy_information, parse_case_data
 from scout.parse.panel import parse_gene_panel
 from scout.utils.handle import get_file_handle
 from scout.utils.scout_requests import (
@@ -190,9 +190,8 @@ def setup_scout(
 
         case_handle = get_file_handle(load_path)
         case_data = yaml.load(case_handle, Loader=yaml.FullLoader)
-        add_peddy_information(case_data)
-
-        adapter.load_case(case_data)
+        config_data = parse_case_data(config=case_data)
+        adapter.load_case(config_data)
 
     LOG.info("Creating indexes")
     adapter.load_indexes()

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -112,12 +112,8 @@ def parse_case_data(
 
     ##################### Add information from peddy if existing #####################
     config_data["peddy_ped"] = peddy_ped or config_data.get("peddy_ped")
-    config_data["peddy_sex_check"] = (
-        peddy_sex or config_data.get("peddy_sex") or config_data.get("peddy_sex_check")
-    )
-    config_data["peddy_ped_check"] = (
-        peddy_check or config_data.get("peddy_check") or config_data.get("peddy_ped_check")
-    )
+    config_data["peddy_sex_check"] = peddy_sex or config_data.get("peddy_sex")
+    config_data["peddy_ped_check"] = peddy_check or config_data.get("peddy_check")
 
     # This will add information from peddy to the individuals
     add_peddy_information(config_data)

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -112,8 +112,12 @@ def parse_case_data(
 
     ##################### Add information from peddy if existing #####################
     config_data["peddy_ped"] = peddy_ped or config_data.get("peddy_ped")
-    config_data["peddy_sex_check"] = peddy_sex or config_data.get("peddy_sex")
-    config_data["peddy_ped_check"] = peddy_check or config_data.get("peddy_check")
+    config_data["peddy_sex_check"] = (
+        peddy_sex or config_data.get("peddy_sex") or config_data.get("peddy_sex_check")
+    )
+    config_data["peddy_ped_check"] = (
+        peddy_check or config_data.get("peddy_check") or config_data.get("peddy_ped_check")
+    )
 
     # This will add information from peddy to the individuals
     add_peddy_information(config_data)


### PR DESCRIPTION
Fix #1989 

The current demo setup doesn't parse the peddy info, so the demo case is missing this info. And when it's uploaded, the case (individuals table) looks like this:

![image](https://user-images.githubusercontent.com/28093618/89871657-0dc98f00-dbb8-11ea-89fd-790bb7b64ef5.png)

This PR fixes the issue and when the same command is run from this branch the info is not missing any more.

**How to test**:
1. From a local instance of Scout, checkout to this branch and `run scout setup demo`
1. Launch the browser (`scout --demo serve`) and go to the demo case page.

Alternative test:
1. Force re-upload the demo case with this other command:
`scout --demo load case scout/demo/643594.config.yaml -u`
Also in this case the individual table should show the peddy info.

**Expected outcome**:
Individuals table should show:
- Sex check
- Ancestry prediction
- Parenthood

![image](https://user-images.githubusercontent.com/28093618/89871948-83355f80-dbb8-11ea-9ef0-49387b1d6400.png)


**Review:**
- [x] code approved by EM
- [x] tests executed by CR, EM
