### PR TITLE
Bugfix: `'` vs`"`  in Pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Marrvel link
+- OMIM gene fields accept any custom number as OMIM gene
 ### Changed
 
 ## [4.27]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Marrvel link
-- OMIM gene fields accept any custom number as OMIM gene
+- OMIM gene field accept any custom number as OMIM gene
 ### Changed
 
 ## [4.27]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Marrvel link
-- OMIM gene field accept any custom number as OMIM gene
+- OMIM gene field accepts any custom number as OMIM gene
 ### Changed
 
 ## [4.27]

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -110,7 +110,7 @@
                     {{ diagnosis_phenotypes(case, institute, omim_terms) }}
                   </div>
                   <div class="col-sm-6">
-                    {{ diagnosis_genes(case, institute, omim_terms) }}
+                    {{ diagnosis_genes(case, institute) }}
                   </div>
                 </div><!--end of card body-->
             </div><!--end of card-->

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -73,7 +73,7 @@
   </div>
 {% endmacro %}
 
-{% macro diagnosis_genes(case, institute, omim_terms) %}
+{% macro diagnosis_genes(case, institute) %}
     <div>OMIM Genes</div>
     {{ diagnosis_form('gene', case, institute) }}
     <div>

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -111,8 +111,13 @@
   <form action="{{ url_for('cases.case_diagnosis', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
     <div class="row data-width="100%">
       <div class="col-md-10">
-        <input name="omim_term" class="typeahead_omim form-control" data-provide="typeahead" autocomplete="off"
-          required placeholder="Disease description or OMIM number">
+        {% if type == "phenotype" %}
+          <input name="omim_term" class="typeahead_omim form-control" data-provide="typeahead" autocomplete="off"
+            required placeholder="Disease description or OMIM number">
+        {% else %}
+          <input name="omim_term" class="typeahead_gene form-control" data-provide="typeahead" autocomplete="off"
+            required placeholder="Gene symbol">
+        {% endif %}
       </div>
       <div class="col-md-2">
         <button class="btn btn-outline-secondary form-control" type="submit" name="{{ type }}">

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -111,12 +111,12 @@
   <form action="{{ url_for('cases.case_diagnosis', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
     <div class="row data-width="100%">
       <div class="col-md-10">
-        {% if type == "phenotype" %}
-          <input name="omim_term" class="typeahead_omim form-control" data-provide="typeahead" autocomplete="off"
+        {% if type == "phenotype"%}
+          <input name="omim_term" class="form-control typeahead_omim" data-provide="typeahead" autocomplete="off"
             required placeholder="Disease description or OMIM number">
         {% else %}
-          <input name="omim_term" class="typeahead_gene form-control" data-provide="typeahead" autocomplete="off"
-            required placeholder="Gene symbol">
+          <input name="omim_term" class="form-control" data-provide="typeahead" autocomplete="off"
+            required placeholder="Gene MIM number">
         {% endif %}
       </div>
       <div class="col-md-2">

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -80,19 +80,9 @@
       <ul class="list-group">
         {% for omim_id in case.diagnosis_genes %}
           <li class="list-group-item d-flex">
-            {% if omim_id in omim_terms %}
-              <a class="flex-fill" target="_blank" href="http://omim.org/entry/{{ omim_id }}">
-                  {{ omim_id }} - {{ omim_terms[omim_id].description }}
-              </a>
-              <a class="text-white" target="_blank" href="{{url_for('diagnoses.omim_diagnosis', omim_nr=omim_terms[omim_id].disease_nr)}}">
-                <span class="badge badge-secondary badge-pill text-white">genes:{{omim_terms[omim_id].genes|length}}</span>
-                <span class="badge badge-info badge-pill text-white">hpo:{{omim_terms[omim_id].hpo_terms|length}}</span>
-              </a>
-            {% else %}
             <a class="flex-fill" target="_blank" href="http://omim.org/entry/{{ omim_id }}">
                 {{ omim_id }}
             </a>
-            {% endif %}
             &nbsp;&nbsp;&nbsp;
             <span>
               {{ remove_form(url_for('cases.case_diagnosis', institute_id=institute._id,
@@ -115,8 +105,7 @@
           <input name="omim_term" class="form-control typeahead_omim" data-provide="typeahead" autocomplete="off"
             required placeholder="Disease description or OMIM number">
         {% else %}
-          <input name="omim_term" class="form-control" data-provide="typeahead" autocomplete="off"
-            required placeholder="Gene MIM number">
+          <input type="number" name="omim_term" class="form-control" required placeholder="Gene MIM number">
         {% endif %}
       </div>
       <div class="col-md-2">

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -456,7 +456,7 @@ def case_diagnosis(institute_id, case_name):
 
     # Make sure omim term exists in database:
     omim_obj = store.disease_term(omim_id.strip())
-    if not omim_obj:
+    if level == "phenotype" and omim_obj is None:
         flash("Couldn't find any disease term with id: {}".format(omim_id), "warning")
         return redirect(request.referrer)
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -445,10 +445,10 @@ def mt_report(institute_id, case_name):
 def case_diagnosis(institute_id, case_name):
     """Add or remove a diagnosis for a case."""
 
+    level = "phenotype" if "phenotype" in request.form else "gene"
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     user_obj = store.user(current_user.email)
     link = url_for(".case", institute_id=institute_id, case_name=case_name)
-    level = "phenotype" if "phenotype" in request.form else "gene"
     omim_id = request.form["omim_term"].split("|")[0]
 
     if not "OMIM:" in omim_id:  # Could be an omim number provided by user

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -449,6 +449,7 @@ def case_diagnosis(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     user_obj = store.user(current_user.email)
     link = url_for(".case", institute_id=institute_id, case_name=case_name)
+
     omim_id = request.form["omim_term"].split("|")[0]
 
     if not "OMIM:" in omim_id:  # Could be an omim number provided by user


### PR DESCRIPTION
This PR adds a functionality or fixes a bug: conflict between pythons double quotation marks `'` and `"` caused a test to fail -maybe only on my machine 😖. Now string comparison test allows both (`'` and `"` ).

**How to test**:
1. how to test it, possibly with real cases/data
` pytest tests/commands/load/test_load_cnv_report_cmd.py`


**Expected outcome**:
The tests should pass:

![image](https://user-images.githubusercontent.com/1150065/101752763-27c99e80-3ad2-11eb-835f-239636632869.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
