### PR TITLE
Remove eyesore yellow and replace it with background color in even lines of lists (variant and case pages)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not choke if case is missing research variants when research requested
 - Improve create new gene panel form validation
 - Make XM- transcripts less visible if they don't overlap with transcript refseq_id in variant page
+- Color of gene panels and comments panels on cases and variant pages
 
 ## [4.29.1]
 ### Added

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -39,7 +39,7 @@
   {% set comments = comments|list %}
   <h6 class="comments-title"></i><i class="far fa-comments"></i> Comments ({{ comments|length }})</h6>
   <div class="list-group" style="max-height:200px; overflow-y: scroll;">
-    <style>.even { background-color: #fdf5ca }</style>
+    <style>.even { background-color: #f6f6f6 }</style>
     <style>.odd { background-color: #d5e8f0 }</style>
     {% for comment in comments %}
       <div class="row ml-1 alert {% if loop.index0 % 2 %}even{% else %}odd{% endif %}">


### PR DESCRIPTION
The page of a demo case from a genomic course is squished to display both lists

Before:

![image](https://user-images.githubusercontent.com/28093618/109834713-c897a800-7c42-11eb-99bf-5768c1f793ac.png)

----

After:

![image](https://user-images.githubusercontent.com/28093618/109834413-7060a600-7c42-11eb-8fe3-c555c682ca77.png)


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
