### PR TITLE
Fix #2069 - show VAF on pinned and causatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Previous buttons for variants pagination
 - Adds a gh action that checks that the changelog is updated
 - Adds a gh action that deploys new releases automatically to pypi
+- Show somatic VAF for pinned and causative variants on case page
 
 ### Fixed
 - Report pages redirect to login instead of crashing when session expires

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -47,7 +47,7 @@
         <li class="list-group-item">
           {% if variant._id %}
             <div class="row align-items-between align-items-center">
-              <div class="col-10">
+              <div class="col">
                 <i class="fa fa-check-circle-o"></i>
                 {{ pretty_link_variant(variant, case) }}
                 {% if variant.sanger_ordered and not variant.validation in ['True positive','False positive'] %}
@@ -56,7 +56,13 @@
                   <span class="badge badge-success">Validated</span>
                 {% endif %}
               </div>
-              <div class="col-2">
+              {% if variant.tumor %}
+                {{ allele_div(variant.tumor, "Tumor") }}
+              {% endif %}
+              {% if variant.normal %}
+                {{ allele_div(variant.normal, "Normal") }}
+              {% endif %}
+              <div class="col-1">
                 {{ remove_form(url_for('cases.mark_causative',
                                        institute_id=institute._id,
                                        case_name=case.display_name,
@@ -77,7 +83,7 @@
         <div class="list-group-item">
           {% if variant._id %}
             <div class="row align-items-between align-items-center">
-              <div class="col-10">
+              <div class="col">
                 <i class="fa fa-check-circle-o"></i>
                 {% if variant.category == "snv" %}
                   <a href="{{ url_for('variant.variant',
@@ -105,10 +111,10 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-4">
+              <div class="col-4">
                 OMIM diagnoses
               </div>
-              <div class="col-sm-8">
+              <div class="col-8">
                 {% for omim in variant_phenotypes.omim_terms %}
                   <span class="badge badge-sm badge-secondary">
                     <a class="text-white" target="_blank" href="http://omim.org/entry/{{omim}}">
@@ -119,10 +125,10 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-sm-4">
+              <div class="col-4">
                 HPO terms
               </div>
-              <div class="col-sm-8">
+              <div class="col-8">
                 {% for hpo in variant_phenotypes.hpo_terms %}
                   <a class="text-white" target="_blank" href="http://hpo.jax.org/app/browse/term/{{hpo.phenotype_id}}">
                     <span class="badge badge-sm badge-info">{{hpo.phenotype_id}}</span>
@@ -146,6 +152,14 @@
   </div>
 {% endmacro %}
 
+{% macro allele_div(allele, type) %}
+  {% if 'alt_freq' in allele %}
+    <div class="col-2" data-toggle="tooltip" data-placement="top" title="{{ type }} alternative AF ">
+      {{ allele.alt_freq|round(4) }}
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% macro suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) %}
   <div class="card panel-default">
     <div data-toggle='tooltip' class="panel-heading panel-heading-secondary"
@@ -158,23 +172,32 @@
         <li class="list-group-item">
           {% if variant._id %}
             <div class="row">
-              <div class="col-sm-8">
+              <div class="col">
                 <div class="form-group row justify-content-between align-items-center">
-                <div class="ml-3">
-                  <i class="fa fa-bookmark"></i>
-                    {{ pretty_link_variant(variant, case) }}
+                  <div class="ml-3">
+                    <i class="fa fa-bookmark"></i>
+                      {{ pretty_link_variant(variant, case) }}
+                  </div>
+                  {% if variant.sanger_ordered and not variant.validation in ['True positive','False positive'] %}
+                    <span class="badge badge-default">Verification ordered</span>
+                  {% elif variant.sanger_ordered %}
+                    <span class="badge badge-success">Validated</span>
+                  {% elif variant.manual_rank or variant.cancer_tier %}
+                    {{ tier_cell(variant, manual_rank_options, cancer_tier_options) }}
+                  {% endif %}
+                  {% if variant.mosaic_tags %}
+                    <span class="badge badge-info">mosaic</span>
+                  {% endif %}
                 </div>
-                {% if variant.sanger_ordered and not variant.validation in ['True positive','False positive'] %}
-                  <span class="badge badge-default">Verification ordered</span>
-                {% elif variant.sanger_ordered %}
-                  <span class="badge badge-success">Validated</span>
-                {% elif variant.manual_rank or variant.cancer_tier %}
-                  {{ tier_cell(variant, manual_rank_options, cancer_tier_options) }}
-                {% endif %}
-                {% if variant.mosaic_tags %}
-                  <span class="badge badge-info">mosaic</span>
-                {% endif %}
-                <form action="{{ url_for('cases.mark_validation',
+              </div>
+              {% if variant.tumor %}
+                {{ allele_div(variant.tumor, "Tumor") }}
+              {% endif %}
+              {% if variant.normal %}
+                {{ allele_div(variant.normal, "Normal") }}
+              {% endif %}
+              <div class="col-2">
+              <form action="{{ url_for('cases.mark_validation',
                                          institute_id=variant.institute,
                                          case_name=case.display_name,
                                          variant_id=variant._id) }}"
@@ -186,9 +209,7 @@
                   </select>
                 </form>
               </div>
-            </div>
-
-            <div class="col-sm-4">
+            <div class="col-1">
               {{ remove_form(url_for('cases.pin_variant',
                                      institute_id=institute._id,
                                      case_name=case.display_name,
@@ -197,7 +218,7 @@
             </div>
           </div>
           {% else %}
-            {{ variant }} <small class="text-muted">(not loaded)</small></t
+            {{ variant }} <small class="text-muted">(not loaded)</small>
           {% endif %}
         </li>
       {% endfor %}


### PR DESCRIPTION
This PR extends a functionality: show VAF on pinned and causative cancer variants on the case page.

Fix #2069!

**How to test**:
1. pin / mark variants causative, ideally both tumor-only, tumor-normal and RD and make sure all looks ok and shows intended values

![Screenshot 2020-09-07 at 17 51 46](https://user-images.githubusercontent.com/758570/92405932-048bfd80-f137-11ea-9cb1-9d887ac2b651.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR
