### PR TITLE
Do not inactivate case whenever the assignee is removed from database using the cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Compatibility with latest version of Black
 - Fixed tests for Click>7
 - Clinical filter required an extra click to Filter to return variants
+- Removing a user from the command line now inactivates the case only if user is last assignee and case is active
 ### Changed
 - Highlight color on normal STRs in the variants table from green to blue
 

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -63,7 +63,7 @@ def user(mail):
             link = url_for(
                 "cases.case", institute_id=institute_obj["_id"], case_name=case_obj["display_name"]
             )
-            if adapter.unassign(institute_obj, case_obj, user_obj, link, True):
+            if adapter.unassign(institute_obj, case_obj, user_obj, link, False):
                 updated_cases += 1
     click.echo(f"User was removed as assignee from {updated_cases} case(s).")
 

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -63,7 +63,10 @@ def user(mail):
             link = url_for(
                 "cases.case", institute_id=institute_obj["_id"], case_name=case_obj["display_name"]
             )
-            inactivate_case = case_obj.get("status", "active") == "active"
+            inactivate_case = case_obj.get("status", "active") == "active" and case_obj[
+                "assignees"
+            ] == [mail]
+            LOG.error(f"Inactivate is:{inactivate_case}")
             if adapter.unassign(institute_obj, case_obj, user_obj, link, inactivate_case):
                 updated_cases += 1
     click.echo(f"User was removed as assignee from {updated_cases} case(s).")

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -63,7 +63,8 @@ def user(mail):
             link = url_for(
                 "cases.case", institute_id=institute_obj["_id"], case_name=case_obj["display_name"]
             )
-            if adapter.unassign(institute_obj, case_obj, user_obj, link, False):
+            inactivate_case = case_obj.get("status", "active") == "active"
+            if adapter.unassign(institute_obj, case_obj, user_obj, link, inactivate_case):
                 updated_cases += 1
     click.echo(f"User was removed as assignee from {updated_cases} case(s).")
 

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -66,7 +66,6 @@ def user(mail):
             inactivate_case = case_obj.get("status", "active") == "active" and case_obj[
                 "assignees"
             ] == [mail]
-            LOG.error(f"Inactivate is:{inactivate_case}")
             if adapter.unassign(institute_obj, case_obj, user_obj, link, inactivate_case):
                 updated_cases += 1
     click.echo(f"User was removed as assignee from {updated_cases} case(s).")

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -111,6 +111,7 @@ def test_delete_user(empty_mock_app, user_obj, case_obj, institute_obj):
     assert store.event_collection.find_one() is None
 
     case_obj["assignees"] = [user_obj["email"]]
+    case_obj["status"] = "active"
     store.case_collection.insert_one(case_obj)
     assert store.case_collection.find_one({"assignees": {"$in": case_obj["assignees"]}})
 
@@ -121,8 +122,11 @@ def test_delete_user(empty_mock_app, user_obj, case_obj, institute_obj):
     assert result.exit_code == 0
     assert store.user_collection.find_one() is None
 
-    ## The case should not have an assignee
-    assert store.case_collection.find_one({"assignees": {"$in": case_obj["assignees"]}}) is None
+    # The case should keep the original status and should not have an assignee
+    updated_case = store.case_collection.find_one({"_id": case_obj["_id"]})
+    assert updated_case["status"] == "active"
+    assert updated_case["assignees"] == []
+
     ## And a new event for unassigning the user should have been created in event collection
     assert store.event_collection.find_one()
 

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -93,7 +93,7 @@ def test_delete_nonexisting_user(empty_mock_app, user_obj):
     assert "User unknown_email@email.com could not be found in database" in result.output
 
 
-def test_delete_user(empty_mock_app, user_obj, case_obj, institute_obj):
+def test_delete_user_active_case(empty_mock_app, user_obj, case_obj, institute_obj):
     "Test the CLI command that will delete a user"
     mock_app = empty_mock_app
 
@@ -122,9 +122,47 @@ def test_delete_user(empty_mock_app, user_obj, case_obj, institute_obj):
     assert result.exit_code == 0
     assert store.user_collection.find_one() is None
 
-    # The case should keep the original status and should not have an assignee
+    # The case should be archived and should not have an assignee
     updated_case = store.case_collection.find_one({"_id": case_obj["_id"]})
     assert updated_case["status"] == "active"
