### PR TITLE
Fix #2067 - previous button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove leading and trailing whitespaces from panel_name and display_name when panel is created
 - Mark MANE transcript in list of transcripts in "Transcript overview" on variant page
 - Show default panel name in case sidebar
+- Previous buttons for variants pagination
 
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -88,7 +88,7 @@
     </table>
   </div>
   <div class="container-fluid">
-    {{ pagination_footer() }}
+    {{ pagination_footer(more_variants, page) }}
   </div>
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -110,7 +110,7 @@
   <br>
 </div><!--end of container-float -->
 <div class="container-fluid">
-  {{ pagination_footer() }}
+  {{ pagination_footer(more_variants, page) }}
 </div>
 
 {% endblock %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -128,46 +128,36 @@
 {% macro footer() %}
 <form>
   <div class="container-fluid">
-    <div class="form-group text-center">
-      {% if more_variants %}
-        <div class="row">
-          <div class="col">
-            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
-                First page
-            </a>
-          </div>
-          {% if page > 1 %}
-            <div class="col">
-              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page - 1), **form.data) }}">
-                Previous page
-              </a>
-            </div>
-          {% endif %}
-          <div class="col">
-            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page + 1), **form.data) }}">
-              Next page
-            </a>
-          </div>
-        </div>
-      {% else %}
+    <div class="row justify-content-center">
+      {% if not more_variants %}
         <i class="text-muted">No more variants to display</i>
-        <div class="row">
-          <div class="col">
-            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
-              First page
-            </a>
-          </div>
-          {% if page > 1 %}
-            <div class="col">
+      {% endif %}
+      <div class="row justify-content-center">
+        <div class="btn-group" role="group">
+          {% if page > 2 %}
+            <div>
+              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
+                First page
+              </a>
+            </div>
+          {% elif page > 1 %}
+            <div>
               <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page - 1), **form.data) }}">
                 Previous page
               </a>
             </div>
           {% endif %}
+          {% if more_variants %}
+            <div class="col">
+              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page + 1), **form.data) }}">
+                Next page
+              </a>
+            </div>
+          {% endif %}
         </div>
-      {% endif %}  
       </div>
     </div>
+  </div>
 </form>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -122,8 +122,54 @@
     </table>
   </div>
   <br>
-  {{ pagination_footer(more_variants) }}
+  {{ footer() }}
 {% endblock %}
+
+{% macro footer() %}
+<form>
+  <div class="container-fluid">
+    <div class="form-group text-center">
+      {% if more_variants %}
+        <div class="row">
+          <div class="col">
+            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
+                First page
+            </a>
+          </div>
+          {% if page > 1 %}
+            <div class="col">
+              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page - 1), **form.data) }}">
+                Previous page
+              </a>
+            </div>
+          {% endif %}
+          <div class="col">
+            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page + 1), **form.data) }}">
+              Next page
+            </a>
+          </div>
+        </div>
+      {% else %}
+        <i class="text-muted">No more variants to display</i>
+        <div class="row">
+          <div class="col">
+            <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
+              First page
+            </a>
+          </div>
+          {% if page > 1 %}
+            <div class="col">
+              <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page - 1), **form.data) }}">
+                Previous page
+              </a>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}  
+      </div>
+    </div>
+</form>
+{% endmacro %}
 
 {% block scripts %}
   {{ super() }}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -128,19 +128,21 @@
 {% macro footer() %}
 <form>
   <div class="container-fluid">
-    <div class="row justify-content-center">
       {% if not more_variants %}
-        <i class="text-muted">No more variants to display</i>
+        <div class="row justify-content-center">
+          <i class="text-muted">No more variants to display</i>
+        </div>
       {% endif %}
       <div class="row justify-content-center">
         <div class="btn-group" role="group">
-          {% if page > 2 %}
+          {% if page > 1 %}
             <div>
               <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=1, **form.data) }}">
                 First page
               </a>
             </div>
-          {% elif page > 1 %}
+          {% endif %}
+          {% if page > 2 %}
             <div>
               <a class="btn btn-outline-secondary mx-auto d-block" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, page=(page - 1), **form.data) }}">
                 Previous page
@@ -157,7 +159,6 @@
         </div>
       </div>
     </div>
-  </div>
 </form>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -89,7 +89,7 @@
     </table>
   </div>
   <div class="container-fluid">
-    {{ pagination_footer(more_variants) }}
+    {{ pagination_footer(more_variants, page) }}
   </div>
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -648,18 +648,19 @@
     {% endif %}
     <div class="row justify-content-center">
         <div class="btn-group" role="group">
