### PR TITLE
Improve create new gene panel form validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can modify LoqusDB instance in Institute settings
 - Style of case synopsis and variants and case comments
 - Switched to igv.js 2.7.5
-- Do not choke if case is missing research variants when reserch requested
+- Do not choke if case is missing research variants when research requested
+- Improve create new gene panel form validation
 
 ## [4.29.1]
 ### Added

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -37,15 +37,16 @@
             <label class="col-form-label">New panel</label>
           </div>
           <div class="form-group col-sm-3 text-center">
-              <select name="institute" class="form-control">
-                <option>Choose institute...</option>
+              <select name="institute" class="form-control" required>
+                <option value="">Choose institute...</option>
                 {% for institute in institutes %}
                   <option value="{{ institute._id }}">{{ institute.display_name }}</option>
                 {% endfor %}
               </select>
           </div>
           <div class="col-sm-3 text-center">
-              <input type="text" name="new_panel_name" class="form-control" placeholder="Panel ID">
+              <input type="text" name="new_panel_name" class="form-control" placeholder="Panel ID" required
+                pattern="^[a-zA-Z0-9_]*$" title="Only alphanumeric characters (A-Z+a-z+0-9) and underscores allowed.">
             </div>
             <div class="col-sm-4 text-center">
               <input type="text" name="display_name" class="form-control" placeholder="Full name">
@@ -56,7 +57,7 @@
             <label class="col-form-label">CSV file</label>
           </div>
           <div class="col-sm-5 text-center">
-            <input type="file" name="csv_file" class="custom-file-input" required>
+            <input type="file" name="csv_file" class="custom-file-input" required onchange="this.nextElementSibling.innerText = this.files[0].name">
             <label class="custom-file-label" for="csv_file">Choose file</label><br>
             <p class="help-block">How do I format my <a href="https://www.clinicalgenomics.se/scout/user-guide/panels/#uploading-a-new-gene-panel-version">gene panel file</a>?</p>
           </div>

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -42,7 +42,7 @@ def panels():
                 store=store,
                 institute_id=request.form["institute"],
                 panel_name=new_panel_name,
-                display_name=request.form["display_name"],
+                display_name=request.form["display_name"] or new_panel_name,
                 csv_lines=lines,
                 maintainer=[current_user._id],
                 description=request.form["description"],

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -42,7 +42,7 @@ def panels():
                 store=store,
                 institute_id=request.form["institute"],
                 panel_name=new_panel_name,
-                display_name=request.form["display_name"] or new_panel_name,
+                display_name=request.form["display_name"] or new_panel_name.replace("_", " "),
                 csv_lines=lines,
                 maintainer=[current_user._id],
                 description=request.form["description"],


### PR DESCRIPTION
Fix #2400

Improve the form validation by:
- Making the customer field select mandatory
- Checking that provided gene panel ID contains only alphanumeric chars and underscore
- Display the name of the file containing panel info after you click "browse"
- Is panel display name is not provided, use panel ID, after replacing _ with spaces 


**How to test**:
1. Create a panel and check all the above changes (you can use the demo panel as the file to upload)
 
**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