+    assert updated_case["assignees"] == []
+
+    ## And a new event for unassigning the user should have been created in event collection
+    assert store.event_collection.find_one()
+
+
+def test_delete_user_solved_case(empty_mock_app, user_obj, case_obj, institute_obj):
+    "Test the CLI command that will delete a user"
+    mock_app = empty_mock_app
+
+    runner = mock_app.test_cli_runner()
+    assert runner
+
+    ## GIVEN there is one user in populated database
+    store.user_collection.insert_one(user_obj)
+    assert store.user_collection.find_one()
+
+    ## And the user is an assignee of a case of an institute
+    store.institute_collection.insert_one(institute_obj)
+
+    ## And no events in the database
+    assert store.event_collection.find_one() is None
+
+    case_obj["assignees"] = [user_obj["email"]]
+    case_obj["status"] = "solved"
+    store.case_collection.insert_one(case_obj)
+    assert store.case_collection.find_one({"assignees": {"$in": case_obj["assignees"]}})
+
+    ## WHEN deleting the user from the CLI
+    result = runner.invoke(cli, ["delete", "user", "-m", user_obj["email"]])
+
+    ## THEN the user should be gone
+    assert result.exit_code == 0
+    assert store.user_collection.find_one() is None
+
+    # The case should keep the original status and should not have an assignee
+    updated_case = store.case_collection.find_one({"_id": case_obj["_id"]})
+    assert updated_case["status"] == "solved"
     assert updated_case["assignees"] == []
 
     ## And a new event for unassigning the user should have been created in event collection

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -93,8 +93,8 @@ def test_delete_nonexisting_user(empty_mock_app, user_obj):
     assert "User unknown_email@email.com could not be found in database" in result.output
 
 
-def test_delete_user_active_case(empty_mock_app, user_obj, case_obj, institute_obj):
-    "Test the CLI command that will delete a user"
+def test_delete_last_user_active_case(empty_mock_app, user_obj, case_obj, institute_obj):
+    "Test the CLI command that will delete the last user of an active case"
     mock_app = empty_mock_app
 
     runner = mock_app.test_cli_runner()
@@ -124,15 +124,54 @@ def test_delete_user_active_case(empty_mock_app, user_obj, case_obj, institute_o
 
     # The case should be archived and should not have an assignee
     updated_case = store.case_collection.find_one({"_id": case_obj["_id"]})
-    assert updated_case["status"] == "active"
+    assert updated_case["status"] == "inactive"
     assert updated_case["assignees"] == []
 
     ## And a new event for unassigning the user should have been created in event collection
     assert store.event_collection.find_one()
 
 
-def test_delete_user_solved_case(empty_mock_app, user_obj, case_obj, institute_obj):
-    "Test the CLI command that will delete a user"
+def test_delete_user_active_case(empty_mock_app, user_obj, case_obj, institute_obj):
+    "Test the CLI command that will delete one of the users of an active case"
+
+    mock_app = empty_mock_app
+
+    runner = mock_app.test_cli_runner()
+    assert runner
+
+    ## GIVEN there is one user in populated database
+    store.user_collection.insert_one(user_obj)
+    assert store.user_collection.find_one()
+
+    ## And the user is an assignee of a case of an institute
+    store.institute_collection.insert_one(institute_obj)
+
+    ## And no events in the database
+    assert store.event_collection.find_one() is None
+
+    case_obj["assignees"] = [user_obj["email"], "user2@email"]
+    case_obj["status"] = "active"
+    store.case_collection.insert_one(case_obj)
+    assert store.case_collection.find_one({"assignees": {"$in": case_obj["assignees"]}})
+
+    ## WHEN deleting the user from the CLI
+    result = runner.invoke(cli, ["delete", "user", "-m", user_obj["email"]])
+
+    ## THEN the user should be gone
+    assert result.exit_code == 0
+    assert store.user_collection.find_one() is None
+
+    # The case should NOT be inactivated and should still have the other assignee
+    updated_case = store.case_collection.find_one({"_id": case_obj["_id"]})
+    assert updated_case["status"] == "active"
+    assert updated_case["assignees"] == ["user2@email"]
+
+    ## And a new event for unassigning the user should have been created in event collection
+    assert store.event_collection.find_one()
+
+
+def test_delete_last_user_solved_case(empty_mock_app, user_obj, case_obj, institute_obj):
+    "Test the CLI command that will delete the last user of a solved case"
     mock_app = empty_mock_app
 
     runner = mock_app.test_cli_runner()


### PR DESCRIPTION
fix #2039.

Current situation is that whenever a user is assignee of one or more cases, if the user is removed using the command line, those cases become inactive. This fix will keep those cases in their status, whichever that is.


**How to test --in a local instance of Scout**:
---> From master branch:
1. Create a dummy user to assign the case to:
`scout --demo load user -u "Dummy User" -m dummyuser@dummysite.se -i cust000`
1. Log in into scout with the dummy users's email
1. Enter the case page and then one of its variants; you should get a notification that the case is active.
1. Assign yourself to the case and log out.
1. Remove dummy user from the command line:
`scout --demo delete user -m dummyuser@dummysite.se`
1. Log in as Clark Kent and note that the case is inactivated

--> Repeat from this branch:
1. In the last step you should see that the case is still active

Try to assign whichever state to the case (not inactive of course) to the case before removing the user and the case should keep this status.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
