### PR TITLE
Edit the right comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Empty variant activity panel
 - STRs variants popover
 - Split correctly ClinVar multiple significance terms for a variant
-- Editing the last comment instead of the selected one 
+- Edit the selected comment, not the latest
 ### Changed
 - Updated RELEASE docs.
 - Pinned variants card style on the case page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Empty variant activity panel
 - STRs variants popover
-- Split correctly ClinVar multiple significance terms for a variant 
+- Split correctly ClinVar multiple significance terms for a variant
+- Editing the last comment instead of the selected one 
 ### Changed
 - Updated RELEASE docs.
 - Pinned variants card style on the case page

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -62,14 +62,14 @@
                     {% endif %}
                     {% if comment.user_id == current_user.email %}
                       <button class="btn btn-link btn-sm" type="submit" name="remove"><i class="fa fa-remove"></i></button>
-                      <button class="btn btn-link btn-sm" type="button" data-toggle="modal" data-target="#editComment"><i class="fa fa-edit"></i></button>
+                      <button class="btn btn-link btn-sm" type="button" data-toggle="modal" data-target="#editComment_{{loop.index}}"><i class="fa fa-edit"></i></button>
                     {% endif %}
                   </small>
                 </form>
               </div>
             </div>
           </a>
-          {{ edit_comment(institute, case, current_user, comment) }}
+          {{ edit_comment(institute, case, current_user, comment, loop.index) }}
         {% else %}
           <a class="list-group-item">No comments yet</a>
         {% endfor %}
@@ -101,10 +101,10 @@
   </div>
 {% endmacro %}
 
-{% macro edit_comment(institute, case, current_user, comment) %}
+{% macro edit_comment(institute, case, current_user, comment, index) %}
 <!-- Edit comment modal -->
 <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id) }}">
-<div class="modal fade" id="editComment" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="editComment_{{index}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
 <div class="modal-dialog" role="document">
   <div class="modal-content">
     <div class="modal-header">


### PR DESCRIPTION
Current master has the following bug: whenever a user tries to update a comment (case comment but possibly variant comment) then the latest comment is updated. This PR fixes it.

**How to test**:
1. Install on Scout stage.
1. Create several comments at the case level and the variant level.
1. Try to edit them and make sure that the right comment is edited every time

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
