### PR TITLE
Reformat output or variant delete command and add analysis date, track and institute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 ### Changed
 - Print output of variants delete command as a tab separated table
-- default delete variants rank score threshold to 10, instead of 5
 
 ## [4.25]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 ### Changed
 - Print output of variants delete command as a tab separated table
+- default delete variants rank score threshold to 10, instead of 5
 
 ## [4.25]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- Extend the delete variants command to include analysis date, track and institute
 ### Fixed
 ### Changed
+- Print output of variants delete command as a tab separated table
 
 ## [4.25]
 ### Added

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -22,7 +22,7 @@ DELETE_VARIANTS_HEADER = "Case n.\tNcases\tInstitute\tCase name\tCase ID\tCase t
     help="Restrict to cases with specified status",
 )
 @click.option("-older-than", type=click.INT, default=0, help="Older than (months)")
-@click.option("-rank-threshold", type=click.INT, default=5, help="With rank threshold lower than")
+@click.option("-rank-threshold", type=click.INT, default=10, help="With rank threshold lower than")
 @click.option("-variants-threshold", type=click.INT, help="With more variants than")
 @click.option(
     "--dry-run",

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -22,7 +22,7 @@ DELETE_VARIANTS_HEADER = "Case n.\tNcases\tInstitute\tCase name\tCase ID\tCase t
     help="Restrict to cases with specified status",
 )
 @click.option("-older-than", type=click.INT, default=0, help="Older than (months)")
-@click.option("-rank-threshold", type=click.INT, default=10, help="With rank threshold lower than")
+@click.option("-rank-threshold", type=click.INT, default=5, help="With rank threshold lower than")
 @click.option("-variants-threshold", type=click.INT, help="With more variants than")
 @click.option(
     "--dry-run",

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -8,6 +8,7 @@ from scout.server.extensions import store
 LOG = logging.getLogger(__name__)
 
 BYTES_IN_ONE_GIGABYTE = 1073741824  # (1024*1024*1024)
+DELETE_VARIANTA_HEADER = "Case n.\tNcases\tInstitute\tCase name\tCase ID\tCase track\tAnalysis date\tTotal variants\tRemoved variants"
 
 
 @click.command("variants", short_help="Delete variants for one or more cases")
@@ -64,13 +65,13 @@ def variants(
     filters = (
         f"Rank-score threshold:{rank_threshold}, case n. variants threshold:{variants_threshold}."
     )
+    click.echo(DELETE_VARIANTA_HEADER)
     for nr, case in enumerate(cases, 1):
         case_id = case["_id"]
         case_n_variants = store.variant_collection.count_documents({"case_id": case_id})
         # Skip case if user provided a number of variants to keep and this number is less than total number of case variants
         if variants_threshold and case_n_variants < variants_threshold:
             continue
-        click.echo(f"#### Case n. {nr}/{n_cases} ###### {case['display_name']} ({case_id})")
         # Get evaluated variants for the case that haven't been dismissed
         case_evaluated = store.evaluated_variants(case_id=case_id)
         evaluated_not_dismissed = [
@@ -86,13 +87,18 @@ def variants(
             # Just print how many variants would be removed for this case
             remove_n_variants = store.variant_collection.count_documents(variants_query)
             total_deleted += remove_n_variants
-            click.echo(f"Remove {remove_n_variants} / {case_n_variants} total variants")
+            click.echo(
+                f"{nr}\t{n_cases}\t{case['owner']}\t{case['display_name']}\t{case_id}\t{case.get('track','')}\t{case['analysis_date']}\t{case_n_variants}\t{total_deleted}"
+            )
             continue
 
         # delete variants specified by variants_query
         result = store.variant_collection.delete_many(variants_query)
         click.echo(f"Deleted {result.deleted_count} / {case_n_variants} total variants")
         total_deleted += result.deleted_count
+        click.echo(
+            f"{nr}\t{n_cases}\t{case['owner']}\t{case['display_name']}\t{case_id}\t{case.get('track','')}\t{case['analysis_date']}\t{case_n_variants}\t{total_deleted}"
+        )
 
         # Create event in database
         institute_obj = store.institute(case["owner"])

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -88,7 +88,19 @@ def variants(
             remove_n_variants = store.variant_collection.count_documents(variants_query)
             total_deleted += remove_n_variants
             click.echo(
-                f"{nr}\t{n_cases}\t{case['owner']}\t{case['display_name']}\t{case_id}\t{case.get('track','')}\t{case['analysis_date']}\t{case_n_variants}\t{total_deleted}"
+                "\t".join(
+                    [
+                        str(nr),
+                        str(n_cases),
+                        case["owner"],
+                        case["display_name"],
+                        case_id,
+                        case.get("track", ""),
+                        str(case["analysis_date"]),
+                        str(case_n_variants),
+                        str(total_deleted),
+                    ]
+                )
             )
             continue
 
@@ -97,7 +109,19 @@ def variants(
         click.echo(f"Deleted {result.deleted_count} / {case_n_variants} total variants")
         total_deleted += result.deleted_count
         click.echo(
-            f"{nr}\t{n_cases}\t{case['owner']}\t{case['display_name']}\t{case_id}\t{case.get('track','')}\t{case['analysis_date']}\t{case_n_variants}\t{total_deleted}"
+            "\t".join(
+                [
+                    str(nr),
+                    str(n_cases),
+                    case["owner"],
+                    case["display_name"],
+                    case_id,
+                    case.get("track", ""),
+                    str(case["analysis_date"]),
+                    str(case_n_variants),
+                    str(total_deleted),
+                ]
+            )
         )
 
         # Create event in database

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -8,7 +8,7 @@ from scout.server.extensions import store
 LOG = logging.getLogger(__name__)
 
 BYTES_IN_ONE_GIGABYTE = 1073741824  # (1024*1024*1024)
-DELETE_VARIANTA_HEADER = "Case n.\tNcases\tInstitute\tCase name\tCase ID\tCase track\tAnalysis date\tTotal variants\tRemoved variants"
+DELETE_VARIANTS_HEADER = "Case n.\tNcases\tInstitute\tCase name\tCase ID\tCase track\tAnalysis date\tTotal variants\tRemoved variants"
 
 
 @click.command("variants", short_help="Delete variants for one or more cases")
@@ -65,7 +65,7 @@ def variants(
     filters = (
         f"Rank-score threshold:{rank_threshold}, case n. variants threshold:{variants_threshold}."
     )
-    click.echo(DELETE_VARIANTA_HEADER)
+    click.echo(DELETE_VARIANTS_HEADER)
     for nr, case in enumerate(cases, 1):
         case_id = case["_id"]
         case_n_variants = store.variant_collection.count_documents({"case_id": case_id})


### PR DESCRIPTION
Print delete variant command output and a \t separated table ad and add to the output:
- analysis date
- instritute
- case track

**How to test**:
1. Load some demo cases locally: demo case + cancer case?
1. Run the scout delete variants command with preferred parameters
1. Check that output contains a header and one line for each case with removed variants. Example:
`scout --demo --loglevel WARNING delete variants -u clark.kent@mail.com  -status inactive -rank-threshold 10 -variants-threshold 1 --dry-run`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
