### PR TITLE
Add action button to dismiss variants from list #2004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Display number of filtered variants vs number of total variants in variants page
 - Search case by HPO terms
+- Dismiss variant column in the variant tables.
 
 ### Fixed
 - Bug occurring when rerun is requested twice

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -46,7 +46,7 @@
     <label class="mt-3">Dismiss variant</label>
     <div class="row">
       <div class="col-8">
-        <select multiple="multiple" name="dismiss_variant" id="dismiss_variant" class="selectpicker">
+        <select multiple="multiple" name="dismiss_variant" id="dismiss_variant" class="selectpicker" data-width="100%">
           {% for rank, data in dismiss_variant_options.items() %}
             <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
               {{ data.label }}
@@ -63,9 +63,9 @@
 
 {% macro dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) %}
   <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
-    <div class="row justify-content-start">
+    <div class="row">
       <div class="col-lg-8"  style="width: 200px">
-        <select multiple="multiple" name="dismiss_variant" class="selectpicker dismiss-dropdown">
+        <select multiple="multiple" name="dismiss_variant" class="selectpicker dismiss-dropdown" data-width="100%">
           {% for rank, data in dismiss_variant_options.items() %}
             <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
               {{ data.label }}

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -46,7 +46,7 @@
     <label class="mt-3">Dismiss variant</label>
     <div class="row">
       <div class="col-8">
-        <select multiple="multiple" name="dismiss_variant" id="dismiss_variant" class="selectpicker" data-width="100%">
+        <select multiple="multiple" name="dismiss_variant" id="dismiss_variant" class="selectpicker">
           {% for rank, data in dismiss_variant_options.items() %}
             <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
               {{ data.label }}
@@ -56,6 +56,25 @@
       </div>
       <div class="col-4">
         <button type="submit" name="dismiss" class="btn btn-outline-secondary form-control">Save</button>
+      </div>
+    </div>
+  </form>
+{% endmacro %}
+
+{% macro dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) %}
+  <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
+    <div class="row justify-content-start">
+      <div class="col-lg-8"  style="width: 200px">
+        <select multiple="multiple" name="dismiss_variant" class="selectpicker dismiss-dropdown">
+          {% for rank, data in dismiss_variant_options.items() %}
+            <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
+              {{ data.label }}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="col-lg-4">
+        <button type="submit" name="dismiss" class="btn btn-outline-secondary form-control dismiss-button" style="width: 63px; margin-left: -15px;">Save</button>
       </div>
     </div>
   </form>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -39,22 +39,23 @@
 {% endblock %}
 
 {% block content_main %}
-<form method="POST" id="filters_form" action="{{url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name)}}" >
   <div class="container-float">
-    <div class="card panel-default" id="accordion">
-      <div class="card-header">
-        <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">SvFilters</a></strong>
+    <form method="POST" id="filters_form" action="{{url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name)}}" >
+      <div class="card panel-default" id="accordion">
+        <div class="card-header">
+          <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">SvFilters</a></strong>
+        </div>
+        <!--Expand filters form if filters were used in a previous POST request-->
+        <div id="collapseFilters" class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}">
+          <div class="card-body">{{ sv_filters(form, institute, case) }}</div>
+        </div>
+        <div class="card-footer text-center py-3">
+          {% if "all_variants" in session %}
+            Filtered {{session['filtered_variants']}} / {{session["all_variants"]}} variants
+          {% endif %}
+        </div>
       </div>
-      <!--Expand filters form if filters were used in a previous POST request-->
-      <div id="collapseFilters" class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}">
-        <div class="card-body">{{ sv_filters(form, institute, case) }}</div>
-      </div>
-      <div class="card-footer text-center py-3">
-        {% if "all_variants" in session %}
-          Filtered {{session['filtered_variants']}} / {{session["all_variants"]}} variants
-        {% endif %}
-      </div>
-    </div>
+    </form>
   </div>
   <div class="card mt-3">
     <table id="variantsTable" class="table table-hover table-bordered">
@@ -88,7 +89,6 @@
   <div class="container-fluid">
     {{ pagination() }}
   </div>
