### PR TITLE
Bugfix - collect LoqusDB instances correctly in institute settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add black border to ideograms
 - Show ClinVar annotations on variantS page
 - Added integration with GENS, copy number visualization tool
-- Added a VUS label to the manual classification variant tags 
+- Added a VUS label to the manual classification variant tags
 - Add additional information to SNV verification emails
 - Tooltips documenting manual annotations from default panels
 ### Fixed
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Patch HPO download test correctly
 - Reference size on STR hover not needed (also wrong)
 - Introduced genome build check (allowed values: 37 or 38) on case load
+- Populating the LoqusDB select in institute settings
 ### Changed
 - Cancer variants table header (pop freq etc)
 - Only admin users can modify LoqusDB instance in Institute settings

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -81,7 +81,6 @@ class InstituteForm(FlaskForm):
     )
     institutes = NonValidatingSelectMultipleField("Institutes to share cases with", choices=[])
 
-    loqus_instances = [instance["id"] for instance in loqusdb.loqusdb_settings]
     loqusdb_id = NonValidatingSelectField("LoqusDB id", choices=[])
 
     submit_btn = SubmitField("Save settings")

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -18,6 +18,13 @@ from scout.server.extensions import loqusdb
 CASE_SEARCH_KEY = [(value["prefix"], value["label"]) for key, value in CASE_SEARCH_TERMS.items()]
 
 
+class NonValidatingSelectField(SelectField):
+    """Necessary to skip validation of dynamic selects in form"""
+
+    def pre_validate(self, form):
+        pass
+
+
 class NonValidatingSelectMultipleField(SelectMultipleField):
     """Necessary to skip validation of dynamic multiple selects in form"""
 
@@ -75,7 +82,7 @@ class InstituteForm(FlaskForm):
     institutes = NonValidatingSelectMultipleField("Institutes to share cases with", choices=[])
 
     loqus_instances = [instance["id"] for instance in loqusdb.loqusdb_settings]
-    loqusdb_id = SelectField("LoqusDB id", [validators.Optional()], choices=loqus_instances)
+    loqusdb_id = NonValidatingSelectField("LoqusDB id", choices=[])
 
     submit_btn = SubmitField("Save settings")
 

--- a/scout/server/blueprints/institutes/templates/overview/institute_settings.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_settings.html
@@ -30,7 +30,7 @@
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
   <div class="col">
-    {{ institute_settings(form, institute, current_user) }}
+    {{ institute_settings(form, institute, current_user, loqus_instances) }}
   </div>
   </div> <!-- end of div id body-row -->
 </div>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -1,4 +1,4 @@
-{% macro institute_settings(form, institute, current_user) %}
+{% macro institute_settings(form, institute, current_user, loqus_instances) %}
 <form action="{{ url_for('overview.institute_settings', institute_id=institute._id) }}" method="POST"
   accept-charset="utf-8" id="institute_form">
 {{ form.csrf_token }}
@@ -100,8 +100,8 @@
               <div class="col-md-5 align-self-center offset-md-2">
                 {{ form.loqusdb_id.label(class="control-label", data_toggle="tooltip", data_placement="top", title="LoqudDB id" ) }}<br>
                 <select class="selectpicker" name="loqusdb_id">
-                  {% for choice in form.loqusdb_id.choices %}
-                    <option value="{{choice}}">{{choice}}</option>
+                  {% for instance in loqus_instances %}
+                    <option value="{{instance}}" {% if institute.loqusdb_id == instance %} selected {% endif %}>{{instance}}</option>
                   {% endfor %}
                 </select>
               </div>

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -16,7 +16,7 @@ from scout.constants import (
     ACMG_MAP,
 )
 from scout.constants import CASE_SEARCH_TERMS
-from scout.server.extensions import store
+from scout.server.extensions import store, loqusdb
 from scout.server.utils import user_institutes, templated, institute_and_case
 from .forms import InstituteForm, GeneVariantFiltersForm, PhenoModelForm, PhenoSubPanelForm
 
@@ -246,12 +246,14 @@ def institute_settings(institute_id):
             return redirect(request.referrer)
 
     data = controllers.institute(store, institute_id)
+    loqus_instances = loqusdb.loqus_ids if hasattr(loqusdb, "loqus_ids") else []
     default_phenotypes = controllers.populate_institute_form(form, institute_obj)
 
     return render_template(
         "/overview/institute_settings.html",
         form=form,
         default_phenotypes=default_phenotypes,
+        loqus_instances=loqus_instances,
         panel=1,
         **data,
     )

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -16,13 +16,46 @@ MAIL_PORT = 587
 MAIL_USE_TLS = True
 MAIL_USE_SSL = False
 
+# Configure gens service
+# GENS_HOST = "127.0.0.1"
+# GENS_PORT = 5000
 
