### PR TITLE
Fix #2323 - throttle back IGV.js to 2.7.0 until a fix is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Broken or missing link in the documentation
 - Multiple gene names in ClinVar submission form
 - Inheritance model select field in ClinVar submission
+- IGV.js >2.7.0 has an issue with the gene track zoom levels - temp freeze at 2.7.0
 ### Changed
 
 ## [4.28]

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -25,7 +25,7 @@
             src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/jquery-ui.min.js"></script>
 
     <!-- IGV JS-->
-     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/igv@2.7.4/dist/igv.min.js"></script>
+     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/igv@2.7.0/dist/igv.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

See issue for details.

**How to test**:
1. select IGV for a variant on master, verify that the gene is not visible at ordinary zoom
2. verify that it is directly visible with patch.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