-</form>
 {% endblock %}
 
 {% macro filters_form() %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -38,11 +38,6 @@
   {{ super() }}
 {% endblock %}
 
-{% block css %}
-{{ super() }}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
-{% endblock %}
-
 {% block content_main %}
   <div class="container-float">
     <form method="POST" id="filters_form" action="{{url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name)}}" >

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,8 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
 {% from "variants/utils.html" import sv_filters,cell_rank %}
+{% from "variant/buttons.html" import dismiss_variant_table_button %}
+
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -59,6 +61,7 @@
       <thead>
         <tr>
           <th>Index</th>
+          <th style="width:4%" title="Dismiss variant">Dismiss variant</th>
           <th>Score</th>
           <th>Type</th>
           <th>Chr</th>
@@ -189,6 +192,7 @@
     <td>
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
+    <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
     <td>{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -67,7 +67,7 @@
       <thead>
         <tr>
           <th>Index</th>
-          <th style="width:4%" title="Dismiss variant">Dismiss variant</th>
+          <th style="width:18%" title="Dismiss variant">Dismiss variant</th>
           <th>Score</th>
           <th>Type</th>
           <th>Chr</th>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -38,6 +38,11 @@
   {{ super() }}
 {% endblock %}
 
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
+{% endblock %}
+
 {% block content_main %}
   <div class="container-float">
     <form method="POST" id="filters_form" action="{{url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name)}}" >

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -58,7 +58,7 @@
       <thead>
             <tr>
               <th style="width:4%" title="Rank position">Rank</th>
-              <th style="width:4%" title="Dismiss variant">Dismiss variant</th>
+              <th style="width:18%" title="Dismiss variant">Dismiss variant</th>
               <th>Gene:Transcript:Exon:HGVS</th>
               <th>Tier</th>
               <th>Score</th>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -1,6 +1,8 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 {% from "variants/utils.html" import cancer_filters, tier_cell, cell_rank %}
+{% from "variant/buttons.html" import dismiss_variant_table_button %}
+
 
 
 {% block title %}
@@ -56,6 +58,7 @@
       <thead>
             <tr>
               <th style="width:4%" title="Rank position">Rank</th>
+              <th style="width:4%" title="Dismiss variant">Dismiss variant</th>
               <th>Gene:Transcript:Exon:HGVS</th>
               <th>Tier</th>
               <th>Score</th>
@@ -75,7 +78,8 @@
           {% else %}
             <tr>
           {% endif %}
-              <td class="text-left">{{cell_rank(variant, institute, case, form, manual_rank_options)}}</td>
+            <td class="text-left">{{cell_rank(variant, institute, case, form, manual_rank_options)}}</td>
+            <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
             <td>
               <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
                                   variant_id=variant._id, cancer='yes') }}">

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -50,8 +50,8 @@
           Filtered {{session['filtered_variants']}} / {{session["all_variants"]}} variants
         {% endif %}
       </div>
+      </form>
     </div>
