### PR TITLE
DockerHub push action on new release tag

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI and Docker Hub
 
 on:
  release:
@@ -45,11 +45,11 @@ jobs:
    steps:
     - name: Get release version
       id: get_version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+      run: echo ::set-output name=release_version::$(echo ${GITHUB_REF:10})
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: clinicalgenomics/scout
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ env.RELEASE_VERSION }}"
+        tags: "latest,${{ steps.vars.outputs.release_version }}"

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -43,13 +43,15 @@ jobs:
    name: Docker Image CI
    runs-on: ubuntu-latest
    steps:
-    - name: Get release version
-      id: get_version
-      run: echo ::set-output name=release_version::$(echo ${GITHUB_REF:10})
-    - name: Publish to Registry
+
+    - name: Check out git repository
+      uses: actions/checkout@v2
+
+    - name: Build and publish to Docker Hub
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: clinicalgenomics/scout
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ steps.vars.outputs.release_version }}"
+        tags: "latest,${{ github.event.release.tag_name }}"
+

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -38,3 +38,18 @@ jobs:
      with:
        user: __token__
        password: ${{ secrets.pypi_password }}
+
+ docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Get release version
+      id: get_version
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/scout
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ env.RELEASE_VERSION }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Institute-level phenotype models with sub-panels containing HPO and OMIM terms
 - Runnable Docker demo
+- Docker image build and push github action
 ### Fixed
 - Update dismissed variant status when variant dismissed key is missing
 - Breakpoint two IGV button now shows correct chromosome when different from bp1


### PR DESCRIPTION
Builds the Docker image and tags with it repo version tag and "latest", Pushes both images to Docker Hub. 
fix #2181

**How to test**:
1. Locally I'll try on a forked repo, and I'll push to my user's Hub

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
