### PR TITLE
Fix splitting multiple clnsig terms in variant parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Empty variant activity panel
 - STRs variants popover
+- Split correctly ClinVar multiple significance terms for a variant 
 ### Changed
 - Updated RELEASE docs.
 - Pinned variants card style on the case page

--- a/scout/parse/variant/clnsig.py
+++ b/scout/parse/variant/clnsig.py
@@ -22,7 +22,6 @@ def parse_clnsig(variant, transcripts=None):
     Returns:
         clnsig_accsessions(list(dict)): A list with clnsig accessions
     """
-
     transcripts = transcripts or []
     acc = variant.INFO.get("CLNACC", variant.INFO.get("CLNVID", ""))
     sig = variant.INFO.get("CLNSIG", "").lower()
@@ -54,7 +53,7 @@ def parse_clnsig(variant, transcripts=None):
             revstat_groups = [rev.lstrip("_") for rev in revstat.replace("&", ",").split(",")]
 
         sig_groups = []
-        for significance in sig.split(","):
+        for significance in sig.replace("&", ",").split(","):
             for term in significance.lstrip("_").split("/"):
                 sig_groups.append("_".join(term.split(" ")))
 

--- a/tests/parse/test_parse_clnsig.py
+++ b/tests/parse/test_parse_clnsig.py
@@ -71,9 +71,9 @@ def test_parse_modern_clnsig(cyvcf2_variant):
 
 def test_parse_modern_clnsig_clnvid(cyvcf2_variant):
     ## GIVEN a variant with classic clinvar annotations
-    acc_nr = "265359"
-    clnsig = "Pathogenic/Likely_pathogenic"
-    revstat = "criteria_provided,_multiple_submitters,_no_conflicts"
+    acc_nr = "10"
+    clnsig = "conflicting_interpretations_of_pathogenicity&_other"
+    revstat = "criteria_provided&_conflicting_interpretations"
 
     cyvcf2_variant.INFO["CLNVID"] = acc_nr
     cyvcf2_variant.INFO["CLNSIG"] = clnsig
@@ -83,11 +83,11 @@ def test_parse_modern_clnsig_clnvid(cyvcf2_variant):
     clnsig_annotations = parse_clnsig(cyvcf2_variant)
 
     ## THEN assert that the correct terms are parsed
-    assert set(["pathogenic", "likely_pathogenic"]) == {
+    assert set(["conflicting_interpretations_of_pathogenicity", "other"]) == {
         term["value"] for term in clnsig_annotations
     }
     ## THEN assert that they where parsed correct
-    assert len(clnsig_annotations) == len(clnsig.split("/"))
+    assert len(clnsig_annotations) == 2
 
 
 def test_parse_semi_modern_clnsig(cyvcf2_variant):


### PR DESCRIPTION
fix #2112.

**How to test**:
1. Install this branch on Hasta stage.
1. Load a case that before showed warnings (vitalmouse?)
1. Make sure that there are no warnings on reupload
1. Go to a variant that previously caused warnings on upload (significance: "Conflicting_interpretations_of_pathogenicity&_other"). For instance: chr6, start:26091179. When clicking on the variant page, it should show the correct significance (conflicting_interpretations and other)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
