### PR TITLE
Transform event cursor to list to avoid having an empty variants event panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Fixed
+- Empty variant activity panel
 ### Changed
 
 ## [4.21.2]

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -116,7 +116,7 @@ def variant(
         variant_case(store, case_obj, variant_obj)
 
     # Collect all the events for the variant
-    events = store.events(institute_obj, case=case_obj, variant_id=variant_id)
+    events = list(store.events(institute_obj, case=case_obj, variant_id=variant_id))
     for event in events:
         event["verb"] = VERBS_MAP[event["verb"]]
 


### PR DESCRIPTION
fix #2097 --> Empty activity panel at the end of  a variant page
The bug is caused by the events being a cursor that becomes empty after a loop in variants controller. Looping over the events is possible if the cursor is transformed into a list.

**How to test**:
1. On a local branch, or stage go to a variant and do something on the page, for instance: comment, tag it, pin it, etc.
1. Note that no activity shows on master branch
1. Install this branch and you should see that activity panel is populated

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
