### PR TITLE
Improve column naming to avoid strange text shrinking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Fixed
+- Small change to Prop Freq column in variants ang gene panels to avoid strange text shrinking on small screens
 ### Changed
 
 

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -39,7 +39,7 @@
         <tr>
           <th scope="col">Case : Score</th>
           <th scope="col">Gene</th>
-          <th scope="col">PopFreq</th>
+          <th scope="col">Pop Freq</th>
           <th scope="col">CADD</th>
           <th scope="col">Gene annotation</th>
           <th scope="col">Func. annotation</th>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -63,16 +63,16 @@
           <thead>
             <tr>
               <th style="width:6%" title="Rank position">Rank </th>
-              <th style="width:18%" title="Dismiss Variant">Dismiss variant</th>
+              <th style="width:15%" title="Dismiss Variant">Dismiss variant</th>
               <th style="width:5%" title="Rank score">Score</th>
               <th style="width:4%" title="Chromosome">Chr.</th>
               <th style="width:8%" title="HGNC symbols">Gene</th>
-              <th style="width:4%" title="Poulation frequency">PopFreq</th>
+              <th style="width:6%" title="Poulation frequency">Pop Freq</th>
               <th style="width:5%" title="CADD score">CADD</th>
               <th style="width:8%" title="Gene region annotation">Gene annotation</th>
               <th style="width:12%" title="Functional annotation">Func. annotation</th>
               <th style="width:12%" title="Inheritance models">Inheritance model</th>
-              <th style="width:6%" title="Overlapping">Overlapping</th>
+              <th style="width:7%" title="Overlapping">Overlapping</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
This PR adds a tiny styling change

**How to test**:
1. Deploy to staging and check this case https://scout-stage.scilifelab.se/cust000/GIAluc14p19fam/variants?variant_type=clinical&gene_panels=OMIM-AUTO
2. Change the browser size to see the table behaviour when changing size

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.
![Screen Shot 2020-09-09 at 12 49 29](https://user-images.githubusercontent.com/6919697/92590135-fdcacb00-f29b-11ea-863f-d8f5395b42a0.png)


**Review:**
- [ ] code approved by
- [ ] tests executed by
