### PR TITLE
Tooltip manual inherit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show ClinVar annotations on variantS page
 - Added integration with GENS, copy number visualization tool
 - Add additional information to SNV verification emails
+- Tooltips documenting manual annotations from default panels
 ### Fixed
 - Center initial igv view on variant start with SNV/indels
 - Don't set initial igv view to negative coordinates

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -136,8 +136,10 @@ def variant(
     if genome_build not in ["37", "38"]:
         genome_build = "37"
 
+    # add default panels extra gene information
     panels = default_panels(store, case_obj)
     variant_obj = add_gene_info(store, variant_obj, gene_panels=panels, genome_build=genome_build)
+
     # Add information about bam files and create a region vcf
     if add_case:
         variant_case(store, case_obj, variant_obj)

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -94,9 +94,9 @@
           </tr>
           <tr>
             <th>OMIM</th>
-            <th>Manual</th>
+            <th data-toggle="tooltip" title="Manual inheritance models from default gene panels">Manual</th>
             <th>OMIM</th>
-            <th>Manual</th>
+            <th data-toggle="tooltip" title="Manual penetrance information from default gene panels">Manual</th>
           </tr>
         </thead>
         <tbody>

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -1,7 +1,7 @@
 
 {% macro disease_associated(variant) %}
   <div class="card panel-default">
-    <div class="panel-heading" data-toggle='tooltip' title="Transcripts described as disease associated in any of the gene panels">Disease associated transcripts</div>
+    <div class="panel-heading" data-toggle='tooltip' title="Transcripts described as disease associated in the case default gene panels">Disease associated transcripts</div>
     <div class=card-body>
       <table class="table table-bordered table-hover table-sm">
         <tr>

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -117,12 +117,13 @@ def update_transcripts_information(variant_gene, hgnc_gene, variant_obj, genome_
 
 
 def add_gene_info(store, variant_obj, gene_panels=None, genome_build=None):
-    """Adds information to variant genes from hgnc genes and gene panels.
+    """Adds information to variant genes from hgnc genes and selected gene panels.
 
     Variants are annotated with gene and transcript information from VEP. In Scout the database
     keeps updated and extended information about genes and transcript. This function will compliment
      the VEP information with the updated database information.
     Also there is sometimes additional information that are manually curated in the gene panels.
+    Only the selected panels passed to this function (typically default) are used.
     This information needs to be added to the variant before sending it to the template.
 
     This function will loop over all genes and add that extra information.


### PR DESCRIPTION
This PR adds tooltips and code docs of manual_inheritance handling: collected for default panels.

**How to test**:
1. add a gene with a manual inheritance an disease transcript annotation to your favourite gene panel
2. check that on a variant, the manual inheritance is displayed with tooltips when your panel is selected as default for the case

![Screenshot 2021-02-25 at 10 03 05](https://user-images.githubusercontent.com/758570/109129838-5a8a4700-7751-11eb-9e89-47eb0cfa34c5.png)
![Screenshot 2021-02-25 at 10 03 32](https://user-images.githubusercontent.com/758570/109129852-5eb66480-7751-11eb-8d1f-e251c59a2a13.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
