### PR TITLE
Bulk dismiss SNVs, SVs and cancer SNVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Small change to Prop Freq column in variants ang gene panels to avoid strange text shrinking on small screens
 - Direct use of HPO list for Clinical HPO SNV (and cancer SNV) filtering
 ### Changed
+- Remove the option to dismiss single variants from all variants pages
+- Bulk dismiss SNVs, SVs and cancer SNVs from variants pages
 
 
 ## [4.21]

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -61,25 +61,6 @@
   </form>
 {% endmacro %}
 
-{% macro dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) %}
-  <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
-    <div class="row">
-      <div class="col-lg-8"  style="width: 200px">
-        <select multiple="multiple" name="dismiss_variant" class="selectpicker dismiss-dropdown" data-width="100%">
-          {% for rank, data in dismiss_variant_options.items() %}
-            <option {% if rank~"" in variant.dismiss_variant %} selected {% endif %} value="{{ rank }}">
-              {{ data.label }}
-            </option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="col-lg-4">
-        <button type="submit" name="dismiss" class="btn btn-outline-secondary form-control dismiss-button" style="width: 63px; margin-left: -15px;">Save</button>
-      </div>
-    </div>
-  </form>
-{% endmacro %}
-
 {% macro mosaic_variant_button(variant, institute, case, mosaic_variant_options) %}
   <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
     <label class="mt-3">Mosaic Tags</label>

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -857,3 +857,32 @@ def activate_case(store, institute_obj, case_obj, current_user):
             case_name=case_obj["display_name"],
         )
         store.update_status(institute_obj, case_obj, user_obj, "active", case_link)
+
+
+def dismiss_variant_list(store, institute_obj, case_obj, variants_list, dismiss_reasons):
+    """Dismiss a list of variants for a case
+
+    Args:
+        store(adapter.MongoAdapter)
+        institute_obj(dict): an institute dictionary
+        case_obj(dict): a case dictionary
+        variants_list(list): list of variant._ids (strings)
+        dismiss_reasons(list): list of dismiss options
+    """
+    user_obj = store.user(current_user.email)
+    for variant_id in variants_list:
+        variant_obj = store.variant(variant_id)
+        if variant_obj is None:
+            continue
+        # create variant link
+        link = link = url_for(
+            "variant.variant",
+            institute_id=institute_obj["_id"],
+            case_name=case_obj["_id"],
+            variant_id=variant_id,
+        )
+        # dismiss variant
+        store.update_dismiss_variant(
+            institute_obj, case_obj, user_obj, link, variant_obj, dismiss_reasons
+        )
+    return

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -886,4 +886,3 @@ def dismiss_variant_list(store, institute_obj, case_obj, link_page, variants_lis
         store.update_dismiss_variant(
             institute_obj, case_obj, user_obj, link, variant_obj, dismiss_reasons
         )
-    return

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -859,13 +859,14 @@ def activate_case(store, institute_obj, case_obj, current_user):
         store.update_status(institute_obj, case_obj, user_obj, "active", case_link)
 
 
-def dismiss_variant_list(store, institute_obj, case_obj, variants_list, dismiss_reasons):
+def dismiss_variant_list(store, institute_obj, case_obj, link_page, variants_list, dismiss_reasons):
     """Dismiss a list of variants for a case
 
     Args:
         store(adapter.MongoAdapter)
         institute_obj(dict): an institute dictionary
         case_obj(dict): a case dictionary
+        link_page(str): "variant.variant" for snvs, "variant.sv_variant" for SVs and so on
         variants_list(list): list of variant._ids (strings)
         dismiss_reasons(list): list of dismiss options
     """
@@ -876,7 +877,7 @@ def dismiss_variant_list(store, institute_obj, case_obj, variants_list, dismiss_
             continue
         # create variant link
         link = link = url_for(
-            "variant.variant",
+            link_page,
             institute_id=institute_obj["_id"],
             case_name=case_obj["_id"],
             variant_id=variant_id,

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -85,7 +85,7 @@ function initSearchConstraints(selectorId, textId){
     });
 }
 
-export function enableDismiss(){
+function enableDismiss(){
   // before enabling the variant dismiss button
   var selectElem = document.getElementById("dismiss_choices");
   // make sure that user selects at least one dismiss reason

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -46,9 +46,6 @@ function populateCytobands(cytobands){
     cytoEnd.appendChild(el);
   }
 }
-
-
-
 // ValidateForm()
 // Controll user input fields (start, end) in varaint filter.
 //
@@ -72,7 +69,6 @@ function validateForm(){
     return true;
 }
 
-
 // syncSearchConstraints(selectorId:HTML-selector, textId:HTML-textfield)
 //
 // Initialize and synchronize 'startelem' and 'cyto_start', used for setting
@@ -88,7 +84,6 @@ function initSearchConstraints(selectorId, textId){
         textId.value = selectorId.options[selectorId.selectedIndex].value
     });
 }
