### PR TITLE
Fix STR hover reference size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed visibility window param from igv.js genes track
 - Updated HPO download URL
 - Patch HPO download test correctly
+- Reference size on STR hover not needed (also wrong)
 ### Changed
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -189,7 +189,6 @@
   data-trigger="hover click"
   data-content="{% if variant.str_normal_max %}
     <table>
-      <tr><td>Reference size</td><td>{{ variant.str_normal_max }}</td></tr>
       <tr><td>Normal max</td><td>{{ variant.str_normal_max }}</td></tr>
       <tr><td>Pathologic min</td><td>{{ variant.str_pathologic_min }}</td><tr>
       <tr><td colspan=2>&nbsp;</td></tr>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

STR reference size was duplicated on the hover, and also showing the wrong number. It has a column of its own, so we remove it for now.
![Screenshot 2021-02-25 at 12 33 13](https://user-images.githubusercontent.com/758570/109147740-a6df8200-7765-11eb-8cf4-087c48adbdbf.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
