### PR TITLE
Fix #1239 comment - add CIViC gene link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Extend the delete variants command to print analysis date, track, institute, status and research status
 - Delete variants by type of analysis (wgs|wes|panel)
-- Links to cBioPortal, MutanTP53, IARC TP53, OncoKB, MyCancerGenome
+- Links to cBioPortal, MutanTP53, IARC TP53, OncoKB, MyCancerGenome, CIViC
 ### Fixed
 ### Changed
 - Print output of variants delete command as a tab separated table

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -632,6 +632,7 @@
           {% if cancer %}
             <a href="{{ gene.cbioportal_link }}" class="btn btn-outline-secondary" target="_blank">cBioPortal</a>
             <a href="{{ gene.oncokb_link }}" class="btn btn-outline-secondary" target="_blank">OncoKB</a>
+            <a href="{{ gene.civic_link }}" class="btn btn-outline-secondary" target="_blank">CIViC</a>
           {% endif %}
           <form action="http://marrvel.org/search" method="POST" target="_blank" style="display:inline;">
             <button type="submit" class="btn btn-outline-secondary">MARRVEL</button>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -59,7 +59,16 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["genemania_link"] = genemania(hgnc_symbol)
     gene_obj["oncokb_link"] = oncokb(hgnc_symbol)
     gene_obj["cbioportal_link"] = cbioportal_gene(hgnc_symbol)
+    gene_obj["civic_link"] = civic_gene(hgnc_symbol)
     gene_obj["iarctp53_link"] = iarctp53(hgnc_symbol)
+
+
+def civic_gene(hgnc_symbol):
+    link = "https://civicdb.org/links/entrez_name/{}"
+
+    if not hgnc_symbol:
+        return None
+    return link.format(hgnc_symbol)
 
 
 def cbioportal_gene(hgnc_symbol):


### PR DESCRIPTION
This PR adds one more left over gene link to cancer variant pages.

![Screenshot 2020-12-01 at 09 45 23](https://user-images.githubusercontent.com/758570/100717417-4afd9b00-33ba-11eb-8911-636275319164.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
