### PR TITLE
Reintroduce requirements install in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [4.25]
+### Fixed
+- Install requirements.txt via setup file
+
 ## [4.24]
 ### Added
 - Institute-level phenotype models with sub-panels containing HPO and OMIM terms

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ WORKDIR /home/worker/app
 COPY . /home/worker/app
 
 # Install scout app
-RUN pip install -r requirements.txt
 RUN pip install -e .
 
 # Run commands as non-root user

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you would like to install Scout for local development: -->
 ```bash
 git clone https://github.com/Clinical-Genomics/scout
 cd scout
-pip install --requirement requirements.txt --editable .
+pip install --editable .
 ```
 
 Scout PDF reports are created using [Flask-WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,34 @@ AUTHOR = "Måns Magnusson"
 here = os.path.abspath(os.path.dirname(__file__))
 
 
+def parse_reqs(req_path="./requirements.txt"):
+    """Recursively parse requirements from nested pip files."""
+    install_requires = []
+    with io.open(os.path.join(here, "requirements.txt"), encoding="utf-8") as handle:
+        # remove comments and empty lines
+        lines = (line.strip() for line in handle if line.strip() and not line.startswith("#"))
+
+        for line in lines:
+            # check for nested requirements files
+            if line.startswith("-r"):
+                # recursively call this function
+                install_requires += parse_reqs(req_path=line[3:])
+
+            else:
+                # add the line as a new requirement
+                install_requires.append(line)
+
+    return install_requires
+
+
+# What packages are required for this module to be executed?
+REQUIRED = parse_reqs()
+
+# The rest you shouldn't have to touch too much :)
+# ------------------------------------------------
+# Except, perhaps the License and Trove Classifiers!
+# If you do change the License, remember to change the Trove Classifier for that!
+
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.rst' is present in your MANIFEST.in file!
 with io.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
@@ -39,6 +67,7 @@ setup(
     url=URL,
     packages=find_packages(exclude=["tests/", "scripts/"]),
     zip_safe=False,
+    install_requires=REQUIRED,
     include_package_data=True,
     extras_require=dict(coverage=["chanjo-report"]),
     entry_points=dict(console_scripts=["scout = scout.commands:cli"]),


### PR DESCRIPTION
Installed requirements.txt in the setup

**How to test**:
1. `pip install scout-browser`  in a clean environment and make sure that it runs by executing any cli command

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [ ] tests executed by
