### PR TITLE
Add missing font lib required by Pango in Docker file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Update dismissed variant status when variant dismissed key is missing
 - Breakpoint two IGV button now shows correct chromosome when different from bp1
+- Missing font lib in Docker image causing the PDF report download page to crash
 ### Changed
 - Make matching causative and managed variants foldable on case page
 - Remove calls to PyMongo functions marked as deprecated in backend and frontend(as of version 3.7).

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL about.license="MIT License (MIT)"
 # Install required libs
 RUN apk update
 RUN apk --no-cache add make automake gcc g++ linux-headers libffi-dev zlib-dev \
-   jpeg-dev libressl-dev cairo-dev pango-dev gdk-pixbuf bash
+   jpeg-dev libressl-dev cairo-dev pango-dev gdk-pixbuf ttf-freefont bash
 RUN pip install numpy Cython
 
 WORKDIR /home/worker/app


### PR DESCRIPTION
Fix #2178 

Pango needs a font lib that is missing in the current Dockerfile. After installing it the download of the PDF report works as it should

**How to test -- locally**:
1. Stop any running mongodb service
1. From current master, start the demo using the command:
`docker-compose up -d`
1. Open a browser to the demo instance of Scout -> http://localhost:5000/
1. Make sure that the download of the PDF report doesn't work
1. Turn off the containers with the command:
`docker-compose down`
1. Switch to this branch and build the Docker image like this:
`docker build -t myscout:latest .`
1. Modify the docker-compose.yml file to use myscout instead of the image pulled from clinical genomics:

![image](https://user-images.githubusercontent.com/28093618/98112878-1eca2980-1ea3-11eb-8a5e-11162ffd8f68.png)

![image](https://user-images.githubusercontent.com/28093618/98112805-035f1e80-1ea3-11eb-81b2-5c4a4a55dbaa.png)
1. Save and restart docker-compose as in step 2
1. Now the PDF download should work 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR