### PR TITLE
Fix gene variants search when looking for similar cases and none is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Don't show TP53 link for silent changes
 - OMIM gene field accepts any custom number as OMIM gene
 - Fix Pytest single quote vs double quote string
-- Bug in gene variants search when providing similar case display name
+- Bug in gene variants search by similar cases and no simlar case is found
 - Delete unused file `userpanel.py`
 - Primary transcripts in variant overview and general report
 - Google OAuth2 login setup in README file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Don't show TP53 link for silent changes
 - OMIM gene field accepts any custom number as OMIM gene
 - Fix Pytest single quote vs double quote string
-- Bug in gene variants search by similar cases and no simlar case is found
+- Bug in gene variants search by similar cases and no similar case is found
 - Delete unused file `userpanel.py`
 - Primary transcripts in variant overview and general report
 - Google OAuth2 login setup in README file

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -142,8 +142,8 @@ class QueryHandler(object):
                 for term in case_obj.get("phenotype_terms", []):
                     hpo_terms.append(term.get("phenotype_id"))
 
-                similar_cases = self.cases_by_phenotype(
-                    hpo_terms, case_obj["owner"], case_obj["_id"]
+                similar_cases = (
+                    self.cases_by_phenotype(hpo_terms, case_obj["owner"], case_obj["_id"]) or []
                 )
                 LOG.debug("Similar cases: %s", similar_cases)
                 select_cases = [similar[0] for similar in similar_cases]


### PR DESCRIPTION
Fix #2313.

To reproduce on a local instance of Scout:
- Install demo case (`scout setup demo`)
- Install other demo case (`scout --demo load case scout/demo/643595.config.yaml`)
- Start the app and go to this page:http://localhost:5000/cust000/gene_variants
- Search for POT1, rank score > 15 in similar case 643595

**How to test**:
- [ ] Root branch should crash
- [ ] After switching to this branch it should work

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
