### PR TITLE
Warn users if case default panels are outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show default panel name in case sidebar
 - Adds a gh action that checks that the changelog is updated
 - Adds a gh action that deploys new releases automatically to pypi
+- Warn users if case default panels are outdated
 
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -131,7 +131,7 @@ def case(store, institute_obj, case_obj):
             missing_genes = [
                 gene["symbol"] for gene in hgnc_ids_latest_panel if gene not in hgnc_ids_case_panel
             ]
-            if len(extra_genes) or len(missing_genes):
+            if extra_genes or missing_genes:
                 case_obj["outdated_panels"][panel_name] = {
                     "missing_genes": missing_genes,
                     "extra_genes": extra_genes,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -223,25 +223,19 @@ def _check_outdated_gene_panel(panel_obj, latest_panel):
         missing_genes, extra_genes
     """
     # Create a list of minified gene object for the case panel {hgnc_id, gene_symbol}
-    hgnc_ids_case_panel = [
+    case_panel_genes = [
         {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
         for gene in panel_obj["genes"]
     ]
     # And for the latest panel
-
-    hgnc_ids_latest_panel = [
+    latest_panel_genes = [
         {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
         for gene in latest_panel["genes"]
     ]
     # Extract the genes unique to case panel
-    extra_genes = [
-        gene["symbol"] for gene in hgnc_ids_case_panel if gene not in hgnc_ids_latest_panel
-    ]
+    extra_genes = [gene["symbol"] for gene in case_panel_genes if gene not in latest_panel_genes]
     # Extract the genes unique to latest panel
-    missing_genes = [
-        gene["symbol"] for gene in hgnc_ids_latest_panel if gene not in hgnc_ids_case_panel
-    ]
-
+    missing_genes = [gene["symbol"] for gene in latest_panel_genes if gene not in case_panel_genes]
     return extra_genes, missing_genes
 
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -116,9 +116,15 @@ def case(store, institute_obj, case_obj):
 
         # Check if case-specific panel is up-to-date with latest version of the panel
         if panel_obj["version"] < latest_panel["version"]:
-            extra_genes = [gene for gene in panel_obj["genes"] if gene not in latest_panel["genes"]]
+            extra_genes = [
+                gene.get("symbol", gene["hgnc_id"])
+                for gene in panel_obj["genes"]
+                if gene not in latest_panel["genes"]
+            ]
             missing_genes = [
-                gene for gene in latest_panel["genes"] if gene not in panel_obj["genes"]
+                gene.get("symbol", gene["hgnc_id"])
+                for gene in latest_panel["genes"]
+                if gene not in panel_obj["genes"]
             ]
             case_obj["outdated_panels"][panel_name] = {
                 "missing_genes": missing_genes,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -116,20 +116,26 @@ def case(store, institute_obj, case_obj):
 
         # Check if case-specific panel is up-to-date with latest version of the panel
         if panel_obj["version"] < latest_panel["version"]:
-            extra_genes = [
-                gene.get("symbol", gene["hgnc_id"])
+            hgnc_ids_latest_panel = [
+                {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
+                for gene in latest_panel["genes"]
+            ]
+            hgnc_ids_case_panel = [
+                {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
                 for gene in panel_obj["genes"]
-                if gene not in latest_panel["genes"]
+            ]
+
+            extra_genes = [
+                gene["symbol"] for gene in hgnc_ids_case_panel if gene not in hgnc_ids_latest_panel
             ]
             missing_genes = [
-                gene.get("symbol", gene["hgnc_id"])
-                for gene in latest_panel["genes"]
-                if gene not in panel_obj["genes"]
+                gene["symbol"] for gene in hgnc_ids_latest_panel if gene not in hgnc_ids_case_panel
             ]
-            case_obj["outdated_panels"][panel_name] = {
-                "missing_genes": missing_genes,
-                "extra_genes": extra_genes,
-            }
+            if len(extra_genes) or len(missing_genes):
+                case_obj["outdated_panels"][panel_name] = {
+                    "missing_genes": missing_genes,
+                    "extra_genes": extra_genes,
+                }
 
         distinct_genes.update([gene["hgnc_id"] for gene in panel_obj.get("genes", [])])
         full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -223,16 +223,16 @@ def _check_outdated_gene_panel(panel_obj, latest_panel):
         missing_genes, extra_genes
     """
     # Create a list of minified gene object for the case panel {hgnc_id, gene_symbol}
-    hgnc_ids_latest_panel = [
-        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
-        for gene in latest_panel["genes"]
-    ]
-    # And for the latest panel
     hgnc_ids_case_panel = [
         {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
         for gene in panel_obj["genes"]
     ]
+    # And for the latest panel
 
+    hgnc_ids_latest_panel = [
+        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
+        for gene in latest_panel["genes"]
+    ]
     # Extract the genes unique to case panel
     extra_genes = [
         gene["symbol"] for gene in hgnc_ids_case_panel if gene not in hgnc_ids_latest_panel

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -116,21 +116,7 @@ def case(store, institute_obj, case_obj):
 
         # Check if case-specific panel is up-to-date with latest version of the panel
         if panel_obj["version"] < latest_panel["version"]:
-            hgnc_ids_latest_panel = [
-                {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
-                for gene in latest_panel["genes"]
-            ]
-            hgnc_ids_case_panel = [
-                {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
-                for gene in panel_obj["genes"]
-            ]
-
-            extra_genes = [
-                gene["symbol"] for gene in hgnc_ids_case_panel if gene not in hgnc_ids_latest_panel
-            ]
-            missing_genes = [
-                gene["symbol"] for gene in hgnc_ids_latest_panel if gene not in hgnc_ids_case_panel
-            ]
+            extra_genes, missing_genes = _check_outdated_gene_panel(panel_obj, latest_panel)
             if extra_genes or missing_genes:
                 case_obj["outdated_panels"][panel_name] = {
                     "missing_genes": missing_genes,
@@ -224,6 +210,39 @@ def case(store, institute_obj, case_obj):
     }
 
     return data
+
+
+def _check_outdated_gene_panel(panel_obj, latest_panel):
+    """Compare genes of a case gene panel with the latest panel version and return differences
+
+    Args:
+        panel_obj(dict): the gene panel of a case
+        latest_panel(dict): the latest version of that gene panel
+
+    returns:
+        missing_genes, extra_genes
+    """
+    # Create a list of minified gene object for the case panel {hgnc_id, gene_symbol}
+    hgnc_ids_latest_panel = [
+        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
+        for gene in latest_panel["genes"]
+    ]
+    # And for the latest panel
+    hgnc_ids_case_panel = [
+        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
+        for gene in panel_obj["genes"]
+    ]
+
+    # Extract the genes unique to case panel
+    extra_genes = [
+        gene["symbol"] for gene in hgnc_ids_case_panel if gene not in hgnc_ids_latest_panel
+    ]
+    # Extract the genes unique to latest panel
+    missing_genes = [
+        gene["symbol"] for gene in hgnc_ids_latest_panel if gene not in hgnc_ids_case_panel
+    ]
+
+    return extra_genes, missing_genes
 
 
 def case_report_content(store, institute_obj, case_obj):

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -33,6 +33,7 @@
 
 {% block content_main %}
 <div class="container-float">
+  {{case}}
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ action_bar(institute, case, collaborators) }} <!-- This is the sidebar -->
     {{ case_page() }}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -33,7 +33,6 @@
 
 {% block content_main %}
 <div class="container-float">
-  {{case}}
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ action_bar(institute, case, collaborators) }} <!-- This is the sidebar -->
     {{ case_page() }}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -42,7 +42,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if panel.panel_name in case.outdated_panels %}
