### PR TITLE
Fix dismissed cancer variants view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Redirect to 'missing file'-icon if configured file is missing
 - Javascript error in case page
 - Fix compound matching during variant loading for hg38
+- Cancer variants view containing variants dismissed with cancer-specific reasons
 ### Changed
 - Save case variants count in case document and not in sessions
 - Style of gene panels multiselect on case page

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -19,6 +19,7 @@ from scout.constants import (
     CANCER_TIER_OPTIONS,
     CLINSIG_MAP,
     DISMISS_VARIANT_OPTIONS,
+    CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
     MANUAL_RANK_OPTIONS,
     MOSAICISM_OPTIONS,
     SEVERE_SO_TERMS,
@@ -209,14 +210,18 @@ def get_manual_assessments(variant_obj):
                 assessment["display_class"] = classification["color"]
 
             if assessment_type == "dismiss_variant":
+                dismiss_variant_options = {
+                    **DISMISS_VARIANT_OPTIONS,
+                    **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
+                }
                 assessment["label"] = "Dismissed"
                 assessment["title"] = "dismiss:<br>"
                 for reason in variant_obj[assessment_type]:
                     if not isinstance(reason, int):
                         reason = int(reason)
                         assessment["title"] += "<strong>{}</strong> - {}<br><br>".format(
-                            DISMISS_VARIANT_OPTIONS[reason]["label"],
-                            DISMISS_VARIANT_OPTIONS[reason]["description"],
+                            dismiss_variant_options[reason]["label"],
+                            dismiss_variant_options[reason]["description"],
                         )
                 assessment["display_class"] = "secondary"
 


### PR DESCRIPTION
fix #2302 

Problem: when a cancer variant is dismissed with a [cancer-specific dismissed option](https://github.com/Clinical-Genomics/scout/blob/1d48b12e47b78d7f7765d0b6506abeb3b4245f80/scout/constants/variant_tags.py#L242), then the cancer variantS page (of the same type of the variant) crashes

**How to test**:
- Locally, load the demo cancer case and dismiss a SNV or SV (or both) with one of the cancer specific reasons
- Go back to the variantS view and notice that it is broken on master branch
- Switch to this branch and the view should work again

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by