### PR TITLE
Fix sv variant header labels#2064

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Peddy info fields in the demo config file
 - Added load config safety check for multiple alignment files for one individual
 - Formatting of cancer variants table
+- Missing Score in SV variants table
 
 ### Changed
 - Updated the documentation on how to create a new software release

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -73,9 +73,9 @@
           <th style="width:5%">Stop loc</th>
           <th style="width:8%">Length</th>
           <th style="width:8%">Region</th>
-          <th style="width:8%">Function</th>
+          <th style="width:9%">Function</th>
           <th style="width:8%">Frequency</th>
-          <th style="width:10%">Gene(s)</th>
+          <th style="width:9%">Gene(s)</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -65,7 +65,8 @@
       <thead>
         <tr>
           <th style="width:8%">Rank</th>
-          <th style="width:18%">Dismiss variant</th>
+          <th style="width:15%">Dismiss variant</th>
+          <th style="width:6%">Score</th>
           <th style="width:6%">Type</th>
           <th style="width:6%">Chr</th>
           <th style="width:5%">Start loc</th>
@@ -73,8 +74,8 @@
           <th style="width:8%">Length</th>
           <th style="width:8%">Region</th>
           <th style="width:8%">Function</th>
-          <th style="width:9%">Frequency</th>
-          <th style="width:7%">Gene(s)</th>
+          <th style="width:8%">Frequency</th>
+          <th style="width:10%">Gene(s)</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -65,17 +65,17 @@
       <thead>
         <tr>
           <th style="width:8%">Rank</th>
-          <th style="width:15%">Dismiss variant</th>
+          <th style="width:16%">Dismiss variant</th>
           <th style="width:6%">Score</th>
           <th style="width:6%">Type</th>
           <th style="width:6%">Chr</th>
-          <th style="width:5%">Start loc</th>
-          <th style="width:5%">Stop loc</th>
+          <th style="width:6%">Start loc</th>
+          <th style="width:6%">Stop loc</th>
           <th style="width:8%">Length</th>
           <th style="width:8%">Region</th>
-          <th style="width:9%">Function</th>
-          <th style="width:8%">Frequency</th>
-          <th style="width:9%">Gene(s)</th>
+          <th style="width:10%">Function</th>
+          <th style="width:10%">Frequency</th>
+          <th style="width:10%">Gene(s)</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
This PR adds fixes a bug

**How to test**:
1. Deploy to staging and click on a SV variant tables. Tested locally but I still cannot deploy to clinical-db.
<img width="1421" alt="Screen Shot 2020-09-04 at 08 07 28" src="https://user-images.githubusercontent.com/6919697/92205389-df249880-ee85-11ea-8506-0cce584dda47.png">


**Expected outcome**:
The table header should include Score

**Review:**
- [ ] code approved by
- [ ] tests executed by
