### PR TITLE
IGV compatible filtering of variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Institute-level phenotype models with sub-panels containing HPO and OMIM terms
 - Runnable Docker demo
 - Docker image build and push github action
+- SV variant filter compatible with genome browser location strings
 ### Fixed
 - Update dismissed variant status when variant dismissed key is missing
 - Breakpoint two IGV button now shows correct chromosome when different from bp1

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -1,21 +1,15 @@
 import logging
 import re
-from scout.constants import (
-    FUNDAMENTAL_CRITERIA,
-    PRIMARY_CRITERIA,
-    SECONDARY_CRITERIA,
-    TRUSTED_REVSTAT_LEVEL,
-)
+from scout.constants import FUNDAMENTAL_CRITERIA, PRIMARY_CRITERIA, SECONDARY_CRITERIA
 
 LOG = logging.getLogger(__name__)
 
-from scout.constants import SPIDEX_HUMAN, CLINSIG_MAP
-
+from scout.constants import (SPIDEX_HUMAN, CLINSIG_MAP)
 
 class QueryHandler(object):
-    def build_variant_query(
-        self, query=None, institute_id=None, category="snv", variant_type=["clinical"]
-    ):
+
+    def build_variant_query(self, query=None, institute_id=None, category='snv',
+                            variant_type=['clinical']):
         """Build a mongo query across multiple cases.
         Translate query options from a form into a complete mongo query dictionary.
 
@@ -30,7 +24,7 @@ class QueryHandler(object):
 
         Args:
             query(dict): A query dictionary for the database, from a query form.
-            category(str): 'snv', 'sv', 'str' 'cancer_sv' or 'cancer'
+            category(str): 'snv', 'sv', 'str' or 'cancer'
             variant_type(str): 'clinical' or 'research'
 
         Possible query dict keys:
@@ -47,54 +41,55 @@ class QueryHandler(object):
 
         LOG.debug("Building a mongo query for %s" % query)
 
-        if query.get("hgnc_symbols"):
-            mongo_variant_query["hgnc_symbols"] = {"$in": query["hgnc_symbols"]}
+        if query.get('hgnc_symbols'):
+            mongo_variant_query['hgnc_symbols'] = {'$in': query['hgnc_symbols']}
 
-        mongo_variant_query["variant_type"] = {"$in": variant_type}
+        mongo_variant_query['variant_type'] = {'$in': variant_type}
 
-        mongo_variant_query["category"] = category
+        mongo_variant_query['category'] = category
 
         select_cases = None
         select_case_obj = None
         mongo_case_query = {}
 
-        if query.get("phenotype_terms"):
-            mongo_case_query["phenotype_terms.phenotype_id"] = {"$in": query["phenotype_terms"]}
+        if query.get('phenotype_terms'):
+            mongo_case_query['phenotype_terms.phenotype_id'] = {'$in': query['phenotype_terms']}
 
-        if query.get("phenotype_groups"):
-            mongo_case_query["phenotype_groups.phenotype_id"] = {"$in": query["phenotype_groups"]}
+        if query.get('phenotype_groups'):
+            mongo_case_query['phenotype_groups.phenotype_id'] = {'$in': query['phenotype_groups']}
 
-        if query.get("cohorts"):
-            mongo_case_query["cohorts"] = {"$in": query["cohorts"]}
+        if query.get('cohorts'):
+            mongo_case_query['cohorts'] = {'$in': query['cohorts']}
 
         if mongo_case_query != {}:
-            mongo_case_query["owner"] = institute_id
+            mongo_case_query['owner'] = institute_id
             LOG.debug("Search cases for selection set, using query {0}".format(select_case_obj))
             select_case_obj = self.case_collection.find(mongo_case_query)
-            select_cases = [case_id.get("display_name") for case_id in select_case_obj]
+            select_cases = [case_id.get('display_name') for case_id in select_case_obj]
 
-        if query.get("similar_case"):
-            similar_case_display_name = query["similar_case"][0]
+        if query.get('similar_case'):
+            similar_case_display_name = query['similar_case'][0]
             case_obj = self.case(display_name=similar_case_display_name, institute_id=institute_id)
             if case_obj:
-                LOG.debug("Search for cases similar to %s", case_obj.get("display_name"))
+                LOG.debug("Search for cases similar to %s", case_obj.get('display_name'))
                 similar_cases = self.get_similar_cases(case_obj)
-                LOG.debug("Similar cases: %s", similar_cases)
+                LOG.debug("Similar cases: %s",similar_cases)
                 select_cases = [similar[0] for similar in similar_cases]
             else:
                 LOG.debug("Case %s not found.", similar_case_display_name)
 
         if select_cases:
-            mongo_variant_query["case_id"] = {"$in": select_cases}
+            mongo_variant_query['case_id'] = {'$in': select_cases}
 
-        rank_score = query.get("rank_score") or 15
-        mongo_variant_query["rank_score"] = {"$gte": rank_score}
+        rank_score = query.get('rank_score') or 15
+        mongo_variant_query['rank_score'] = {'$gte': rank_score}
 
         LOG.debug("Querying %s" % mongo_variant_query)
 
         return mongo_variant_query
 
-    def build_query(self, case_id, query=None, variant_ids=None, category="snv"):
+
+    def build_query(self, case_id, query=None, variant_ids=None, category='snv'):
         """Build a mongo query
 
         These are the different query options:
@@ -106,7 +101,6 @@ class QueryHandler(object):
                 'clingen_ngi': int,
                 'cadd_score': float,
                 'cadd_inclusive": boolean,
-                'tumor_frequency': float,
                 'genetic_models': list(str),
                 'hgnc_symbols': list,
                 'region_annotations': list,
@@ -117,7 +111,6 @@ class QueryHandler(object):
                 'chrom': str,
                 'start': int,
                 'end': int,
-                'chrom_pos': str,
                 'svtype': list,
                 'size': int,
                 'size_shorter': boolean,
