### PR TITLE
Fixed link to Marrvel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Fixed
+- Marrvel link
 ### Changed
 
 ## [4.27]

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -634,16 +634,7 @@
             <a href="{{ gene.oncokb_link }}" class="btn btn-outline-secondary" target="_blank">OncoKB</a>
             <a href="{{ gene.civic_link }}" class="btn btn-outline-secondary" target="_blank">CIViC</a>
           {% endif %}
-          <form action="http://v1.marrvel.org/search" method="POST" target="_blank" style="display:inline;">
-            <button type="submit" class="btn btn-outline-secondary">MARRVEL</button>
-            <input type="hidden" name="variantGeneId" value="{{ variant.chromosome }}:{{ variant.position }} {{ variant.reference }}>{{ variant.alternative }}">
-            <input type="hidden" name="inGeneSymbol" value="{{ gene.common.hgnc_symbol if gene.common }}">
-            <input type="hidden" name="OMIMdbCheck" value="on">
-            <input type="hidden" name="ExACdbCheck" value="on">
-            <input type="hidden" name="Geno2MPdbCheck" value="on">
-            <input type="hidden" name="DGVdbCheck" value="on">
-            <input type="hidden" name="DECIPHERdbCheck" value="on">
-          </form>
+            <a href="http://marrvel.org/human/variant/{{ variant.chromosome }}:{{ variant.position }} {{ variant.reference }}>{{variant.alternative}}" class="btn btn-outline-secondary" target="_blank">MARRVEL</a>
       </div>
     {% endfor %}
   </div>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -634,7 +634,7 @@
             <a href="{{ gene.oncokb_link }}" class="btn btn-outline-secondary" target="_blank">OncoKB</a>
             <a href="{{ gene.civic_link }}" class="btn btn-outline-secondary" target="_blank">CIViC</a>
           {% endif %}
-          <form action="http://marrvel.org/search" method="POST" target="_blank" style="display:inline;">
+          <form action="http://v1.marrvel.org/search" method="POST" target="_blank" style="display:inline;">
             <button type="submit" class="btn btn-outline-secondary">MARRVEL</button>
             <input type="hidden" name="variantGeneId" value="{{ variant.chromosome }}:{{ variant.position }} {{ variant.reference }}>{{ variant.alternative }}">
             <input type="hidden" name="inGeneSymbol" value="{{ gene.common.hgnc_symbol if gene.common }}">


### PR DESCRIPTION
Marrvel has recently (last summer I think) updated the website to v2 (beta).
I've tried to update the input fields to query Marrvel v2 but without success. The thing is I don't understand the name of the new input fields, check here: https://github.com/LiuzLab/MARRVEL2/blob/master/src/app/components/search-box/search-box.component.html

But I managed to fix the link to the v1 of the portal, so at least the links are not broken. Fix #2220

**How to test**:
1. Install this branch and go to a variant, check that the Marrvel link works.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by