-
 
   <div class="card mt-3">
     <table class="table table-hover table-bordered">

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -12,11 +12,6 @@
 {% block css %}
 {{ super() }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
-<style>
-  .bootstrap-select {
-    width: 100% !important;
-  }
-</style>
 {% endblock %}
 
 {% block top_nav %}
@@ -49,7 +44,7 @@
       <thead>
         <tr>
           <th style="width:8%" title="Index">Index</th>
-          <th style="width:20%" title="Dismiss Variant">Dismiss variant</th>
+          <th style="width:18%" title="Dismiss Variant">Dismiss variant</th>
           <th style="width:6%" title="Repeat ID">Repeat locus</th>
           <th style="width:4%" title="Repeat unit">Reference repeat unit</th>
           <th style="width:4%" title="ALT">Estimated size</th>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -2,6 +2,8 @@
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 {% from "utils.html" import comments_table %}
 {% from "variants/utils.html" import cell_rank %}
+{% from "variant/buttons.html" import dismiss_variant_table_button %}
+
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - STR variants
@@ -37,10 +39,11 @@
       <thead>
         <tr>
           <th style="width:8%" title="Index">Index</th>
+          <th style="width:10%" title="Dismiss Variant">Dismiss variant</th>
           <th style="width:8%" title="Repeat ID">Repeat locus</th>
-          <th style="width:12%" title="Repeat unit">Reference repeat unit</th>
+          <th style="width:6%" title="Repeat unit">Reference repeat unit</th>
           <th style="width:8%" title="ALT">Estimated size</th>
-          <th style="width:8%" title="ReferenceSize">Reference size</th>
+          <th style="width:4%" title="ReferenceSize">Reference size</th>
           <th style="width:10%" title="Status">Status</th>
           <th style="width:8%" title="Max normal">Max normal</th>
           <th style="width:8%" title="Min pathologic">Min pathologic</th>
@@ -68,6 +71,7 @@
 	            <tr>
 	        {% endif %}
             <td>{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
+            <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
             <td>{{ variant.str_repid }}</td>
 	          <td class="text-right">{{ variant.str_ru }}</td>
             <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -9,6 +9,16 @@
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - STR variants
 {% endblock %}
 
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
+<style>
+  .bootstrap-select {
+    width: 100% !important;
+  }
+</style>
+{% endblock %}
+
 {% block top_nav %}
   {{ super() }}
   <li class="nav-item">
@@ -39,10 +49,10 @@
       <thead>
         <tr>
           <th style="width:8%" title="Index">Index</th>
-          <th style="width:10%" title="Dismiss Variant">Dismiss variant</th>
-          <th style="width:8%" title="Repeat ID">Repeat locus</th>
-          <th style="width:6%" title="Repeat unit">Reference repeat unit</th>
-          <th style="width:8%" title="ALT">Estimated size</th>
+          <th style="width:20%" title="Dismiss Variant">Dismiss variant</th>
+          <th style="width:6%" title="Repeat ID">Repeat locus</th>
+          <th style="width:4%" title="Repeat unit">Reference repeat unit</th>
+          <th style="width:4%" title="ALT">Estimated size</th>
           <th style="width:4%" title="ReferenceSize">Reference size</th>
           <th style="width:10%" title="Status">Status</th>
           <th style="width:8%" title="Max normal">Max normal</th>
@@ -150,6 +160,7 @@
   {{ super() }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
   <script>
     $(function () {
       $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -89,7 +89,6 @@
   <div class="container-fluid">
     {{ pagination() }}
   </div>
-</form>
 {% endblock %}
 
 {% macro variant_row(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -40,23 +40,24 @@
 {% endblock %}
 
 {% block content_main %}
-<form method="POST" id="filters_form" action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name)}}"
-  onsubmit="return validateForm()">
   <div class="container-float">
-    <div class="card panel-default" id="accordion">
-      <div class="card-header">
-        <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">SvFilters</a></strong>
-      </div>
-      <!--Expand filters form if filters were used in a previous POST request-->
-      <div id="collapseFilters" class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}">
-        <div class="card-body">{{ sv_filters(form, institute, case) }}</div>
-      </div>
-      <div class="card-footer text-center py-3">
-        {% if "all_variants" in session %}
-          Showing {{session['filtered_variants']}} / {{session["all_variants"]}} variants
-        {% endif %}
-      </div>
+    <form method="POST" id="filters_form" action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name)}}"
+  onsubmit="return validateForm()">
+      <div class="card panel-default" id="accordion">
+        <div class="card-header">
+          <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">SvFilters</a></strong>
+        </div>
+        <!--Expand filters form if filters were used in a previous POST request-->
+        <div id="collapseFilters" class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}">
+          <div class="card-body">{{ sv_filters(form, institute, case) }}</div>
+        </div>
+        <div class="card-footer text-center py-3">
+          {% if "all_variants" in session %}
+            Showing {{session['filtered_variants']}} / {{session["all_variants"]}} variants
+          {% endif %}
+        </div>
     </div>
+    </form>
   </div>
   <div class="card mt-3">
     <table id="variantsTable" class="table table-hover table-bordered">

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -2,6 +2,8 @@
 {% from "utils.html" import comments_table %}
 {% from "variants/utils.html" import sv_filters, cell_rank %}
 {% from "variants/components.html" import frequency_cell_general %}
+{% from "variant/buttons.html" import dismiss_variant_table_button %}
+
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -60,17 +62,17 @@
     <table id="variantsTable" class="table table-hover table-bordered">
       <thead>
         <tr>
-          <th>Rank</th>
-          <th>Score</th>
-          <th>Type</th>
-          <th>Chr</th>
-          <th>Start loc</th>
-          <th>Stop loc</th>
-          <th>Length</th>
-          <th>Region</th>
-          <th>Function</th>
-          <th>Frequency</th>
-          <th>Gene(s)</th>
+          <th style="width:12%">Rank</th>
+          <th style="width:18%">Dismiss variant</th>
+          <th style="width:8%">Type</th>
+          <th style="width:8%">Chr</th>
+          <th style="width:8%">Start loc</th>
+          <th style="width:8%">Stop loc</th>
+          <th style="width:8%">Length</th>
+          <th style="width:8%">Region</th>
+          <th style="width:8%">Function</th>
+          <th style="width:8%">Frequency</th>
+          <th style="width:8%">Gene(s)</th>
         </tr>
       </thead>
       <tbody>
