### PR TITLE
More compact synopsis and comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings
 - Switched to igv.js 2.4.7
+- Style of case synopsis and variants and case comments
 
 ## [4.29]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -221,12 +221,16 @@
   <div class="card panel-default">
     <div data-toggle='tooltip' class="panel-heading" title="Free text field. Write a summary about the case! Markdown format"><i class="fa fa-id-card-o"></i>&nbsp;Synopsis</div>
       <div class="card-body">
-        {{ case.synopsis|markdown if case.synopsis else 'Nothing written yet...' }}
-      </div>
-      <div class="card-footer">
-        <button type="button" class="btn btn-outline-secondary form-control" data-toggle="modal" data-target="#edit-synopsis">
-          Edit
-        </button>
+        <div class="row">
+          <div class="col-10">
+           {{ case.synopsis|markdown if case.synopsis else 'Nothing written yet...' }}
+          </div>
+          <div class="col-2">
+            <button type="button" class="btn btn-outline-secondary form-control" data-toggle="modal" data-target="#edit-synopsis">
+              Edit
+            </button>
+          </div>
+        </div>
       </div>
   </div>
 {% endmacro %}

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -35,70 +35,20 @@
 {% endmacro %}
 
 {% macro comments_panel(institute, case, current_user, comments, variant_id=None) %}
-  <div class="card panel-default">
-    <div class="panel-heading" id="comments"><span class="fa fa-comment"></span>&nbsp;Comments</div>
-    <div class="card-body">
-      <div class="list-group" style="max-height:200px; overflow-y: scroll;">
-        {% for comment in comments %}
-          <a class="list-group-item">
-            <div class="row">
-              <div class="col-xs-12 text-break">{{ comment.content }}</div>
-            </div>
-            <div class="row">
-              <div class="d-flex justify-content-between align-items-center">
-                <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
-                  <small>
-                    <br>
-                    <strong>{{ comment.user_name }}</strong>
-                    on {{ comment.created_at.date() }}
-                    {% if comment.level == 'global' %}
-                      <span class="badge badge-info">GLOBAL</span>
-                    {% endif %}
-                    {% if comment.created_at < case.updated_at %}
-                      <span class="badge badge-warning">OLD</span>
-                    {% endif %}
-                    {% if comment.created_at < comment.updated_at %}
-                      <span class='badge badge-secondary'>edited</span>
-                    {% endif %}
-                    {% if comment.user_id == current_user.email %}
-                      <button class="btn btn-link btn-sm" type="submit" name="remove"><i class="fa fa-remove"></i></button>
-                      <button class="btn btn-link btn-sm" type="button" data-toggle="modal" data-target="#editComment_{{loop.index}}"><i class="fa fa-edit"></i></button>
-                    {% endif %}
-                  </small>
-                </form>
-              </div>
-            </div>
-          </a>
-          {{ edit_comment(institute, case, current_user, comment, loop.index) }}
-        {% else %}
-          <a class="list-group-item">No comments yet</a>
-        {% endfor %}
-      </div>
+<div class="mt-3">
+  {% set comments = comments|list %}
+  <h6 class="comments-title"><i class="fa fa-comments"></i> Comments ({{ comments|length }})</h6>
+  {% for comment in comments %}
+    <div class="row">
+      {% if loop.cycle('odd') %}
+      {% else %}
+        
+      {% endif %}
     </div>
-    <div class="card-footer">
-      <form action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id, _anchor='comments') }}" method="POST">
-        <input type="hidden" name="link" value="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id) if variant_id else url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
-        <div class="form-group">
-          <textarea class="form-control" name="content" placeholder="Leave a comment"></textarea>
-        </div>
-        <div class="row">
-          {% if variant_id %}
-            <div class="col-sm-6">
-              <div class="checkbox">
-                <label>
-                  <input type="checkbox" name="level" value="global">
-                  Comment globally
-                </label>
-              </div>
-            </div>
-          {% endif %}
-          <div class="col-sm-{{ 6 if variant_id else 12 }}">
-            <button class="btn btn-outline-secondary form-control" type="submit">Comment</button>
-          </div>
-        </div>
-      </form>
-    </div>
-  </div>
+  {% endfor %}
+</div>
+
+
 {% endmacro %}
 
 {% macro edit_comment(institute, case, current_user, comment, index) %}

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -37,15 +37,63 @@
 {% macro comments_panel(institute, case, current_user, comments, variant_id=None) %}
 <div class="mt-3">
   {% set comments = comments|list %}
