### PR TITLE
Stricter LoqusDB management in institute settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Center initial igv view on variant start with SNV/indels
 - Display of GQ for SV and STR
 - Parsing of AD and related info for STRs
+- LoqusDB field in institute settings accepts only existing Loqus instances
 ### Changed
-- Cancer variants table header (pop freq etc)
+- Only admin users can modify LoqusDB instance in Institute settings
 
 ## [4.29]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parsing of AD and related info for STRs
 - LoqusDB field in institute settings accepts only existing Loqus instances
 ### Changed
+- Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings
 
 ## [4.29]

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -13,6 +13,7 @@ from wtforms import (
     Field,
 )
 from scout.constants import PHENOTYPE_GROUPS, CASE_SEARCH_TERMS
+from scout.server.extensions import loqusdb
 
 CASE_SEARCH_KEY = [(value["prefix"], value["label"]) for key, value in CASE_SEARCH_TERMS.items()]
 
@@ -72,7 +73,9 @@ class InstituteForm(FlaskForm):
         "Available patient cohorts", validators=[validators.Optional()]
     )
     institutes = NonValidatingSelectMultipleField("Institutes to share cases with", choices=[])
-    loqusdb_id = TextField("LoqusDB id", validators=[validators.Optional()])
+
+    loqus_instances = [instance["id"] for instance in loqusdb.loqusdb_settings]
+    loqusdb_id = SelectField("LoqusDB id", [validators.Optional()], choices=loqus_instances)
 
     submit_btn = SubmitField("Save settings")
 

--- a/scout/server/blueprints/institutes/templates/overview/institute_settings.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_settings.html
@@ -30,7 +30,7 @@
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
   <div class="col">
-    {{ institute_settings(form, institute) }}
+    {{ institute_settings(form, institute, current_user) }}
   </div>
   </div> <!-- end of div id body-row -->
 </div>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -88,7 +88,7 @@
             </div>
           </div>
           <div class="form-row mt-3 d-flex justify-content-center">
-            <div class="col-md-12 align-self-center">
+            <div class="col-md-5 align-self-center">
               {{ form.institutes.label(class="control-label",data_toggle="tooltip", data_placement="top", title="Allow case sharing only with preselected institutes.") }}
               <select multiple="multiple" class="selectpicker" name="institutes">
               {% for choice in form.institutes.choices %}
@@ -96,18 +96,17 @@
               {% endfor %}
               </select>
             </div>
+            {% if "admin" in current_user.roles %}
+              <div class="col-md-5 align-self-center offset-md-2">
+                {{ form.loqusdb_id.label(class="control-label", data_toggle="tooltip", data_placement="top", title="LoqudDB id" ) }}<br>
+                <select class="selectpicker" name="loqusdb_id">
+                  {% for choice in form.loqusdb_id.choices %}
+                    <option value="{{choice}}">{{choice}}</option>
+                  {% endfor %}
+                </select>
+              </div>
+            {% endif %}
           </div>
-          {% if "admin" in current_user.roles %}
-          <div class="form-row mt-3 d-flex justify-content-left" id="Custom_LoqusDB">
-            <div class="col-md-2 align-self-center" >
-              {{ form.loqusdb_id.label(class="control-label", data_toggle="tooltip", data_placement="top", title="LoqudDB id", placeholder="Search HPO.." ) }}
-            </div>
-            <div class="col-md-6 align-self-center" >
-              {{ form.loqusdb_id(class='form-control')}}
-            </div>
-            <div class="col-md-6 align-self-center" ></div>
-          </div>
-          {% endif %}
           <div class="form-row mt-3 d-flex justify-content-center">
               {{ form.submit_btn(class="btn-primary btn") }}
           </div>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -1,4 +1,4 @@
-{% macro institute_settings(form, institute) %}
+{% macro institute_settings(form, institute, current_user) %}
 <form action="{{ url_for('overview.institute_settings', institute_id=institute._id) }}" method="POST"
   accept-charset="utf-8" id="institute_form">
 {{ form.csrf_token }}
@@ -97,6 +97,7 @@
               </select>
             </div>
           </div>
+          {% if "admin" in current_user.roles %}
           <div class="form-row mt-3 d-flex justify-content-left" id="Custom_LoqusDB">
             <div class="col-md-2 align-self-center" >
               {{ form.loqusdb_id.label(class="control-label", data_toggle="tooltip", data_placement="top", title="LoqudDB id", placeholder="Search HPO.." ) }}
@@ -106,6 +107,7 @@
             </div>
             <div class="col-md-6 align-self-center" ></div>
           </div>
+          {% endif %}
           <div class="form-row mt-3 d-flex justify-content-center">
               {{ form.submit_btn(class="btn-primary btn") }}
           </div>


### PR DESCRIPTION
This PR adds a functionality:
- Allow only admin users to modify the Loqus instance in use for the institute
- Transform the loqus textfield of this form into a select with only existing loqus instance ids as possible values

fix #2352 

**How to test - local scout demo**:
1. Create a new user that has not an admin role: 
```
scout --demo load user -i cust000 -u "Diana Prince" -m wonderwoman@dc.com
```
2. Log in with this user and see the difference between master  branch and this branch (The loqus field should not be visible on the bottom of the institute settings in this branch)
3. Log out and login with Clark Kent (that is an admin) and see the difference with master branch (on master you should have a textfield accepting any value and on this branch a select showing only one value --> default)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
