### PR TITLE
Format cancer variants table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Compatibility with latest version of Black
 - Fixed tests for Click>7
 - Clinical filter required an extra click to Filter to return variants
-- Restore pagination to variants pages
+- Restore pagination and shrink badges in the variants page tables
 
 ### Changed
 - Highlight color on normal STRs in the variants table from green to blue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bug occurring when rerun is requested twice
 - Peddy info fields in the demo config file
 - Added load config safety check for multiple alignment files for one individual
+- Formatting of cancer variants table
 
 ### Changed
 - Updated the documentation on how to create a new software release

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -105,43 +105,43 @@ CANCER_TIER_OPTIONS = {
 
 MANUAL_RANK_OPTIONS = {
     8: {
-        "label": "Known pathogenic",
-        "description": "Previously known pathogenic in ClinVar, HGMD, literature, etc",
+        "label": "KP",
+        "description": "Known pathogenic, previously known pathogenic in ClinVar, HGMD, literature, etc",
         "label_class": "danger",
     },
     7: {
-        "label": "Pathogenic",
+        "label": "P",
         "description": (
-            "Novel mutation but overlapping phenotype with known pathogenic, "
+            "Pathogenic, novel mutation but overlapping phenotype with known pathogenic, "
             "no further experimental validation needed"
         ),
         "label_class": "danger",
     },
     6: {
-        "label": "Novel validated pathogenic",
-        "description": "Novel mutation and validated experimentally",
+        "label": "NVP",
+        "description": "Novel validated pathogenic, novel mutation and validated experimentally",
         "label_class": "danger",
     },
     5: {
-        "label": "Pathogenic partial phenotype",
+        "label": "PPP",
         "description": (
-            "Pathogenic variant explains part of patients phenotype, but " "not all symptoms"
+            "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but " "not all symptoms"
         ),
         "label_class": "danger",
     },
     4: {
-        "label": "Likely pathogenic",
-        "description": "Experimental validation required to prove causality",
+        "label": "LP",
+        "description": "Likely pathogenic, experimental validation required to prove causality",
         "label_class": "warning",
     },
     3: {
-        "label": "Possibly pathogenic",
-        "description": "Uncertain significance, but cannot disregard yet",
+        "label": "PP",
+        "description": "Possibly pathogenic, uncertain significance, but cannot disregard yet",
         "label_class": "primary",
     },
     2: {
-        "label": "Likely benign",
-        "description": "Uncertain significance, but can discard",
+        "label": "LB",
+        "description": "Likely benign, uncertain significance, but can discard",
         "label_class": "info",
     },
     1: {

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -106,11 +106,13 @@ CANCER_TIER_OPTIONS = {
 MANUAL_RANK_OPTIONS = {
     8: {
         "label": "KP",
+        "name": "Known pathogenic",
         "description": "Known pathogenic, previously known pathogenic in ClinVar, HGMD, literature, etc",
         "label_class": "danger",
     },
     7: {
         "label": "P",
+        "name": "Pathogenic",
         "description": (
             "Pathogenic, novel mutation but overlapping phenotype with known pathogenic, "
             "no further experimental validation needed"
@@ -119,11 +121,13 @@ MANUAL_RANK_OPTIONS = {
     },
     6: {
         "label": "NVP",
+        "name": "Novel validated pathogenic",
         "description": "Novel validated pathogenic, novel mutation and validated experimentally",
         "label_class": "danger",
     },
     5: {
         "label": "PPP",
+        "name": "Pathogenic partial phenotype",
         "description": (
             "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but "
             "not all symptoms"
@@ -132,27 +136,32 @@ MANUAL_RANK_OPTIONS = {
     },
     4: {
         "label": "LP",
+        "name": "Likely pathogenic",
         "description": "Likely pathogenic, experimental validation required to prove causality",
         "label_class": "warning",
     },
     3: {
         "label": "PP",
+        "name": "Possibly pathogenic",
         "description": "Possibly pathogenic, uncertain significance, but cannot disregard yet",
         "label_class": "primary",
     },
     2: {
         "label": "LB",
+        "name": "Likely benign",
         "description": "Likely benign, uncertain significance, but can discard",
         "label_class": "info",
     },
     1: {
-        "label": "Benign",
-        "description": "Does not cause phenotype",
+        "label": "B",
+        "name": "Benign",
+        "description": "Benign, does not cause phenotype",
         "label_class": "success",
     },
     0: {
-        "label": "Other",
-        "description": "Phenotype not related to disease",
+        "label": "O",
+        "name": "Other",
+        "description": "Other, phenotype not related to disease",
         "label_class": "default",
     },
 }

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -125,7 +125,8 @@ MANUAL_RANK_OPTIONS = {
     5: {
         "label": "PPP",
         "description": (
-            "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but " "not all symptoms"
+            "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but "
+            "not all symptoms"
         ),
         "label_class": "danger",
     },

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -8,7 +8,7 @@
           <option value="-1">Select a tag...</option>
           {% for rank, data in manual_rank_options.items() %}
             <option {% if rank == variant.manual_rank %} selected {% endif %} value="{{ rank }}">
-              {{ data.label }}
+              {{ data.name }}
             </option>
           {% endfor %}
         </select>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -53,17 +53,17 @@
   </form>
 
   <div class="card mt-3">
-    <table class="table table-hover table-bordered">
+    <table class="table table-hover table-bordered" style="table-layout:fixed">
       <thead>
             <tr>
-              <th style="width:4%" title="Rank position">Rank</th>
-              <th style="width:18%" title="Dismiss variant">Dismiss variant</th>
-              <th style="width:18%">Gene:Transcript:Exon:HGVS</th>
-              <th style="width:4%" >Tier</th>
-              <th style="width:6%" >Score</th>
-              <th style="width:6%">Gene</th>
+              <th style="width:6%" title="Rank position">Rank</th>
+              <th style="width:15%" title="Dismiss variant">Dismiss variant</th>
+              <th style="width:12%">Gene:Transcript:Exon:HGVS</th>
+              <th style="width:6%" >Tier</th>
+              <th style="width:5%" >Score</th>
+              <th style="width:10%">Gene</th>
               <th style="width:6%">Chr pos</th>
-              <th style="width:4%">ExAC</th>
+              <th style="width:6%">ExAC</th>
               <th style="width:6%">Type</th>
               <th style="width:14%">Consequence</th>
               <th style="width:6%" data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -58,16 +58,16 @@
             <tr>
               <th style="width:4%" title="Rank position">Rank</th>
               <th style="width:18%" title="Dismiss variant">Dismiss variant</th>
-              <th>Gene:Transcript:Exon:HGVS</th>
-              <th>Tier</th>
-              <th>Score</th>
-              <th>Gene</th>
-              <th>Chr pos</th>
-              <th>ExAC</th>
-              <th>Type</th>
-              <th>Consequence</th>
-              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
-              <th data-toggle="tooltip" data-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
+              <th style="width:18%">Gene:Transcript:Exon:HGVS</th>
+              <th style="width:4%" >Tier</th>
+              <th style="width:6%" >Score</th>
+              <th style="width:6%">Gene</th>
+              <th style="width:6%">Chr pos</th>
+              <th style="width:4%">ExAC</th>
+              <th style="width:6%">Type</th>
+              <th style="width:14%">Consequence</th>
+              <th style="width:6%" data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
+              <th style="width:6%" data-toggle="tooltip" data-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
             </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -22,7 +22,8 @@
         {% endif %}
       </div>"
         href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
-      </a>&nbsp;&nbsp;
+      </a>
+      <br>
     {% endfor %}
     {% if variant.panels|count > 0 %}
         <a

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -1,5 +1,5 @@
 {% macro gene_cell(variant) %}
-  <div class="d-flex justify-content-between align-items-center">
+  <div class="align-items-center">
     {% for gene in variant.genes %}
       <a data-toggle="tooltip" data-html="true" title="
       <div>
@@ -23,7 +23,6 @@
       </div>"
         href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
       </a>
-      <br>
     {% endfor %}
     {% if variant.panels|count > 0 %}
         <a


### PR DESCRIPTION
This PR formats the cancer variant tables

**How to test**:
1. Deployed this branch to staging
2. Checked out the table of this variant that contains a lot of text.
https://scout-stage.scilifelab.se/cust000/20190327_cancer_T_N/cancer/variants?variant_type=clinical

**Expected outcome**:
It should look fine.
<img width="1429" alt="Screen Shot 2020-09-01 at 09 25 00" src="https://user-images.githubusercontent.com/6919697/91817688-a55d5300-ec35-11ea-9f82-6fd6d2541a52.png">
The content is still a bit compressed but it has to be with so much text. The other solution is to decrease the text size but then it wouldn't be so readable.
Edit: with shrinked tags and tooltip:
<img width="510" alt="Screen Shot 2020-09-01 at 12 03 10" src="https://user-images.githubusercontent.com/6919697/91836788-8ec1f680-ec4b-11ea-8bc7-1421a59f11a8.png">
When not hovering:
<img width="268" alt="Screen Shot 2020-09-01 at 12 07 11" src="https://user-images.githubusercontent.com/6919697/91836909-ba44e100-ec4b-11ea-839a-94dc0cb16eeb.png">


**Review:**
- [x] code approved by CR
- [x] tests executed by EM