@@ -137,80 +130,44 @@ class QueryHandler(object):
         """
         query = query or {}
         mongo_query = {}
-        coordinate_query = None
+        gene_query = None
 
         ##### Base query params
 
         # set up the fundamental query params: case_id, category, type and
         # restrict to list of variants (if var list is provided)
         for criterion in FUNDAMENTAL_CRITERIA:
-            if criterion == "case_id":
+            if criterion == 'case_id':
                 LOG.debug("Building a mongo query for %s" % case_id)
-                mongo_query["case_id"] = case_id
+                mongo_query['case_id'] = case_id
 
-            elif criterion == "variant_ids" and variant_ids:
-                LOG.debug("Adding variant_ids %s to query" % ", ".join(variant_ids))
-                mongo_query["variant_id"] = {"$in": variant_ids}
+            elif criterion == 'variant_ids' and variant_ids:
+                LOG.debug("Adding variant_ids %s to query" % ', '.join(variant_ids))
+                mongo_query['variant_id'] = {'$in': variant_ids}
 
-            elif criterion == "category":
+            elif criterion == 'category':
                 LOG.debug("Querying category %s" % category)
-                mongo_query["category"] = category
+                mongo_query['category'] = category
 
-            elif criterion == "variant_type":
-                mongo_query["variant_type"] = query.get("variant_type", "clinical")
-                LOG.debug("Set variant type to %s", mongo_query["variant_type"])
+            elif criterion == 'variant_type':
+                mongo_query['variant_type'] = query.get('variant_type', 'clinical')
+                LOG.debug("Set variant type to %s", mongo_query['variant_type'])
 
             # Requests to filter based on gene panels, hgnc_symbols or
             # coordinate ranges must always be honored. They are always added to
-            # query as top level, implicit '$and'. When hgnc_symbols or gene panels
-            # are used, addition of relative gene symbols is delayed until after
-            # the rest of the query content is clear.
+            # query as top level, implicit '$and'. When both hgnc_symbols and a
+            # panel is used, addition of this is delayed until after the rest of
+            # the query content is clear.
 
-            elif criterion in ["hgnc_symbols", "gene_panels"]:
+            elif criterion in ['hgnc_symbols', 'gene_panels'] and gene_query is None:
                 gene_query = self.gene_filter(query, mongo_query)
-                if len(gene_query) > 0 or "hpo" in query.get("gene_panels", []):
-                    mongo_query["hgnc_symbols"] = {"$in": gene_query}
 
-            elif criterion == "chrom" and query.get("chrom"):  # filter by coordinates
-                coordinate_query = None
-                if category == "snv":
-                    mongo_query["chromosome"] = query["chrom"]
-                    if query.get("start") and query.get("end"):
-                        self.coordinate_filter(query, mongo_query)
-                else:  # sv
-                    coordinate_query = [self.sv_coordinate_query(query)]
+            elif criterion == 'chrom' and query.get('chrom'): # filter by coordinates
+                self.coordinate_filter(query, mongo_query)
 
-            elif criterion == "chrom_pos" and query.get("chrom_pos"):  # filter by coordinates
-                pattern = re.compile(r"^([0-9a-z]+):(\d+)-(\d+)(?:([+-]{1})(\d+))?$", re.I)
-                chrom_pos = query.get("chrom_pos").replace(",", "")
-                if bool(re.match(pattern, chrom_pos)):
-                    chrom, start, end, sign, padding = re.search(pattern, chrom_pos).groups()
-                    if padding:  # increase or decrease search window
-                        LOG.debug(f"Applying padding")
-                        start, end, padding = map(int, [start, end, padding])
-                        if sign == "+":
-                            start = 0 if start - padding < 1 else start - padding
-                            end = end + padding
-                        else:
-                            start = start + padding
-                            end = 0 if end - padding < 0 else end - padding
-                            start, end = (end, start) if end < start else (start, end)
-                    # modify query dict
-                    query["chrom"] = chrom
-                    query["start"] = start
-                    query["end"] = end
-                    # query database
-                    coordinate_query = None
-                    if category == "snv":
-                        mongo_query["chromosome"] = query["chrom"]
-                        if query.get("start") and query.get("end"):
-                            self.coordinate_filter(query, mongo_query)
-                    else:  # sv
-                        coordinate_query = [self.sv_coordinate_query(query)]
-
-            elif criterion == "variant_ids" and variant_ids:
-                LOG.debug("Adding variant_ids %s to query" % ", ".join(variant_ids))
-                mongo_query["variant_id"] = {"$in": variant_ids}
+            elif criterion == 'variant_ids' and variant_ids:
+                LOG.debug("Adding variant_ids %s to query" % ', '.join(variant_ids))
+                mongo_query['variant_id'] = {'$in': variant_ids}
 
             ##### end of fundamental query params
 
@@ -219,7 +176,7 @@ class QueryHandler(object):
         primary_terms = False
 
         # gnomad_frequency, local_obs, clingen_ngi, swegen, spidex_human, cadd_score, genetic_models, mvl_tag
-        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency, tumor_frequency
+        # functional_annotations, region_annotations, size, svtype, decipher, depth, alt_count, control_frequency
         secondary_terms = False
 
         # check if any of the primary criteria was specified in the query
@@ -240,101 +197,124 @@ class QueryHandler(object):
         # such as a Pathogenic ClinSig.
         if secondary_terms is True:
             secondary_filter = self.secondary_query(query, mongo_query)
+
             # If there are no primary criteria given, all secondary criteria are added as a
             # top level '$and' to the query.
             if primary_terms is False:
-                mongo_query["$and"] = secondary_filter
+                if gene_query:
+                    mongo_query['$and'] = [ {'$or': gene_query}, {'$and': secondary_filter}]
+                else:
+                    mongo_query['$and'] = secondary_filter
 
             # If there is only one primary criterion given without any secondary, it will also be
             # added as a top level '$and'.
             # Otherwise, primary criteria are added as a high level '$or' and all secondary criteria
             # are joined together with them as a single lower level '$and'.
-            if primary_terms is True:  # clinsig is specified
+            if primary_terms is True: # clinsig is specified
                 # Given a request to always return confident clinical variants,
                 # add the clnsig query as a major criteria, but only
                 # trust clnsig entries with trusted revstat levels.
-                if query.get("clinsig_confident_always_returned") is True:
-                    mongo_query["$or"] = [
-                        {"$and": secondary_filter},
-                        clinsign_filter,
-                    ]
-                else:  # clisig terms are provided but no need for trusted revstat levels
+                if query.get('clinsig_confident_always_returned') == True:
+                    if gene_query:
+                        mongo_query['$and'] = [
+                            {'$or': gene_query},
+                            {
+                                '$or': [
+                                    {'$and': secondary_filter}, clinsign_filter
+                                ]
+                            }
+                        ]
+                    else:
+                        mongo_query['$or'] = [ {'$and': secondary_filter}, clinsign_filter ]
+                else: # clisig terms are provided but no need for trusted revstat levels
                     secondary_filter.append(clinsign_filter)
-                    mongo_query["$and"] = secondary_filter
+                    if gene_query:
+                        mongo_query['$and'] = [ {'$or': gene_query}, {'$and': secondary_filter}]
+                    else:
+                        mongo_query['$and'] = secondary_filter
 
-        elif primary_terms is True:  # clisig is provided without secondary terms query
+        elif primary_terms is True: # clisig is provided without secondary terms query
             # use implicit and
-            mongo_query["clnsig"] = clinsign_filter["clnsig"]
+            mongo_query['clnsig'] = clinsign_filter['clnsig']
+            if gene_query:
+                mongo_query['$and'] = [{ '$or': gene_query }]
 
-        # if chromosome coordinates exist in query, add them as first element of the mongo_query['$and']
-        if coordinate_query:
-            if mongo_query.get("$and"):
-                mongo_query["$and"] = coordinate_query + mongo_query["$and"]
-            else:
-                mongo_query["$and"] = coordinate_query
+        elif gene_query: # no primary or secondary filters provided
+            mongo_query['$and'] = [{ '$or': gene_query }]
 
         LOG.info("mongo query: %s", mongo_query)
+
         return mongo_query
 
+
     def clinsig_query(self, query, mongo_query):
-        """Add clinsig filter values to the mongo query object
+        """ Add clinsig filter values to the mongo query object
 
-        Args:
-            query(dict): a dictionary of query filters specified by the users
-            mongo_query(dict): the query that is going to be submitted to the database
+            Args:
+                query(dict): a dictionary of query filters specified by the users
+                mongo_query(dict): the query that is going to be submitted to the database
 
-        Returns:
-            clinsig_query(dict): a dictionary with clinsig key-values
+            Returns:
+                clinsig_query(dict): a dictionary with clinsig key-values
 
         """
-        LOG.debug("clinsig is a query parameter")
-        trusted_revision_level = TRUSTED_REVSTAT_LEVEL
+        LOG.debug('clinsig is a query parameter')
+        trusted_revision_level = ['mult', 'single', 'exp', 'guideline']
         rank = []
         str_rank = []
         clnsig_query = {}
 
-        for item in query["clinsig"]:
+        for item in query['clinsig']:
             rank.append(int(item))
             # search for human readable clinsig values in newer cases
             rank.append(CLINSIG_MAP[int(item)])
             str_rank.append(CLINSIG_MAP[int(item)])
 
-        if query.get("clinsig_confident_always_returned") is True:
+        if query.get('clinsig_confident_always_returned') == True:
             LOG.debug("add CLINSIG filter with trusted_revision_level")
 
