### PR TITLE
Relax tumor purity check and fix missing tooltips on cases with no default panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix compound matching during variant loading for hg38
 - Cancer variants view containing variants dismissed with cancer-specific reasons
 - Zoom to SV variant length was missing IGV contig select
+- Tooltips on case page when case has no default gene panels
 ### Changed
 - Save case variants count in case document and not in sessions
 - Style of gene panels multiselect on case page
 - Collapse/expand main HPO checkboxes in phenomodel preview
 - Replaced GQ (Genotype quality) with VAF (Variant allele frequency) in cancer variants GT table
+- Allow loading of cancer cases with no tumor_purity field
 
 
 ## [4.27]

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -534,8 +534,6 @@
   </form>
 {% endmacro %}
 
-
-
 {% block scripts %}
 {{ super() }}
 <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>
@@ -561,14 +559,16 @@
                                    );
   }
 
-  $('#panel-table').DataTable({
-    scrollY: 350,
-    scrollCollapse: true,
-    paging: false,
-    searching: false,
-    ordering: true,
-    info: false
-        });
+  {% if case.panels %}
+    $('#panel-table').DataTable({
+      scrollY: 350,
+      scrollCollapse: true,
+      paging: false,
+      searching: false,
+      ordering: true,
+      info: false
+    });
+  {% endif %}
 
   $(function(){
       function getHpoTerms(query, process) {

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -512,7 +512,7 @@
                         <td class="text-right"><small>N/A</small></td>
                     {% endif %}
                     {% if cancer %}
-                      {% if sample.allele_depths[1] != -1 %}
+                      {% if sample.read_depth and sample.allele_depths[1] != -1 %}
                         <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
                       {% else %}
                         <td class="text-right">N/A</td>
@@ -972,7 +972,7 @@
                       <td class="text-right"><small>N/A</small></td>
                   {% endif %}
                   {% if cancer %}
-                    {% if sample.allele_depths[1] != -1 and sample.read_depth %}
+                    {% if sample.read_depth and sample.allele_depths[1] != -1 %}
                       <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
                     {% else %}
                       <td class="text-right">N/A</td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1116,5 +1116,5 @@
 
 {% block scripts %}
 {{ super() }}
-  <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>s
+  <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -972,7 +972,7 @@
                       <td class="text-right"><small>N/A</small></td>
                   {% endif %}
                   {% if cancer %}
-                    {% if sample.allele_depths[1] != -1 %}
+                    {% if sample.allele_depths[1] != -1 and sample.read_depth %}
                       <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
                     {% else %}
                       <td class="text-right">N/A</td>
@@ -1116,5 +1116,5 @@
 
 {% block scripts %}
 {{ super() }}
-  <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>
+  <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>s
 {% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -39,9 +39,11 @@
               <td>{{ ind.msi or 'N/A' }}</td>
               {% if ind.phenotype_human == "tumor" %}
                 <td class="d-flex flex-row align-items-center"><input name="tumor_purity.{{ind.individual_id}}" type="number" step="0.01" min="0.1" max=1
-                    class="form-control col-7" value="{{ind.tumor_purity}}">
-                {% if ind.tumor_purity|float <0.2 %} &nbsp;&nbsp; <i class="fa fa-exclamation" data-toggle='tooltip' data-container='body'
-                title="Low or missing tumor purity"></i> {% endif %}</td>
+                  class="form-control col-7" value="{{ind.tumor_purity}}">
+                  {% if not ind.tumor_purity or ind.tumor_purity|float < 0.2 %}
+                    &nbsp;&nbsp; <i class="fa fa-exclamation" data-toggle='tooltip' data-container='body' title="Low or missing tumor purity"></i>
+                  {% endif %}
+                </td>
               {% else %}
                 <td>N/A</td>
               {% endif %}


### PR DESCRIPTION
This PR fixes 3 things:
- Bug that causes the app crashing when a cancer case doesn't have a default tumor_purity value (fix #2310)
- Broken tooltips on case page when case doesn't have any associated default gene panel (#2307)
- Potential bug in general report whenever a case has a read depth that is None (it occurred to me with a variant of the demo cancer case)

**How to test - locally**:
1. on master branch, remove the tumor_purity field from the demo cancer config file and load the cancer demo case with the command:
```
scout --demo load case scout/demo/cancer.load_config.yaml
```
1. While staying on master branch, go to the case page of this demo cancer case and notice that crashes with the error described in #2310
1. Switch to this branch and the error should be gone. You should be seeing a question mark indicating the the field is missing:
1. The tooltip when you hover over the question mark and all the other tooltips on this page should be working

**How to test on stage**
1. Install this branch on clinical-db stage and go to a cancer case with no tumor purity (that now is not working): https://scout-stage.scilifelab.se/cust000/actualgecko
1. The case page should be working

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
