### PR TITLE
Perform gene variant search only if user provides genes and at least one is in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - missing `vcf_cancer_sv` and `vcf_cancer_sv_research` to manual.
 - Split ClinVar multiple clnsig values (slash-separated) and strip them of underscore for annotations without accession number
+- Timeout of `All SNVs and INDELs` page when no valid gene is provided in the search
 ### Changed
 - Do not freeze mkdocs-material to version 4.6.1
 - Remove pre-commit dependency

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -174,7 +174,6 @@ def gene_variants(institute_id):
     # populate form, conditional on request method
     if request.method == "POST":
         form = GeneVariantFiltersForm(request.form)
-        flash(request.form)
     else:
         form = GeneVariantFiltersForm(request.args)
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -174,6 +174,7 @@ def gene_variants(institute_id):
     # populate form, conditional on request method
     if request.method == "POST":
         form = GeneVariantFiltersForm(request.form)
+        flash(request.form)
     else:
         form = GeneVariantFiltersForm(request.args)
 
@@ -217,6 +218,12 @@ def gene_variants(institute_id):
                 "Gene not included in clinical list: {}".format(", ".join(non_clinical_symbols)),
                 "warning",
             )
+
+        if hgnc_symbols == []:
+            # If there are not genes to search, return to previous page with a warning
+            flash("No valid gene provided for variant search.", "warning")
+            return redirect(request.referrer)
+
         form.hgnc_symbols.data = hgnc_symbols
 
         LOG.debug("query {}".format(form.data))

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -373,6 +373,31 @@ def test_gene_variants_filter(app, institute_obj, case_obj):
         assert "POT1" in str(resp.data)
 
 
+def test_gene_variants_no_valid_gene(app, institute_obj, case_obj):
+    """Test the gene_variant endpoint with a gene symbol not in database"""
+
+    # GIVEN an initialized app
+    # GIVEN a valid user and institute
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        # When user submits a query for a variants in a gene that is not in database
+        filter_query = {
+            "hgnc_symbols": "UNKNOWN-GENE",
+            "variant_type": ["clinical"],
+            "rank_score": 11,
+        }
+
+        resp = client.post(
+            url_for("overview.gene_variants", institute_id=institute_obj["internal_id"]),
+            data=filter_query,
+        )
+        # THEN the page should redirect
+        assert resp.status_code == 302
+
+
 def test_institute_users(app, institute_obj, user_obj):
     """Test the link to all institute users"""
     # GIVEN an initialized app


### PR DESCRIPTION
Fix #2020 --> whenever a database contains many variants (stage and prod server), if a user provides a gene not in database then the search is performed on all genes, and that causes a timeout in the page.

This fix prevents a search if no valid gene is provided in the case_variants page form. If no valid gene is provided then there is a flash message to the user with a warning and the page is redirected to the previous page.


**How to test**:
1. On clinical-db stage, current master, go to an institute page and then to "All SNVs and Indels" page. Input a gene that doesn't exist in database.
1. Notice that page times out.
1. Install this branch and repeat the search.
1. This time it should show a warning instead and the page will not timeout.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