-              <span class="badge badge-pill badge-sm badge-warning" data-toggle="tooltip" data-placement="right" title="Panel version used in the analysis ({{panel.version}}) is outdated. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}">!</span>
+              <span class="badge badge-pill badge-sm badge-warning" data-toggle="tooltip" data-placement="right" title="Panel version used in the analysis ({{panel.version}}) is outdated. Case panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span>
             {% endif %}
         </div>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -41,6 +41,9 @@
             <a href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}">
               {{ panel.display_name|truncate(18, True) }}
             </a>
+            {% if panel.panel_name in case.outdated_panels %}
+              <span class="badge badge-pill badge-warning">!</span>
+            {% endif %}
         </div>
       </div>
   {% endfor %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -42,7 +42,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if panel.panel_name in case.outdated_panels %}
-              <span class="badge badge-pill badge-warning">!</span>
+              <span class="badge badge-pill badge-sm badge-warning" data-toggle="tooltip" data-placement="right" title="Panel version used in the analysis ({{panel.version}}) is outdated. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}">!</span>
             {% endif %}
         </div>
       </div>

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,5 +1,6 @@
 """Tests for the cases controllers"""
-from flask import Flask
+from flask import Flask, url_for
+from scout.server.extensions import store
 
 from scout.server.blueprints.cases.controllers import case, case_report_content
 
