### PR TITLE
Exclude one or more variant categories in variant delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- Exclude one or more variant categories when running variants delete command
 ### Fixed
-- Links with 1-letter aa codes crash on frameshift etc
 ### Changed
 
 ## [4.26.1]

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -42,7 +42,7 @@ class QueryHandler(object):
         return case_query
 
     def delete_variants_query(
-        self, case_id, variants_to_keep=[], min_rank_threshold=None, exclude_ctg=[]
+        self, case_id, variants_to_keep=[], min_rank_threshold=None, keep_ctg=[]
     ) -> dict:
         """Build a query to delete variants from a case
 
@@ -50,7 +50,7 @@ class QueryHandler(object):
             case_id(str): id of a case
             variants_to_keep(list): a list of variant ids
             min_rank_threshold(int): remove variants with rank lower than this number
-            exclude_ctg(list): exclude one of more variants categories. Example ["cancer", "cancer_sv"]
+            keep_ctg(list): exclude one of more variants categories from deletion. Example ["cancer", "cancer_sv"]
 
         Return:
             variant_query(dict): query dictionary
@@ -59,12 +59,12 @@ class QueryHandler(object):
         case_subquery = {"case_id": case_id}
 
         # Create query to delete all variants that shouldn't be kept or with rank higher than min_rank_threshold
-        if variants_to_keep or min_rank_threshold or exclude_ctg:
+        if variants_to_keep or min_rank_threshold or keep_ctg:
             variants_query["$and"] = [case_subquery]
             if variants_to_keep:
                 variants_query["$and"].append({"_id": {"$nin": variants_to_keep}})
-            if exclude_ctg:
-                variants_query["$and"].append({"category": {"$nin": exclude_ctg}})
+            if keep_ctg:
+                variants_query["$and"].append({"category": {"$nin": keep_ctg}})
             if min_rank_threshold:
                 variants_query["$and"].append({"rank_score": {"$lt": min_rank_threshold}})
         else:

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -22,6 +22,7 @@ DELETE_VARIANTS_HEADER = [
     "Removed variants",
 ]
 CASE_STATUS = ["solved", "archived", "migrated", "active", "inactive", "prioritized"]
+VARIANT_CATEGORIES = ["snv", "sv", "cancer", "cancer_sv", "str"]
 
 
 @click.command("variants", short_help="Delete variants for one or more cases")
@@ -45,9 +46,14 @@ CASE_STATUS = ["solved", "archived", "migrated", "active", "inactive", "prioriti
 @click.option("--rank-threshold", type=click.INT, default=5, help="With rank threshold lower than")
 @click.option("--variants-threshold", type=click.INT, help="With more variants than")
 @click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Perform a simulation without removing any variant",
+    "--exclude-ctg",
+    type=click.Choice(VARIANT_CATEGORIES),
+    multiple=True,
+    default=["str"],
+    help="Exclude one of more variant categories from deletion",
+)
+@click.option(
+    "--dry-run", is_flag=True, help="Perform a simulation without removing any variant",
 )
 @with_appcontext
 def variants(
@@ -58,6 +64,7 @@ def variants(
     analysis_type: list,
     rank_threshold: int,
     variants_threshold: int,
+    exclude_ctg: list,
     dry_run: bool,
 ) -> None:
     """Delete variants for one or more cases"""
@@ -101,7 +108,9 @@ def variants(
         variants_to_keep = (
             case.get("suspects", []) + case.get("causatives", []) + evaluated_not_dismissed or []
         )
-        variants_query = store.delete_variants_query(case_id, variants_to_keep, rank_threshold)
+        variants_query = store.delete_variants_query(
+            case_id, variants_to_keep, rank_threshold, exclude_ctg
+        )
 
         if dry_run:
             # Just print how many variants would be removed for this case

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -49,11 +49,13 @@ VARIANT_CATEGORIES = ["snv", "sv", "cancer", "cancer_sv", "str"]
     "--exclude-ctg",
     type=click.Choice(VARIANT_CATEGORIES),
     multiple=True,
-    default=["str"],
+    required=False,
     help="Exclude one of more variant categories from deletion",
 )
 @click.option(
-    "--dry-run", is_flag=True, help="Perform a simulation without removing any variant",
+    "--dry-run",
+    is_flag=True,
+    help="Perform a simulation without removing any variant",
 )
 @with_appcontext
 def variants(
@@ -111,6 +113,8 @@ def variants(
         variants_query = store.delete_variants_query(
             case_id, variants_to_keep, rank_threshold, exclude_ctg
         )
+
+        LOG.error(variants_query)
 
         if dry_run:
             # Just print how many variants would be removed for this case

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -114,8 +114,6 @@ def variants(
             case_id, variants_to_keep, rank_threshold, exclude_ctg
         )
 
-        LOG.error(variants_query)
-
         if dry_run:
             # Just print how many variants would be removed for this case
             remove_n_variants = store.variant_collection.count_documents(variants_query)

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -46,11 +46,11 @@ VARIANT_CATEGORIES = ["snv", "sv", "cancer", "cancer_sv", "str"]
 @click.option("--rank-threshold", type=click.INT, default=5, help="With rank threshold lower than")
 @click.option("--variants-threshold", type=click.INT, help="With more variants than")
 @click.option(
-    "--exclude-ctg",
+    "--keep-ctg",
     type=click.Choice(VARIANT_CATEGORIES),
     multiple=True,
     required=False,
-    help="Exclude one of more variant categories from deletion",
+    help="Do not delete one of more variant categories",
 )
 @click.option(
     "--dry-run",
@@ -66,7 +66,7 @@ def variants(
     analysis_type: list,
     rank_threshold: int,
     variants_threshold: int,
-    exclude_ctg: list,
+    keep_ctg: list,
     dry_run: bool,
 ) -> None:
     """Delete variants for one or more cases"""
@@ -111,7 +111,7 @@ def variants(
             case.get("suspects", []) + case.get("causatives", []) + evaluated_not_dismissed or []
         )
         variants_query = store.delete_variants_query(
-            case_id, variants_to_keep, rank_threshold, exclude_ctg
+            case_id, variants_to_keep, rank_threshold, keep_ctg
         )
 
         if dry_run:

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -39,6 +39,8 @@ def test_delete_variants_dry_run(mock_app, case_obj, user_obj):
         RANK_THRESHOLD,
         "--variants-threshold",
         VARIANTS_THRESHOLD,
+        "--exclude-ctg",
+        "str",
         "--dry-run",
     ]
     result = runner.invoke(cli, cmd_params)

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -39,7 +39,7 @@ def test_delete_variants_dry_run(mock_app, case_obj, user_obj):
         RANK_THRESHOLD,
         "--variants-threshold",
         VARIANTS_THRESHOLD,
-        "--exclude-ctg",
+        "--keep-ctg",
         "str",
         "--dry-run",
     ]


### PR DESCRIPTION
**How to test**:
1. Run the delete variants command with and without the exclude-ctg param and see the difference

**Expected outcome**:
1. If you exclude a variant category from deletion all variants of that category will be left, regardless of their rank score
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
