### PR TITLE
Silence tp53 link synonymous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bugfix: unused `chromgraph_prefix |tojson` removed
 - Freeze coloredlogs temporarily
 - Marrvel link
-- Don't show TP53 link for silent changes
+- Don't show TP53 link for silent or synonymous changes
 - OMIM gene field accepts any custom number as OMIM gene
 - Fix Pytest single quote vs double quote string
 - Bug in gene variants search when providing similar case display name

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -522,7 +522,7 @@ def cbioportal(hgnc_symbol, protein_sequence_name):
 def mutantp53(hgnc_id, protein_variant):
     if hgnc_id != 11998:
         return None
-    if not protein_variant:
+    if not protein_variant or protein_variant.endswith("="):
         return None
 
     url_template = "http://mutantp53.broadinstitute.org/?query={}"

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -522,7 +522,7 @@ def cbioportal(hgnc_symbol, protein_sequence_name):
 def mutantp53(hgnc_id, protein_variant):
     if hgnc_id != 11998:
         return None
-    if not protein_variant or protein_variant.endswith("="):
+    if not protein_variant or protein_variant.endswith("=") or protein_variant.endswith("%3D"):
         return None
 
     url_template = "http://mutantp53.broadinstitute.org/?query={}"


### PR DESCRIPTION
This PR  fixes a bug.

**How to test**:
1. note that synonymous variants in TP53 still have a `p.=` `HGVS_p` string and thus get a mutatnTP53 link.
2. apply patch and see it dissapear

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
