### PR TITLE
Load STRs regardless of rank score threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LoqusDB field in institute settings accepts only existing Loqus instances
 - Fix DECIPHER link to work after DECIPHER migrated to GRCh38
 - Removed visibility window param from igv.js genes track
+- Always load STR variants regardless of RankScore threshold
 ### Changed
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -425,6 +425,7 @@ class VariantLoader(object):
                 or mt_variant
                 or pathogenic
                 or managed
+                or category in ["str"]
             ):
                 nr_inserted += 1
                 # Parse the vcf variant


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. try loading an STR file produced with Stranger 0.7 and note how few variants are loaded if rank score threshold is at 5 or higher
2. try with patch version and find variants loaded

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
