### PR TITLE
Patch the HPO download resource correctly in a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LoqusDB field in institute settings accepts only existing Loqus instances
 - Fix DECIPHER link to work after DECIPHER migrated to GRCh38
 - Removed visibility window param from igv.js genes track
-- Path HPO download test correctly
+- Patch HPO download test correctly
 ### Changed
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LoqusDB field in institute settings accepts only existing Loqus instances
 - Fix DECIPHER link to work after DECIPHER migrated to GRCh38
 - Removed visibility window param from igv.js genes track
+- Path HPO download test correctly
 ### Changed
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings

--- a/tests/commands/download/test_download_hpo_cmd.py
+++ b/tests/commands/download/test_download_hpo_cmd.py
@@ -4,19 +4,22 @@ import pathlib
 import tempfile
 
 from scout.commands.download.hpo import hpo as hpo_cmd
+from scout.utils.scout_requests import fetch_hpo_files
 
 
 def test_download_hpo_cmd(mocker, empty_mock_app):
     """Test download hpo command"""
+
     # GIVEN a temporary directory
     mock_app = empty_mock_app
     runner = mock_app.test_cli_runner()
 
-    mocker.patch("scout.commands.download.hpo.print_hpo")
+    mocker.patch("scout.utils.scout_requests.fetch_resource")
     with tempfile.TemporaryDirectory() as dir_name:
         the_dir = pathlib.Path(dir_name)
         # WHEN running the command
         result = runner.invoke(hpo_cmd, ["-o", the_dir])
+        assert "Download HPO" in result.output
+
         # THEN check it exits without problems
         assert result.exit_code == 0
-        assert "Download HPO" in result.output

--- a/tests/commands/download/test_download_hpo_cmd.py
+++ b/tests/commands/download/test_download_hpo_cmd.py
@@ -19,7 +19,7 @@ def test_download_hpo_cmd(mocker, empty_mock_app):
         the_dir = pathlib.Path(dir_name)
         # WHEN running the command
         result = runner.invoke(hpo_cmd, ["-o", the_dir])
-        assert "Download HPO" in result.output
 
         # THEN check it exits without problems
         assert result.exit_code == 0
+        assert "Download HPO" in result.output


### PR DESCRIPTION
Fixing a test failing when the real resource is not available. Real resource: http://compbio.charite.de/jenkins/job/hpo.annotations/lastSuccessfulBuild/artifact/util/annotation/genes_to_phenotype.txt

**How to test**:
1. Pytest should pass

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
