### PR TITLE
Move outdated panel info from tooltip to popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bugfix, LoqusDB per institute feature crashed when institute id was empty string
 - Bugfix, LoqusDB calls where missing case count
 - filter removal and upload for filters deleted from another page/other user
+- Visualize outdated gene panels info in a popover instead of a tooltip in case page side panel
 
 ### Changed
 - Highlight color on normal STRs in the variants table from green to blue

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -411,7 +411,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.13/js/bootstrap-multiselect.min.js"></script>
 <script src="//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
 
 <script>
  $('#panel-table').DataTable({
@@ -462,6 +462,13 @@ $(function () {
       });
 
       $('[data-toggle="tooltip"]').tooltip();
+
+      $('[data-toggle="popover"]').popover({
+        sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
+        container: 'body',
+      });
 
       $('select[multiple]').multiselect({
         buttonWidth: '100%'

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -42,7 +42,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if panel.panel_name in case.outdated_panels %}
-              <span class="badge badge-pill badge-sm badge-warning" data-toggle="tooltip" data-placement="right" title="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span>
+              <span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span>
             {% endif %}
         </div>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -42,7 +42,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if panel.panel_name in case.outdated_panels %}
-              <span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span>
+              <a><span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
             {% endif %}
         </div>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -42,7 +42,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if panel.panel_name in case.outdated_panels %}
-              <a><span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering. Genes present in case panel and not in latest version: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}. Genes present only in latest version: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
+              <a><span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-html="true" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
             {% endif %}
         </div>
       </div>

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -136,7 +136,7 @@ table.dataTable {margin-bottom: 0rem}
 }
 
 .popover {
-    max-width: none;
+    max-width: 60%;
     pointer-events: none;
 }
 


### PR DESCRIPTION
While testing #2077 on stage using older cases, I've realized that there are so many differences in genes that the info no longer fits in a tooltip, so a popover looks like a better solution.

**How to test**:
1. On stage, master branch, go to a case runned with an older panel, for instance: https://scout-stage.scilifelab.se/cust000/WNB127N
1. Notice that the gene panel differences from the latest panels are a lot:

![image](https://user-images.githubusercontent.com/28093618/92457987-2b911080-f1c5-11ea-8469-79bf2a14d22c.png)

1. Install this branch and see that the visualization of the message improves

![image](https://user-images.githubusercontent.com/28093618/92458851-3e581500-f1c6-11ea-8a14-cebfe312f260.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
