### PR TITLE
use single quotes in inner html badge class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Editable variants comments
 ### Fixed
 - Empty variant activity panel
+- STRs variants popover
 ### Changed
 - Updated RELEASE docs.
 - Pinned variants card style on the case page

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -18,7 +18,7 @@
                     <span class='badge badge-info'>GLOBAL</span>
             {% endif %}
             {% if comment.created_at < case.updated_at %}
-              <span class="badge badge-warning">OLD</span>
+              <span class='badge badge-warning'>OLD</span>
             {% endif %}
       	    {% if comment.created_at < comment.updated_at %}
               <span class='badge badge-secondary'>edited</span>


### PR DESCRIPTION
Fix #2110 
Double quotes in inner HTML probably closed the string content of the popover.

 
**How to test**:
1. Install master branch on Stage and check that this page doesn't render properly: https://scout-stage.scilifelab.se/cust000/643594-300M/str/variants?variant_type=clinical
1. Install the branch and check that same page is looking normal

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by EM
- [x] tests executed by CR
