### PR TITLE
Center igv on variant start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Introduced a `reset dismiss variant` verb
 - Button to reset all dismissed variants for a case
 ### Fixed
+- Center initial igv view on variant start with SNV/indels 
 ### Changed
 
 

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -463,7 +463,7 @@
                   <input type="hidden" name="build" value="{{case.genome_build}}">
                   <input type="hidden" name="contig" value="{{variant.chromosome}}">
                   <input type="hidden" name="start" value="{{variant.position - 50}}">
-                  <input type="hidden" name="stop" value="{{variant.end_position + 50}}">
+                  <input type="hidden" name="stop" value="{{variant.position + 50}}">
                   <!-- end of general hidden form fields -->
                 {% if variant.chromosome == "MT" %}
                   {% if case.mt_bams %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fix #2345 by setting SNV variant view IGV initial window end to center from variant start rather than end.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