@@ -77,7 +78,7 @@ def test_case_controller_no_panels(adapter, institute_obj, dummy_case):
     assert fetched_case["panel_names"] == []
 
 
-def test_case_controller_with_panel(adapter, institute_obj, panel, dummy_case):
+def test_case_controller_with_panel(app, institute_obj, panel, dummy_case):
     # GIVEN an adapter with a case with a gene panel
     dummy_case["panels"] = [
         {
@@ -87,20 +88,20 @@ def test_case_controller_with_panel(adapter, institute_obj, panel, dummy_case):
             "is_default": True,
         }
     ]
-    adapter.case_collection.insert_one(dummy_case)
-    adapter.institute_collection.insert_one(institute_obj)
+    store.case_collection.insert_one(dummy_case)
+
     # GIVEN an adapter with a gene panel
-    adapter.panel_collection.insert_one(panel)
-    fetched_case = adapter.case_collection.find_one()
+    store.panel_collection.insert_one(panel)
+    fetched_case = store.case_collection.find_one()
     app = Flask(__name__)
     # WHEN fetching a case with the controller
     with app.app_context():
-        data = case(adapter, institute_obj, fetched_case)
+        data = case(store, institute_obj, fetched_case)
     # THEN assert that the display information has been added to case
     assert len(fetched_case["panel_names"]) == 1
 
 