-            clnsig_query = {
-                "clnsig": {
-                    "$elemMatch": {
-                        "$and": [
-                            {
-                                "$or": [
-                                    {"value": {"$in": rank}},
-                                    {"value": re.compile("|".join(str_rank))},
+            clnsig_query = { "clnsig":
+                        {
+                            '$elemMatch': {
+                                '$or' : [
+                                    {
+                                        '$and' : [
+                                             {'value' : { '$in': rank }},
+                                             {'revstat': { '$in': trusted_revision_level }}
+                                        ]
+                                    },
+                                    {
+                                        '$and': [
+                                            {'value' : re.compile('|'.join(str_rank))},
+                                            {'revstat' : re.compile('|'.join(trusted_revision_level))}
+                                        ]
+                                    }
                                 ]
-                            },
-                            {"revstat": re.compile("|".join(trusted_revision_level))},
-                        ]
+                            }
+                         }
                     }
-                }
-            }
         else:
-            LOG.debug("add CLINSIG filter for rank: %s" % ", ".join(str(query["clinsig"])))
+            LOG.debug("add CLINSIG filter for rank: %s" %
+                             ', '.join(str(query['clinsig'])))
 
             clnsig_query = {
-                "clnsig": {
-                    "$elemMatch": {
-                        "$or": [
-                            {"value": {"$in": rank}},
-                            {"value": re.compile("|".join(str_rank))},
-                        ]
-                    }
+                    "clnsig":
+                        {
+                            '$elemMatch': {
+                                '$or' : [
+                                    { 'value' : { '$in': rank }},
+                                    { 'value' : re.compile('|'.join(str_rank)) }
+                                ]
+                            }
+                        }
                 }
-            }
+
         return clnsig_query
 
+
+
     def coordinate_filter(self, query, mongo_query):
-        """Adds genomic coordinated-related filters to the query object
-            This method is called to buid coordinate query for non-sv variants
+        """ Adds genomic coordinated-related filters to the query object
 
         Args:
             query(dict): a dictionary of query filters specified by the users
@@ -344,103 +324,60 @@ class QueryHandler(object):
             mongo_query(dict): returned object contains coordinate filters
 
         """
-        mongo_query["position"] = {"$lte": int(query["end"])}
-        mongo_query["end"] = {"$gte": int(query["start"])}
+        LOG.debug('Adding genomic coordinates to the query')
+        chromosome = query['chrom']
+        mongo_query['chromosome'] = chromosome
+
+        if (query.get('start') and query.get('end')):
+            mongo_query['position'] = {'$lte': int(query['end'])}
+            mongo_query['end'] = {'$gte': int(query['start'])}
 
         return mongo_query
 
-    def sv_coordinate_query(self, query):
-        """Adds genomic coordinated-related filters to the query object
-            This method is called to buid coordinate query for sv variants
 
-        Args:
-            query(dict): a dictionary of query filters specified by the users
-            mongo_query(dict): the query that is going to be submitted to the database
-
-        Returns:
-            coordinate_query(dict): returned object contains coordinate filters for sv variant
-
-        """
-        coordinate_query = None
-        chromosome_query = {"$or": [{"chromosome": query["chrom"]}, {"end_chrom": query["chrom"]}]}
-        if query.get("start") and query.get("end"):
-            # Query for overlapping intervals. Taking into account these cases:
-            # 1
-            # filter                 xxxxxxxxx
-            # Variant           xxxxxxxx
-
-            # 2
-            # filter                 xxxxxxxxx
-            # Variant                    xxxxxxxx
-
-            # 3
-            # filter                 xxxxxxxxx
-            # Variant                   xx
-
-            # 4
-            # filter                 xxxxxxxxx
-            # Variant             xxxxxxxxxxxxxx
-            position_query = {
-                "$or": [
-                    {"end": {"$gte": int(query["start"]), "$lte": int(query["end"])}},  # 1
-                    {
-                        "position": {
-                            "$lte": int(query["end"]),
-                            "$gte": int(query["start"]),
-                        }
-                    },  # 2
-                    {
-                        "$and": [
-                            {"position": {"$gte": int(query["start"])}},
-                            {"end": {"$lte": int(query["end"])}},
-                        ]
-                    },  # 3
-                    {
-                        "$and": [
-                            {"position": {"$lte": int(query["start"])}},
-                            {"end": {"$gte": int(query["end"])}},
-                        ]
-                    },  # 4
-                ]
-            }
-            coordinate_query = {"$and": [chromosome_query, position_query]}
-        else:
-            coordinate_query = chromosome_query
-        return coordinate_query
 
     def gene_filter(self, query, mongo_query):
-        """Adds gene symbols to the query. Gene symbols query is a list of combined hgnc_symbols and genes included in the given panels
+        """ Adds gene-related filters to the query object
 
         Args:
             query(dict): a dictionary of query filters specified by the users
             mongo_query(dict): the query that is going to be submitted to the database
 
         Returns:
-            hgnc_symbols: The genes to filter by
+            mongo_query(dict): returned object contains gene and panel-related filters
 
         """
-        LOG.debug("Adding panel and genes-related parameters to the query")
-        hgnc_symbols = set(query.get("hgnc_symbols", []))
+        LOG.debug('Adding panel and genes-related parameters to the query')
+        gene_query = []
+        hgnc_symbols = query.get('hgnc_symbols')
+        gene_panels = query.get('gene_panels')
 
-        for panel in query.get("gene_panels", []):
-            if panel == "hpo":
-                continue  # HPO genes are already provided in the eventual hgnc_symbols fields
-            hgnc_symbols.update(self.panel_to_genes(panel_name=panel))
+        if hgnc_symbols and gene_panels:
+            gene_query.append({'hgnc_symbols': {'$in': hgnc_symbols}})
+            gene_query.append({'panels': {'$in': gene_panels}})
+        elif hgnc_symbols:
+            mongo_query['hgnc_symbols'] = {'$in': hgnc_symbols}
+            LOG.debug("Adding hgnc_symbols: %s to query" %
+                            ', '.join(hgnc_symbols))
+        elif gene_panels: #gene_panels
+            mongo_query['panels'] = {'$in': gene_panels}
 
-        return list(hgnc_symbols)
+        return gene_query
+
+
 
     def secondary_query(self, query, mongo_query, secondary_filter=None):
         """Creates a secondary query object based on secondary parameters specified by user
 
-        Args:
-            query(dict): a dictionary of query filters specified by the users
-            mongo_query(dict): the query that is going to be submitted to the database
+            Args:
+                query(dict): a dictionary of query filters specified by the users
+                mongo_query(dict): the query that is going to be submitted to the database
 
-        Returns:
-            mongo_secondary_query(list): a dictionary with secondary query parameters
+            Returns:
+                mongo_secondary_query(list): a dictionary with secondary query parameters
 
         """
-        LOG.debug("Creating a query object with secondary parameters")
+        LOG.debug('Creating a query object with secondary parameters')
 
         mongo_secondary_query = []
 
@@ -449,165 +386,142 @@ class QueryHandler(object):
             if not query.get(criterion):
                 continue
 
-            if criterion == "gnomad_frequency":
-                gnomad = query.get("gnomad_frequency")
-                if gnomad == "-1":
+            if criterion == 'gnomad_frequency':
+                gnomad = query.get('gnomad_frequency')
+                if gnomad == '-1':
                     # -1 means to exclude all variants that exists in gnomad
-                    mongo_query["gnomad_frequency"] = {"$exists": False}
+                    mongo_query['gnomad_frequency'] = {'$exists': False}
                 else:
                     # Replace comma with dot
                     mongo_secondary_query.append(
                         {
-                            "$or": [
-                                {"gnomad_frequency": {"$lt": float(gnomad)}},
-                                {"gnomad_frequency": {"$exists": False}},
+                            '$or': [
+                                {
+                                    'gnomad_frequency': {'$lt': float(gnomad)}
+                                },
+                                {
+                                    'gnomad_frequency': {'$exists': False}
+                                }
                             ]
                         }
                     )
                 LOG.debug("Adding gnomad_frequency to query")
 
-            if criterion == "local_obs":
-                local_obs = query.get("local_obs")
-                mongo_secondary_query.append(
-                    {
-                        "$or": [
-                            {"local_obs_old": None},
-                            {"local_obs_old": {"$lt": local_obs + 1}},
-                        ]
-                    }
-                )
+            if criterion == 'local_obs':
+                local_obs = query.get('local_obs')
+                mongo_secondary_query.append({
+                    '$or': [
+                        {'local_obs_old': None},
+                        {'local_obs_old': {'$lt': local_obs + 1}},
+                    ]
+                })
 
-            if criterion in ["clingen_ngi", "swegen"]:
-                mongo_secondary_query.append(
-                    {
-                        "$or": [
-                            {criterion: {"$exists": False}},
-                            {criterion: {"$lt": query[criterion] + 1}},
-                        ]
-                    }
-                )
+            if criterion in ['clingen_ngi', 'swegen']:
+                mongo_secondary_query.append({
+                    '$or': [
+                        { criterion : {'$exists': False}},
+                        { criterion : {'$lt': query[criterion] + 1}},
+                    ]
+                })
 
-            if criterion == "spidex_human":
+            if criterion == 'spidex_human':
                 # construct spidex query. Build the or part starting with empty SPIDEX values
-                spidex_human = query["spidex_human"]
+                spidex_human = query['spidex_human']
 
                 spidex_query_or_part = []
-                if "not_reported" in spidex_human:
-                    spidex_query_or_part.append({"spidex": {"$exists": False}})
+                if ( 'not_reported' in spidex_human):
+                    spidex_query_or_part.append({'spidex': {'$exists': False}})
 
                 for spidex_level in SPIDEX_HUMAN:
-                    if spidex_level in spidex_human:
-                        spidex_query_or_part.append(
-                            {
-                                "$or": [
-                                    {
-                                        "$and": [
-                                            {
-                                                "spidex": {
-                                                    "$gt": SPIDEX_HUMAN[spidex_level]["neg"][0]
-                                                }
-                                            },
-                                            {
-                                                "spidex": {
-                                                    "$lt": SPIDEX_HUMAN[spidex_level]["neg"][1]
-                                                }
-                                            },
-                                        ]
-                                    },
-                                    {
-                                        "$and": [
-                                            {
-                                                "spidex": {
-                                                    "$gt": SPIDEX_HUMAN[spidex_level]["pos"][0]
-                                                }
-                                            },
-                                            {
-                                                "spidex": {
-                                                    "$lt": SPIDEX_HUMAN[spidex_level]["pos"][1]
-                                                }
-                                            },
-                                        ]
-                                    },
-                                ]
-                            }
-                        )
+                    if ( spidex_level in spidex_human ):
+                        spidex_query_or_part.append({'$or': [
+                                    {'$and': [{'spidex': {'$gt': SPIDEX_HUMAN[spidex_level]['neg'][0]}},
+                                              {'spidex': {'$lt': SPIDEX_HUMAN[spidex_level]['neg'][1]}}]},
+                                    {'$and': [{'spidex': {'$gt': SPIDEX_HUMAN[spidex_level]['pos'][0]}},
+                                              {'spidex': {'$lt': SPIDEX_HUMAN[spidex_level]['pos'][1]}} ]} ]})
 
-                mongo_secondary_query.append({"$or": spidex_query_or_part})
+                mongo_secondary_query.append({'$or': spidex_query_or_part })
 
-            if criterion == "cadd_score":
-                cadd = query["cadd_score"]
-                cadd_query = {"cadd_score": {"$gt": float(cadd)}}
+            if criterion == 'cadd_score':
+                cadd = query['cadd_score']
+                cadd_query = {'cadd_score': {'$gt': float(cadd)}}
                 LOG.debug("Adding cadd_score: %s to query", cadd)
 
-                if query.get("cadd_inclusive") is True:
-                    cadd_query = {"$or": [cadd_query, {"cadd_score": {"$exists": False}}]}
+                if query.get('cadd_inclusive') is True:
+                    cadd_query = {
+                        '$or': [
+                            cadd_query,
+                            {'cadd_score': {'$exists': False}}
+                            ]}
                     LOG.debug("Adding cadd inclusive to query")
 
                 mongo_secondary_query.append(cadd_query)
 
-            if criterion in [
-                "genetic_models",
-                "functional_annotations",
-                "region_annotations",
-            ]:
+            if criterion in ['genetic_models', 'functional_annotations', 'region_annotations']:
                 criterion_values = query[criterion]
-                if criterion == "genetic_models":
-                    mongo_secondary_query.append({criterion: {"$in": criterion_values}})
+                if criterion == 'genetic_models':
+                    mongo_secondary_query.append({criterion: {'$in': criterion_values}})
                 else:
                     # filter key will be genes.[criterion (minus final char)]
-                    mongo_secondary_query.append(
-                        {".".join(["genes", criterion[:-1]]): {"$in": criterion_values}}
-                    )
+                    mongo_secondary_query.append({ '.'.join(['genes', criterion[:-1]]) : {'$in': criterion_values}})
 
-                LOG.debug("Adding {0}: {1} to query".format(criterion, ", ".join(criterion_values)))
+                LOG.debug("Adding {0}: {1} to query".format(criterion, ', '.join(criterion_values)))
 
-            if criterion == "size":
-                size = query["size"]
-                size_query = {"length": {"$gt": int(size)}}
+            if criterion == 'size':
+                size = query['size']
+                size_query = {'length': {'$gt': int(size)}}
                 LOG.debug("Adding length: %s to query" % size)
 
-                if query.get("size_shorter"):
+                if query.get('size_shorter'):
                     size_query = {
-                        "$or": [
-                            {"length": {"$lt": int(size)}},
-                            {"length": {"$exists": False}},
-                        ]
-                    }
+                        '$or': [
+                            {'length': {'$lt': int(size)}},
+                            {'length': {'$exists': False}}
+                        ]}
                     LOG.debug("Adding size less than, undef inclusive to query.")
 
                 mongo_secondary_query.append(size_query)
 
-            if criterion == "svtype":
-                svtype = query["svtype"]
-                mongo_secondary_query.append({"sub_category": {"$in": svtype}})
-                LOG.debug("Adding SV_type %s to query" % ", ".join(svtype))
+            if criterion == 'svtype':
+                svtype = query['svtype']
+                mongo_secondary_query.append({'sub_category': {'$in': svtype}})
+                LOG.debug("Adding SV_type %s to query" %
+                             ', '.join(svtype))
 
-            if criterion == "decipher":
-                mongo_query["decipher"] = {"$exists": True}
+            if criterion == 'decipher':
+                mongo_query['decipher'] = {'$exists': True}
                 LOG.debug("Adding decipher to query")
 
-            if criterion == "depth":
+            if criterion == 'depth':
                 LOG.debug("add depth filter")
-                mongo_secondary_query.append({"tumor.read_depth": {"$gt": query.get("depth")}})
+                mongo_secondary_query.append({
+                    'tumor.read_depth': {
+                        '$gt': query.get('depth'),
+                    }
+                })
 
-            if criterion == "alt_count":
+            if criterion == 'alt_count':
                 LOG.debug("add min alt count filter")
-                mongo_secondary_query.append({"tumor.alt_depth": {"$gt": query.get("alt_count")}})
+                mongo_secondary_query.append({
+                    'tumor.alt_depth': {
+                        '$gt': query.get('alt_count'),
+                    }
+                })
 
-            if criterion == "control_frequency":
+            if criterion == 'control_frequency':
                 LOG.debug("add minimum control frequency filter")
-                mongo_secondary_query.append(
-                    {"normal.alt_freq": {"$lt": float(query.get("control_frequency"))}}
-                )
+                mongo_secondary_query.append({
+                    'normal.alt_freq': {
+                        '$lt': float(query.get('control_frequency')),
+                    }
+                })
 
-            if criterion == "tumor_frequency":
-                LOG.debug("add minimum VAF filter")
-                mongo_secondary_query.append(
-                    {"tumor.alt_freq": {"$gt": float(query.get("tumor_frequency"))}}
-                )
-
-            if criterion == "mvl_tag":
+            if criterion == 'mvl_tag':
                 LOG.debug("add managed variant list filter")
-                mongo_secondary_query.append({"mvl_tag": {"$exists": True}})
+                mongo_secondary_query.append({
+                    'mvl_tag': {
+                        '$exists': True,
+                    }
+                })
 
         return mongo_secondary_query

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -182,8 +182,9 @@ class QueryHandler(object):
 
             elif criterion == "chrom_pos" and query.get("chrom_pos"):  # filter by coordinates
                 pattern = re.compile(r"^([0-9a-z]+):(\d+)-(\d+)(?:([+-]{1})(\d+))?$", re.I)
+                chrom_pos = query.get("chrom_pos").replace(',', '')
                 chrom, start, end, sign, padding = re.search(
-                    pattern, query.get("chrom_pos")
+                    pattern, chrom_pos
                 ).groups()
                 if padding:  # increase or decrease search window
                     LOG.debug(f"Applying padding")

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -182,11 +182,9 @@ class QueryHandler(object):
 
             elif criterion == "chrom_pos" and query.get("chrom_pos"):  # filter by coordinates
                 pattern = re.compile(r"^([0-9a-z]+):(\d+)-(\d+)(?:([+-]{1})(\d+))?$", re.I)
-                chrom_pos = query.get("chrom_pos").replace(',', '')
+                chrom_pos = query.get("chrom_pos").replace(",", "")
                 if bool(re.match(pattern, chrom_pos)):
-                    chrom, start, end, sign, padding = re.search(
-                        pattern, chrom_pos
-                    ).groups()
+                    chrom, start, end, sign, padding = re.search(pattern, chrom_pos).groups()
                     if padding:  # increase or decrease search window
                         LOG.debug(f"Applying padding")
                         start, end, padding = map(int, [start, end, padding])

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -4,12 +4,13 @@ from scout.constants import FUNDAMENTAL_CRITERIA, PRIMARY_CRITERIA, SECONDARY_CR
 
 LOG = logging.getLogger(__name__)
 
-from scout.constants import (SPIDEX_HUMAN, CLINSIG_MAP)
+from scout.constants import SPIDEX_HUMAN, CLINSIG_MAP
+
 
 class QueryHandler(object):
-
-    def build_variant_query(self, query=None, institute_id=None, category='snv',
-                            variant_type=['clinical']):
+    def build_variant_query(
+        self, query=None, institute_id=None, category="snv", variant_type=["clinical"]
+    ):
         """Build a mongo query across multiple cases.
         Translate query options from a form into a complete mongo query dictionary.
 
@@ -41,55 +42,54 @@ class QueryHandler(object):
 
         LOG.debug("Building a mongo query for %s" % query)
 
-        if query.get('hgnc_symbols'):
-            mongo_variant_query['hgnc_symbols'] = {'$in': query['hgnc_symbols']}
+        if query.get("hgnc_symbols"):
+            mongo_variant_query["hgnc_symbols"] = {"$in": query["hgnc_symbols"]}
 
-        mongo_variant_query['variant_type'] = {'$in': variant_type}
+        mongo_variant_query["variant_type"] = {"$in": variant_type}
 
-        mongo_variant_query['category'] = category
+        mongo_variant_query["category"] = category
 
         select_cases = None
         select_case_obj = None
         mongo_case_query = {}
 
-        if query.get('phenotype_terms'):
-            mongo_case_query['phenotype_terms.phenotype_id'] = {'$in': query['phenotype_terms']}
+        if query.get("phenotype_terms"):
+            mongo_case_query["phenotype_terms.phenotype_id"] = {"$in": query["phenotype_terms"]}
 
-        if query.get('phenotype_groups'):
-            mongo_case_query['phenotype_groups.phenotype_id'] = {'$in': query['phenotype_groups']}
+        if query.get("phenotype_groups"):
+            mongo_case_query["phenotype_groups.phenotype_id"] = {"$in": query["phenotype_groups"]}
 
-        if query.get('cohorts'):
-            mongo_case_query['cohorts'] = {'$in': query['cohorts']}
+        if query.get("cohorts"):
+            mongo_case_query["cohorts"] = {"$in": query["cohorts"]}
 
         if mongo_case_query != {}:
-            mongo_case_query['owner'] = institute_id
+            mongo_case_query["owner"] = institute_id
             LOG.debug("Search cases for selection set, using query {0}".format(select_case_obj))
             select_case_obj = self.case_collection.find(mongo_case_query)
-            select_cases = [case_id.get('display_name') for case_id in select_case_obj]
+            select_cases = [case_id.get("display_name") for case_id in select_case_obj]
 
-        if query.get('similar_case'):
-            similar_case_display_name = query['similar_case'][0]
+        if query.get("similar_case"):
+            similar_case_display_name = query["similar_case"][0]
             case_obj = self.case(display_name=similar_case_display_name, institute_id=institute_id)
             if case_obj:
-                LOG.debug("Search for cases similar to %s", case_obj.get('display_name'))
+                LOG.debug("Search for cases similar to %s", case_obj.get("display_name"))
                 similar_cases = self.get_similar_cases(case_obj)
-                LOG.debug("Similar cases: %s",similar_cases)
+                LOG.debug("Similar cases: %s", similar_cases)
                 select_cases = [similar[0] for similar in similar_cases]
             else:
                 LOG.debug("Case %s not found.", similar_case_display_name)
 
         if select_cases:
-            mongo_variant_query['case_id'] = {'$in': select_cases}
+            mongo_variant_query["case_id"] = {"$in": select_cases}
 
-        rank_score = query.get('rank_score') or 15
-        mongo_variant_query['rank_score'] = {'$gte': rank_score}
+        rank_score = query.get("rank_score") or 15
+        mongo_variant_query["rank_score"] = {"$gte": rank_score}
 
         LOG.debug("Querying %s" % mongo_variant_query)
 
         return mongo_variant_query
 
-
-    def build_query(self, case_id, query=None, variant_ids=None, category='snv'):
+    def build_query(self, case_id, query=None, variant_ids=None, category="snv"):
         """Build a mongo query
 
         These are the different query options:
@@ -137,21 +137,21 @@ class QueryHandler(object):
         # set up the fundamental query params: case_id, category, type and
         # restrict to list of variants (if var list is provided)
         for criterion in FUNDAMENTAL_CRITERIA:
-            if criterion == 'case_id':
+            if criterion == "case_id":
                 LOG.debug("Building a mongo query for %s" % case_id)
-                mongo_query['case_id'] = case_id
+                mongo_query["case_id"] = case_id
 
-            elif criterion == 'variant_ids' and variant_ids:
-                LOG.debug("Adding variant_ids %s to query" % ', '.join(variant_ids))
-                mongo_query['variant_id'] = {'$in': variant_ids}
+            elif criterion == "variant_ids" and variant_ids:
+                LOG.debug("Adding variant_ids %s to query" % ", ".join(variant_ids))
+                mongo_query["variant_id"] = {"$in": variant_ids}
 
-            elif criterion == 'category':
+            elif criterion == "category":
                 LOG.debug("Querying category %s" % category)
-                mongo_query['category'] = category
+                mongo_query["category"] = category
 
-            elif criterion == 'variant_type':
-                mongo_query['variant_type'] = query.get('variant_type', 'clinical')
-                LOG.debug("Set variant type to %s", mongo_query['variant_type'])
+            elif criterion == "variant_type":
+                mongo_query["variant_type"] = query.get("variant_type", "clinical")
+                LOG.debug("Set variant type to %s", mongo_query["variant_type"])
 
             # Requests to filter based on gene panels, hgnc_symbols or
             # coordinate ranges must always be honored. They are always added to
@@ -159,15 +159,15 @@ class QueryHandler(object):
             # panel is used, addition of this is delayed until after the rest of
             # the query content is clear.
 
-            elif criterion in ['hgnc_symbols', 'gene_panels'] and gene_query is None:
+            elif criterion in ["hgnc_symbols", "gene_panels"] and gene_query is None:
                 gene_query = self.gene_filter(query, mongo_query)
 
-            elif criterion == 'chrom' and query.get('chrom'): # filter by coordinates
+            elif criterion == "chrom" and query.get("chrom"):  # filter by coordinates
                 self.coordinate_filter(query, mongo_query)
 
-            elif criterion == 'variant_ids' and variant_ids:
-                LOG.debug("Adding variant_ids %s to query" % ', '.join(variant_ids))
-                mongo_query['variant_id'] = {'$in': variant_ids}
+            elif criterion == "variant_ids" and variant_ids:
+                LOG.debug("Adding variant_ids %s to query" % ", ".join(variant_ids))
+                mongo_query["variant_id"] = {"$in": variant_ids}
 
             ##### end of fundamental query params
 
@@ -202,119 +202,107 @@ class QueryHandler(object):
             # top level '$and' to the query.
             if primary_terms is False:
                 if gene_query:
-                    mongo_query['$and'] = [ {'$or': gene_query}, {'$and': secondary_filter}]
+                    mongo_query["$and"] = [{"$or": gene_query}, {"$and": secondary_filter}]
                 else:
-                    mongo_query['$and'] = secondary_filter
+                    mongo_query["$and"] = secondary_filter
 
             # If there is only one primary criterion given without any secondary, it will also be
             # added as a top level '$and'.
             # Otherwise, primary criteria are added as a high level '$or' and all secondary criteria
             # are joined together with them as a single lower level '$and'.
-            if primary_terms is True: # clinsig is specified
+            if primary_terms is True:  # clinsig is specified
                 # Given a request to always return confident clinical variants,
                 # add the clnsig query as a major criteria, but only
                 # trust clnsig entries with trusted revstat levels.
-                if query.get('clinsig_confident_always_returned') == True:
+                if query.get("clinsig_confident_always_returned") == True:
                     if gene_query:
-                        mongo_query['$and'] = [
-                            {'$or': gene_query},
-                            {
-                                '$or': [
-                                    {'$and': secondary_filter}, clinsign_filter
-                                ]
-                            }
+                        mongo_query["$and"] = [
+                            {"$or": gene_query},
+                            {"$or": [{"$and": secondary_filter}, clinsign_filter]},
                         ]
                     else:
-                        mongo_query['$or'] = [ {'$and': secondary_filter}, clinsign_filter ]
-                else: # clisig terms are provided but no need for trusted revstat levels
+                        mongo_query["$or"] = [{"$and": secondary_filter}, clinsign_filter]
+                else:  # clisig terms are provided but no need for trusted revstat levels
                     secondary_filter.append(clinsign_filter)
                     if gene_query:
-                        mongo_query['$and'] = [ {'$or': gene_query}, {'$and': secondary_filter}]
+                        mongo_query["$and"] = [{"$or": gene_query}, {"$and": secondary_filter}]
                     else:
-                        mongo_query['$and'] = secondary_filter
+                        mongo_query["$and"] = secondary_filter
 
-        elif primary_terms is True: # clisig is provided without secondary terms query
+        elif primary_terms is True:  # clisig is provided without secondary terms query
             # use implicit and
-            mongo_query['clnsig'] = clinsign_filter['clnsig']
+            mongo_query["clnsig"] = clinsign_filter["clnsig"]
             if gene_query:
-                mongo_query['$and'] = [{ '$or': gene_query }]
+                mongo_query["$and"] = [{"$or": gene_query}]
 
-        elif gene_query: # no primary or secondary filters provided
-            mongo_query['$and'] = [{ '$or': gene_query }]
+        elif gene_query:  # no primary or secondary filters provided
+            mongo_query["$and"] = [{"$or": gene_query}]
 
         LOG.info("mongo query: %s", mongo_query)
 
         return mongo_query
 
-
     def clinsig_query(self, query, mongo_query):
-        """ Add clinsig filter values to the mongo query object
+        """Add clinsig filter values to the mongo query object
 
-            Args:
-                query(dict): a dictionary of query filters specified by the users
-                mongo_query(dict): the query that is going to be submitted to the database
+        Args:
+            query(dict): a dictionary of query filters specified by the users
+            mongo_query(dict): the query that is going to be submitted to the database
 
-            Returns:
-                clinsig_query(dict): a dictionary with clinsig key-values
+        Returns:
+            clinsig_query(dict): a dictionary with clinsig key-values
 
         """
-        LOG.debug('clinsig is a query parameter')
-        trusted_revision_level = ['mult', 'single', 'exp', 'guideline']
+        LOG.debug("clinsig is a query parameter")
+        trusted_revision_level = ["mult", "single", "exp", "guideline"]
         rank = []
         str_rank = []
         clnsig_query = {}
 
-        for item in query['clinsig']:
+        for item in query["clinsig"]:
             rank.append(int(item))
             # search for human readable clinsig values in newer cases
             rank.append(CLINSIG_MAP[int(item)])
             str_rank.append(CLINSIG_MAP[int(item)])
 
-        if query.get('clinsig_confident_always_returned') == True:
+        if query.get("clinsig_confident_always_returned") == True:
             LOG.debug("add CLINSIG filter with trusted_revision_level")
 
-            clnsig_query = { "clnsig":
-                        {
-                            '$elemMatch': {
-                                '$or' : [
-                                    {
-                                        '$and' : [
-                                             {'value' : { '$in': rank }},
-                                             {'revstat': { '$in': trusted_revision_level }}
-                                        ]
-                                    },
-                                    {
-                                        '$and': [
-                                            {'value' : re.compile('|'.join(str_rank))},
-                                            {'revstat' : re.compile('|'.join(trusted_revision_level))}
-                                        ]
-                                    }
+            clnsig_query = {
+                "clnsig": {
+                    "$elemMatch": {
+                        "$or": [
+                            {
+                                "$and": [
+                                    {"value": {"$in": rank}},
+                                    {"revstat": {"$in": trusted_revision_level}},
                                 ]
-                            }
-                         }
+                            },
+                            {
+                                "$and": [
+                                    {"value": re.compile("|".join(str_rank))},
+                                    {"revstat": re.compile("|".join(trusted_revision_level))},
+                                ]
+                            },
+                        ]
                     }
+                }
+            }
         else:
-            LOG.debug("add CLINSIG filter for rank: %s" %
-                             ', '.join(str(query['clinsig'])))
+            LOG.debug("add CLINSIG filter for rank: %s" % ", ".join(str(query["clinsig"])))
 
             clnsig_query = {
-                    "clnsig":
-                        {
-                            '$elemMatch': {
-                                '$or' : [
-                                    { 'value' : { '$in': rank }},
-                                    { 'value' : re.compile('|'.join(str_rank)) }
-                                ]
-                            }
-                        }
+                "clnsig": {
+                    "$elemMatch": {
+                        "$or": [{"value": {"$in": rank}}, {"value": re.compile("|".join(str_rank))}]
+                    }
                 }
+            }
 
         return clnsig_query
 
-
-
     def coordinate_filter(self, query, mongo_query):
-        """ Adds genomic coordinated-related filters to the query object
+        """Adds genomic coordinated-related filters to the query object
 
         Args:
             query(dict): a dictionary of query filters specified by the users
@@ -324,20 +312,18 @@ class QueryHandler(object):
             mongo_query(dict): returned object contains coordinate filters
 
         """
-        LOG.debug('Adding genomic coordinates to the query')
-        chromosome = query['chrom']
-        mongo_query['chromosome'] = chromosome
+        LOG.debug("Adding genomic coordinates to the query")
+        chromosome = query["chrom"]
+        mongo_query["chromosome"] = chromosome
 
-        if (query.get('start') and query.get('end')):
-            mongo_query['position'] = {'$lte': int(query['end'])}
-            mongo_query['end'] = {'$gte': int(query['start'])}
+        if query.get("start") and query.get("end"):
+            mongo_query["position"] = {"$lte": int(query["end"])}
+            mongo_query["end"] = {"$gte": int(query["start"])}
 
         return mongo_query
 
-
-
     def gene_filter(self, query, mongo_query):
-        """ Adds gene-related filters to the query object
+        """Adds gene-related filters to the query object
 
         Args:
             query(dict): a dictionary of query filters specified by the users
@@ -347,37 +333,34 @@ class QueryHandler(object):
             mongo_query(dict): returned object contains gene and panel-related filters
 
         """
-        LOG.debug('Adding panel and genes-related parameters to the query')
+        LOG.debug("Adding panel and genes-related parameters to the query")
         gene_query = []
-        hgnc_symbols = query.get('hgnc_symbols')
-        gene_panels = query.get('gene_panels')
+        hgnc_symbols = query.get("hgnc_symbols")
+        gene_panels = query.get("gene_panels")
 
         if hgnc_symbols and gene_panels:
-            gene_query.append({'hgnc_symbols': {'$in': hgnc_symbols}})
-            gene_query.append({'panels': {'$in': gene_panels}})
+            gene_query.append({"hgnc_symbols": {"$in": hgnc_symbols}})
+            gene_query.append({"panels": {"$in": gene_panels}})
         elif hgnc_symbols:
-            mongo_query['hgnc_symbols'] = {'$in': hgnc_symbols}
-            LOG.debug("Adding hgnc_symbols: %s to query" %
-                            ', '.join(hgnc_symbols))
-        elif gene_panels: #gene_panels
-            mongo_query['panels'] = {'$in': gene_panels}
+            mongo_query["hgnc_symbols"] = {"$in": hgnc_symbols}
+            LOG.debug("Adding hgnc_symbols: %s to query" % ", ".join(hgnc_symbols))
+        elif gene_panels:  # gene_panels
+            mongo_query["panels"] = {"$in": gene_panels}
 
         return gene_query
-
-
 
     def secondary_query(self, query, mongo_query, secondary_filter=None):
         """Creates a secondary query object based on secondary parameters specified by user
 
-            Args:
-                query(dict): a dictionary of query filters specified by the users
-                mongo_query(dict): the query that is going to be submitted to the database
+        Args:
+            query(dict): a dictionary of query filters specified by the users
+            mongo_query(dict): the query that is going to be submitted to the database
 
-            Returns:
-                mongo_secondary_query(list): a dictionary with secondary query parameters
+        Returns:
+            mongo_secondary_query(list): a dictionary with secondary query parameters
 
         """
-        LOG.debug('Creating a query object with secondary parameters')
+        LOG.debug("Creating a query object with secondary parameters")
 
         mongo_secondary_query = []
 
@@ -386,142 +369,174 @@ class QueryHandler(object):
             if not query.get(criterion):
                 continue
 
-            if criterion == 'gnomad_frequency':
-                gnomad = query.get('gnomad_frequency')
-                if gnomad == '-1':
+            if criterion == "gnomad_frequency":
+                gnomad = query.get("gnomad_frequency")
+                if gnomad == "-1":
                     # -1 means to exclude all variants that exists in gnomad
-                    mongo_query['gnomad_frequency'] = {'$exists': False}
+                    mongo_query["gnomad_frequency"] = {"$exists": False}
                 else:
                     # Replace comma with dot
                     mongo_secondary_query.append(
                         {
-                            '$or': [
-                                {
-                                    'gnomad_frequency': {'$lt': float(gnomad)}
-                                },
-                                {
-                                    'gnomad_frequency': {'$exists': False}
-                                }
+                            "$or": [
+                                {"gnomad_frequency": {"$lt": float(gnomad)}},
+                                {"gnomad_frequency": {"$exists": False}},
                             ]
                         }
                     )
                 LOG.debug("Adding gnomad_frequency to query")
 
-            if criterion == 'local_obs':
-                local_obs = query.get('local_obs')
-                mongo_secondary_query.append({
-                    '$or': [
-                        {'local_obs_old': None},
-                        {'local_obs_old': {'$lt': local_obs + 1}},
-                    ]
-                })
+            if criterion == "local_obs":
+                local_obs = query.get("local_obs")
+                mongo_secondary_query.append(
+                    {
+                        "$or": [
+                            {"local_obs_old": None},
+                            {"local_obs_old": {"$lt": local_obs + 1}},
+                        ]
+                    }
+                )
 
-            if criterion in ['clingen_ngi', 'swegen']:
-                mongo_secondary_query.append({
-                    '$or': [
-                        { criterion : {'$exists': False}},
-                        { criterion : {'$lt': query[criterion] + 1}},
-                    ]
-                })
+            if criterion in ["clingen_ngi", "swegen"]:
+                mongo_secondary_query.append(
+                    {
+                        "$or": [
+                            {criterion: {"$exists": False}},
+                            {criterion: {"$lt": query[criterion] + 1}},
+                        ]
+                    }
+                )
 
-            if criterion == 'spidex_human':
+            if criterion == "spidex_human":
                 # construct spidex query. Build the or part starting with empty SPIDEX values
-                spidex_human = query['spidex_human']
+                spidex_human = query["spidex_human"]
 
                 spidex_query_or_part = []
-                if ( 'not_reported' in spidex_human):
-                    spidex_query_or_part.append({'spidex': {'$exists': False}})
+                if "not_reported" in spidex_human:
+                    spidex_query_or_part.append({"spidex": {"$exists": False}})
 
                 for spidex_level in SPIDEX_HUMAN:
-                    if ( spidex_level in spidex_human ):
-                        spidex_query_or_part.append({'$or': [
-                                    {'$and': [{'spidex': {'$gt': SPIDEX_HUMAN[spidex_level]['neg'][0]}},
-                                              {'spidex': {'$lt': SPIDEX_HUMAN[spidex_level]['neg'][1]}}]},
-                                    {'$and': [{'spidex': {'$gt': SPIDEX_HUMAN[spidex_level]['pos'][0]}},
-                                              {'spidex': {'$lt': SPIDEX_HUMAN[spidex_level]['pos'][1]}} ]} ]})
+                    if spidex_level in spidex_human:
+                        spidex_query_or_part.append(
+                            {
+                                "$or": [
+                                    {
+                                        "$and": [
+                                            {
+                                                "spidex": {
+                                                    "$gt": SPIDEX_HUMAN[spidex_level]["neg"][0]
+                                                }
+                                            },
+                                            {
+                                                "spidex": {
+                                                    "$lt": SPIDEX_HUMAN[spidex_level]["neg"][1]
+                                                }
+                                            },
+                                        ]
+                                    },
+                                    {
+                                        "$and": [
+                                            {
+                                                "spidex": {
+                                                    "$gt": SPIDEX_HUMAN[spidex_level]["pos"][0]
+                                                }
+                                            },
+                                            {
+                                                "spidex": {
+                                                    "$lt": SPIDEX_HUMAN[spidex_level]["pos"][1]
+                                                }
+                                            },
+                                        ]
+                                    },
+                                ]
+                            }
+                        )
 
-                mongo_secondary_query.append({'$or': spidex_query_or_part })
+                mongo_secondary_query.append({"$or": spidex_query_or_part})
 
-            if criterion == 'cadd_score':
-                cadd = query['cadd_score']
-                cadd_query = {'cadd_score': {'$gt': float(cadd)}}
+            if criterion == "cadd_score":
+                cadd = query["cadd_score"]
+                cadd_query = {"cadd_score": {"$gt": float(cadd)}}
                 LOG.debug("Adding cadd_score: %s to query", cadd)
 
-                if query.get('cadd_inclusive') is True:
-                    cadd_query = {
-                        '$or': [
-                            cadd_query,
-                            {'cadd_score': {'$exists': False}}
-                            ]}
+                if query.get("cadd_inclusive") is True:
+                    cadd_query = {"$or": [cadd_query, {"cadd_score": {"$exists": False}}]}
                     LOG.debug("Adding cadd inclusive to query")
 
                 mongo_secondary_query.append(cadd_query)
 
-            if criterion in ['genetic_models', 'functional_annotations', 'region_annotations']:
+            if criterion in ["genetic_models", "functional_annotations", "region_annotations"]:
                 criterion_values = query[criterion]
-                if criterion == 'genetic_models':
-                    mongo_secondary_query.append({criterion: {'$in': criterion_values}})
+                if criterion == "genetic_models":
+                    mongo_secondary_query.append({criterion: {"$in": criterion_values}})
                 else:
                     # filter key will be genes.[criterion (minus final char)]
-                    mongo_secondary_query.append({ '.'.join(['genes', criterion[:-1]]) : {'$in': criterion_values}})
+                    mongo_secondary_query.append(
+                        {".".join(["genes", criterion[:-1]]): {"$in": criterion_values}}
+                    )
 
-                LOG.debug("Adding {0}: {1} to query".format(criterion, ', '.join(criterion_values)))
+                LOG.debug("Adding {0}: {1} to query".format(criterion, ", ".join(criterion_values)))
 
-            if criterion == 'size':
-                size = query['size']
-                size_query = {'length': {'$gt': int(size)}}
+            if criterion == "size":
+                size = query["size"]
+                size_query = {"length": {"$gt": int(size)}}
                 LOG.debug("Adding length: %s to query" % size)
 
-                if query.get('size_shorter'):
+                if query.get("size_shorter"):
                     size_query = {
-                        '$or': [
-                            {'length': {'$lt': int(size)}},
-                            {'length': {'$exists': False}}
-                        ]}
+                        "$or": [{"length": {"$lt": int(size)}}, {"length": {"$exists": False}}]
+                    }
                     LOG.debug("Adding size less than, undef inclusive to query.")
 
                 mongo_secondary_query.append(size_query)
 
-            if criterion == 'svtype':
-                svtype = query['svtype']
-                mongo_secondary_query.append({'sub_category': {'$in': svtype}})
-                LOG.debug("Adding SV_type %s to query" %
-                             ', '.join(svtype))
+            if criterion == "svtype":
+                svtype = query["svtype"]
+                mongo_secondary_query.append({"sub_category": {"$in": svtype}})
+                LOG.debug("Adding SV_type %s to query" % ", ".join(svtype))
 
-            if criterion == 'decipher':
-                mongo_query['decipher'] = {'$exists': True}
+            if criterion == "decipher":
+                mongo_query["decipher"] = {"$exists": True}
                 LOG.debug("Adding decipher to query")
 
-            if criterion == 'depth':
+            if criterion == "depth":
                 LOG.debug("add depth filter")
-                mongo_secondary_query.append({
-                    'tumor.read_depth': {
-                        '$gt': query.get('depth'),
+                mongo_secondary_query.append(
+                    {
+                        "tumor.read_depth": {
+                            "$gt": query.get("depth"),
+                        }
                     }
-                })
+                )
 
-            if criterion == 'alt_count':
+            if criterion == "alt_count":
                 LOG.debug("add min alt count filter")
-                mongo_secondary_query.append({
-                    'tumor.alt_depth': {
-                        '$gt': query.get('alt_count'),
+                mongo_secondary_query.append(
+                    {
+                        "tumor.alt_depth": {
+                            "$gt": query.get("alt_count"),
+                        }
                     }
-                })
+                )
 
-            if criterion == 'control_frequency':
+            if criterion == "control_frequency":
                 LOG.debug("add minimum control frequency filter")
-                mongo_secondary_query.append({
-                    'normal.alt_freq': {
-                        '$lt': float(query.get('control_frequency')),
+                mongo_secondary_query.append(
+                    {
+                        "normal.alt_freq": {
+                            "$lt": float(query.get("control_frequency")),
+                        }
                     }
-                })
+                )
 
-            if criterion == 'mvl_tag':
+            if criterion == "mvl_tag":
                 LOG.debug("add managed variant list filter")
-                mongo_secondary_query.append({
-                    'mvl_tag': {
-                        '$exists': True,
+                mongo_secondary_query.append(
+                    {
+                        "mvl_tag": {
+                            "$exists": True,
+                        }
                     }
-                })
+                )
 
         return mongo_secondary_query

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -183,31 +183,32 @@ class QueryHandler(object):
             elif criterion == "chrom_pos" and query.get("chrom_pos"):  # filter by coordinates
                 pattern = re.compile(r"^([0-9a-z]+):(\d+)-(\d+)(?:([+-]{1})(\d+))?$", re.I)
                 chrom_pos = query.get("chrom_pos").replace(',', '')
-                chrom, start, end, sign, padding = re.search(
-                    pattern, chrom_pos
-                ).groups()
-                if padding:  # increase or decrease search window
-                    LOG.debug(f"Applying padding")
-                    start, end, padding = map(int, [start, end, padding])
-                    if sign == "+":
-                        start = 0 if start - padding < 1 else start - padding
-                        end = end + padding
-                    else:
-                        start = start + padding
-                        end = 0 if end - padding < 0 else end - padding
-                        start, end = (end, start) if end < start else (start, end)
-                # modify query dict
-                query["chrom"] = chrom
-                query["start"] = start
-                query["end"] = end
-                # query database
-                coordinate_query = None
-                if category == "snv":
-                    mongo_query["chromosome"] = query["chrom"]
-                    if query.get("start") and query.get("end"):
-                        self.coordinate_filter(query, mongo_query)
-                else:  # sv
-                    coordinate_query = [self.sv_coordinate_query(query)]
+                if bool(re.match(pattern, chrom_pos)):
+                    chrom, start, end, sign, padding = re.search(
+                        pattern, chrom_pos
+                    ).groups()
+                    if padding:  # increase or decrease search window
+                        LOG.debug(f"Applying padding")
+                        start, end, padding = map(int, [start, end, padding])
+                        if sign == "+":
+                            start = 0 if start - padding < 1 else start - padding
+                            end = end + padding
+                        else:
+                            start = start + padding
+                            end = 0 if end - padding < 0 else end - padding
+                            start, end = (end, start) if end < start else (start, end)
+                    # modify query dict
+                    query["chrom"] = chrom
+                    query["start"] = start
+                    query["end"] = end
+                    # query database
+                    coordinate_query = None
+                    if category == "snv":
+                        mongo_query["chromosome"] = query["chrom"]
+                        if query.get("start") and query.get("end"):
+                            self.coordinate_filter(query, mongo_query)
+                    else:  # sv
+                        coordinate_query = [self.sv_coordinate_query(query)]
 
             elif criterion == "variant_ids" and variant_ids:
                 LOG.debug("Adding variant_ids %s to query" % ", ".join(variant_ids))

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -14,6 +14,7 @@ FUNDAMENTAL_CRITERIA = [
     "chrom",
     "start",
     "end",
+    "chrom_pos",
     "variant_ids",
 ]
 

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,6 +105,8 @@ class VariantFiltersForm(FlaskForm):
     load_filter = SubmitField(label="Load filter")
     delete_filter = SubmitField(label="Delete filter")
 
+    chrom_pos = StringField("Chromosome position", [validators.Optional()])
+
     chrom = SelectField(
         "Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS, default=""
     )

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,7 +105,8 @@ class VariantFiltersForm(FlaskForm):
     load_filter = SubmitField(label="Load filter")
     delete_filter = SubmitField(label="Delete filter")
 
-    chrom_pos = StringField("Chromosome position", [validators.Optional()])
+    chrom_pos = StringField("Chromosome position", [validators.Optional()],
+                            render_kw={"placeholder": "<chr>:<start pos>-<end pos>(+<span>)"})
 
     chrom = SelectField(
         "Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS, default=""

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -106,7 +106,7 @@ class VariantFiltersForm(FlaskForm):
     delete_filter = SubmitField(label="Delete filter")
 
     chrom_pos = StringField("Chromosome position", [validators.Optional()],
-                            render_kw={"placeholder": "<chr>:<start pos>-<end pos>(+<span>)"})
+                            render_kw={"placeholder": "<chr>:<start pos>-<end pos>[optional +/-<span>]"})
 
     chrom = SelectField(
         "Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS, default=""

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,8 +105,11 @@ class VariantFiltersForm(FlaskForm):
     load_filter = SubmitField(label="Load filter")
     delete_filter = SubmitField(label="Delete filter")
 
-    chrom_pos = StringField("Chromosome position", [validators.Optional()],
-                            render_kw={"placeholder": "<chr>:<start pos>-<end pos>[optional +/-<span>]"})
+    chrom_pos = StringField(
+        "Chromosome position",
+        [validators.Optional()],
+        render_kw={"placeholder": "<chr>:<start pos>-<end pos>[optional +/-<span>]"},
+    )
 
     chrom = SelectField(
         "Chromosome", [validators.Optional()], choices=CHROMOSOME_OPTIONS, default=""

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -80,7 +80,7 @@ function validateForm(){
     }
     // Validate Chromosome position form
     //Expected format: <chr number>:<start>-<end>[+-]?<padding>
-    var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value
+    var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value.replaceAll(',', '')
     const chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
     if(chrom_pos) {
         if (!chromPosPattern.test(chrom_pos)) {
@@ -159,7 +159,7 @@ function updateCoordinateFields(element) {
   // parse chromosome position info
   let chrName, startPos, endPos;
   try {
-    [_, chrName, startPos, endPos] = chromPos.value.match(chromPosPattern);
+    [_, chrName, startPos, endPos] = chromPos.value.replaceAll(',', '').match(chromPosPattern);
     console.log(`Parsing ChrPos: ${chrName}, start: ${startPos}-${endPos}`)
   } catch (err) {
     console.log('ChrPos empty')

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -48,7 +48,8 @@ function populateCytobands(cytobands){
 }
 // ValidateForm()
 // Controll user input fields (start, end) in varaint filter.
-//
+// Verify the format of Chromosome position
+// 
 function validateForm(){
     var start = document.forms["filters_form"].elements["start"].value
     var end = document.forms["filters_form"].elements["end"].value
@@ -64,6 +65,29 @@ function validateForm(){
         else if( (isNaN(start) || isNaN(end)) || Number(end)<Number(start) ){
             alert("Coordinate field not valid");
             return false;
+        }
+    }
+    // Validate Chromosome position form
+    //Expected format: <chr number>:<start>-<end>[+-]?<padding>
+    var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value
+    if(chrom_pos) {
+        pattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
+        if (!pattern.test(chrom_pos)) {
+            alert("Invalid format of chromosome position, expected format <chr number>:<start>-<end>[+-]?<padding>");
+            return false;
+        }
+        var _, chr, start, end, sign, padding;
+        [_, chr, start, end, padding] = pattern.exec(chrom_pos);
+        sign = padding[0];
+        padding = padding.slice(1, padding.length);
+        if (Number(start) < 0 || Number(end) < 0) {
+            alert("Invalid coordinates, coordinates must be greater than zero");
+            return false;
+        } else if (Number(start) > Number(end)) {
+            alert("Invalid coordinates, end coordinate must be greater than start");
+            return false;
+        } else if (Number(padding) < 1) {
+            alert("Padding must be greater than zero!")
         }
     }
     return true;

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -121,7 +121,6 @@ function initSearchConstraints(selectorId, textId){
         }
         // populate textfield
         textId.value = selectorId.options[selectorId.selectedIndex].value
-        updateCoordinateFields(event.target)
     });
 }
 
@@ -155,12 +154,12 @@ function enableDismiss(){
 }
 
 
-// Update chromosome position
+// Link chromosome position input field with chromosome and cytoband dropdowns.
+// Changes to chrom and cytoband dropdowns are reflected in chrom_pos input
+// Changes in chrom_pos input are reflected in chrom, start and end fields
 function updateCoordinateFields(element) {
   const chrom = document.forms["filters_form"].elements["chrom"];
   const chromPos = document.forms["filters_form"].elements["chrom_pos"];
-  const cytoStart = document.forms["filters_form"].elements["cytoband_start"];
-  const cytoEnd = document.forms["filters_form"].elements["cytoband_end"];
   const chromPosPattern = "(?:chr)?([1-9]|1[0-9]|2[0-2]|X|Y|MT)(?::([0-9]+)?(?:-([0-9]+)?)?)?$";
   // parse chromosome position info
   let chrName, startPos, endPos;
@@ -176,12 +175,6 @@ function updateCoordinateFields(element) {
     chromPos.value = element.selectedOptions[0].value;
   } else if (element === chromPos && chrName == null) {
     console.log('regex not matching')
-  } else if (element === cytoStart) {
-    // If the cytoband changed
-    chromPos.value = updateChromPos(chrName, cytoStart.value, endPos);
-  } else if (element === cytoEnd) {
-    // If the cytoband changed
-    chromPos.value = updateChromPos(chrName, startPos, cytoEnd.value);
   } else {
     // update start, end input fields
     chrom.querySelector(`[value="${chrName}"]`).toggleAttribute('selected');
@@ -192,16 +185,4 @@ function updateCoordinateFields(element) {
       document.forms["filters_form"].elements["end"].value = endPos;
     }
   }
-}
-
-
-// Update chromosome position field
-function updateChromPos(chrName="", start, end) {
-  let results = chrName == null ? "" : chrName;
-  if ([start, end].some(pos => pos !== null)){
-    start = start == null ? "" : start
-    end = end == null ? "" : end
-    results = `${results}:${start}-${end}`
-  }
-  return results
 }

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -1,12 +1,23 @@
 function populateCytobands(cytobands){
+  var chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2})");
   var chrom = document.forms["filters_form"].elements["chrom"].value;
-  if(chrom===""){
+  var chromPos = document.forms["filters_form"].elements["chrom_pos"].value;
+  var chromosome = "";
+  console.log("Populate cytobands")
+  if(chrom==="" && chromPos===""){
     startElem.value = "";
     endElem.value = "";
     return //only reset cytoband select element
+  // Set the selected chromosome name
+  } else if (chrom!=="" && chromPos!==""){
+    chromosome = chromPos.match(chromPosPattern)[0];
+  } else if (chrom==="" && chromPos!==""){
+    chromosome = chromPos.match(chromPosPattern)[0];
+  } else {
+    chromosome = chrom;
   }
-
-  var chrom_cytobands = cytobands[chrom]["cytobands"]; // chromosome-specific cytobands
+  
+  var chrom_cytobands = cytobands[chromosome]["cytobands"]; // chromosome-specific cytobands
 
   for (elem of [cytoStart, cytoEnd]) {
     if (elem.options.length > 0){
@@ -70,9 +81,9 @@ function validateForm(){
     // Validate Chromosome position form
     //Expected format: <chr number>:<start>-<end>[+-]?<padding>
     var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value
+    chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
     if(chrom_pos) {
-        pattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
-        if (!pattern.test(chrom_pos)) {
+        if (!chromPosPattern.test(chrom_pos)) {
             alert("Invalid format of chromosome position, expected format <chr number>:<start>-<end>[+-]?<padding>");
             return false;
         }

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -81,16 +81,14 @@ function validateForm(){
     // Validate Chromosome position form
     //Expected format: <chr number>:<start>-<end>[+-]?<padding>
     var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value
-    chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
+    const chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
     if(chrom_pos) {
         if (!chromPosPattern.test(chrom_pos)) {
             alert("Invalid format of chromosome position, expected format <chr number>:<start>-<end>[+-]?<padding>");
             return false;
         }
         var _, chr, start, end, sign, padding;
-        [_, chr, start, end, padding] = pattern.exec(chrom_pos);
-        sign = padding[0];
-        padding = padding.slice(1, padding.length);
+        [_, chr, start, end, padding] = chromPosPattern.exec(chrom_pos);
         if (Number(start) < 0 || Number(end) < 0) {
             alert("Invalid coordinates, coordinates must be greater than zero");
             return false;

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -81,7 +81,7 @@ function validateForm(){
     // Validate Chromosome position form
     //Expected format: <chr number>:<start>-<end>[+-]?<padding>
     var chrom_pos = document.forms["filters_form"].elements["chrom_pos"].value.replaceAll(',', '')
-    const chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2}):([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?$");
+    const chromPosPattern = new RegExp("^([0-9]{1,2}|[X|T|MT]{1,2})(:([0-9]+)-([0-9]+)([+-]{1}[0-9]+)?)?$");
     if(chrom_pos) {
         if (!chromPosPattern.test(chrom_pos)) {
             alert("Invalid format of chromosome position, expected format <chr number>:<start>-<end>[+-]?<padding>");

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -115,6 +115,7 @@ function initSearchConstraints(selectorId, textId){
         }
         // populate textfield
         textId.value = selectorId.options[selectorId.selectedIndex].value
+        updateCoordinateFields(event.target)
     });
 }
 
@@ -145,4 +146,54 @@ function enableDismiss(){
   else{
     btnElem.disabled = true;
   }
+}
+
+
+// Update chromosome position
+function updateCoordinateFields(element) {
+  const chrom = document.forms["filters_form"].elements["chrom"];
+  const chromPos = document.forms["filters_form"].elements["chrom_pos"];
+  const cytoStart = document.forms["filters_form"].elements["cytoband_start"];
+  const cytoEnd = document.forms["filters_form"].elements["cytoband_end"];
+  const chromPosPattern = "^([0-9]{1,2}|[X|T|MT]{1,2})(?::([0-9]+)?(?:-([0-9]+)?)?)?";
+  // parse chromosome position info
+  let chrName, startPos, endPos;
+  try {
+    [_, chrName, startPos, endPos] = chromPos.value.match(chromPosPattern);
+    console.log(`Parsing ChrPos: ${chrName}, start: ${startPos}-${endPos}`)
+  } catch (err) {
+    console.log('ChrPos empty')
+  }
+  // update elements
+  if (element === chrom) {
+    // if alterations in chromosome input field triggered the event
+    chromPos.value = element.selectedOptions[0].value;
+  } else if (element === cytoStart) {
+    // If the cytoband changed
+    chromPos.value = updateChromPos(chrName, cytoStart.value, endPos);
+  } else if (element === cytoEnd) {
+    // If the cytoband changed
+    chromPos.value = updateChromPos(chrName, startPos, cytoEnd.value);
+  } else {
+    // update start, end input fields
+    chrom.querySelector(`[value="${chrName}"]`).toggleAttribute('selected');
+    if (startPos != null) {
+      document.forms["filters_form"].elements["start"].value = startPos;
+    }
+    if (endPos != null) {
+      document.forms["filters_form"].elements["end"].value = endPos;
+    }
+  }
+}
+
+
+// Update chromosome position field
+function updateChromPos(chrName="", start, end) {
+  let results = chrName == null ? "" : chrName;
+  if ([start, end].some(pos => pos !== null)){
+    start = start == null ? "" : start
+    end = end == null ? "" : end
+    results = `${results}:${start}-${end}`
+  }
+  return results
 }

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -252,6 +252,15 @@
       populateCytobands({{cytobands|safe}});
     });
 
+    var chromPosInpt = document.getElementById("chrom_pos");
+    chromPosInpt.addEventListener("change", function() {
+      populateCytobands({{cytobands|safe}});
+    })
+
+   chromPosInpt.addEventListener("input", function() {
+      updateCoordinateFields(event.target)
+   })
+
     var cytoStart = document.getElementById("cytoband_start");
     initSearchConstraints(cytoStart, startElem)
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -162,7 +162,6 @@
     var chromSel = document.getElementById("chrom");
     chromSel.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
-      updateCoordinateFields(event.target)
     });
 
     var chromPosInpt = document.getElementById("chrom_pos");

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -164,6 +164,11 @@
       populateCytobands({{cytobands|safe}});
     });
 
+    var chromPosInpt = document.getElementById("chrom_pos");
+    chromPosInpt.addEventListener("change", function() {
+      populateCytobands({{cytobands|safe}});
+    })
+
     var cytoStart = document.getElementById("cytoband_start");
     initSearchConstraints(cytoStart, startElem)
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -162,12 +162,17 @@
     var chromSel = document.getElementById("chrom");
     chromSel.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
+      updateCoordinateFields(event.target)
     });
 
     var chromPosInpt = document.getElementById("chrom_pos");
     chromPosInpt.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
     })
+
+   chromPosInpt.addEventListener("input", function() {
+      updateCoordinateFields(event.target)
+   })
 
     var cytoStart = document.getElementById("cytoband_start");
     initSearchConstraints(cytoStart, startElem)

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -375,13 +375,13 @@
 </div>
 <div class="form-group">
   <div class="row">
-    <div class="col-2">
-    </div>
     <div class="col-1">
     </div>
     <div class="col-1">
     </div>
-    <div class="col-2">
+    <div class="col-1">
+    </div>
+    <div class="col-5">
       {{ wtf.form_field(form.chrom_pos) }}
     </div>
     <div class="col-2">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -256,6 +256,25 @@
       {{ wtf.form_field(form.cytoband_end) }}
     </div>
   </div>
+  <div class="form-group">
+    <div class="row">
+      <div class="col-1">
+      </div>
+      <div class="col-1">
+      </div>
+      <div class="col-1">
+      </div>
+      <div class="col-5">
+        {{ wtf.form_field(form.chrom_pos) }}
+      </div>
+      <div class="col-2">
+      </div>
+      <div class="col-2">
+      </div>
+      <div class="col-2">
+      </div>
+    </div>
+  </div>
 </div>
 <div class="form-group">
   <div class="row justify-content-between" style="margin-top:20px;">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -375,6 +375,25 @@
 </div>
 <div class="form-group">
   <div class="row">
+    <div class="col-2">
+    </div>
+    <div class="col-1">
+    </div>
+    <div class="col-1">
+    </div>
+    <div class="col-2">
+      {{ wtf.form_field(form.chrom_pos) }}
+    </div>
+    <div class="col-2">
+    </div>
+    <div class="col-2">
+    </div>
+    <div class="col-2">
+    </div>
+  </div>
+</div>
+<div class="form-group">
+  <div class="row">
     <div class="col-4">
       {{ form.filter_variants(class="btn btn-primary form-control") }}
     </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -256,25 +256,12 @@
       {{ wtf.form_field(form.cytoband_end) }}
     </div>
   </div>
-  <div class="form-group">
-    <div class="row">
-      <div class="col-1">
-      </div>
-      <div class="col-1">
-      </div>
-      <div class="col-1">
-      </div>
-      <div class="col-5">
-        {{ wtf.form_field(form.chrom_pos) }}
-      </div>
-      <div class="col-2">
-      </div>
-      <div class="col-2">
-      </div>
-      <div class="col-2">
-      </div>
+  <div class="row justify-content-center">
+    <div class="col-5">
+      {{ wtf.form_field(form.chrom_pos) }}
     </div>
   </div>
+</div>
 </div>
 <div class="form-group">
   <div class="row justify-content-between" style="margin-top:20px;">
@@ -391,23 +378,9 @@
       {{ wtf.form_field(form.cytoband_end) }}
     </div>
   </div>
-</div>
-<div class="form-group">
-  <div class="row">
-    <div class="col-1">
-    </div>
-    <div class="col-1">
-    </div>
-    <div class="col-1">
-    </div>
+  <div class="row justify-content-center">
     <div class="col-5">
       {{ wtf.form_field(form.chrom_pos) }}
-    </div>
-    <div class="col-2">
-    </div>
-    <div class="col-2">
-    </div>
-    <div class="col-2">
     </div>
   </div>
 </div>
@@ -525,6 +498,11 @@
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
         <div class="col-md-1 col-lg-1 col-xl-5" id="empty_space"></div>
+      </div>
+      <div class="row justify-content-center">
+        <div class="col-5">
+          {{ wtf.form_field(form.chrom_pos) }}
+        </div>
       </div>
     </div>
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -176,7 +176,17 @@
     var chromSel = document.getElementById("chrom");
     chromSel.addEventListener("change", function() {
       populateCytobands({{cytobands|safe}});
+      updateCoordinateFields(event.target)
     });
+   
+    var chromPosInpt = document.getElementById("chrom_pos");
+    chromPosInpt.addEventListener("change", function() {
+      populateCytobands({{cytobands|safe}});
+    })
+
+   chromPosInpt.addEventListener("input", function() {
+      updateCoordinateFields(event.target)
+   })
 
     var cytoStart = document.getElementById("cytoband_start");
     initSearchConstraints(cytoStart, startElem)


### PR DESCRIPTION
This PR adds a new input field when filtering variants. The filter takes an IGV position string (<chr>:<start>-<end>) as input which is a feature frequently requested by the analysts at Clinical Genomics Lund. The intent is to enable copy-pasting in position information from genome browsers such as IGV directly into scout.

**How to test**
1. Load test case 643594 into scout.
2. Go to http://localhost:5000/cust000/643594/sv/variants
3. Try searches such as in Chromosome position field 9:1,8500,001-2,800,0001

**Expected outcome**:
1. The same type of filtering as when using the ordinary filters.

**Review:**
- [ ] code approved by
- [ ] tests executed by