-
 
 function enableDismiss()
 {

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -85,7 +85,7 @@ function initSearchConstraints(selectorId, textId){
     });
 }
 
-function enableDismiss(){
+export function enableDismiss(){
   // before enabling the variant dismiss button
   var selectElem = document.getElementById("dismiss_choices");
   // make sure that user selects at least one dismiss reason
@@ -105,7 +105,7 @@ function enableDismiss(){
         break;
       }
   }
-  var btnElem = document.getElementById('dismiss_submit');
+  var btnElem = document.getElementById("dismiss_submit");
   if (selectedOptions & checkedVars) {
     btnElem.disabled = false;
   }

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -88,7 +88,7 @@ function initSearchConstraints(selectorId, textId){
 function enableDismiss()
 {
   // before enabling the variant dismiss button
-  var selectElem = document.getElementById("dismiss_options");
+  var selectElem = document.getElementById("dismiss_choices");
   // make sure that user selects at least one dismiss reason
   var selectedOptions = false;
   for (var i = 0; i < selectElem.length; i++) {

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -85,8 +85,7 @@ function initSearchConstraints(selectorId, textId){
     });
 }
 
-function enableDismiss()
-{
+function enableDismiss(){
   // before enabling the variant dismiss button
   var selectElem = document.getElementById("dismiss_choices");
   // make sure that user selects at least one dismiss reason
@@ -107,7 +106,7 @@ function enableDismiss()
       }
   }
   var btnElem = document.getElementById('dismiss_submit');
-  if (selectedOptions & checkedVars){
+  if (selectedOptions & checkedVars) {
     btnElem.disabled = false;
   }
   else{

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -6,7 +6,6 @@ function populateCytobands(cytobands){
     return //only reset cytoband select element
   }
 
-
   var chrom_cytobands = cytobands[chrom]["cytobands"]; // chromosome-specific cytobands
 
   for (elem of [cytoStart, cytoEnd]) {
@@ -91,8 +90,32 @@ function initSearchConstraints(selectorId, textId){
 }
 
 
-
-
-
-
-
+function enableDismiss()
+{
+  // before enabling the variant dismiss button
+  var selectElem = document.getElementById("dismiss_options");
+  // make sure that user selects at least one dismiss reason
+  var selectedOptions = false;
+  for (var i = 0; i < selectElem.length; i++) {
+      if (selectElem.options[i].selected){
+        selectedOptions = true;
+        break;
+      }
+  }
+  // make sure that at least one checkbox corresponding to a variant is checked
+  var variantCheckboxes = document.getElementsByName("dismiss");
+  var checkedVars=false
+  for (var i = 0; i < variantCheckboxes.length; i++) {
+      if (variantCheckboxes[i].checked){
+        checkedVars = true;
+        break;
+      }
+  }
+  var btnElem = document.getElementById('dismiss_submit');
+  if (selectedOptions & checkedVars){
+    btnElem.disabled = false;
+  }
+  else{
+    btnElem.disabled = true;
+  }
+}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import sv_filters,cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block %}
+{% from "variants/utils.html" import sv_filters,cell_rank, pagination_footer, pagination_hidden_div %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -59,7 +59,6 @@
     <table id="variantsTable" class="table table-hover table-bordered">
       <thead>
         <tr>
-          <th style="width:3%"></th>
           <th>Index</th>
           <th>Score</th>
           <th>Type</th>
@@ -83,9 +82,8 @@
         {% endfor %}
       </tbody>
     </table>
-    {{ dismiss_variants_block(dismiss_variant_options) }}
-  </div>
   </form>
+  </div>
   <div class="container-fluid">
     {{ pagination_footer(more_variants, page) }}
   </div>
@@ -191,7 +189,6 @@
   {% else %}
   <tr>
   {% endif %}
-    <td><input type="checkbox" value="{{variant._id}}" name="dismiss" onclick="enableDismiss()"></td>
     <td>
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,8 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import sv_filters,cell_rank, pagination_footer, pagination_hidden_div %}
-{% from "variant/buttons.html" import dismiss_variant_table_button %}
-
+{% from "variants/utils.html" import sv_filters,cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -56,14 +54,13 @@
           {% endif %}
         </div>
       </div>
-    </form>
   </div>
   <div class="card mt-3">
     <table id="variantsTable" class="table table-hover table-bordered">
       <thead>
         <tr>
+          <th style="width:3%"></th>
           <th>Index</th>
-          <th style="width:18%" title="Dismiss variant">Dismiss variant</th>
           <th>Score</th>
           <th>Type</th>
           <th>Chr</th>
@@ -86,7 +83,9 @@
         {% endfor %}
       </tbody>
     </table>
+    {{ dismiss_variants_block(dismiss_variant_options) }}
   </div>
+  </form>
   <div class="container-fluid">
     {{ pagination_footer(more_variants, page) }}
   </div>
@@ -192,10 +191,10 @@
   {% else %}
   <tr>
   {% endif %}
+    <td><input type="checkbox" value="{{variant._id}}" name="dismiss" onclick="enableDismiss()"></td>
     <td>
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
-    <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
     <td>{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -1,7 +1,6 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
-{% from "variants/utils.html" import cancer_filters, tier_cell, cell_rank, pagination_footer, pagination_hidden_div %}
-{% from "variant/buttons.html" import dismiss_variant_table_button %}
+{% from "variants/utils.html" import cancer_filters, tier_cell, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block %}
 
 {% block title %}
   {{ variant_type|capitalize }} cancer variants
@@ -50,24 +49,23 @@
         {% endif %}
       </div>
     </div>
-  </form>
 
   <div class="card mt-3">
     <table class="table table-hover table-bordered" style="table-layout:fixed">
       <thead>
             <tr>
-              <th style="width:6%" title="Rank position">Rank</th>
-              <th style="width:15%" title="Dismiss variant">Dismiss variant</th>
-              <th style="width:12%">Gene:Transcript:Exon:HGVS</th>
-              <th style="width:6%" >Tier</th>
-              <th style="width:5%" >Score</th>
-              <th style="width:10%">Gene</th>
-              <th style="width:6%">Chr pos</th>
-              <th style="width:6%">ExAC</th>
-              <th style="width:6%">Type</th>
-              <th style="width:14%">Consequence</th>
-              <th style="width:6%" data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
-              <th style="width:6%" data-toggle="tooltip" data-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
+              <th style="width:3%"></th>
+              <th style="width:4%" title="Rank position">Rank</th>
+              <th style="width:20%">Gene:Transcript:Exon:HGVS</th>
+              <th>Tier</th>
+              <th>Score</th>
+              <th>Gene</th>
+              <th>Chr pos</th>
+              <th>ExAC</th>
+              <th>Type</th>
+              <th style="width:18%">Consequence</th>
+              <th data-toggle="tooltip" data-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
+              <th data-toggle="tooltip" data-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
             </tr>
       </thead>
       <tbody>
@@ -79,8 +77,8 @@
           {% else %}
             <tr>
           {% endif %}
+            <td><input type="checkbox" value="{{variant._id}}" name="dismiss" onclick="enableDismiss()"></td>
             <td class="text-left">{{cell_rank(variant, institute, case, form, manual_rank_options)}}</td>
-            <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
             <td>
               <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
                                   variant_id=variant._id, cancer='yes') }}">
@@ -106,13 +104,11 @@
         {% endfor %}
       </tbody>
     </table>
+    {{ dismiss_variants_block(dismiss_variant_options) }}
   </div><!-- end of card-->
-  <br>
+</form><!--end of form containing filters and variants' table elements -->
 </div><!--end of container-float -->
-<div class="container-fluid">
-  {{ pagination_footer(more_variants, page) }}
-</div>
-
+{{ pagination_footer(more_variants, page) }}
 {% endblock %}
 
 {% macro actions_cell(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -55,7 +55,7 @@
       <thead>
             <tr>
               <th style="width:3%"></th>
-              <th style="width:4%" title="Rank position">Rank</th>
+              <th title="Rank position">Rank</th>
               <th style="width:20%">Gene:Transcript:Exon:HGVS</th>
               <th>Tier</th>
               <th>Score</th>
@@ -108,7 +108,9 @@
   </div><!-- end of card-->
 </form><!--end of form containing filters and variants' table elements -->
 </div><!--end of container-float -->
+<div class="container-fluid">
 {{ pagination_footer(more_variants, page) }}
+</div>
 {% endblock %}
 
 {% macro actions_cell(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -38,7 +38,6 @@
 {% endblock %}
 
 {% block content_main %}
-<form method="POST" id="dismiss_form" action="{{url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name)}}">
   <div class="card mt-3">
     <table class="table table-bordered table-hover" style="table-layout: fixed">
       <thead>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -1,8 +1,7 @@
 {% extends "layout_bs4.html" %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import cell_rank, pagination_footer %}
-{% from "variant/buttons.html" import dismiss_variant_table_button %}
+{% from "variants/utils.html" import cell_rank, dismiss_variants_block%}
 
 
 {% block title %}
@@ -39,22 +38,22 @@
 {% endblock %}
 
 {% block content_main %}
+<form method="POST" id="dismiss_form" action="{{url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name)}}">
   <div class="card mt-3">
     <table class="table table-bordered table-hover" style="table-layout: fixed">
       <thead>
         <tr>
           <th style="width:8%" title="Index">Index</th>
-          <th style="width:18%" title="Dismiss Variant">Dismiss variant</th>
-          <th style="width:8%" title="Repeat ID">Repeat locus</th>
-          <th style="width:8%" title="Repeat unit">Reference repeat unit</th>
-          <th style="width:5%" title="ALT">Estimated size</th>
-          <th style="width:5%" title="ReferenceSize">Reference size</th>
-          <th style="width:8%" title="Status">Status</th>
-          <th style="width:6%" title="Max normal">Max normal</th>
-          <th style="width:6%" title="Min pathologic">Min pathologic</th>
-          <th style="width:12%" title="GT">Genotype</th>
-          <th style="width:6%" title="Chromosome">Chr.</th>
-          <th style="width:10%" title="Position">Position</th>
+          <th title="Repeat ID">Repeat locus</th>
+          <th title="Repeat unit">Reference repeat unit</th>
+          <th title="ALT">Estimated size</th>
+          <th title="ReferenceSize">Reference size</th>
+          <th title="Status">Status</th>
+          <th title="Max normal">Max normal</th>
+          <th title="Min pathologic">Min pathologic</th>
+          <th title="GT">Genotype</th>
+          <th title="Chromosome">Chr.</th>
+          <th title="Position">Position</th>
         </tr>
       </thead>
       <tbody>
@@ -78,7 +77,6 @@
 	            <tr>
 	        {% endif %}
             <td>{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
-            <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
             <td>{{ variant.str_repid }}</td>
 	          <td class="text-right">{{ variant.str_ru }}</td>
             <td class="text-right">{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -88,7 +88,9 @@
       </div>
     </form>
   </div>
+  <div class="container-fluid">
   {{ pagination_footer(more_variants, page) }}
+  </div>
 {% endblock %}
 
 {% macro variant_row(variant) %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -1,9 +1,7 @@
 {% extends "layout_bs4.html" %}
 {% from "utils.html" import comments_table %}
-{% from "variants/utils.html" import sv_filters, cell_rank, pagination_footer, pagination_hidden_div %}
+{% from "variants/utils.html" import sv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block %}
 {% from "variants/components.html" import frequency_cell_general %}
-{% from "variant/buttons.html" import dismiss_variant_table_button %}
-
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -58,40 +56,39 @@
           {% endif %}
         </div>
       </div>
+      <div class="card mt-3">
+        <table id="variantsTable" class="table table-hover table-bordered" style="table-layout: fixed">
+          <thead>
+            <tr>
+              <th style="width:3%"></th>
+              <th>Rank</th>
+              <th>Score</th>
+              <th>Type</th>
+              <th>Chr</th>
+              <th>Start loc</th>
+              <th>Stop loc</th>
+              <th>Length</th>
+              <th>Region</th>
+              <th>Function</th>
+              <th>Frequency</th>
+              <th>Gene(s)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for variant in variants %}
+              {{ variant_row(variant) }}
+            {% else %}
+              <tr>
+                  <td colspan="11">No matching variants</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        {{ dismiss_variants_block(dismiss_variant_options) }}
+      </div>
     </form>
   </div>
-  <div class="card mt-3">
-    <table id="variantsTable" class="table table-hover table-bordered" style="table-layout: fixed">
-      <thead>
-        <tr>
-          <th style="width:8%">Rank</th>
-          <th style="width:16%">Dismiss variant</th>
-          <th style="width:6%">Score</th>
-          <th style="width:6%">Type</th>
-          <th style="width:6%">Chr</th>
-          <th style="width:6%">Start loc</th>
-          <th style="width:6%">Stop loc</th>
-          <th style="width:8%">Length</th>
-          <th style="width:8%">Region</th>
-          <th style="width:10%">Function</th>
-          <th style="width:10%">Frequency</th>
-          <th style="width:10%">Gene(s)</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for variant in variants %}
-          {{ variant_row(variant) }}
-        {% else %}
-          <tr>
-              <td colspan="11">No matching variants</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  <div class="container-fluid">
-    {{ pagination_footer(more_variants, page) }}
-  </div>
+  {{ pagination_footer(more_variants, page) }}
 {% endblock %}
 
 {% macro variant_row(variant) %}
@@ -102,10 +99,10 @@
   {% else %}
   <tr>
   {% endif %}
+    <td><input type="checkbox" value="{{variant._id}}" name="dismiss" onclick="enableDismiss()"></td>
     <td class="text-left">
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
-    <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
     <td class="text-right">{{ variant.rank_score|int }}</td>
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
@@ -170,7 +167,6 @@
 
     var cytoEnd = document.getElementById("cytoband_end");
     initSearchConstraints(cytoEnd, endElem)
-
 
     $('select[multiple]').selectpicker({
         width: '100%'

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -2,7 +2,7 @@
 {% from "utils.html" import comments_table %}
 
 {% macro dismiss_variants_block(dismiss_variant_options) %}
-<div class="row d-flex align-items-center">
+<div class="row d-flex align-items-center mb-3">
   <div class="col-2 ml-3">Dismiss selected variants:</div>
   <div class="col-5 align-items-start">
     <select multiple="multiple" name="dismiss_options" id="dismiss_options" class="selectpicker" data-width="100%" onchange="enableDismiss();">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1,6 +1,23 @@
 {% import "bootstrap/wtf.html" as wtf %}
 {% from "utils.html" import comments_table %}
 
+{% macro dismiss_variants_block(dismiss_variant_options) %}
+<div class="row d-flex align-items-center">
+  <div class="col-2 ml-3">Dismiss selected variants:</div>
+  <div class="col-5 align-items-start">
+    <select multiple="multiple" name="dismiss_options" id="dismiss_options" class="selectpicker" data-width="100%" onchange="enableDismiss();">
+      {% for value, data in dismiss_variant_options.items() %}
+      {{dismiss_variant_options}}
+        <option value="{{ value }}">{{ data.label }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-2">
+    <button type="submit" disabled name="dismiss_submit" id="dismiss_submit" class="btn btn-sm btn-primary form-control">Dismiss variants</button>
+  </div>
+</div>
+{% endmacro %}
+
 {% macro compounds_table(institute, case, compounds) %}
   <table class='table table-condensed table-bordered table-sm'>
     <thead>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -5,7 +5,7 @@
 <div class="row d-flex align-items-center mb-3">
   <div class="col-2 ml-3">Dismiss selected variants:</div>
   <div class="col-5 align-items-start">
-    <select multiple="multiple" name="dismiss_options" id="dismiss_options" class="selectpicker" data-width="100%" onchange="enableDismiss();">
+    <select multiple="multiple" name="dismiss_choices" id="dismiss_choices" class="selectpicker" data-width="100%" onchange="enableDismiss();">
       {% for value, data in dismiss_variant_options.items() %}
         <option value="{{ value }}">{{ data.label }}</option>
       {% endfor %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -7,7 +7,6 @@
   <div class="col-5 align-items-start">
     <select multiple="multiple" name="dismiss_options" id="dismiss_options" class="selectpicker" data-width="100%" onchange="enableDismiss();">
       {% for value, data in dismiss_variant_options.items() %}
-      {{dismiss_variant_options}}
         <option value="{{ value }}">{{ data.label }}</option>
       {% endfor %}
     </select>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -199,7 +199,6 @@
             break;
           }
       }
-      console.log(checkedVars)
       var btnElem = document.getElementById('dismiss_submit');
       if (selectedOptions & checkedVars){
         btnElem.disabled = false;

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -1,8 +1,6 @@
 {% extends "layout_bs4.html" %}
-{% from "variants/utils.html" import compounds_table, svs_table, snv_filters, cell_rank, pagination_footer, pagination_hidden_div%}
+{% from "variants/utils.html" import compounds_table, svs_table, snv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block %}
 {% from "variants/components.html" import gene_cell, frequency_cell %}
-{% from "variant/buttons.html" import dismiss_variant_table_button %}
-
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ form.variant_type.data|capitalize }} variants
@@ -39,7 +37,7 @@
 {% endblock %}
 {% block content_main %}
     <div class="container-float">
-<form method="POST" id="filters_form" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name)}}"
+      <form method="POST" id="filters_form" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name)}}"
          enctype="multipart/form-data" onsubmit="return validateForm()">
          {{ pagination_hidden_div(page) }}
         <div class="card panel-default" id="accordion">
@@ -57,22 +55,22 @@
           </div>
         </div>
 
-      </form>
+
       <div class="card mt-3">
         <table class="table table-hover table-bordered" style="table-layout: fixed">
           <thead>
             <tr>
-              <th style="width:6%" title="Rank position">Rank </th>
-              <th style="width:15%" title="Dismiss Variant">Dismiss variant</th>
-              <th style="width:5%" title="Rank score">Score</th>
-              <th style="width:4%" title="Chromosome">Chr.</th>
+              <th style="width:3%"></th>
+              <th style="width:12%" title="Rank position">Rank </th>
+              <th style="width:6%" title="Rank score">Score</th>
+              <th style="width:6%" title="Chromosome">Chr.</th>
               <th style="width:8%" title="HGNC symbols">Gene</th>
               <th style="width:6%" title="Poulation frequency">Pop Freq</th>
-              <th style="width:5%" title="CADD score">CADD</th>
+              <th style="width:6%" title="CADD score">CADD</th>
               <th style="width:8%" title="Gene region annotation">Gene annotation</th>
-              <th style="width:12%" title="Functional annotation">Func. annotation</th>
-              <th style="width:12%" title="Inheritance models">Inheritance model</th>
-              <th style="width:7%" title="Overlapping">Overlapping</th>
+              <th style="width:18%" title="Functional annotation">Func. annotation</th>
+              <th style="width:18%" title="Inheritance models">Inheritance model</th>
+              <th style="width:8%" title="Overlapping">Overlapping</th>
             </tr>
           </thead>
           <tbody>
@@ -84,8 +82,8 @@
               {% else %}
                 <tr>
               {% endif %}
+                <td><input type="checkbox" value="{{variant._id}}" name="dismiss" onclick="enableDismiss()"></td>
                 <td class="text-left">{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
-                <td>{{ dismiss_variant_table_button(variant, institute, case, dismiss_variant_options) }}</td>
                 <td class="text-right">{{ variant.rank_score|int }}</td>
                 <td>{{ variant.chromosome }}</td>
                 <td>{{ gene_cell(variant) }}</td>
@@ -113,7 +111,9 @@
             {% endfor %}
           </tbody>
         </table>
+        {{ dismiss_variants_block(dismiss_variant_options) }}
       </div><!-- end of <div class="card mt-3">-->
+    </form> <!--end of form containing filters and variants' table elements -->
     </div> <!-- end of class="container-float"> -->
       {{ pagination_footer(more_variants, page) }}
 {% endblock %}
@@ -178,7 +178,36 @@
     var cytoEnd = document.getElementById("cytoband_end");
     initSearchConstraints(cytoEnd, endElem)
 
-
+    function enableDismiss()
+    {
+      // before enabling the variant dismiss button
+      var selectElem = document.getElementById("dismiss_options");
+      // make sure that user selects at least one dismiss reason
+      var selectedOptions = false;
+      for (var i = 0; i < selectElem.length; i++) {
+          if (selectElem.options[i].selected){
+            selectedOptions = true;
+            break;
+          }
+      }
+      // make sure that at least one checkbox corresponding to a variant is checked
+      var variantCheckboxes = document.getElementsByName("dismiss");
+      var checkedVars=false
+      for (var i = 0; i < variantCheckboxes.length; i++) {
+          if (variantCheckboxes[i].checked){
+            checkedVars = true;
+            break;
+          }
+      }
+      console.log(checkedVars)
+      var btnElem = document.getElementById('dismiss_submit');
+      if (selectedOptions & checkedVars){
+        btnElem.disabled = false;
+      }
+      else{
+        btnElem.disabled = true;
+      }
+    }
 
     window.onload=function() {
       populateCytobands({{cytobands|safe}});

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -178,36 +178,6 @@
     var cytoEnd = document.getElementById("cytoband_end");
     initSearchConstraints(cytoEnd, endElem)
 
-    function enableDismiss()
-    {
-      // before enabling the variant dismiss button
-      var selectElem = document.getElementById("dismiss_options");
-      // make sure that user selects at least one dismiss reason
-      var selectedOptions = false;
-      for (var i = 0; i < selectElem.length; i++) {
-          if (selectElem.options[i].selected){
-            selectedOptions = true;
-            break;
-          }
-      }
-      // make sure that at least one checkbox corresponding to a variant is checked
-      var variantCheckboxes = document.getElementsByName("dismiss");
-      var checkedVars=false
-      for (var i = 0; i < variantCheckboxes.length; i++) {
-          if (variantCheckboxes[i].checked){
-            checkedVars = true;
-            break;
-          }
-      }
-      var btnElem = document.getElementById('dismiss_submit');
-      if (selectedOptions & checkedVars){
-        btnElem.disabled = false;
-      }
-      else{
-        btnElem.disabled = true;
-      }
-    }
-
     window.onload=function() {
       populateCytobands({{cytobands|safe}});
     }

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -115,7 +115,9 @@
       </div><!-- end of <div class="card mt-3">-->
     </form> <!--end of form containing filters and variants' table elements -->
     </div> <!-- end of class="container-float"> -->
+    <div class="container-fluid">
       {{ pagination_footer(more_variants, page) }}
+    </div>
 {% endblock %}
 
 {% macro cell_cadd(variant) %}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -291,6 +291,15 @@ def cancer_variants(institute_id, case_name):
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
+        if request.form.getlist("dismiss"):  # dismiss a list of variants
+            controllers.dismiss_variant_list(
+                store,
+                institute_obj,
+                case_obj,
+                request.form.getlist("dismiss"),
+                request.form.getlist("dismiss_options"),
+            )
+
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -373,6 +373,7 @@ def cancer_variants(institute_id, case_name):
 def cancer_sv_variants(institute_id, case_name):
     """Display a list of cancer structural variants."""
 
+    flash(request.form)
     page = int(request.form.get("page", 1))
     variant_type = request.args.get("variant_type", "clinical")
     category = "cancer_sv"
@@ -381,6 +382,16 @@ def cancer_sv_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
+    """
+    if request.form.getlist("dismiss"):  # dismiss a list of variants
+        controllers.dismiss_variant_list(
+            store,
+            institute_obj,
+            case_obj,
+            request.form.getlist("dismiss"),
+            request.form.getlist("dismiss_options"),
+        )
+    """
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -65,8 +65,9 @@ def variants(institute_id, case_name):
                 store,
                 institute_obj,
                 case_obj,
+                "variant.variant",
                 request.form.getlist("dismiss"),
-                request.form.getlist("dismiss_options"),
+                request.form.getlist("dismiss_choices"),
             )
 
         form = controllers.populate_filters_form(
@@ -245,8 +246,9 @@ def sv_variants(institute_id, case_name):
             store,
             institute_obj,
             case_obj,
+            "variant.sv_variant",
             request.form.getlist("dismiss"),
-            request.form.getlist("dismiss_options"),
+            request.form.getlist("dismiss_choices"),
         )
 
     # update status of case if visited for the first time
@@ -296,8 +298,9 @@ def cancer_variants(institute_id, case_name):
                 store,
                 institute_obj,
                 case_obj,
+                "variant.variant",
                 request.form.getlist("dismiss"),
-                request.form.getlist("dismiss_options"),
+                request.form.getlist("dismiss_choices"),
             )
 
         form = controllers.populate_filters_form(
@@ -373,7 +376,6 @@ def cancer_variants(institute_id, case_name):
 def cancer_sv_variants(institute_id, case_name):
     """Display a list of cancer structural variants."""
 
-    flash(request.form)
     page = int(request.form.get("page", 1))
     variant_type = request.args.get("variant_type", "clinical")
     category = "cancer_sv"
@@ -382,17 +384,7 @@ def cancer_sv_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
-    """
-    if request.form.getlist("dismiss"):  # dismiss a list of variants
-        controllers.dismiss_variant_list(
-            store,
-            institute_obj,
-            case_obj,
-            request.form.getlist("dismiss"),
-            request.form.getlist("dismiss_options"),
-        )
-    """
-
+        
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -60,7 +60,6 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
-        flash(request.form)
         if request.form.getlist("dismiss"):  # dismiss a list of variants
             controllers.dismiss_variant_list(
                 store,

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -60,6 +60,16 @@ def variants(institute_id, case_name):
     user_obj = store.user(current_user.email)
 
     if request.method == "POST":
+        flash(request.form)
+        if request.form.getlist("dismiss"):  # dismiss a list of variants
+            controllers.dismiss_variant_list(
+                store,
+                institute_obj,
+                case_obj,
+                request.form.getlist("dismiss"),
+                request.form.getlist("dismiss_options"),
+            )
+
         form = controllers.populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -240,6 +240,15 @@ def sv_variants(institute_id, case_name):
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
 
+    if request.form.getlist("dismiss"):  # dismiss a list of variants
+        controllers.dismiss_variant_list(
+            store,
+            institute_obj,
+            case_obj,
+            request.form.getlist("dismiss"),
+            request.form.getlist("dismiss_options"),
+        )
+
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
     form = controllers.populate_sv_filters_form(store, institute_obj, case_obj, category, request)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -384,7 +384,7 @@ def cancer_sv_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
-        
+
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)
 

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -86,6 +86,41 @@ def test_variants(app, institute_obj, case_obj):
         assert resp.status_code == 200
 
 
+def test_bulk_dismiss_variants(app, institute_obj, case_obj):
+    """Sending a POST request to variants view to test variant dismiss funtionality"""
+    # GIVEN an initialized app
+    # GIVEN a valid user and institute
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+
+        # GIVEN a test variant to be dismissed
+        snv_variant = store.variant_collection.find_one({"category": "snv"})
+
+        # When a POST request with filter containing wrongly formatted parameters is sent
+        dismiss_choices = ["2", "5"]
+        form_data = {
+            "dismiss": snv_variant["_id"],
+            "dismiss_choices": dismiss_choices,
+        }
+
+        resp = client.post(
+            url_for(
+                "variants.variants",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+            ),
+            data=form_data,
+        )
+        # THEN it should return a redirected page
+        assert resp.status_code == 200
+
+        # and the variant should be updated with the dismissed options
+        updated_variant = store.variant_collection.find_one({"_id": snv_variant["_id"]})
+        for option in dismiss_choices:
+            assert option in updated_variant["dismiss_variant"]
+
+
 def test_variants_research(app, institute_obj, case_obj):
     # GIVEN an initialized app
     # GIVEN a valid user and institute


### PR DESCRIPTION
Fix #2081 

This PR:
- removes the code to dismiss single variants from variants pages (all types of variants).
- Adds a system to dismiss many variants at the time for 
  - SNVs (rare disease track)
  - SVs (rare disease track)
  - Cancer SNVs (cancer track)

Screenshot:
![image](https://user-images.githubusercontent.com/28093618/92728235-ac404000-f370-11ea-8756-c7d56eb2aa0a.png)


I've tried to apply this system also to cancer SVs and STRS but I had problems:
- cancer SVs  returns an error that I couldn't fix yet 
- and STRS page contains a form to show bam files and since this multi-checkbox system must be included in another form, but you can't have a form inside a form, I just reverted the code to how it was before the dismiss.

Of course the things above might be fixed, but it will take time, and we don't have much time for the patch of current version..


**How to test**:
1. On stage, try to dismiss SNVs, SVs and cancer SNVs.
1. Make sure that if you were filtering the variants using any filter, these filters are still used when the page reloads after dismissing one or more variants
1. It shouldn't be possible to dismiss single variants any more from STRs and cancer SVs (cancer SVs behavior might be tested on a local instance of scout after loading the demo cancer sample)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
