### PR TITLE
Do not filter research variants by panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Fixed
+- Do not pre-filter research variants by (case-default) gene panels
 ### Changed
 
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -701,6 +701,21 @@ def populate_filters_form(store, institute_obj, case_obj, user_obj, category, re
     return form
 
 
+def case_default_panels(case_obj):
+    """Get a list of case default panels from a case dictionary
+
+    Args:
+        case_obj(dict): a case object
+
+    Returns:
+        case_panels(list): a list of panels (panel_name)
+    """
+    case_panels = [
+        panel["panel_name"] for panel in case_obj.get("panels", []) if panel["is_default"] is True
+    ]
+    return case_panels
+
+
 def populate_sv_filters_form(store, institute_obj, case_obj, category, request_obj):
     """Populate a filters form object of the type SvFiltersForm
 
@@ -720,14 +735,12 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
 
     if request_obj.method == "GET":
         form = SvFiltersForm(request_obj.args)
-        form.variant_type.data = request_obj.args.get("variant_type", "clinical")
+        variant_type = request_obj.args.get("variant_type", "clinical")
+        form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request_obj.args.get("chrom", "")
-        form.gene_panels.data = [
-            panel["panel_name"]
-            for panel in case_obj.get("panels", [])
-            if panel["is_default"] is True
-        ]
+        if variant_type == "clinical":
+            form.gene_panels.data = case_default_panels(case_obj)
 
     else:  # POST
         form = populate_filters_form(

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -80,12 +80,8 @@ def variants(institute_id, case_name):
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
 
-        if form.gene_panels.data == []:
-            form.gene_panels.data = [
-                panel["panel_name"]
-                for panel in case_obj.get("panels", [])
-                if panel["is_default"] is True
-            ]
+        if form.gene_panels.data == [] and variant_type == "clinical":
+            form.gene_panels.data = controllers.case_default_panels(case_obj)
 
     # populate filters dropdown
     available_filters = store.filters(institute_id, category)
@@ -330,11 +326,7 @@ def cancer_variants(institute_id, case_name):
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
         if form.gene_panels.data == []:
-            form.gene_panels.data = [
-                panel["panel_name"]
-                for panel in case_obj.get("panels", [])
-                if panel["is_default"] is True
-            ]
+            form.gene_panels.data = controllers.case_default_panels(case_obj)
 
     # update status of case if visited for the first time
     controllers.activate_case(store, institute_obj, case_obj, current_user)


### PR DESCRIPTION
Fix #2091

Landing page of research variants (SNVs and SVs) should have no gene panels selected.

**How to test**:
1. On stage, pick a case with research variants.
1. On current master, note that research variants landing pages are pre-filtered by case default gene panels.
1. Install this branch and make sure that research variants should not be filtered any panel instead
1. Clinical variants instead should be filtered by case default gene panels. 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by EM
- [x] tests executed by CR
