### PR TITLE
Fixed missing str vars from browser page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ClinVar submissions crashing due to pinned variants that are not loaded
 - Point ExAC pLI score to new gnomad server address
 - Bug uploading cases missing phenotype terms in config file
+- STRs loaded but not shown on browser page
 ### Changed
 - Make matching causative and managed variants foldable on case page
 - Remove calls to PyMongo functions marked as deprecated in backend and frontend(as of version 3.7).

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -203,15 +203,16 @@ def get_manual_assessments(variant_obj):
     return assessments
 
 
-def str_variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50):
+def str_variants(
+    store, institute_obj, case_obj, variants_query, variant_count, page=1, per_page=50
+):
     """Pre-process list of STR variants."""
 
     # Nothing unique to STRs on this level. Inheritance? yep, you will want it.
 
     # case bam_files for quick access to alignment view.
     case_append_alignments(case_obj)
-
-    return variants(store, institute_obj, case_obj, variants_query, page, per_page)
+    return variants(store, institute_obj, case_obj, variants_query, variant_count, page, per_page)
 
 
 def parse_variant(

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -208,8 +208,10 @@ def str_variants(institute_id, case_name):
             ("position", pymongo.ASCENDING),
         ]
     )
-
-    data = controllers.str_variants(store, institute_obj, case_obj, variants_query, page)
+    result_size = store.count_variants(case_obj["_id"], {}, None, category)
+    data = controllers.str_variants(
+        store, institute_obj, case_obj, variants_query, result_size, page
+    )
     return dict(
         institute=institute_obj,
         case=case_obj,


### PR DESCRIPTION
Bug fix #2207 

**How to test**:
1. On a local instance of scout, load the demo case

**Expected outcome**:
1. Strs should show in their respective page

**Review:**
- [x] code approved by
- [x] tests executed by
