### PR TITLE
Return to anchor after submitted comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Show a flash message with clear info about non-valid genes when gene panel creation fails
 - CNV report link in cancer case side navigation
+- Return to comment section after editing, deleting or submitting a comment
 ### Fixed
 - missing `vcf_cancer_sv` and `vcf_cancer_sv_research` to manual.
 - Split ClinVar multiple clnsig values (slash-separated) and strip them of underscore for annotations without accession number

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -103,7 +103,7 @@
 
 {% macro edit_comment(institute, case, current_user, comment, index) %}
 <!-- Edit comment modal -->
-<form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id, _anchor='comment') }}">
+<form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id, _anchor='comments') }}">
 <div class="modal fade" id="editComment_{{index}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
 <div class="modal-dialog" role="document">
   <div class="modal-content">

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -36,7 +36,7 @@
 
 {% macro comments_panel(institute, case, current_user, comments, variant_id=None) %}
   <div class="card panel-default">
-    <div class="panel-heading">Comments</div>
+    <div class="panel-heading" id="comments">Comments</div>
     <div class="card-body">
       <div class="list-group" style="max-height:200px; overflow-y: scroll;">
         {% for comment in comments %}
@@ -46,7 +46,7 @@
             </div>
             <div class="row">
               <div class="d-flex justify-content-between align-items-center">
-                <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id) }}">
+                <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
                   <small>
                     <br>
                     <strong>{{ comment.user_name }}</strong>
@@ -76,7 +76,7 @@
       </div>
     </div>
     <div class="card-footer">
-      <form action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id) }}" method="POST">
+      <form action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id, _anchor='comments') }}" method="POST">
         <input type="hidden" name="link" value="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id) if variant_id else url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
         <div class="form-group">
           <textarea class="form-control" name="content" placeholder="Leave a comment"></textarea>
@@ -103,7 +103,7 @@
 
 {% macro edit_comment(institute, case, current_user, comment, index) %}
 <!-- Edit comment modal -->
-<form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id) }}">
+<form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id, _anchor='comment') }}">
 <div class="modal fade" id="editComment_{{index}}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
 <div class="modal-dialog" role="document">
   <div class="modal-content">


### PR DESCRIPTION
This PR adds a return to the comments section when comments are edited, deleted or added.

**How to test**:
1. Locally, try submitting, editing and deleting a comment

**Expected outcome**:
After the request went trough, the view should be at the comment section
Case page:
![Sep-29-2020 11-25-52](https://user-images.githubusercontent.com/6919697/94540603-eea9be00-0246-11eb-9e91-5ed93790251a.gif)
Variant page:
![Sep-29-2020 11-26-26](https://user-images.githubusercontent.com/6919697/94540594-ebaecd80-0246-11eb-8f5f-d473d0004f84.gif)


**Review:**
- [ ] code approved by
- [X] tests executed by EM
