### PR TITLE
Patch release 4.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+
 ## [X.X.X]
 ### Added
 ### Fixed


### PR DESCRIPTION
## [4.30.2]
### Added
### Fixed
- Use VEP RefSeq ID if RefSeq list is empty in RefSeq transcripts overview
- Bug creating variant links for variants with no end_chrom
### Changed

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
