### PR TITLE
Fix parsing multi-cnlsig vars when clnsig acc is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - CNV report link in cancer case side navigation
 ### Fixed
 - missing `vcf_cancer_sv` and `vcf_cancer_sv_research` to manual.
-- Split ClinVar multiple clnsig values (slash-separated) for annotations without accession number
+- Split ClinVar multiple clnsig values (slash-separated) and strip them of underscore for annotations without accession number
 ### Changed
 - Do not freeze mkdocs-material to version 4.6.1
 - Remove pre-commit dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- CNV report link in cancer case side navigation
 ### Fixed
 - missing `vcf_cancer_sv` and `vcf_cancer_sv_research` to manual.
-
+- Split ClinVar multiple clnsig values (slash-separated) for annotations without accession number
 ### Changed
 - Do not freeze mkdocs-material to version 4.6.1
 - Remove pre-commit dependency
@@ -18,7 +19,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Editable cases comments
 - Editable variants comments
-- CNV report link in cancer case side navigation
 ### Fixed
 - Empty variant activity panel
 - STRs variants popover

--- a/scout/parse/variant/clnsig.py
+++ b/scout/parse/variant/clnsig.py
@@ -34,7 +34,8 @@ def parse_clnsig(variant, transcripts=None):
             clnsig = set()
             for transcript in transcripts:
                 for annotation in transcript.get("clnsig", []):
-                    clnsig.add(annotation)
+                    for anno in annotation.split("/"):
+                        clnsig.add(anno)
             for annotation in clnsig:
                 clnsig_accessions.append({"value": annotation})
 

--- a/scout/parse/variant/clnsig.py
+++ b/scout/parse/variant/clnsig.py
@@ -35,7 +35,7 @@ def parse_clnsig(variant, transcripts=None):
             for transcript in transcripts:
                 for annotation in transcript.get("clnsig", []):
                     for anno in annotation.split("/"):
-                        clnsig.add(anno)
+                        clnsig.add(anno.lstrip("_"))
             for annotation in clnsig:
                 clnsig_accessions.append({"value": annotation})
 

--- a/tests/parse/test_parse_clnsig.py
+++ b/tests/parse/test_parse_clnsig.py
@@ -158,15 +158,19 @@ def test_parse_complex_clnsig(cyvcf2_variant):
 
 
 def test_parse_clnsig_transcripts(cyvcf2_variant):
-    ## GIVEN a variant with classic clinvar annotations
-    transcripts = [{"clnsig": ["likely_benign"]}]
+    ## GIVEN a variant with slash-separated values or values that start with underscore
+    transcripts = [
+        {"clnsig": ["pathogenic/likely_pathogenic", "likely_pathogenic", "pathogenic", "_other"]}
+    ]
 
     ## WHEN parsing the annotations
     clnsig_annotations = parse_clnsig(cyvcf2_variant, transcripts=transcripts)
 
     ## THEN assert that they where parsed correct
-    assert len(clnsig_annotations) == 1
-    assert clnsig_annotations[0]["value"] == "likely_benign"
+    assert len(clnsig_annotations) == 3
+    for clnsig in ["pathogenic", "likely_pathogenic", "other"]:
+        clnsig_dict = {"value": clnsig}
+        assert clnsig_dict in clnsig_annotations
 
 
 def test_is_pathogenic_pathogenic(cyvcf2_variant):


### PR DESCRIPTION
fix #2123 

I've been testing with some variants and I think the error occurs when the variant has clnsig values with no accession. In #2114 I've been kind of fixing the same situation when the clnsig has accession values and the't why this problem is still there in this case.

Clinvar parsing in Scout has been changing over the years and for backward compatibility we have kept old code and added new lines without really planning what we expect from the pipelines. And that's why we get unexpected situations and different keys and values from MIP and BALSAMIC. We often don't know if something is wrong unless a user complains about warnings. In the future we should simplify this code, otherwise it's too prone to bugs.

Anyway, this should fix the error in the issue.

**How to test**:
1. Keep in mind a variant with values that has VCF annotation causing warnings, for instance this one: https://scout-stage.scilifelab.se/cust000/actualgecko/afacfdf4b9e4ba11b6fa45d86d9fea22?cancer=yes
At the VCF level this variant has the following annotation: `pathogenic/likely_pathogenic&likely_pathogenic&pathogenic`
1. Variant on current master looks like this:
![image](https://user-images.githubusercontent.com/28093618/94407878-58a56300-0174-11eb-98ec-c7862b3b87d7.png)
1. Install this branch on hasta stage and reupload the case (with -u option to force-update).
1. Make sure that there are no warnings during the variants upload
- [x] Make sure that the clnsig values of the variant on the variant page changes, and `other` annotation should disappear.
- [x] `Clinsig value _other does not have an internal representation `warning should not show any more


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
