### PR TITLE
Redirect and display error when trying to open a non-existent ACMG classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 ### Fixed
+- ACMG classification page crashing when trying to visualize a classification that was removed
 ### Changed
 
 ## [4.28]

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -228,6 +228,9 @@ def variant_update(institute_id, case_name, variant_id):
 def evaluation(evaluation_id):
     """Show or delete an ACMG evaluation."""
     evaluation_obj = store.get_evaluation(evaluation_id)
+    if evaluation_obj is None:
+        flash("Evaluation was not found in database", "warning")
+        return redirect(request.referrer)
     evaluation_controller(store, evaluation_obj)
     if request.method == "POST":
         link = url_for(


### PR DESCRIPTION
Fix #2317 
The bug happens when for instance you have 2 browser tabs open on the same variant and you remove one acmg classification from it, If in the second browser tab, without refreshing the page, you click on the classification link, the app will crash

**How to test**:
1. Create an ACMG classification for a variant (rare disease, not cancer) and do the steps described above.
1. With master branch the app should crash
1. Using this branch you shoudn't just get an error message and it shouldn't crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
