### PR TITLE
Enable csrf protect module

### DIFF
--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -6,6 +6,7 @@ from flask import Flask, current_app, redirect, request, url_for
 from flask_babel import Babel
 from flask_login import current_user
 from flaskext.markdown import Markdown
+from flask_wtf.csrf import CSRFProtect
 
 from scout.utils.matchmaker import mme_nodes
 
@@ -96,6 +97,7 @@ def configure_extensions(app):
     extensions.login_manager.init_app(app)
     extensions.mail.init_app(app)
 
+    CSRFProtect(app)
     Markdown(app)
 
     if app.config.get("SQLALCHEMY_DATABASE_URI"):

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -273,8 +273,6 @@ def cancer_variants(institute_id, case_name):
             store, institute_obj, case_obj, user_obj, category, request.form
         )
 
-        flash(f"submitted info was {request.form}")
-
         if form.validate_on_submit() is False:
             # Flash a message with errors
             for field, err_list in form.errors.items():

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -277,7 +277,7 @@ def cancer_variants(institute_id, case_name):
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:
-                    flash(f"Content of field '{err_list}' has not a valid format", "warning")
+                    flash(f"Content of field '{field}' has not a valid format", "warning")
             # And do not submit the form
             return redirect(
                 url_for(

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -273,11 +273,13 @@ def cancer_variants(institute_id, case_name):
             store, institute_obj, case_obj, user_obj, category, request.form
         )
 
+        flash(f"submitted info was {request.form}")
+
         if form.validate_on_submit() is False:
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:
-                    flash(f"Content of field '{field}' has not a valid format", "warning")
+                    flash(f"Content of field '{err_list}' has not a valid format", "warning")
             # And do not submit the form
             return redirect(
                 url_for(


### PR DESCRIPTION
Load csrf protection at the app level. Fix #2021. Documentation is here: https://flask-wtf.readthedocs.io/en/v0.12/csrf.html

**How to test**:
1. Install the branch either locally or on scout stage
1. If testing locally, load the demo cancer case with the following command:
`scout --demo load case scout/demo/cancer.load_config.yaml `
1. Go to the cancer variants and try to filter by some criteria (your choice really)
1. Make sure that variants are filtered correctly
1. Save the filters used using the "save filter" button
1. Reset filter and make sure you see again all variants
1. Load the saved filter.
1. Filter load and filtering itself should work
1. Remove the filter

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