@@ -99,6 +101,7 @@
     <td class="text-left">
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
+    <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
     <td class="text-right">{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -38,23 +38,24 @@
   {{ super() }}
 {% endblock %}
 {% block content_main %}
-  <form method="POST" id="filters_form" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name)}}"
-    enctype="multipart/form-data" onsubmit="return validateForm()">
     <div class="container-float">
-      <div class="card panel-default" id="accordion">
-        <div class="card-header">
-          <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">Filters</a></strong>
+       <form method="POST" id="filters_form" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name)}}"
+         enctype="multipart/form-data" onsubmit="return validateForm()">
+        <div class="card panel-default" id="accordion">
+          <div class="card-header">
+            <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">Filters</a></strong>
+          </div>
+          <!--Expand filters form if filters were used in a previous POST request-->
+          <div class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}" id="collapseFilters">
+              {{ snv_filters(form, institute, case) }}
+          </div>
+          <div class="card-footer text-center py-3">
+            {% if "all_variants" in session %}
+              Filtered {{session['filtered_variants']}} / {{session["all_variants"]}} variants
+            {% endif %}
+          </div>
         </div>
-        <!--Expand filters form if filters were used in a previous POST request-->
-        <div class="card-body panel-collapse collapse {{ 'show' if expand_search == 'True' }}" id="collapseFilters">
-            {{ snv_filters(form, institute, case) }}
-        </div>
-        <div class="card-footer text-center py-3">
-          {% if "all_variants" in session %}
-            Filtered {{session['filtered_variants']}} / {{session["all_variants"]}} variants
-          {% endif %}
-        </div>
-      </div>
+      </form>
       <div class="card mt-3">
         <table class="table table-hover table-bordered">
           <thead>
@@ -111,7 +112,6 @@
       </div><!-- end of <div class="card mt-3">-->
     </div> <!-- end of class="container-float"> -->
       {{ footer() }}
-  </form>
 {% endblock %}
 
 {% macro cell_cadd(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -1,6 +1,8 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/utils.html" import compounds_table, svs_table, snv_filters, cell_rank %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
+{% from "variant/buttons.html" import dismiss_variant_table_button %}
+
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ form.variant_type.data|capitalize }} variants
@@ -57,16 +59,17 @@
         <table class="table table-hover table-bordered">
           <thead>
             <tr>
-              <th style="width:12%" title="Rank position">Rank </th>
-              <th style="width:6%" title="Rank score">Score</th>
-              <th style="width:6%" title="Chromosome">Chr.</th>
+              <th style="width:4%" title="Rank position">Rank </th>
+              <th style="width:30%" title="Dismiss Variant">Dismiss variant</th>
+              <th style="width:4%" title="Rank score">Score</th>
+              <th style="width:4%" title="Chromosome">Chr.</th>
               <th style="width:8%" title="HGNC symbols">Gene</th>
-              <th style="width:8%" title="Poulation frequency">PopFreq</th>
-              <th style="width:8%" title="CADD score">CADD</th>
+              <th style="width:4%" title="Poulation frequency">PopFreq</th>
+              <th style="width:4%" title="CADD score">CADD</th>
               <th style="width:8%" title="Gene region annotation">Gene annotation</th>
-              <th style="width:18%"" title="Functional annotation">Func. annotation</th>
-              <th style="width:18%" title="Inheritance models">Inheritance model</th>
-              <th style="width:8%"" title="Overlapping">Overlapping</th>
+              <th style="width:14%" title="Functional annotation">Func. annotation</th>
+              <th style="width:12%" title="Inheritance models">Inheritance model</th>
+              <th style="width:4%" title="Overlapping">Overlapping</th>
             </tr>
           </thead>
           <tbody>
