### PR TITLE
fix export command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Point ExAC pLI score to new gnomad server address
 - Bug uploading cases missing phenotype terms in config file
 - STRs loaded but not shown on browser page
+- Bug when using adapter.variant.get_causatives with case_id without causatives
+- Problem with fetching "solved" from scout export cases cli
+- Better serialising of datetime and bson.ObjectId
+
 ### Changed
 - Make matching causative and managed variants foldable on case page
 - Remove calls to PyMongo functions marked as deprecated in backend and frontend(as of version 3.7).

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -325,17 +325,20 @@ class CaseHandler(object):
             order = self._populate_name_query(query, name_query, owner, collaborator)
 
         if within_days:
-            verbs = []
+            verbs = set()
 
             if has_causatives:
-                verbs.append("mark_causative")
+                verbs.add("mark_causative")
             if finished:
-                verbs.append("archive")
-                verbs.append("mark_causative")
+                verbs.add("archive")
+                verbs.add("mark_causative")
             if reruns:
-                verbs.append("rerun")
+                verbs.add("rerun")
             if research_requested:
-                verbs.append("open_research")
+                verbs.add("open_research")
+            if status and status == "solved":
+                verbs.add("mark_causative")
+            verbs = list(verbs)
 
             days_datetime = datetime.datetime.now() - datetime.timedelta(days=within_days)
             # Look up 'mark_causative' events added since specified number days ago

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -578,7 +578,6 @@ class CaseHandler(object):
         if existing_case and not update:
             raise IntegrityError("Case %s already exists in database" % case_obj["_id"])
 
-
         old_evaluated_variants = (
             None  # acmg, manual rank, cancer tier, dismissed, mosaic, commented
         )

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -550,7 +550,6 @@ class CaseHandler(object):
         institute_obj = self.institute(config_data["owner"])
         if not institute_obj:
             raise IntegrityError("Institute '%s' does not exist in database" % config_data["owner"])
-
         # Parse the case information
         parsed_case = parse_case(config=config_data)
         # Build the case object
@@ -576,6 +575,7 @@ class CaseHandler(object):
         if existing_case and not update:
             raise IntegrityError("Case %s already exists in database" % case_obj["_id"])
 
+
         old_evaluated_variants = (
             None  # acmg, manual rank, cancer tier, dismissed, mosaic, commented
         )
@@ -600,6 +600,7 @@ class CaseHandler(object):
         ]
 
         try:
+
             for vcf_file in files:
                 # Check if file exists
                 if not case_obj["vcf_files"].get(vcf_file["file_name"]):

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -413,7 +413,7 @@ class VariantHandler(VariantLoader):
         if case_id:
 
             case_obj = self.case_collection.find_one({"_id": case_id})
-            causatives = [causative for causative in case_obj["causatives"]]
+            causatives = [causative for causative in case_obj.get("causatives", [])]
 
         elif institute_id:
 

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -138,6 +138,7 @@ def build_case(case_data, adapter):
     sorted_inds = sorted(ind_objs, key=lambda ind: -ind["phenotype"])
     case_obj["individuals"] = sorted_inds
 
+
     now = datetime.now()
     case_obj["created_at"] = now
     case_obj["updated_at"] = now
@@ -220,23 +221,27 @@ def build_case(case_data, adapter):
 
     # phenotype information
     phenotypes = []
-    for phenotype in case_data.get("phenotype_terms", []):
-        phenotype_obj = adapter.hpo_term(phenotype)
-        if phenotype_obj is None:
-            LOG.warning(
-                f"Could not find term with ID '{phenotype}' in HPO collection, skipping phenotype term."
-            )
-            continue
-        phenotypes.append({"phenotype_id": phenotype, "feature": phenotype_obj.get("description")})
+    case_phenotype_terms = case_data.get("phenotype_terms")
+    if case_phenotype_terms:
+        for phenotype in case_phenotype_terms:
+            phenotype_obj = adapter.hpo_term(phenotype)
+            if phenotype_obj is None:
+                LOG.warning(
+                    f"Could not find term with ID '{phenotype}' in HPO collection, skipping phenotype term."
+                )
+                continue
+            phenotypes.append({"phenotype_id": phenotype, "feature": phenotype_obj.get("description")})
     if phenotypes:
         case_obj["phenotype_terms"] = phenotypes
 
     # phenotype groups
     phenotype_groups = []
-    for phenotype in case_data.get("phenotype_groups", []):
-        phenotype_obj = build_phenotype(phenotype, adapter)
-        if phenotype_obj:
-            phenotype_groups.append(phenotype_obj)
+    case_phenotype_groups = case_data.get("phenotype_groups")
+    if case_phenotype_groups:
+        for phenotype in case_phenotype_groups:
+            phenotype_obj = build_phenotype(phenotype, adapter)
+            if phenotype_obj:
+                phenotype_groups.append(phenotype_obj)
     if phenotype_groups:
         case_obj["phenotype_groups"] = phenotype_groups
 

