### PR TITLE
Fix #2011. Add safety check for load config alignment_path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Bug occurring when rerun is requested twice
 - Peddy info fields in the demo config file
+- Added load config safety check for multiple alignment files for one individual
 
 ### Changed
 - Updated the documentation on how to create a new software release

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -366,11 +366,17 @@ def parse_individual(sample):
     ind_info["predicted_ancestry"] = sample.get("predicted_ancestry")
 
     # IGV files these can be bam or cram format
-    bam_path_options = ["bam_path", "bam_file", "alignment_path"]
+    bam_path_options = ["alignment_path", "bam_path", "bam_file"]
     for option in bam_path_options:
         if sample.get(option) and not sample.get(option).strip() == "":
-            ind_info["bam_file"] = sample[option]
-            break
+            if "bam_file" in ind_info:
+                LOG.warning(
+                    "Multiple alignment paths given for individual %s in load config. Using %s",
+                    ind_info["individual_id"],
+                    ind_info["bam_file"],
+                )
+            else:
+                ind_info["bam_file"] = sample[option]
 
     ind_info["rhocall_bed"] = sample.get("rhocall_bed", sample.get("rhocall_bed"))
     ind_info["rhocall_wig"] = sample.get("rhocall_wig", sample.get("rhocall_wig"))

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -204,6 +204,24 @@ def test_parse_case_alignment_path(scout_config):
         assert ind["bam_file"] == bam_path
 
 
+def test_parse_case_multiple_alignment_files(scout_config):
+    # GIVEN a load config with both cram and bam files
+    bam_path = "a bam"
+    for sample in scout_config["samples"]:
+        sample["bam_file"] = bam_path
+
+    cram_path = "a cram"
+    for sample in scout_config["samples"]:
+        sample["alignment_path"] = cram_path
+
+    # WHEN case is parsed
+    case_data = parse_case(scout_config)
+
+    # THEN assert that cram files are added correctly, ignoring bam
+    for ind in case_data["individuals"]:
+        assert ind["bam_file"] == cram_path
+
+
 def test_parse_ped_file(ped_file):
     # GIVEN a pedigree with three samples
     with open(ped_file, "r") as case_lines:


### PR DESCRIPTION
This PR adds a sanity check for file loading, changing the priority from bam to cram (alignment_path), warning the user if multiple files were added to config.

**How to test**:
1. add an extra non empty bam_file or bam_path entry to an individual that has an alignment_path entry - or vice versa.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
