### PR TITLE
Restore HPO panel use in clinical filtering for SNVs and cancer SNVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Small change to Prop Freq column in variants ang gene panels to avoid strange text shrinking on small screens
+- Direct use of HPO list for Clinical HPO SNV (and cancer SNV) filtering
 ### Changed
 
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -299,9 +299,7 @@ def cancer_variants(institute_id, case_name):
         form = CancerFiltersForm(request.args)
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
-        if request.args.get("gene_panels"):
-            form.gene_panels.data = [request.args.get("gene_panels")]
-        else:
+        if form.gene_panels.data == []:
             form.gene_panels.data = [
                 panel["panel_name"]
                 for panel in case_obj.get("panels", [])

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -56,6 +56,7 @@ def variants(institute_id, case_name):
 
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
+        form.gene_panels.data = ["hpo"]
 
     user_obj = store.user(current_user.email)
 
@@ -69,11 +70,13 @@ def variants(institute_id, case_name):
         form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
-        form.gene_panels.data = [
-            panel["panel_name"]
-            for panel in case_obj.get("panels", [])
-            if panel["is_default"] is True
-        ]
+
+        if form.gene_panels.data == []:
+            form.gene_panels.data = [
+                panel["panel_name"]
+                for panel in case_obj.get("panels", [])
+                if panel["is_default"] is True
+            ]
 
     # populate filters dropdown
     available_filters = store.filters(institute_id, category)
@@ -297,11 +300,14 @@ def cancer_variants(institute_id, case_name):
         form = CancerFiltersForm(request.args)
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
-        form.gene_panels.data = [
-            panel["panel_name"]
-            for panel in case_obj.get("panels", [])
-            if panel["is_default"] is True
-        ]
+        if request.args.get("gene_panels"):
+            form.gene_panels.data = [request.args.get("gene_panels")]
+        else:
+            form.gene_panels.data = [
+                panel["panel_name"]
+                for panel in case_obj.get("panels", [])
+                if panel["is_default"] is True
+            ]
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
@@ -351,6 +357,7 @@ def cancer_sv_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
+        form.gene_panels.data = ["hpo"]
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -56,7 +56,6 @@ def variants(institute_id, case_name):
 
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
-        form.gene_panels.data = ["hpo"]
 
     user_obj = store.user(current_user.email)
 
@@ -357,7 +356,6 @@ def cancer_sv_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
-        form.gene_panels.data = ["hpo"]
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)


### PR DESCRIPTION
fix #2082
The dynamic gene list generated by the selected HPO terms in a case is not currently recognized as the list of genes to be used by clinical filter, even if it is marked so:


![image](https://user-images.githubusercontent.com/28093618/92594266-d4fa0400-f2a2-11ea-9326-5a26f7e8db98.png)


This PR fixes this behavior and introduces the same behavior in cancer SNVs filtering, that currently don't support this feature either

**How to test**:
1. On stage, master branch, assign one of more HPO phenotypes to a case, then click "HPO panel":


![image](https://user-images.githubusercontent.com/28093618/92594521-2bffd900-f2a3-11ea-852f-3c137e4612e8.png)

1. Then select "Use HPO list for clinical filter" option at the bottom of that panel, and click the `Clinical HPO snv variants button`:
![image](https://user-images.githubusercontent.com/28093618/92594618-5487d300-f2a3-11ea-885a-146caee222f5.png)


1. The variants page, filters field named "HGNC symbols", should be empty and the variants search should return variants from the case default gene panels:

![image](https://user-images.githubusercontent.com/28093618/92594738-839e4480-f2a3-11ea-961f-7d9316e57112.png)

1. Switch to this branch and repeat the search from the case page. Notice that:
 - "HGNC symbols" field will be populated with gene names
 - Variants search returns variants in those genes

1. The functionality should work also for cancer SNVs

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
