### PR TITLE
Make get_coding_intervals() in load_variants() aware of genome build.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Google OAuth2 login setup in README file
 - Redirect to 'missing file'-icon if configured file is missing
 - Javascript error in case page
+- Fix compound matching during variant loading for hg38
 ### Changed
 - Save case variants count in case document and not in sessions
 - Style of gene panels multiselect on case page

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -587,6 +587,8 @@ class CaseHandler(object):
 
         old_sanger_variants = self.case_sanger_variants(case_obj["_id"])
 
+        genome_build = str(parsed_case.get("genome_build", 37))
+
         if old_case:
             LOG.info(
                 "Update case id for existing case: %s -> %s",
@@ -644,6 +646,7 @@ class CaseHandler(object):
                     case_obj=case_obj,
                     variant_type=variant_type,
                     category=category,
+                    build=genome_build,
                     rank_threshold=case_obj.get("rank_score_threshold", 5),
                 )
 

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -390,7 +390,7 @@ class VariantLoader(object):
         genes = [gene_obj for gene_obj in self.all_genes(build=build)]
         gene_to_panels = self.gene_to_panels(case_obj)
         hgncid_to_gene = self.hgncid_to_gene(genes=genes, build=build)
-        genomic_intervals = self.get_coding_intervals(genes=genes)
+        genomic_intervals = self.get_coding_intervals(genes=genes, build=build)
 
         LOG.info("Start inserting {0} {1} variants into database".format(variant_type, category))
         start_insertion = datetime.now()

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -475,6 +475,10 @@ def parse_case(config):
     if "family" not in config:
         raise ConfigError("A case has to have a 'family'")
 
+    allowed_genome_builds = ["37", "38"]
+    if str(config.get("human_genome_build")) not in allowed_genome_builds:
+        raise ConfigError(f"human_genome_build must be one of {allowed_genome_builds}")
+
     individuals = parse_individuals(config["samples"])
     synopsis = None
     if config.get("synopsis"):

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -475,10 +475,6 @@ def parse_case(config):
     if "family" not in config:
         raise ConfigError("A case has to have a 'family'")
 
-    allowed_genome_builds = ["37", "38"]
-    if str(config.get("human_genome_build")) not in allowed_genome_builds:
-        raise ConfigError(f"human_genome_build must be one of {allowed_genome_builds}")
-
     individuals = parse_individuals(config["samples"])
     synopsis = None
     if config.get("synopsis"):


### PR DESCRIPTION
My first scout hacking in 8 months turned into a 3 hour debugging session with minimal code changes in the end... :)

We've occasionally had compounds appear as "not loaded" (and links not working) although they are certainly loaded. Turns out get_coding_intervals() would always use hg19 intervals, thus sometimes causing variants from the same gene to be processed in different "bulks". This fixes that.