### PR TITLE
Highlight causative variants in the variants list #2012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Display number of filtered variants vs number of total variants in variants page
 - Search case by HPO terms
-- Dismiss variant column in the variant tables.
+- Dismiss variant column in the variants tables
 - Black and pre-commit packages to dev requirements
+- Highlight on causative variants in the variants tables
 
 ### Fixed
 - Bug occurring when rerun is requested twice
@@ -20,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Genome build-aware cytobands coordinates
 - Styling update of the Matchmaker card
 - Select search type in case search form
+- Highlight color on normal STRs in the variants table from green to blue
 
 
 ## [4.19]

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -50,8 +50,6 @@
         {% for variant in variants %}
           {% if variant.dismiss_variant %}
             <tr class="dismiss">
-           {% elif variant._id in case.causatives %}
-            <tr class="causative">
     {% else %}
       <tr>
     {% endif %}

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -50,6 +50,8 @@
         {% for variant in variants %}
           {% if variant.dismiss_variant %}
             <tr class="dismiss">
+           {% elif variant._id in case.causatives %}
+            <tr class="causative">
     {% else %}
       <tr>
     {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -186,6 +186,8 @@
 {% macro variant_row(variant) %}
   {% if variant.dismiss_variant %}
   <tr class="dismiss">
+  {% elif variant._id in case.causatives %}
+  <tr class="causative">
   {% else %}
   <tr>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -75,6 +75,8 @@
         {% for variant in variants %}
           {% if variant.dismiss_variant %}
             <tr class="dismiss">
+          {% elif variant._id in case.causatives %}
+            <tr class="causative">
           {% else %}
             <tr>
           {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -40,19 +40,19 @@
 
 {% block content_main %}
   <div class="card mt-3">
-    <table class="table table-bordered table-hover">
+    <table class="table table-bordered table-hover" style="table-layout: fixed">
       <thead>
         <tr>
           <th style="width:8%" title="Index">Index</th>
           <th style="width:18%" title="Dismiss Variant">Dismiss variant</th>
-          <th style="width:6%" title="Repeat ID">Repeat locus</th>
-          <th style="width:4%" title="Repeat unit">Reference repeat unit</th>
-          <th style="width:4%" title="ALT">Estimated size</th>
-          <th style="width:4%" title="ReferenceSize">Reference size</th>
-          <th style="width:10%" title="Status">Status</th>
-          <th style="width:8%" title="Max normal">Max normal</th>
-          <th style="width:8%" title="Min pathologic">Min pathologic</th>
-          <th style="width:14%" title="GT">Genotype</th>
+          <th style="width:8%" title="Repeat ID">Repeat locus</th>
+          <th style="width:8%" title="Repeat unit">Reference repeat unit</th>
+          <th style="width:5%" title="ALT">Estimated size</th>
+          <th style="width:5%" title="ReferenceSize">Reference size</th>
+          <th style="width:8%" title="Status">Status</th>
+          <th style="width:6%" title="Max normal">Max normal</th>
+          <th style="width:6%" title="Min pathologic">Min pathologic</th>
+          <th style="width:12%" title="GT">Genotype</th>
           <th style="width:6%" title="Chromosome">Chr.</th>
           <th style="width:10%" title="Position">Position</th>
         </tr>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -66,8 +66,10 @@
           {% set ns.allele0 = variant.chromosome + variant.position|string %}
           {% if variant.dismiss_variant %}
               <tr class="dismiss">
+          {% elif variant._id in case.causatives %}
+             <tr class="causative">
           {% elif variant.str_status == 'normal' %}
-              <tr class="bg-success">
+              <tr class="bg-primary">
           {% elif variant.str_status == 'full_mutation' %}
               <tr class="bg-danger">
           {% elif variant.str_status == 'pre_mutation' %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -94,7 +94,9 @@
 
 {% macro variant_row(variant) %}
   {% if variant.dismiss_variant %}
-  <tr class="dismiss">
+   <tr class="dismiss">
+  {% elif variant._id in case.causatives %}
+   <tr class="causative">
   {% else %}
   <tr>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -60,20 +60,20 @@
     </form>
   </div>
   <div class="card mt-3">
-    <table id="variantsTable" class="table table-hover table-bordered">
+    <table id="variantsTable" class="table table-hover table-bordered" style="table-layout: fixed">
       <thead>
         <tr>
-          <th style="width:12%">Rank</th>
+          <th style="width:8%">Rank</th>
           <th style="width:18%">Dismiss variant</th>
-          <th style="width:8%">Type</th>
-          <th style="width:8%">Chr</th>
-          <th style="width:8%">Start loc</th>
-          <th style="width:8%">Stop loc</th>
+          <th style="width:6%">Type</th>
+          <th style="width:6%">Chr</th>
+          <th style="width:5%">Start loc</th>
+          <th style="width:5%">Stop loc</th>
           <th style="width:8%">Length</th>
           <th style="width:8%">Region</th>
           <th style="width:8%">Function</th>
-          <th style="width:8%">Frequency</th>
-          <th style="width:8%">Gene(s)</th>
+          <th style="width:9%">Frequency</th>
+          <th style="width:7%">Gene(s)</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -599,6 +599,10 @@
     {% endfor %}
   {% endif %}
 
+  {% if variant._id in case.causatives %}
+    <span class="badge badge-success" style="margin-left:1px" data-toggle="tooltip" data-placement="right" title="Causative variant">Causative</span>
+  {% endif %}
+
   {% if comment_count > 0 %}
     {% set comments_content = comments_table(institute, case, variant.comments, variant._id) %}
     <a href="#"

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -77,6 +77,8 @@
             {% for variant in variants %}
               {% if variant.dismiss_variant %}
                 <tr class="dismiss">
+              {% elif variant._id in case.causatives %}
+                <tr class="causative">
               {% else %}
                 <tr>
               {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -57,20 +57,20 @@
         </div>
       </form>
       <div class="card mt-3">
-        <table class="table table-hover table-bordered">
+        <table class="table table-hover table-bordered" style="table-layout: fixed">
           <thead>
             <tr>
-              <th style="width:4%" title="Rank position">Rank </th>
-              <th style="width:30%" title="Dismiss Variant">Dismiss variant</th>
-              <th style="width:4%" title="Rank score">Score</th>
+              <th style="width:6%" title="Rank position">Rank </th>
+              <th style="width:18%" title="Dismiss Variant">Dismiss variant</th>
+              <th style="width:5%" title="Rank score">Score</th>
               <th style="width:4%" title="Chromosome">Chr.</th>
               <th style="width:8%" title="HGNC symbols">Gene</th>
               <th style="width:4%" title="Poulation frequency">PopFreq</th>
-              <th style="width:4%" title="CADD score">CADD</th>
+              <th style="width:5%" title="CADD score">CADD</th>
               <th style="width:8%" title="Gene region annotation">Gene annotation</th>
-              <th style="width:14%" title="Functional annotation">Func. annotation</th>
+              <th style="width:12%" title="Functional annotation">Func. annotation</th>
               <th style="width:12%" title="Inheritance models">Inheritance model</th>
-              <th style="width:4%" title="Overlapping">Overlapping</th>
+              <th style="width:6%" title="Overlapping">Overlapping</th>
             </tr>
           </thead>
           <tbody>

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -52,6 +52,11 @@ table.dataTable {margin-bottom: 0rem}
    background-color: #C9C9C9;
 }
 
+/* causative table row */
+.causative {
+   background-color: #dff0d8;
+}
+
 /* Custom navbar theme */
 .navbar{
   background-color:#1181B2;


### PR DESCRIPTION
This PR adds a functionality, in the variant list causative variants are now highlighted. The tables style was also improved.
<img width="816" alt="Screen Shot 2020-08-18 at 10 40 15" src="https://user-images.githubusercontent.com/6919697/90510171-c3698480-e15a-11ea-9a0e-50adb7b4aae2.png">

**How to test**:
1. Run Scout locally, mark a variant causative.

**Expected outcome**:
In the list, the causative variant should be highlighted.

**Review:**
- [ ] code approved by
- [ ] tests executed by