-LOQUSDB_SETTINGS = [
-    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "default"},
-    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "hejhej"},
-    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "Mayo"},
-]
+# connection details for LoqusDB MongoDB database
+#
+# 1. One LoqusDB
+# LOQUSDB_SETTINGS = dict(
+#  binary_path="/miniconda3/envs/loqus2.5/bin/loqusdb")
+# # config_path=<path/to/loqus/config>
+#
+# 2. LoqusDB configurable per Institute
+# LOQUSDB_SETTINGS = [
+#     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "default"},
+#     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "hejhej"},
+#     {"binary_path": "/bin/yetanother/loqusdb", "id": "Mayo"},
+# ]
 
+# )
+# If not on localhost 27017 one needs to provide uri with
+# connection details for LoqusDB MongoDB database in the loqusdb config file
+#    uri=("mongodb://{}:{}@localhost:{}/loqusdb".format(MONGO_USERNAME, MONGO_PASSWORD, MONGO_PORT))
+
+# Cloud IGV tracks can be configured here to allow users to enable them on their IGV views.
+# CLOUD_IGV_TRACKS = [
+#    {
+#        "name": "custom_public_bucket",
+#        "access": "public",
+#        "tracks": [
+#            {
+#                "name": "dbVar Pathogenic or Likely Pathogenic",
+#                "type": "variant",
+#                "format": "vcf",
+#                "build": "37",
+#                "url": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777457/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz",
+#                "indexURL": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777460/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz.tbi",
+#            }
+#        ],
+#    },
+# ]
 
 # Chanjo-Report
 REPORT_LANGUAGE = "en"

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -16,46 +16,13 @@ MAIL_PORT = 587
 MAIL_USE_TLS = True
 MAIL_USE_SSL = False
 
-# Configure gens service
-# GENS_HOST = "127.0.0.1"
-# GENS_PORT = 5000
 
-# connection details for LoqusDB MongoDB database
-#
-# 1. One LoqusDB
-# LOQUSDB_SETTINGS = dict(
-#  binary_path="/miniconda3/envs/loqus2.5/bin/loqusdb")
-# # config_path=<path/to/loqus/config>
-#
-# 2. LoqusDB configurable per Institute
-# LOQUSDB_SETTINGS = [
-#     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "default"},
-#     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "hejhej"},
-#     {"binary_path": "/bin/yetanother/loqusdb", "id": "Mayo"},
-# ]
+LOQUSDB_SETTINGS = [
+    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "default"},
+    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "hejhej"},
+    {"binary_path": "/Users/chiararasi/miniconda3/envs/loqus/bin/loqusdb", "id": "Mayo"},
+]
 
-# )
-# If not on localhost 27017 one needs to provide uri with
-# connection details for LoqusDB MongoDB database in the loqusdb config file
-#    uri=("mongodb://{}:{}@localhost:{}/loqusdb".format(MONGO_USERNAME, MONGO_PASSWORD, MONGO_PORT))
-
-# Cloud IGV tracks can be configured here to allow users to enable them on their IGV views.
-# CLOUD_IGV_TRACKS = [
-#    {
-#        "name": "custom_public_bucket",
-#        "access": "public",
-#        "tracks": [
-#            {
-#                "name": "dbVar Pathogenic or Likely Pathogenic",
-#                "type": "variant",
-#                "format": "vcf",
-#                "build": "37",
-#                "url": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777457/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz",
-#                "indexURL": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777460/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz.tbi",
-#            }
-#        ],
-#    },
-# ]
 
 # Chanjo-Report
 REPORT_LANGUAGE = "en"

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -53,6 +53,7 @@ class LoqusDB:
         self.loqusdb_settings = [
             {"id": "default", "binary_path": loqusdb_binary, "config_path": loqusdb_args}
         ]
+        self.loqus_ids = []
         self.version = version
         LOG.info(
             "Initializing loqus extension with config: %s",
@@ -63,6 +64,7 @@ class LoqusDB:
         """Initialize from Flask."""
         LOG.info("Init loqusdb app")
         self.loqusdb_settings = self.app_config(app)
+        self.loqus_ids = [setting.get("id", "default") for setting in self.loqusdb_settings]
         self.version = self.get_configured_version()
         if not self.version:
             self.version = self.get_version()


### PR DESCRIPTION
This PR:
- Prevents a bug caused by the server settings form initialized before the loqus instance settings and resulting in an empty Loqus instances select in institute settings
- Removes some code from #2349, that looks intimidating already.

**Prepare for test, locally**:
- Edit demo config file by uncomment the following lines:
```
LOQUSDB_SETTINGS = [
     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "default"},
     {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "id": "hejhej"},
     {"binary_path": "/bin/yetanother/loqusdb", "id": "Mayo"},
 ]
```
- Clone and install in a dedicated environment [loqusDB executable](https://github.com/moonso/loqusdb).
- Replace the binary_path of the 3 instances in the settings with the path to the loqus binary, something like this: `/Users/your-username/miniconda3/envs/loqus_env_name/bin/loqusdb`

**How to test**:
1. On master branch start scout demo and go to [institute settings page](http://localhost:5000/overview/cust000/settings)
2. Note that the the loqusdb id select has only one option: "default".
3. Switch to this branch and the 3 options should be shown
4. Test the branch on clinical-db stage and make sure that variants have observations

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