-def test_case_controller_panel_wrong_version(adapter, institute_obj, panel, dummy_case):
+def test_case_controller_panel_wrong_version(adapter, app, institute_obj, panel, dummy_case):
     # GIVEN an adapter with a case with a gene panel with wrong version
     dummy_case["panels"] = [
         {
@@ -115,15 +116,19 @@ def test_case_controller_panel_wrong_version(adapter, institute_obj, panel, dumm
     # GIVEN an adapter with a gene panel
     adapter.panel_collection.insert_one(panel)
     fetched_case = adapter.case_collection.find_one()
-    app = Flask(__name__)
-    # WHEN fetching a case with the controller
-    with app.app_context():
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+
+        # WHEN fetching a case with the controller
         data = case(adapter, institute_obj, fetched_case)
     # THEN assert that it succeded to fetch another panel version
     assert str(panel["version"]) in fetched_case["panel_names"][0]
 
 
-def test_case_controller_non_existing_panel(adapter, institute_obj, dummy_case, panel):
+def test_case_controller_non_existing_panel(adapter, app, institute_obj, dummy_case, panel):
     # GIVEN an adapter with a case with a gene panel but no panel objects
     dummy_case["panels"] = [
         {
@@ -134,11 +139,14 @@ def test_case_controller_non_existing_panel(adapter, institute_obj, dummy_case, 
         }
     ]
     adapter.case_collection.insert_one(dummy_case)
-    adapter.institute_collection.insert_one(institute_obj)
     fetched_case = adapter.case_collection.find_one()
-    app = Flask(__name__)
-    # WHEN fetching a case with the controller
-    with app.app_context():
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+
+        # WHEN fetching a case with the controller
         data = case(adapter, institute_obj, fetched_case)
     # THEN assert that it succeded to fetch another panel version
     assert len(fetched_case["panel_names"]) == 0

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -249,7 +249,7 @@ def test_case_outdated_panel(app, institute_obj, case_obj, dummy_case):
         # THEN it should return a valid page
         assert resp.status_code == 200
 
-        # THEN it should show that the gene panel is outdated
+        # WITH a tooltip explaining that the gene panel is outdated
         assert "Panel version used in the analysis (1.0) is outdated." in str(resp.data)
 
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -16,42 +16,6 @@ from scout.server.blueprints.cases.views import (
 TEST_TOKEN = "test_token"
 
 
-def test_case_outdated_panel(app, institute_obj, case_obj, dummy_case):
-    """Test case displaying an outdated panel warning badge"""
-
-    # GIVEN an adapter with a case with a gene panel of version 1
-    case_panel = case_obj["panels"][0]
-    assert case_panel["version"] == 1
-
-    # AND an updated version of the same panel in the database
-    updated_panel = {
-        "panel_name": case_panel["panel_name"],
-        "display_name": case_panel["display_name"],
-        "version": 2,
-        "genes": [{"symbol": "POT1", "hgnc_id": 17284}],
-    }
-    store.panel_collection.insert_one(updated_panel)
-
-    # GIVEN an initialized app
-    with app.test_client() as client:
-        # GIVEN that the user could be logged in
-        resp = client.get(url_for("auto_login"))
-
-        # WHEN case page is loaded
-        resp = client.get(
-            url_for(
-                "cases.case",
-                institute_id=institute_obj["internal_id"],
-                case_name=case_obj["display_name"],
-            )
-        )
-        # THEN it shoulr return a page
-        assert resp.status_code == 200
-
-        # THEN it should show that the gene panel is outdated
-        assert "Panel version used in the analysis (1.0) is outdated." in str(resp.data)
-
-
 def test_rerun(app, institute_obj, case_obj, monkeypatch):
     """test case rerun function"""
 
@@ -253,16 +217,28 @@ def test_institutes(app):
         assert resp.status_code == 200
 
 
-def test_case(app, case_obj, institute_obj):
-    # GIVEN an initialized app
-    # GIVEN a valid user, case and institute
+def test_case_outdated_panel(app, institute_obj, case_obj, dummy_case):
+    """Test case displaying an outdated panel warning badge"""
 
+    # GIVEN an adapter with a case with a gene panel of version 1
+    case_panel = case_obj["panels"][0]
+    assert case_panel["version"] == 1
+
+    # AND an updated version of the same panel in the database
+    updated_panel = {
+        "panel_name": case_panel["panel_name"],
+        "display_name": case_panel["display_name"],
+        "version": 2,
+        "genes": [{"symbol": "POT1", "hgnc_id": 17284}],
+    }
+    store.panel_collection.insert_one(updated_panel)
+
+    # GIVEN an initialized app
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
 
-        # WHEN accessing the case page
+        # WHEN case page is loaded
         resp = client.get(
             url_for(
                 "cases.case",
@@ -270,9 +246,11 @@ def test_case(app, case_obj, institute_obj):
                 case_name=case_obj["display_name"],
             )
         )
-
-        # THEN it should return a page
+        # THEN it should return a valid page
         assert resp.status_code == 200
+
+        # THEN it should show that the gene panel is outdated
+        assert "Panel version used in the analysis (1.0) is outdated." in str(resp.data)
 
 
 def test_case_sma(app, case_obj, institute_obj):


### PR DESCRIPTION
Display a warning badge if case default panels' version is older than panel version in database. This PR goes together with #2007

![image](https://user-images.githubusercontent.com/28093618/92280947-db7f2900-eefa-11ea-9688-91512d9813f4.png)

**How to test**:
1. Can be done both on stage or a local implementation of scout.
1. Update a gene panel that is the default gene panel of a case
1. Go to the case and see the warning badge
1. On mouseover it should tell you the gene differences between case panel and updated panel.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