@@ -77,6 +80,7 @@
                 <tr>
               {% endif %}
                 <td class="text-left">{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
+                <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
                 <td class="text-right">{{ variant.rank_score|int }}</td>
                 <td>{{ variant.chromosome }}</td>
                 <td>{{ gene_cell(variant) }}</td>

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -159,15 +159,13 @@ def variants(institute_id, case_name):
     if request.form.get("export"):
         return controllers.download_variants(store, case_obj, variants_query)
 
-    dismiss_options = return_dismissed_variants(case_obj.get("track"))
-
     data = controllers.variants(store, institute_obj, case_obj, variants_query, page)
     return dict(
         institute=institute_obj,
         case=case_obj,
         form=form,
         manual_rank_options=MANUAL_RANK_OPTIONS,
-        dismiss_variant_options=dismiss_options,
+        dismiss_variant_options=DISMISS_VARIANT_OPTIONS,
         cancer_tier_options=CANCER_TIER_OPTIONS,
         severe_so_terms=SEVERE_SO_TERMS,
         cytobands=cytobands,
@@ -201,13 +199,12 @@ def str_variants(institute_id, case_name):
             ("position", pymongo.ASCENDING),
         ]
     )
-    dismiss_options = return_dismissed_variants(case_obj.get("track"))
 
     data = controllers.str_variants(store, institute_obj, case_obj, variants_query, page)
     return dict(
         institute=institute_obj,
         case=case_obj,
-        dismiss_variant_options=dismiss_options,
+        dismiss_variant_options=DISMISS_VARIANT_OPTIONS,
         variant_type=variant_type,
         manual_rank_options=MANUAL_RANK_OPTIONS,
         form=form,
@@ -247,12 +244,10 @@ def sv_variants(institute_id, case_name):
 
     data = controllers.sv_variants(store, institute_obj, case_obj, variants_query, page)
 
-    dismiss_options = return_dismissed_variants(case_obj.get("track"))
-
     return dict(
         institute=institute_obj,
         case=case_obj,
-        dismiss_variant_options=dismiss_options,
+        dismiss_variant_options=DISMISS_VARIANT_OPTIONS,
         variant_type=variant_type,
         form=form,
         cytobands=cytobands,
@@ -325,12 +320,13 @@ def cancer_variants(institute_id, case_name):
         store, institute_id, case_name, variants_query, form, page=page
     )
 
-    dismiss_options = return_dismissed_variants(case_obj.get("track"))
-
     return dict(
         variant_type=variant_type,
         cytobands=cytobands,
-        dismiss_variant_options=dismiss_options,
+        dismiss_variant_options={
+            **DISMISS_VARIANT_OPTIONS,
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
+        },
         expand_search=str(request.method == "POST"),
         **data,
     )
@@ -369,12 +365,13 @@ def cancer_sv_variants(institute_id, case_name):
 
     data = controllers.sv_variants(store, institute_obj, case_obj, variants_query, page)
 
-    dismiss_options = return_dismissed_variants(case_obj.get("track"))
-
     return dict(
         institute=institute_obj,
         case=case_obj,
-        dismiss_variant_options=dismiss_options,
+        dismiss_variant_options={
+            **DISMISS_VARIANT_OPTIONS,
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
+        },
         variant_type=variant_type,
         form=form,
         severe_so_terms=SEVERE_SO_TERMS,
@@ -418,7 +415,7 @@ def upload_panel(institute_id, case_name):
     # HTTP redirect code 307 asks that the browser preserves the method of request (POST).
     if category == "sv":
         return redirect(
-            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data,),
+            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data, ),
             code=307,
         )
     return redirect(
@@ -456,9 +453,3 @@ def download_verified():
         )
     flash("No verified variants could be exported for user's institutes", "warning")
     return redirect(request.referrer)
-
-
-def return_dismissed_variants(case_track, dismiss_options=DISMISS_VARIANT_OPTIONS):
-    if case_track == "cancer":
-        dismiss_options = {**DISMISS_VARIANT_OPTIONS, **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS}
-    return dismiss_options

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -21,7 +21,8 @@ from flask import (
 )
 from flask_login import current_user
 
-from scout.constants import CANCER_TIER_OPTIONS, MANUAL_RANK_OPTIONS, SEVERE_SO_TERMS
+from scout.constants import CANCER_TIER_OPTIONS, MANUAL_RANK_OPTIONS, SEVERE_SO_TERMS, DISMISS_VARIANT_OPTIONS, \
+    CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
 from scout.server.extensions import store
 from scout.server.utils import institute_and_case, templated
 
@@ -153,12 +154,16 @@ def variants(institute_id, case_name):
     if request.form.get("export"):
         return controllers.download_variants(store, case_obj, variants_query)
 
