### PR TITLE
Skip validation of a pre-existing variant filter -- Alternative to #2028, because I'm a chicken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Search case by HPO terms
 - Dismiss variant column in the variants tables
 - Black and pre-commit packages to dev requirements
-- Highlight on causative variants in the variants tables
 
 ### Fixed
 - Bug occurring when rerun is requested twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Highlight causative variants in the variants list
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires
+- Variants filter loading in cancer variants page
 ### Changed
+- Highlight color on normal STRs in the variants table from green to blue
 
 
 ## [4.20]
@@ -29,7 +31,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Genome build-aware cytobands coordinates
 - Styling update of the Matchmaker card
 - Select search type in case search form
-- Highlight color on normal STRs in the variants table from green to blue
 
 
 ## [4.19]

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -273,7 +273,8 @@ def cancer_variants(institute_id, case_name):
             store, institute_obj, case_obj, user_obj, category, request.form
         )
 
-        if form.validate_on_submit() is False:
+        # if user is not loading an existing filter, check filter form
+        if request.form.get("load_filter") is None and form.validate_on_submit() is False:
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:


### PR DESCRIPTION
This is a much safer fix #2021 

**How to test**:
1. Install the branch either locally or on scout stage
1. If testing locally, load the demo cancer case with the following command:
`scout --demo load case scout/demo/cancer.load_config.yaml `
1. Go to the cancer variants and try to filter by some criteria (your choice really)
1. Make sure that variants are filtered correctly
1. Save the filters used using the "save filter" button
1. Reset filter and make sure you see again all variants
1. Load the saved filter.
1. Filter load and filtering itself should work
1. Remove the filter

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by ML
- [x] tests executed by ML