### PR TITLE
Add pre-commit and black packages in dev requirements, edit README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display number of filtered variants vs number of total variants in variants page
 - Search case by HPO terms
 - Dismiss variant column in the variant tables.
+- Black and pre-commit packages to dev requirements
 
 ### Fixed
 - Bug occurring when rerun is requested twice

--- a/README.md
+++ b/README.md
@@ -191,6 +191,33 @@ A user-oriented guide describing how to share case and variant data to MatchMake
 be found [here][matchmaker-scout-sharing].
 
 
+## Development
+
+To keep the code base consistent, formatting with [Black](https://github.com/psf/black) is enforced.
+Black defaults to 88 characters per line, we use 100.
+
+To format all the files in the project run:
+
+```bash
+black --line-length 100 .
+```
+
+We recommend using Black with [pre-commit](https://github.com/pre-commit/pre-commit).
+In `.pre-commit-config.yaml` you can find the pre-commit configuration.
+To enable this configuration run:
+
+```bash
+pre-commit install
+```
+
+### Test
+
+To run unit tests:
+
+```bash
+pytest
+```
+
 ## Example of analysis config
 
 TODO.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,9 @@ wheel>=0.23
 twine
 
 # utils
+black
 invoke
+pre-commit
 
 # docs
 mkdocs


### PR DESCRIPTION
This PR adds Black and pre-commit packages to requirements-dev. Since Black is run in Github Actions
I think it's a good idea to have it installed by default when setting up the project.

**Review:**
- [x] code approved by
