### PR TITLE
Fix #2153 - hide causatives subtly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Update dismissed variant status when variant dismissed key is missing
 ### Changed
+- Make matching causative and managed variants foldable on case page
 
 ## [4.23]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -233,12 +233,12 @@
 {% endmacro %}
 
 {% macro matching_causatives(other_causatives, institute, case) %}
-  <div class="card panel-default">
+  <div class="card panel-default" >
     <div data-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
       that have been marked as causative in another case for this insitute">
-      Matching causatives from other cases
+      <strong><a data-toggle="collapse" href="#matchingCausatives" class="text-white">Matching causatives from other cases ({{other_causatives|length}})</a></strong>
     </div>
-    <ul class="list-group">
+    <ul class="list-group collapse" id="matchingCausatives">
       {% for variant in other_causatives %}
         <li class="list-group-item">
           <a href="{{ url_for('variant.variant', institute_id=institute._id,
@@ -257,11 +257,11 @@
   <div class="card panel-default">
     <div data-toggle='tooltip' class="panel-heading" title="Any variants in this case
       that have been marked as managed">
-      Managed variants
+      <strong><a data-toggle="collapse" href="#matchingManaged" class="text-white">Managed variants ({{managed_variants|length}})</a></strong>
     </div>
     <ul class="list-group">
       {% for variant in managed_variants %}
-        <li class="list-group-item">
+        <li class="list-group-item collapse" id="matchingManaged">
           <a href="{{ url_for('variant.variant', institute_id=institute._id,
                               case_name=case.display_name, variant_id=variant._id) }}">
             {{ variant.hgnc_symbols|join(', ') }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. open a case with matching causative and / or matching managed variants
1. note that managed variants and causative variants are shown folded with a number of variants until clicked

![Screenshot 2020-10-07 at 15 18 17](https://user-images.githubusercontent.com/758570/95336890-7d56b480-08b1-11eb-8c6f-6f0ec55450fd.png)

![Screenshot 2020-10-07 at 15 18 28](https://user-images.githubusercontent.com/758570/95336891-7e87e180-08b1-11eb-8e5a-c14fe2911a45.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
