### PR TITLE
Fix coverage report PDF download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Small change to Prop Freq column in variants ang gene panels to avoid strange text shrinking on small screens
 - Direct use of HPO list for Clinical HPO SNV (and cancer SNV) filtering
+- PDF coverage report redirecting to login page
 ### Changed
 
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -79,6 +79,7 @@ def create_app(config_file=None, config=None):
             relevant_endpoint = not (static_endpoint or public_endpoint)
             # if endpoint requires auth, check if user is authenticated
             if relevant_endpoint and not current_user.is_authenticated:
+                LOG.error("HERE")
                 # combine visited URL (convert byte string query string to unicode!)
                 next_url = "{}?{}".format(request.path, request.query_string.decode())
                 login_url = url_for("public.index", next=next_url)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -79,7 +79,7 @@ def create_app(config_file=None, config=None):
             relevant_endpoint = not (static_endpoint or public_endpoint)
             # if endpoint requires auth, check if user is authenticated
             if relevant_endpoint and not current_user.is_authenticated:
-                LOG.error("HERE")
+                LOG.error(f"HERE----->{request.endpoint}")
                 # combine visited URL (convert byte string query string to unicode!)
                 next_url = "{}?{}".format(request.path, request.query_string.decode())
                 login_url = url_for("public.index", next=next_url)
@@ -231,6 +231,8 @@ def configure_coverage(app):
         configure_template_filters(app)
         # register chanjo report blueprint
         app.register_blueprint(report_bp, url_prefix="/reports")
+
+
 
     babel = Babel(app)
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -74,12 +74,11 @@ def create_app(config_file=None, config=None):
     def check_user():
         if not app.config.get("LOGIN_DISABLED") and request.endpoint:
             # check if the endpoint requires authentication
-            static_endpoint = "static" in request.endpoint
+            static_endpoint = "static" in request.endpoint or request.endpoint == "report.report"
             public_endpoint = getattr(app.view_functions[request.endpoint], "is_public", False)
             relevant_endpoint = not (static_endpoint or public_endpoint)
             # if endpoint requires auth, check if user is authenticated
             if relevant_endpoint and not current_user.is_authenticated:
-                LOG.error(f"HERE----->{request.endpoint}")
                 # combine visited URL (convert byte string query string to unicode!)
                 next_url = "{}?{}".format(request.path, request.query_string.decode())
                 login_url = url_for("public.index", next=next_url)


### PR DESCRIPTION
fix #2086 

This is a fix to the problem of the PDF coverage report redirecting to the login page. This problem is affecting 2 pages:
- Coverage report, HTML page, when you click on the "PDF" button
- PDF version of the general report. The last section of the report, which is containing the coverage data.

Perhaps there is a better solution to fix this problem, but I haven't found it. Any other suggestion is highly appreciated!

**How to test**:
1. Test with one case on stage, for instance this: https://scout-stage.scilifelab.se/cust002/F0015031
1. Make sure that with master branch the 2 errors described above show up.
1. Install the branch and make sure that the 2 errors don't occur any more

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
