### PR TITLE
Remove overflow auto to avoid cut tables from several pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires
 - Variants filter loading in cancer variants page
+- User, Causative and Cases tables not scaling to full page
 ### Changed
 - Highlight color on normal STRs in the variants table from green to blue
 

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -259,7 +259,7 @@
           </div>
         </div>
       {% endif %}
-      <div style="overflow-y: auto; height: 600px;">
+      <div>
         {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', ] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -27,7 +27,7 @@
 
 {% macro causatives() %}
 <div class="card mt-3">
-  <div class="card-body" style="overflow-y: auto; height: 700px;">
+  <div class="card-body">
       <table id="causatives_table" class="table display table-sm" cellspacing="0">
         <thead>
           <tr>

--- a/scout/server/blueprints/institutes/templates/overview/users.html
+++ b/scout/server/blueprints/institutes/templates/overview/users.html
@@ -23,7 +23,7 @@
 <div class="container-float">
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
-  <div class="col" style="overflow-y: auto; height: 700px;">
+  <div class="col">
     {{ users_table(users) }}
   </div>
   </div> <!-- end of div id body-row -->


### PR DESCRIPTION
This PR changes the styling in some pages

**How to test**:
1. run this branch in staging (you will need a lot of data and long tables) and check out the users, causatives and institute tables

**Expected outcome**:
The tables should look fine

**Review:**
- [x] code approved by
- [x] tests executed by