+    dismiss_options = return_dismissed_variants(case_obj.get("track"))
+
     data = controllers.variants(store, institute_obj, case_obj, variants_query, page)
     return dict(
         institute=institute_obj,
         case=case_obj,
+
         form=form,
         manual_rank_options=MANUAL_RANK_OPTIONS,
+        dismiss_variant_options=dismiss_options,
         cancer_tier_options=CANCER_TIER_OPTIONS,
         severe_so_terms=SEVERE_SO_TERMS,
         cytobands=cytobands,
@@ -192,10 +197,13 @@ def str_variants(institute_id, case_name):
             ("position", pymongo.ASCENDING),
         ]
     )
+    dismiss_options = return_dismissed_variants(case_obj.get("track"))
+
     data = controllers.str_variants(store, institute_obj, case_obj, variants_query, page)
     return dict(
         institute=institute_obj,
         case=case_obj,
+        dismiss_variant_options=dismiss_options,
         variant_type=variant_type,
         manual_rank_options=MANUAL_RANK_OPTIONS,
         form=form,
@@ -235,9 +243,12 @@ def sv_variants(institute_id, case_name):
 
     data = controllers.sv_variants(store, institute_obj, case_obj, variants_query, page)
 
+    dismiss_options = return_dismissed_variants(case_obj.get("track"))
+
     return dict(
         institute=institute_obj,
         case=case_obj,
+        dismiss_variant_options=dismiss_options,
         variant_type=variant_type,
         form=form,
         cytobands=cytobands,
@@ -310,9 +321,12 @@ def cancer_variants(institute_id, case_name):
         store, institute_id, case_name, variants_query, form, page=page
     )
 
+    dismiss_options = return_dismissed_variants(case_obj.get("track"))
+
     return dict(
         variant_type=variant_type,
         cytobands=cytobands,
+        dismiss_variant_options=dismiss_options,
         expand_search=str(request.method == "POST"),
         **data,
     )
@@ -351,9 +365,12 @@ def cancer_sv_variants(institute_id, case_name):
 
     data = controllers.sv_variants(store, institute_obj, case_obj, variants_query, page)
 
+    dismiss_options = return_dismissed_variants(case_obj.get("track"))
+
     return dict(
         institute=institute_obj,
         case=case_obj,
+        dismiss_variant_options=dismiss_options,
         variant_type=variant_type,
         form=form,
         severe_so_terms=SEVERE_SO_TERMS,
@@ -397,7 +414,7 @@ def upload_panel(institute_id, case_name):
     # HTTP redirect code 307 asks that the browser preserves the method of request (POST).
     if category == "sv":
         return redirect(
-            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data,),
+            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data, ),
             code=307,
         )
     return redirect(
@@ -435,3 +452,12 @@ def download_verified():
         )
     flash("No verified variants could be exported for user's institutes", "warning")
     return redirect(request.referrer)
+
+
+def return_dismissed_variants(case_track, dismiss_options=DISMISS_VARIANT_OPTIONS):
+    if case_track == "cancer":
+        dismiss_options = {
+            **DISMISS_VARIANT_OPTIONS,
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
+        }
+    return dismiss_options

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -325,7 +325,7 @@ def cancer_variants(institute_id, case_name):
         cytobands=cytobands,
         dismiss_variant_options={
             **DISMISS_VARIANT_OPTIONS,
-            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
         },
         expand_search=str(request.method == "POST"),
         **data,
@@ -370,7 +370,7 @@ def cancer_sv_variants(institute_id, case_name):
         case=case_obj,
         dismiss_variant_options={
             **DISMISS_VARIANT_OPTIONS,
-            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
         },
         variant_type=variant_type,
         form=form,
@@ -415,7 +415,7 @@ def upload_panel(institute_id, case_name):
     # HTTP redirect code 307 asks that the browser preserves the method of request (POST).
     if category == "sv":
         return redirect(
-            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data, ),
+            url_for(".sv_variants", institute_id=institute_id, case_name=case_name, **form.data,),
             code=307,
         )
     return redirect(


### PR DESCRIPTION
This PR adds the column "Dismiss variant" to all the variants tables.

![Aug-17-2020 10-19-35](https://user-images.githubusercontent.com/6919697/90374174-5d560200-e073-11ea-90dc-5b762cb8a54b.gif)


**How to test**:
1. Deploy this branch to scout-stating, look at the variant tables for a "Rare disease variant" and then for a "Cancer" variant. Try out the filtering of the table as well since I changed the form a little bit.

**Expected outcome**:
The functionality should be working

**Review:**
- [ ] code approved by
- [ ] tests executed by
