### PR TITLE
Use VEP RefSeq ID if RefSeq list is empty in RefSeq transcripts overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [X.X.X]
 ### Added
 ### Fixed
+- Use VEP RefSeq ID if list if available in RefSeq transcripts overview
 ### Changed
 
 ## [4.30.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [X.X.X]
 ### Added
 ### Fixed
-- Use VEP RefSeq ID if list if available in RefSeq transcripts overview
+- Use VEP RefSeq ID if RefSeq list is empty in RefSeq transcripts overview
 ### Changed
 
 ## [4.30.1]

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -28,7 +28,7 @@
 
 {% macro transcripts_overview(variant) %}
   <div class="card panel-default">
-    <div data-toggle='tooltip' class="panel-heading" title="Displays all transcripts with RefSeq id. The complete list of transcripts is available below. One ensembl transcript can have multiple RefSeq ids. Blue color indicates that the ensembl transcript is mapped to a transcript that is canonical according to HGNC">
+    <div data-toggle='tooltip' class="panel-heading" title="Displays all transcripts with RefSeq id. The complete list of transcripts is available below. One ensembl transcript can have multiple RefSeq ids. Blue color indicates that the ensembl transcript is mapped to a transcript that is primary according to HGNC">
       RefSeq transcripts</div>
     <div class=card-body>
       <table id="transcript_overview_table" class="table table-bordered table-hover table-sm">

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -54,13 +54,16 @@
                   <td>
                     {% set decorated_txs = [] %}
                     {% for tx_id in transcript.refseq_identifiers %}
-                      {% if tx_id.startswith('XM') and transcript.refseq_id != tx_id %}
+                      {% if tx_id.startswith('XM') and transcript.refseq_id != tx_id %} <!-- tx of minor importance -->
                         {% set decorated_tx = '<font class="text-muted font-italic">' + tx_id + '</font>' %}
                       {% else %}
-                        {% set decorated_tx = tx_id %}
+                        {% set decorated_tx = tx_id %} <!-- tx with refseq ID -->
                       {% endif %}
                       {{ decorated_txs.append(decorated_tx)|default("", true) }}
                     {% endfor %}
+                    {% if transcript.transcript_id.startswith('NM') and not decorated_txs %} <!-- VEP RefSeq annotation, use tx id as refseq ID -->
+                      {{ decorated_txs.append(transcript.transcript_id)|default("", true) }}
+                    {% endif %}
                     {{ decorated_txs|join(", ")|safe or '<font class="text-muted font-italic">Check complete list of transcripts</font>'|safe }}
                   </td> <!-- Refseq IDs -->
                   <td class="d-flex align-items-center">


### PR DESCRIPTION
Fix #2404, specifically https://github.com/Clinical-Genomics/scout/issues/2404#issuecomment-790530420

VEP refseq transcripts have always an empty list of refseq ids so the field prints always "Check complete list of transcripts". This fix replaces that message with the transcripts ID, which is a refseq ID.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
