### PR TITLE
Better panels multiselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bug in gene variants search when providing similar case display name
 ### Changed
 - Save case variants count in case document and not in sessions
-
+- Style of gene panels multiselect on case page
 
 
 ## [4.27]

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -13,7 +13,7 @@
 
 {% block css %}
 {{ super() }}
-
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
 {% endblock %}
 
 {% block top_nav %}
@@ -438,7 +438,7 @@
   <script src="{{ url_for('cases.static', filename='case_images.js') }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.13/js/bootstrap-multiselect.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
 <script src="//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
 
@@ -515,6 +515,11 @@ $(function () {
           return DOMPurify.sanitize(content)
         },
         container: 'body',
+      });
+
+      $('select[multiple]').selectpicker({
+        width: '100%'
+        });
       });
 
       $('select[multiple]').multiselect({

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -38,14 +38,14 @@
           <label>Change default gene panels</label>
         </div>
         <div class="row">
-          <div class="col-xs-8">
-            <select name="panel_ids" class="form-control" multiple>
+          <div class="col-8">
+            <select name="panel_ids" class="selectpicker" multiple="multiple">
               {% for panel in case.panels %}
                 <option value="{{ panel.panel_id }}" {% if panel.is_default %} selected {% endif %}>{{ panel.display_name }}</option>
               {% endfor %}
             </select>
           </div>
-          <div class="col-xs-4">
+          <div class="col-4">
             <button class="btn btn-outline-secondary form-control">Save</button>
           </div>
         </div>


### PR DESCRIPTION
fix #2269

Changes the style of case gene panels multiselect from this:

![image](https://user-images.githubusercontent.com/28093618/102599504-da76ae00-411d-11eb-9092-1e1ba1867b53.png)


To this:

![image](https://user-images.githubusercontent.com/28093618/102599709-245f9400-411e-11eb-8bb6-a15a01914a14.png)


**How to test**:
1. Install locally or Scout stage and see the difference from master. You might need to clear the cache

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
