### PR TITLE
Enforce updates to changelog on PRs

### DIFF
--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dangoslen/changelog-enforcer@v1.1.1
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabel: 'Skip-Changelog'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove leading and trailing whitespaces from panel_name and display_name when panel is created
 - Mark MANE transcript in list of transcripts in "Transcript overview" on variant page
 - Show default panel name in case sidebar
+- Adds a gh action that checks that the changelog is updated
 
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires


### PR DESCRIPTION
This PR adds a GitHub Action that reminds developers to update the CHANGELOG.md whenever a PR is opened.

**How to test**:
- [x] Check that a changelog reminder appears among the Check list for the PR and is failing 
- [x] Update CHANGELOG.md
- [x] Make sure that the check is passing

**Expected outcome**:
The functionality should be working
- [x] Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by @moonso 
