### PR TITLE
Fix empty other causatives lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Timeout of `All SNVs and INDELs` page when no valid gene is provided in the search
 - Round CADD (MIPv9)
 - Missing default panel value
+- Invisible other causatives lines when other causatives lack gene symbols
 ### Changed
 - Do not freeze mkdocs-material to version 4.6.1
 - Remove pre-commit dependency

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -243,7 +243,7 @@
         <li class="list-group-item">
           <a href="{{ url_for('variant.variant', institute_id=institute._id,
                               case_name=case.display_name, variant_id=variant._id) }}">
-            {{ variant.hgnc_symbols|join(', ') }}
+            {{ variant.hgnc_symbols|join(', ') or variant.hgnc_ids|join(', ')}}
           </a>
         </li>
       {% else %}


### PR DESCRIPTION
fix #2139 --> Whenever the other causative variant has no hgnc symbol, display hgnc id instead!

**How to test on a local scout instance (scout demo)**:
1. load another case into cust000: case  643595 that is the exact replica of test case 643594.
1. Go to case 643595, variants page, and in variants filter UNcheck the test panel, so that all variants are shown:

![image](https://user-images.githubusercontent.com/28093618/94898794-733c4c80-0492-11eb-982c-7ea7ba54ce1f.png)

1. Mark as causative a couple of variants that have no gene symbol, for instance the one ranked 1 (gene 14931) and 12 (gene 12015).

1. Go to the other case page and see two empty lines under the other causatives.

1. Switch to this branch and make sure that the other causatives under the case 643594 are now shown (their hgnc id).

1. Bonus test: mark POT1 as causative on case 643595 and see that "POT1" is shown under the other cases other causatives

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
