### PR TITLE
handle none upload research

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,13 @@ lib
 lib64
 dist/
 
+# Environments
+
+venv/
+
+# Pycharm
+.idea/
+
 # Installer logs
 pip-log.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can modify LoqusDB instance in Institute settings
 - Style of case synopsis and variants and case comments
 - Switched to igv.js 2.7.5
+- Do not choke if case is missing research variants when reserch requested
 
 ## [4.29.1]
 ### Added

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -26,14 +26,21 @@ def upload_research_variants(
         rank_threshold=rank_treshold,
     )
 
-def get_case_and_institute(adapter: MongoAdapter, case_id: str, institute: Optional[str]) -> (str, str):
+
+def get_case_and_institute(
+    adapter: MongoAdapter, case_id: str, institute: Optional[str]
+) -> (str, str):
+    """Fetch the case_id and institute_id
+
+    There was an old way to create case ids so we need a special case to handle this.
+    For old case_id we assume institute-case combo
+    We check if first part of the case_id is institute, then we know it is the old format
+    """
     if institute:
         return case_id, institute
-    # There was an old way to create case ids so we need a special case to handle this
-    # Assume institute-case combo
     split_case = case_id.split("-")
     institute_id = None
-    # Check if first part is institute, then we know it is the old format
+
     if len(split_case) > 1:
         institute_id = split_case[0]
         institute_obj = adapter.institute(institute_id)
@@ -61,7 +68,9 @@ def research(case_id, institute, force):
     adapter = store
 
     if case_id:
-        case_id, institute_id = get_case_and_institute(adapter=adapter, case_id=case_id, institute=institute)
+        case_id, institute_id = get_case_and_institute(
+            adapter=adapter, case_id=case_id, institute=institute
+        )
         case_obj = adapter.case(institute_id=institute, case_id=case_id)
         if case_obj is None:
             LOG.warning("No matching case found")

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -10,11 +10,12 @@ from scout.server.extensions import store
 
 LOG = logging.getLogger(__name__)
 
-def upload_research_variants(adapter: MongoAdapter, case_obj: dict, variant_type: str, category: str, rank_treshold: int):
+
+def upload_research_variants(
+    adapter: MongoAdapter, case_obj: dict, variant_type: str, category: str, rank_treshold: int
+):
     """Delete existing variants and upload new variants"""
-    adapter.delete_variants(
-        case_id=case_obj["_id"], variant_type=variant_type, category=category
-    )
+    adapter.delete_variants(case_id=case_obj["_id"], variant_type=variant_type, category=category)
 
     LOG.info("Load %s %s for: %s", variant_type, category.upper(), case_obj["_id"])
     adapter.load_variants(
@@ -23,6 +24,7 @@ def upload_research_variants(adapter: MongoAdapter, case_obj: dict, variant_type
         category=category,
         rank_threshold=rank_treshold,
     )
+
 
 @click.command(short_help="Upload research variants")
 @click.option("-c", "--case-id", help="family or case id")
@@ -70,19 +72,35 @@ def research(case_id, institute, force):
         # Test to upload research snvs
         if case_obj["vcf_files"].get("vcf_snv_research"):
             files = True
-            upload_research_variants(adapter=adapter, case_obj=case_obj, variant_type="research", category="snv", rank_treshold=default_threshold)
+            upload_research_variants(
+                adapter=adapter,
+                case_obj=case_obj,
+                variant_type="research",
+                category="snv",
+                rank_treshold=default_threshold,
+            )
 
             # Test to upload research svs
         if case_obj["vcf_files"].get("vcf_sv_research"):
             files = True
-            upload_research_variants(adapter=adapter, case_obj=case_obj, variant_type="research", category="sv",
-                                     rank_treshold=default_threshold)
+            upload_research_variants(
+                adapter=adapter,
+                case_obj=case_obj,
+                variant_type="research",
+                category="sv",
+                rank_treshold=default_threshold,
+            )
 
             # Test to upload research cancer variants
         if case_obj["vcf_files"].get("vcf_cancer_research"):
             files = True
-            upload_research_variants(adapter=adapter, case_obj=case_obj, variant_type="research", category="cancer",
-                                     rank_treshold=default_threshold)
+            upload_research_variants(
+                adapter=adapter,
+                case_obj=case_obj,
+                variant_type="research",
+                category="cancer",
+                rank_treshold=default_threshold,
+            )
 
         if not files:
             LOG.warning("No research files found for case %s", case_id)


### PR DESCRIPTION
This PR changes the behaviour of the CLI so that it does not exit fail if there are no research variants when uploading reseach variants.


**Expected outcome**:
The command `scout upload research` will not exit fail if there are no variants

**Review:**
- [ ] code approved by
- [ ] tests executed by