--- a/scout/commands/export/case.py
+++ b/scout/commands/export/case.py
@@ -72,7 +72,7 @@ def cases(
             LOG.info("No cases could be found")
 
     if json:
-        click.echo(json_lib.dumps(models, default=bson_handler()))
+        click.echo(json_lib.dumps(models, default=bson_handler))
         return
 
     for model in models:

--- a/scout/commands/export/case.py
+++ b/scout/commands/export/case.py
@@ -1,10 +1,9 @@
 import logging
-import json
+import json as json_lib
 
 
 from pprint import pprint as pp
 
-from bson.json_util import dumps
 from flask.cli import with_appcontext
 
 import click
@@ -12,6 +11,7 @@ import click
 from scout.constants import CASE_STATUSES
 from scout.server.extensions import store
 from .utils import json_option
+from .export_handler import my_handler
 
 LOG = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ def cases(
             LOG.info("No cases could be found")
 
     if json:
-        click.echo(dumps(models))
+        click.echo(json_lib.dumps(models, default=my_handler))
         return
 
     for model in models:

--- a/scout/commands/export/case.py
+++ b/scout/commands/export/case.py
@@ -11,7 +11,7 @@ import click
 from scout.constants import CASE_STATUSES
 from scout.server.extensions import store
 from .utils import json_option
-from .export_handler import my_handler
+from .export_handler import bson_handler
 
 LOG = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ def cases(
             LOG.info("No cases could be found")
 
     if json:
-        click.echo(json_lib.dumps(models, default=my_handler))
+        click.echo(json_lib.dumps(models, default=bson_handler()))
         return
 
     for model in models:

--- a/scout/commands/export/export_command.py
+++ b/scout/commands/export/export_command.py
@@ -20,7 +20,7 @@ from .exon import exons
 from .gene import genes
 from .hpo import hpo_genes
 from .mitochondrial_report import mt_report
-from .panel import panel
+from .panel import panel_cmd
 from .transcript import transcripts
 from .variant import variants, verified
 
@@ -36,7 +36,7 @@ def export():
     pass
 
 
-export.add_command(panel)
+export.add_command(panel_cmd)
 export.add_command(genes)
 export.add_command(transcripts)
 export.add_command(exons)

--- a/scout/commands/export/export_handler.py
+++ b/scout/commands/export/export_handler.py
@@ -1,0 +1,13 @@
+"""Code for handler that helps export bson to json"""
+
+import datetime
+import bson
+
+
+def my_handler(x):
+    if isinstance(x, datetime.datetime):
+        return x.isoformat()
+    elif isinstance(x, bson.objectid.ObjectId):
+        return str(x)
+    else:
+        raise TypeError(x)

--- a/scout/commands/export/export_handler.py
+++ b/scout/commands/export/export_handler.py
@@ -4,10 +4,10 @@ import datetime
 import bson
 
 
-def my_handler(x):
-    if isinstance(x, datetime.datetime):
-        return x.isoformat()
-    elif isinstance(x, bson.objectid.ObjectId):
-        return str(x)
+def bson_handler(field):
+    if isinstance(field, datetime.datetime):
+        return field.isoformat()
+    if isinstance(field, bson.objectid.ObjectId):
+        return str(field)
     else:
-        raise TypeError(x)
+        raise TypeError(field)

--- a/scout/commands/export/panel.py
+++ b/scout/commands/export/panel.py
@@ -21,16 +21,13 @@ LOG = logging.getLogger(__name__)
 )
 @click.option("--bed", help="Export genes in bed like format", is_flag=True)
 @with_appcontext
-def panel(panel, build, bed, version):
+def panel_cmd(panel: str, build: str, bed: bool, version: float):
     """Export gene panels to .bed like format.
 
     Specify any number of panels on the command line
     """
     LOG.info("Running scout export panel")
     adapter = store
-
-    # Save all chromosomes found in the collection if panels
-    chromosomes_found = set()
 
     if not panel:
         LOG.warning("Please provide at least one gene panel")

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -7,7 +7,6 @@ from flask.cli import with_appcontext
 from xlsxwriter import Workbook
 
 from scout.export.variant import export_variants, export_verified_variants
-from scout.adapter.mongo import MongoAdapter
 from .utils import json_option
 from .export_handler import bson_handler
 from scout.constants import CALLERS
@@ -129,7 +128,7 @@ def variants(collaborator: str, document_id: str, case_id: str, json: bool):
     variants = export_variants(adapter, collaborator, document_id=document_id, case_id=case_id)
 
     if json:
-        click.echo(json_lib.dumps([var for var in variants], default=bson_handler()))
+        click.echo(json_lib.dumps([var for var in variants], default=bson_handler))
         return
 
     vcf_header = VCF_HEADER

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -7,6 +7,7 @@ from bson.json_util import dumps
 from xlsxwriter import Workbook
 
 from scout.export.variant import export_variants, export_verified_variants
+from scout.adapter.mongo import MongoAdapter
 from .utils import json_option
 from scout.constants import CALLERS
 from scout.constants.variants_export import VCF_HEADER, VERIFIED_VARIANTS_HEADER
@@ -112,11 +113,17 @@ def verified(collaborator, test, outpath=None):
 @click.option("--case-id", help="Find causative variants for case")
 @json_option
 @with_appcontext
-def variants(collaborator, document_id, case_id, json):
+def variants(collaborator: str, document_id: str, case_id: str, json: bool):
     """Export causatives for a collaborator in .vcf format"""
     LOG.info("Running scout export variants")
-    adapter = store
+    adapter: MongoAdapter = store
     collaborator = collaborator or "cust000"
+    LOG.info("Use collaborator %s", collaborator)
+    if case_id:
+        case_obj = adapter.case(case_id)
+        if not case_obj:
+            LOG.info("Case %s does not exist", case_id)
+            raise click.Abort
 
     variants = export_variants(adapter, collaborator, document_id=document_id, case_id=case_id)
 

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -9,7 +9,7 @@ from xlsxwriter import Workbook
 from scout.export.variant import export_variants, export_verified_variants
 from scout.adapter.mongo import MongoAdapter
 from .utils import json_option
-from .export_handler import my_handler
+from .export_handler import bson_handler
 from scout.constants import CALLERS
 from scout.constants.variants_export import VCF_HEADER, VERIFIED_VARIANTS_HEADER
 from scout.server.extensions import store
@@ -117,7 +117,7 @@ def verified(collaborator, test, outpath=None):
 def variants(collaborator: str, document_id: str, case_id: str, json: bool):
     """Export causatives for a collaborator in .vcf format"""
     LOG.info("Running scout export variants")
-    adapter: MongoAdapter = store
+    adapter = store
     collaborator = collaborator or "cust000"
     LOG.info("Use collaborator %s", collaborator)
     if case_id:
@@ -129,7 +129,7 @@ def variants(collaborator: str, document_id: str, case_id: str, json: bool):
     variants = export_variants(adapter, collaborator, document_id=document_id, case_id=case_id)
 
     if json:
-        click.echo(json_lib.dumps([var for var in variants], default=my_handler))
+        click.echo(json_lib.dumps([var for var in variants], default=bson_handler()))
         return
 
     vcf_header = VCF_HEADER

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -2,13 +2,14 @@ import os
 import click
 import logging
 import datetime
+import json as json_lib
 from flask.cli import with_appcontext
-from bson.json_util import dumps
 from xlsxwriter import Workbook
 
 from scout.export.variant import export_variants, export_verified_variants
 from scout.adapter.mongo import MongoAdapter
 from .utils import json_option
+from .export_handler import my_handler
 from scout.constants import CALLERS
 from scout.constants.variants_export import VCF_HEADER, VERIFIED_VARIANTS_HEADER
 from scout.server.extensions import store
@@ -128,7 +129,7 @@ def variants(collaborator: str, document_id: str, case_id: str, json: bool):
     variants = export_variants(adapter, collaborator, document_id=document_id, case_id=case_id)
 
     if json:
-        click.echo(dumps([var for var in variants]))
+        click.echo(json_lib.dumps([var for var in variants], default=my_handler))
         return
 
     vcf_header = VCF_HEADER

--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -109,7 +109,7 @@ def case(
     LOG.info("Use family %s" % config_data["family"])
 
     try:
-        case_obj = adapter.load_case(config_data, update, keep_actions)
+        adapter.load_case(config_data, update, keep_actions)
     except Exception as err:
         LOG.error("Something went wrong during loading")
         LOG.warning(err)


### PR DESCRIPTION
This PR fixes some problems with the export cases command.

## datetime
The date time objects was not serialised in a correct way. Previously they where dumped in the json string as `datetime.datetime(2019, 6, 3, 10, 13, 47, 762000)` which is not possible for a json decoder to read. Now they are serialised as standardised strings on the format `"2020-05-06T09:26:04.348000"`

## status=solved

When running command `scout export cases --status solved` the events was not collected which made it impossible to fetch cases together with the `--within-days` parameter

## non-existing causatives

When querying `get_causatives` with a case_id for a case without causatives there was a syntax error

## bson.ObjectID

These where also serialised in the wrong way before. Previously they where dumped to json like `ObjectId('5e3185fd124f63addb79384b')` which can not be parsed, but now the string is used.

**Expected outcome**:
Export cases command should behave as expected

**Review:**
- [ ] code approved by
- [ ] tests executed by