+          {% if page > 1 %}
+             <div>
+               <label for="paginate-first" class="btn btn-outline-secondary" tabindex="0">
+                 First page
+               </label>
+             </div>
+          {% endif %}
           {% if page > 2 %}
             <div>
               <label for="paginate-previous" class="btn btn-outline-secondary" tabindex="0">
                 Previous page
               </label>
             </div>
-          {% elif page > 1 %}
-             <div>
-               <label for="paginate-first" class="btn btn-outline-secondary" tabindex="0">
-                 First page
-               </label>
-             </div>
           {% endif %}
           {% if more_variants %}
             <div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -633,11 +633,12 @@
 {# Used inside filters form to introduce submit buttons for footer pagniation #}
   <div class="hidden">
     <input type="submit" name="page" id="paginate-first" value=1 hidden="true">
+    <input type="submit" name="page" id="paginate-previous" value={{page-1}} hidden="true">
     <input type="submit" name="page" id="paginate-next" value={{page+1}} hidden="true">
   </div>
 {% endmacro %}
 
-{% macro pagination_footer(more_variants) %}
+{% macro pagination_footer(more_variants, page) %}
 {# Used outside filters form to introduce footer pagniation labels #}
   <div class="container-fluid">
       {% if more_variants %}
@@ -647,6 +648,11 @@
               First page
             </label>
           </div>
+          {% if page > 1 %}
+            <label for="paginate-previous" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
+              Previous page
+            </label>
+          {% endif %}
           <div>
             <label for="paginate-next" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
               Next page
@@ -655,9 +661,16 @@
 	     </div>
       {% else %}
         <i class="text-muted">No more variants to display</i>
-        <label for="paginate-first" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-          First page
-        </label>
+        <div class="d-flex justify-content-around">
+          <label for="paginate-first" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
+            First page
+          </label>
+          {% if page > 1 %}
+            <label for="paginate-previous" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
+              Previous page
+            </label>
+          {% endif %}
+        </div>
       {% endif %}
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -641,36 +641,34 @@
 {% macro pagination_footer(more_variants, page) %}
 {# Used outside filters form to introduce footer pagniation labels #}
   <div class="container-fluid">
-      {% if more_variants %}
-        <div class="d-flex justify-content-around">
-	         <div>
-             <label for="paginate-first" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-              First page
-            </label>
-          </div>
-          {% if page > 1 %}
-            <label for="paginate-previous" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-              Previous page
-            </label>
-          {% endif %}
-          <div>
-            <label for="paginate-next" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-              Next page
-            </label>
-          </div>
-	     </div>
-      {% else %}
+    {% if not more_variants %}
+      <div class="row justify-content-center">
         <i class="text-muted">No more variants to display</i>
-        <div class="d-flex justify-content-around">
-          <label for="paginate-first" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-            First page
-          </label>
-          {% if page > 1 %}
-            <label for="paginate-previous" class="btn btn-outline-secondary mx-auto d-block" tabindex="0">
-              Previous page
-            </label>
+      </div>
+    {% endif %}
+    <div class="row justify-content-center">
+        <div class="btn-group" role="group">
+          {% if page > 2 %}
+            <div>
+              <label for="paginate-previous" class="btn btn-outline-secondary" tabindex="0">
+                Previous page
+              </label>
+            </div>
+          {% elif page > 1 %}
+             <div>
+               <label for="paginate-first" class="btn btn-outline-secondary" tabindex="0">
+                 First page
+               </label>
+             </div>
+          {% endif %}
+          {% if more_variants %}
+            <div>
+              <label for="paginate-next" class="btn btn-outline-secondary" tabindex="0">
+                Next page
+              </label>
+            </div>
           {% endif %}
         </div>
-      {% endif %}
-  </div>
+      </div>
+    </div>
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -115,7 +115,7 @@
         </table>
       </div><!-- end of <div class="card mt-3">-->
     </div> <!-- end of class="container-float"> -->
-      {{ pagination_footer(more_variants) }}
+      {{ pagination_footer(more_variants, page) }}
 {% endblock %}
 
 {% macro cell_cadd(variant) %}


### PR DESCRIPTION
This PR adds a functionality: previous buttons.

It also reverts the STR variants page to previous behaviour (e.g. v4.19 and v4.20 - prior to current master), without the general pagination footer. This can migrate when filters are turned on for STRs.

![Screenshot 2020-09-03 at 17 20 27](https://user-images.githubusercontent.com/758570/92137064-0c813000-ee0d-11ea-9729-11fddab77645.png)

Feel free to suggest an alternative row layout, e.g. button spacing and alignment. 😸 

**How to test**:
1. access snv, sv, str, cancer and cancer_sv variants pages and click all pagination buttons, with and without applied filters to ensure behaviour is as per the button labels

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR, DN
