### PR TITLE
Fix filter removal and upload for un-existing filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Restore pagination and shrink badges in the variants page tables
 - Removing a user from the command line now inactivates the case only if user is last assignee and case is active
 - Bugfix, LoqusDB per institute feature crashed when institute id was empty string
+- filter removal and upload for filters deleted from another page/other user
 
 ### Changed
 - Highlight color on normal STRs in the variants table from green to blue

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from bson.objectid import ObjectId
-from flask import url_for
+from flask import url_for, flash
 
 import pymongo
 
@@ -20,11 +20,12 @@ class FilterHandler(object):
         Returns:
             filter_obj(dict)
         """
+        filter_obj = None
         LOG.debug("Retrieve filter {}".format(filter_id))
         filter_obj = self.filter_collection.find_one({"_id": ObjectId(filter_id)})
-
-        # use _id to preselect the currently loaded filter, and drop it while we are at it
-        filter_obj.update([("filters", filter_obj.pop("_id", None))])
+        if filter_obj is not None:
+            # use _id to preselect the currently loaded filter, and drop it while we are at it
+            filter_obj.update([("filters", filter_obj.pop("_id", None))])
         return filter_obj
 
     def stash_filter(
@@ -116,6 +117,9 @@ class FilterHandler(object):
             result()
         """
         filter_obj = self.filter_collection.find_one({"_id": ObjectId(filter_id)})
+        if filter_obj is None:
+            flash("Requested filter was not found", "warning")
+            return
 
         LOG.info(
             "User {} deleting filter {} for institute {}.".format(

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 from bson.objectid import ObjectId
-from flask import url_for, flash
+from flask import url_for
 
 import pymongo
 
@@ -118,7 +118,6 @@ class FilterHandler(object):
         """
         filter_obj = self.filter_collection.find_one({"_id": ObjectId(filter_id)})
         if filter_obj is None:
-            flash("Requested filter was not found", "warning")
             return
 
         LOG.info(

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -658,7 +658,7 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
         if filter_obj is not None:
             form = FiltersFormClass(MultiDict(filter_obj))
         else:
-            flash("Could not find filter")
+            flash("Requested filter was not found", "warning")
             form = FiltersFormClass(request_form)
     elif bool(request_form.get("delete_filter")):
         filter_id = request_form.get("filters")

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -655,7 +655,11 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
     elif bool(request_form.get("load_filter")):
         filter_id = request_form.get("filters")
         filter_obj = store.retrieve_filter(filter_id)
-        form = FiltersFormClass(MultiDict(filter_obj))
+        if filter_obj is not None:
+            form = FiltersFormClass(MultiDict(filter_obj))
+        else:
+            flash("Could not find filter")
+            form = FiltersFormClass(request_form)
     elif bool(request_form.get("delete_filter")):
         filter_id = request_form.get("filters")
         institute_id = institute_obj.get("_id")

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -593,6 +593,7 @@ def upload_panel(store, institute_id, case_name, stream):
 
 def populate_filters_form(store, institute_obj, case_obj, user_obj, category, request_form):
     # Update filter settings if Clinical Filter was requested
+    form = None
     clinical_filter_panels = []
 
     default_panels = []
@@ -659,13 +660,15 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
             form = FiltersFormClass(MultiDict(filter_obj))
         else:
             flash("Requested filter was not found", "warning")
-            form = FiltersFormClass(request_form)
     elif bool(request_form.get("delete_filter")):
         filter_id = request_form.get("filters")
         institute_id = institute_obj.get("_id")
         filter_obj = store.delete_filter(filter_id, institute_id, current_user.email)
-        form = FiltersFormClass(request_form)
-    else:
+        if filter_obj is not None:
+            form = FiltersFormClass(request_form)
+        else:
+            flash("Requested filter was not found", "warning")
+    if form is None:
         form = FiltersFormClass(request_form)
 
     return form


### PR DESCRIPTION
fix #2060

**How to test**:
1. Install the branch and open the variants page for a case.
1. Create a custom filter
1. Open the same page on another browser tab
1. Delete the filter from one tab and try to delete it from the second tab. It should flash an error message and not crash.
1. Repeat the filter creation and have it displayed on the 2 tabs
1. Remove from the first tab and try to load it from the second tab. Also in this case it should display an error message, no page crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