-  <h6 class="comments-title"><i class="fa fa-comments"></i> Comments ({{ comments|length }})</h6>
-  {% for comment in comments %}
-    <div class="row">
-      {% if loop.cycle('odd') %}
-      {% else %}
-        
-      {% endif %}
+  <h6 class="comments-title"></i><i class="far fa-comments"></i> Comments ({{ comments|length }})</h6>
+  <div class="list-group" style="max-height:200px; overflow-y: scroll;">
+    <style>.even { background-color: #fdf5ca }</style>
+    <style>.odd { background-color: #d5e8f0 }</style>
+    {% for comment in comments %}
+      <div class="row ml-1 alert {% if loop.index0 % 2 %}even{% else %}odd{% endif %}">
+          <div class="col-7">
+          {{ comment.content }}
+          </div>
+          <div class="col-5 text-right">
+            <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
+              <small>
+                <strong>{{ comment.user_name }}</strong>
+                on {{ comment.created_at.date() }}
+                {% if comment.level == 'global' %}
+                  <span class="badge badge-info">GLOBAL</span>
+                {% endif %}
+                {% if comment.created_at < case.updated_at %}
+                  <span class="badge badge-warning">OLD</span>
+                {% endif %}
+                {% if comment.created_at < comment.updated_at %}
+                  <span class='badge badge-secondary'>edited</span>
+                {% endif %}
+                {% if comment.user_id == current_user.email %}
+                  <button class="btn btn-link btn-sm" type="submit" name="remove"><i class="fa fa-remove"></i></button>
+                  <button class="btn btn-link btn-sm" type="button" data-toggle="modal" data-target="#editComment_{{loop.index}}"><i class="fa fa-edit"></i></button>
+                {% endif %}
+              </small>
+            </form>
+          </div>
+        </div>
+        {{ edit_comment(institute, case, current_user, comment, loop.index) }}
+    {% endfor %}
+  </div> <!-- end of <div class="list-group" -->
+    <div class="card-footer">
+      <form action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id, _anchor='comments') }}" method="POST">
+        <input type="hidden" name="link" value="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id) if variant_id else url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
+        <div class="form-group">
+          <textarea class="form-control" name="content" placeholder="Leave a comment"></textarea>
+        </div>
+        <div class="row">
+          {% if variant_id %}
+            <div class="col-sm-6">
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" name="level" value="global">
+                  Comment globally
+                </label>
+              </div>
+            </div>
+          {% endif %}
+          <div class="col-sm-{{ 6 if variant_id else 12 }}">
+            <button class="btn btn-outline-secondary form-control" type="submit">Comment</button>
+          </div>
+        </div>
+      </form>
     </div>
-  {% endfor %}
 </div>
 
 

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -43,9 +43,7 @@
     <style>.odd { background-color: #d5e8f0 }</style>
     {% for comment in comments %}
       <div class="row ml-1 alert {% if loop.index0 % 2 %}even{% else %}odd{% endif %}">
-          <div class="col-7">
-          {{ comment.content }}
-          </div>
+          <div class="col-7">{{ comment.content }}</div>
           <div class="col-5 text-right">
             <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
               <small>


### PR DESCRIPTION
I've started working on extending the phenotyping of cases including the phenomodels and I've realized that there are components that take too much space in the page.  This PR changes the style of synopsis and comments. 

**Case page** changes from this:
![image](https://user-images.githubusercontent.com/28093618/107964297-6b94c480-6fa9-11eb-8312-07dcaf9850cc.png)


To this:
![image](https://user-images.githubusercontent.com/28093618/107964181-528c1380-6fa9-11eb-9433-5ef10bf106fb.png)


**Variants pages** change from this:
![image](https://user-images.githubusercontent.com/28093618/107964512-a8f95200-6fa9-11eb-99b1-5f6ae760de3b.png)

To this:
![image](https://user-images.githubusercontent.com/28093618/107964686-d6de9680-6fa9-11eb-9087-188212af4dda.png)


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
