### PR TITLE
Add missing links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
-### Addeds
+### Added
 ### Fixed
 - ACMG classification page crashing when trying to visualize a classification that was removed
 - Broken or missing link in the documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
-### Added
+### Addeds
 ### Fixed
 - ACMG classification page crashing when trying to visualize a classification that was removed
+- Broken or missing link in the documentation
 ### Changed
 
 ## [4.28]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Added
+- markdown_include in development requirements file
 ### Fixed
 - ACMG classification page crashing when trying to visualize a classification that was removed
 - Broken or missing link in the documentation

--- a/docs/admin-guide/containers/container-deploy.md
+++ b/docs/admin-guide/containers/container-deploy.md
@@ -21,7 +21,7 @@ The container with the docker image contains only the app installation files and
 
 ## Docker tips and tricks
 
-Docker can simplify the development of Scout as it offers a portable configuration-free environment with all dependancies included. The default `docker-compose.yml` file is designed for demoing and not for development. You can extend the included compose file with your own custom configuration to make it more development friendly. For more information on how to extend docker-compse files see, [https://docs.docker.com/compose/extends/][docker docs]. The following is an example configuration:
+Docker can simplify the development of Scout as it offers a portable configuration-free environment with all dependancies included. The default `docker-compose.yml` file is designed for demoing and not for development. You can extend the included compose file with your own custom configuration to make it more development friendly. For more information on how to extend docker-compose files see [docker docs](https://docs.docker.com/compose/extends/). The following is an example configuration:
 
 ``` yaml
 services:

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -14,5 +14,5 @@ Scout is a web-based visualizer for VCF-files. It helps to manage multiple patie
 * [Genes](./genes.md)
 * [Gene Panels](./panels.md)
 * [Annotations](./annotations.md)
-* [ACMG criterias](user-guide/acmg-criterias.md)
-* [Dashboard](user-guide/dashboard.md)
+* [ACMG criterias](./acmg-criterias.md)
+* [Dashboard](./dashboard.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - HPO phenotypes: 'features/hpo.md'
 
   - User guide:
+      - Readme: 'user-guide/README.md'
       - Getting started: 'user-guide/getting-started.md'
       - General: 'user-guide/using-scout.md'
       - Pages: 'user-guide/pages.md'
@@ -45,6 +46,10 @@ nav:
   - Admin guide:
       - Intro: 'admin-guide/README.md'
       - Setup: 'admin-guide/setup-scout.md'
+      - Deploying Scout in containers:
+          - Dockerfile and docker-compose: 'admin-guide/containers/container-deploy.md'
+          - Deploying using Kubernetes: 'admin-guide/containers/kubernetes.md'
+          - Deploying as a systemd service with podman: 'admin-guide/containers/systemd.md'
       - Loading: 'admin-guide/loading.md'
       - Load config: 'admin-guide/load-config.md'
       - Gene definitions: 'admin-guide/genes.md'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ black
 # docs
 mkdocs
 mkdocs-material
+markdown-include


### PR DESCRIPTION
I've realized that in a previous PR I forgot to include the links of some new doc files in the mkdocs file. I'm adding these missing file now and I'm fixing also a couple of other links that didn't work from before. 
Note that **you might need to install mkdocs as a dependency**.

**How to test**:
1. run `mkdocks serve` on master branch and make sure these pages don't work:
- From http://0.0.0.0:4000/user-guide/ the links to the ACMG classification and the dashboard (on the bottom of the list)
- http://0.0.0.0:4000/admin-guide/containers/container-deploy/
- http://0.0.0.0:4000/admin-guide/containers/kubernetes/
- http://0.0.0.0:4000/admin-guide/containers/systemd/

**Expected outcome**:
Run `mkdocs serve` from this branch and the links above should work

**Review:**
- [ ] code approved by
- [ ] tests executed by
