### PR TITLE
Fix gene variants query with similar phenotype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Don't show TP53 link for silent changes
 - OMIM gene field accepts any custom number as OMIM gene
 - Fix Pytest single quote vs double quote string
+- Bug in gene variants search when providing similar case display name
 ### Changed
 
 ## [4.27]

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -137,7 +137,14 @@ class QueryHandler(object):
             case_obj = self.case(display_name=similar_case_display_name, institute_id=institute_id)
             if case_obj:
                 LOG.debug("Search for cases similar to %s", case_obj.get("display_name"))
-                similar_cases = self.get_similar_cases(case_obj)
+
+                hpo_terms = []
+                for term in case_obj.get("phenotype_terms", []):
+                    hpo_terms.append(term.get("phenotype_id"))
+
+                similar_cases = self.cases_by_phenotype(
+                    hpo_terms, case_obj["owner"], case_obj["_id"]
+                )
                 LOG.debug("Similar cases: %s", similar_cases)
                 select_cases = [similar[0] for similar in similar_cases]
             else:


### PR DESCRIPTION
fix #2260. This bug is my fault, when I rewrote the get_similar_cases function I have missed to fix all the calls to it. This was a tricky one!

**How to test, on a local instance of Scout**:
1. To replicate on a local instance, master branch, upload the clone of the demo case:
`scout --demo load case scout/demo/643595.config.yaml`
1. Start the server (`scout --demo serve`) and go to this page: `http://localhost:5000/cust000/gene_variants`
1. Search for HGNC symbol "POT1", rank score "5", and Phenotypically similar case "643594"
1. The browser should crash
1. Switch to this branch and repeat
1. The browser should NOT crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
