### PR TITLE
Fix #2244-b: dont TP53 link to silent aa change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Freeze coloredlogs temporarily
 - Marrvel link
+- Don't show TP53 link for silent changes
 - OMIM gene field accepts any custom number as OMIM gene
 - Fix Pytest single quote vs double quote string
 ### Changed

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -522,6 +522,8 @@ def cbioportal(hgnc_symbol, protein_sequence_name):
 def mutantp53(hgnc_id, protein_variant):
     if hgnc_id != 11998:
         return None
+    if not protein_variant:
+        return None
 
     url_template = "http://mutantp53.broadinstitute.org/?query={}"
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. check a protein changing and a silent variant. The TP53 PHANTM variant link icon should only appear on amino acid changing variants.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by
