### PR TITLE
Adds workflow to upload releases to PyPI

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.7
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.7
+
+   - name: Install build tools
+     run: >-
+        python -m
+        pip install
+        wheel
+        twine
+        --user
+
+   - name: Build a binary wheel and a source tarball
+     run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+
+   - name: Publish distribution 📦 to PyPI
+     uses: pypa/gh-action-pypi-publish@master
+     with:
+       user: __token__
+       password: ${{ secrets.pypi_password }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Mark MANE transcript in list of transcripts in "Transcript overview" on variant page
 - Show default panel name in case sidebar
 - Adds a gh action that checks that the changelog is updated
+- Adds a gh action that deploys new releases automatically to pypi
 
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ responses
 
 # utils
 invoke
+black
 pre-commit
 
 # docs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,12 +7,7 @@ pytest-flask
 mongomock<=3.12
 responses
 
-# packaging
-wheel>=0.23
-twine
-
 # utils
-black
 invoke
 pre-commit
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-# Note: To use the 'upload' functionality of this file, you must:
-#   $ pip install twine
+"""Build instructions for packaging and installing"""
 
 import io
 import os
@@ -60,39 +56,6 @@ with open(os.path.join(here, "scout", "__version__.py")) as f:
     exec(f.read(), about)
 
 
-class UploadCommand(Command):
-    """Support setup.py upload."""
-
-    description = "Build and publish the package."
-    user_options = []
-
-    @staticmethod
-    def status(s):
-        """Prints things in bold."""
-        print("\033[1m{0}\033[0m".format(s))
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        try:
-            self.status("Removing previous builds…")
-            rmtree(os.path.join(here, "dist"))
-        except OSError:
-            pass
-
-        self.status("Building Source and Wheel (universal) distribution…")
-        os.system("{0} setup.py sdist bdist_wheel --universal".format(sys.executable))
-
-        self.status("Uploading the package to PyPi via Twine…")
-        os.system("twine upload dist/*")
-
-        sys.exit()
-
-
 setup(
     name=NAME,
     version=about["__version__"],
@@ -119,6 +82,4 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python :: 3.6",
     ],
-    # $ setup.py publish support.
-    cmdclass={"upload": UploadCommand},
 )


### PR DESCRIPTION
This PR adds a GitHub Action workflow for publishing the package to pypi.
The event will be triggered whenever a new release is made.

**How to test**:
1. Create a new release

**Expected outcome**:
The the package should be published to pypi
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @northwestwitch 
