### PR TITLE
Freeze actions ubuntu version during rollout

### DIFF
--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -5,7 +5,7 @@ on: ["push", "pull_request"]
 jobs:
   build:
     name: Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can modify LoqusDB instance in Institute settings
 - Style of case synopsis and variants and case comments
 - Switched to igv.js 2.7.5
+- Temp freeze github actions ubuntu version to avoid rollout warnings
 
 ## [4.29.1]
 ### Added


### PR DESCRIPTION
This PR adds a functionality or fixes a bug. 

Unblocking stalled PR Actions due to warning during ubuntu-20.04 rollout.

![Screenshot 2021-02-23 at 16 52 30](https://user-images.githubusercontent.com/758570/108873817-ceb2d680-75fb-11eb-8244-0e0da0054dfd.png)

**How to test**:
1. automatic test on GitHub Actions

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
