### PR TITLE
Bug fix --> uploading of cases where no phenotype is specified in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Sentieon Manta calls lack Somaticscore - load anyway
 - ClinVar submissions crashing due to pinned variants that are not loaded
 - Point ExAC pLI score to new gnomad server address
+- Bug uploading cases missing phenotype terms in config file
 ### Changed
 - Make matching causative and managed variants foldable on case page
 - Remove calls to PyMongo functions marked as deprecated in backend and frontend(as of version 3.7).

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -222,7 +222,6 @@ def build_case(case_data, adapter):
     if case_data.get("phenotype_terms"):
         phenotypes = []
         for phenotype in case_data["phenotype_terms"]:
-            LOG.error(f"PHENOTYPE IN LOOP:{phenotype}")
             phenotype_obj = adapter.hpo_term(phenotype)
             if phenotype_obj is None:
                 LOG.warning(

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -219,17 +219,21 @@ def build_case(case_data, adapter):
             )
 
     # phenotype information
-    phenotypes = []
-    for phenotype in case_data.get("phenotype_terms", []):
-        phenotype_obj = adapter.hpo_term(phenotype)
-        if phenotype_obj is None:
-            LOG.warning(
-                f"Could not find term with ID '{phenotype}' in HPO collection, skipping phenotype term."
+    if case_data.get("phenotype_terms"):
+        phenotypes = []
+        for phenotype in case_data["phenotype_terms"]:
+            LOG.error(f"PHENOTYPE IN LOOP:{phenotype}")
+            phenotype_obj = adapter.hpo_term(phenotype)
+            if phenotype_obj is None:
+                LOG.warning(
+                    f"Could not find term with ID '{phenotype}' in HPO collection, skipping phenotype term."
+                )
+                continue
+            phenotypes.append(
+                {"phenotype_id": phenotype, "feature": phenotype_obj.get("description")}
             )
-            continue
-        phenotypes.append({"phenotype_id": phenotype, "feature": phenotype_obj.get("description")})
-    if phenotypes:
-        case_obj["phenotype_terms"] = phenotypes
+        if phenotypes:
+            case_obj["phenotype_terms"] = phenotypes
 
     # phenotype groups
     phenotype_groups = []

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -235,13 +235,14 @@ def build_case(case_data, adapter):
             case_obj["phenotype_terms"] = phenotypes
 
     # phenotype groups
-    phenotype_groups = []
-    for phenotype in case_data.get("phenotype_groups", []):
-        phenotype_obj = build_phenotype(phenotype, adapter)
-        if phenotype_obj:
-            phenotype_groups.append(phenotype_obj)
-    if phenotype_groups:
-        case_obj["phenotype_groups"] = phenotype_groups
+    if case_data.get("phenotype_groups"):
+        phenotype_groups = []
+        for phenotype in case_data["phenotype_groups"]:
+            phenotype_obj = build_phenotype(phenotype, adapter)
+            if phenotype_obj:
+                phenotype_groups.append(phenotype_obj)
+        if phenotype_groups:
+            case_obj["phenotype_groups"] = phenotype_groups
 
     # Files
     case_obj["madeline_info"] = case_data.get("madeline_info")


### PR DESCRIPTION
A scary bug in current master that would have made it impossible to upload any sample without pre-assigned phenotypes in the config file. Good that I've found it before deploying! :sweat_smile:

fix #2198 

**How to test**:
Try to upload the cancer demo file (doesn't have synopsis, cohort and phenotype info on the config file): `scout --demo load case scout/demo/cancer.load_config.yaml`

**Expected outcome**:
When using master branch the case won't upload
When using this branch the case will be loaded into Scout

**Review:**
- [x] code approved by MM
- [x] tests executed by CR
