### PR TITLE
No trailing spaces in new gene panels #2032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Highlight causative variants in the variants list
 - Add tests. Mostly regarding building internal datatypes.
+- Remove leading and trailing whitespaces from panel_name and display_name
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires
 - Variants filter loading in cancer variants page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Highlight causative variants in the variants list
 - Add tests. Mostly regarding building internal datatypes.
-- Remove leading and trailing whitespaces from panel_name and display_name
+- Remove leading and trailing whitespaces from panel_name and display_name when panel is created
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires
 - Variants filter loading in cancer variants page

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -161,7 +161,6 @@ class PanelHandler:
             Args:
                 panel_obj(dict)
         """
-        panel_obj["panel_name"] = panel_obj["panel_name"].strip()
         panel_name = panel_obj["panel_name"]
         panel_version = panel_obj["version"]
         display_name = panel_obj.get("display_name", panel_name)

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -161,7 +161,7 @@ class PanelHandler:
             Args:
                 panel_obj(dict)
         """
-        panel_name = panel_obj["panel_name"]
+        panel_name = panel_obj["panel_name"].strip()
         panel_version = panel_obj["version"]
         display_name = panel_obj.get("display_name", panel_name)
 

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -161,7 +161,8 @@ class PanelHandler:
             Args:
                 panel_obj(dict)
         """
-        panel_name = panel_obj["panel_name"].strip()
+        panel_obj["panel_name"] = panel_obj["panel_name"].strip()
+        panel_name = panel_obj["panel_name"]
         panel_version = panel_obj["version"]
         display_name = panel_obj.get("display_name", panel_name)
 

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -44,9 +44,7 @@ def build_gene(gene_info, adapter):
             raise KeyError()
     except KeyError as err:
         raise KeyError(
-            "Gene {0} is missing hgnc id. Panel genes has to have hgnc_id".format(
-                symbol
-            )
+            "Gene {0} is missing hgnc id. Panel genes has to have hgnc_id".format(symbol)
         )
 
     hgnc_gene = adapter.hgnc_gene(hgnc_id)
@@ -58,8 +56,7 @@ def build_gene(gene_info, adapter):
     gene_obj["symbol"] = hgnc_gene["hgnc_symbol"]
     if symbol != gene_obj["symbol"]:
         LOG.warning(
-            "Symbol in database does not correspond to symbol in panel file for gene %s",
-            hgnc_id,
+            "Symbol in database does not correspond to symbol in panel file for gene %s", hgnc_id,
         )
         LOG.warning(
             "Using symbol %s for gene %s, instead of %s"
@@ -121,7 +118,7 @@ def build_panel(panel_info, adapter):
 
     """
 
-    panel_name = panel_info.get("panel_id", panel_info.get("panel_name"))
+    panel_name = panel_info.get("panel_id", panel_info.get("panel_name")).strip()
     if not panel_name:
         raise KeyError("Panel has to have a id")
 
@@ -147,7 +144,7 @@ def build_panel(panel_info, adapter):
         raise KeyError("Panel has to have a date")
 
     panel_obj["maintainer"] = panel_info.get("maintainer", [])
-    panel_obj["display_name"] = panel_info.get("display_name", panel_obj["panel_name"])
+    panel_obj["display_name"] = panel_info.get("display_name", panel_obj["panel_name"]).strip()
     panel_obj["description"] = panel_info.get("description")
 
     gene_objs = []
@@ -161,9 +158,7 @@ def build_panel(panel_info, adapter):
             fail = True
 
     if fail:
-        raise IntegrityError(
-            "Some genes did not exist in database. Please see log messages."
-        )
+        raise IntegrityError("Some genes did not exist in database. Please see log messages.")
 
     panel_obj["genes"] = gene_objs
 

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -118,8 +118,11 @@ def build_panel(panel_info, adapter):
 
     """
 
-    panel_name = panel_info.get("panel_id", panel_info.get("panel_name")).strip()
-    if not panel_name:
+    panel_name = panel_info.get("panel_id", panel_info.get("panel_name"))
+
+    if panel_name:
+        panel_name = panel_name.strip()
+    else:
         raise KeyError("Panel has to have a id")
 
     panel_obj = dict(panel_name=panel_name)
@@ -144,7 +147,9 @@ def build_panel(panel_info, adapter):
         raise KeyError("Panel has to have a date")
 
     panel_obj["maintainer"] = panel_info.get("maintainer", [])
-    panel_obj["display_name"] = panel_info.get("display_name", panel_obj["panel_name"]).strip()
+    panel_obj["display_name"] = panel_info.get("display_name", panel_obj["panel_name"])
+    if panel_obj["display_name"]:
+        panel_obj["display_name"] = panel_obj["display_name"].strip()
     panel_obj["description"] = panel_info.get("description")
 
     gene_objs = []

--- a/tests/build/test_build_panel.py
+++ b/tests/build/test_build_panel.py
@@ -27,6 +27,7 @@ def test_build_panel(institute_database, test_gene):
     adapter = institute_database
     adapter.load_hgnc_gene(test_gene)
 
+    # panel_id and display_name contain leading and trailing whitespaces to test that the spaces are removed
     panel_info = {
         "panel_id": " panel1",
         "institute": "cust000",
@@ -39,7 +40,7 @@ def test_build_panel(institute_database, test_gene):
     ## WHEN building a gene panel
     panel_obj = build_panel(panel_info, adapter)
 
-    ## THEN assert that the panel was given the right attributes
+    ## THEN assert that the panel was given the right attributes and that the leading and trailing spaces were removed
     assert panel_obj["institute"] == panel_info["institute"]
     assert panel_obj["panel_name"] == "panel1"
     assert panel_obj["display_name"] == "first panel"

--- a/tests/build/test_build_panel.py
+++ b/tests/build/test_build_panel.py
@@ -28,10 +28,10 @@ def test_build_panel(institute_database, test_gene):
     adapter.load_hgnc_gene(test_gene)
 
     panel_info = {
-        "panel_id": "panel1",
+        "panel_id": " panel1",
         "institute": "cust000",
         "date": datetime.now(),
-        "display_name": "first panel",
+        "display_name": "first panel ",
         "description": "first panel description",
         "genes": [{"hgnc_id": 1}],
         "version": 1.0,
@@ -41,6 +41,8 @@ def test_build_panel(institute_database, test_gene):
 
     ## THEN assert that the panel was given the right attributes
     assert panel_obj["institute"] == panel_info["institute"]
+    assert panel_obj["panel_name"] == "panel1"
+    assert panel_obj["display_name"] == "first panel"
     assert len(panel_info["genes"]) == len(panel_obj["genes"])
 
 


### PR DESCRIPTION
This PR filters remove leading and trailing whitespaces from the gene panel name
**How to test**:
Add a panel with a name that contains trailing whitespaces in your local or stage branch
**Expected outcome**:
The uploaded gene panel name should not have trailing whitespaces

**Review:**
- [x] code approved by CR
- [x] tests executed by CR, EM
