### PR TITLE
A more compact case groups panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- A more compact case groups panel
 
 ## [4.30.2]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -257,7 +257,7 @@
               </div>
               <input type="text" class="form-control" name="label" id="case_group_label-{{group_id}}" placeholder="{{ case_group_label[group_id] }}">
             </div>
-            <button type="submit" class="btn btn-secondary btn-sm mb-2">save label</button>
+            <button type="submit" class="btn btn-secondary btn-sm mb-2">Save label</button>
             <button type="button" class="btn btn-secondary btn-sm mb-2 ml-3 text-right" data-toggle="modal" data-target="#add-case-group-{{group_id}}">
               <i class="fas fa-user-plus" data-toggle='tooltip' title="Add other case to this group"></i>
             </button>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -243,7 +243,7 @@
       <span>
         <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}} groups)
       </span>
-      <span class="float-sm-right" data-toggle='tooltip' title="Create a new group containing case {{case.display_name}}"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>New group</a></span>
+      <span class="float-sm-right" data-toggle='tooltip' data-placement="right" title="Create a new group containing case {{case.display_name}}"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>New group</a></span>
     </div>
     <div class="card-body">
       <div class="list-group" style="max-height:200px; overflow-y: scroll;">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -241,7 +241,7 @@
   <div class="card panel-default" id="case_groups">
     <div class="panel-heading">
       <span data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
-        <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}})
+        <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}} groups)
       </span>
       <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>new group</a></span>
     </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -265,15 +265,15 @@
 
           <div class="col-12">
             {% for grouped_case in case_group %}
-              <div class="mb-2">
+              <span class="badge badge-pill badge-light">
                 <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}"">{{ grouped_case.display_name }}</a>
-                    <span class="pull-right">
-                      <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
+                  <span>
+                    <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
                         <span class="fa fa-remove"></span></a>
-                    </span>
-              </div>
+                  </span>
+              </span>
             {% endfor %}
-            <hr style="height:1px;">
+            <hr style="height:2px;">
           </div>
 
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -249,8 +249,12 @@
       <div class="list-group" style="max-height:200px; overflow-y: scroll;">
       {% if case_groups %}
         {% for group_id, case_group in case_groups.items() %}
+          {% if loop.index > 1 %}
+            <span><hr style="height:10px;"></span>
+          {% endif %}
+
           {{ modal_add_to_group(group_id, case_group, case_group_label[group_id]) }}
-          <form class="form-inline mt-2" action="{{ url_for('cases.case_group_update_label', case_group=group_id)}}" method="POST">
+          <form class="form-inline" action="{{ url_for('cases.case_group_update_label', case_group=group_id)}}" method="POST">
             <div class="input-group mb-2 mr-sm-2">
               <div class="input-group-prepend">
                 <div class="input-group-text"><i class="fa fa-users"></i></div>
@@ -273,9 +277,7 @@
                   </span>
               </span>
             {% endfor %}
-            <hr style="height:2px;">
           </div>
-
 
         {% endfor %}
       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -238,12 +238,12 @@
 {% endmacro %}
 
 {% macro group_panel() %}
-  <div class="card panel-default" id="case_groups">
+  <div class="card panel-default" id="case_groups" data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups."">
     <div class="panel-heading">
-      <span data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
+      <span>
         <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}} groups)
       </span>
-      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>New group</a></span>
+      <span class="float-sm-right" data-toggle='tooltip' title="Create a new group containing case {{case.display_name}}"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>New group</a></span>
     </div>
     <div class="card-body">
       <div class="list-group" style="max-height:200px; overflow-y: scroll;">
@@ -278,8 +278,8 @@
 
 
         {% endfor %}
-        </div> <!-- end of <div class="list-group" style="max-height:200px; overflow-y: scroll;" -->
       {% endif %}
+      </div> <!-- end of <div class="list-group" style="max-height:200px; overflow-y: scroll;" -->
     </div>
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -243,7 +243,7 @@
       <span data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
         <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}} groups)
       </span>
-      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>new group</a></span>
+      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>New group</a></span>
     </div>
     <div class="card-body">
       <div class="list-group" style="max-height:200px; overflow-y: scroll;">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -238,50 +238,47 @@
 {% endmacro %}
 
 {% macro group_panel() %}
-  <div class="card panel-default">
-    <div data-toggle='tooltip' class="panel-heading" title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
-      <span class="fa fa-users"></span>&nbsp;Group connected cases
-      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-3"></span>new group</a></span>
+  <div class="card panel-default" id="case_groups">
+    <div class="panel-heading">
+      <span data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
+        <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}})
+      </span>
+      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-1"></span>new group</a></span>
     </div>
     <div class="card-body">
+      <div class="list-group" style="max-height:200px; overflow-y: scroll;">
       {% if case_groups %}
         {% for group_id, case_group in case_groups.items() %}
           {{ modal_add_to_group(group_id, case_group, case_group_label[group_id]) }}
-          <div class="row" >
-            <div class="col">
-              <form action="{{ url_for('cases.case_group_update_label', case_group=group_id)}}" method="POST">
-                <div class="input-group">
-                  <div class="input-group-prepend"><span class="fa fa-users input-group-text"></span></div>
-
-                  <input type="text" class="form-control" name="label" id="case_group_label-{{group_id}}" placeholder="{{ case_group_label[group_id] }}">
-                    <button type="submit" class="input-group-append btn btn-outline-secondary text-secondary form-control">Label</button>
-                </div>
-              </form>
-            </div>
-            <div class="col text-right">
-              <div class="btn-group">
-                <button type="button" class="btn btn-outline-secondary form-control" data-toggle="modal" data-target="#add-case-group-{{group_id}}">
-                  <span class="fa fa-plus-square-o"></span>&nbsp;Bind other case
-                </button>
+          <form class="form-inline mt-2" action="{{ url_for('cases.case_group_update_label', case_group=group_id)}}" method="POST">
+            <div class="input-group mb-2 mr-sm-2">
+              <div class="input-group-prepend">
+                <div class="input-group-text"><i class="fa fa-users"></i></div>
               </div>
+              <input type="text" class="form-control" name="label" id="case_group_label-{{group_id}}" placeholder="{{ case_group_label[group_id] }}">
             </div>
-          </div>
-          <div class="row mb-4">
-            <div class="col-12">
-              <ul class="list-group">
-              {% for grouped_case in case_group %}
-                <li class="list-group-item">
-                    <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}"">{{ grouped_case.display_name }}</a>
+            <button type="submit" class="btn btn-secondary btn-sm mb-2">save label</button>
+            <button type="button" class="btn btn-secondary btn-sm mb-2 ml-3 text-right" data-toggle="modal" data-target="#add-case-group-{{group_id}}">
+              <i class="fas fa-user-plus" data-toggle='tooltip' title="Add other case to this group"></i>
+            </button>
+          </form>
+
+          <div class="col-12">
+            {% for grouped_case in case_group %}
+              <div class="mb-2">
+                <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}"">{{ grouped_case.display_name }}</a>
                     <span class="pull-right">
                       <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
                         <span class="fa fa-remove"></span></a>
                     </span>
-                </li>
-              {% endfor %}
-              </ul>
-            </div>
+              </div>
+            {% endfor %}
+            <hr style="height:1px;">
           </div>
+
+
         {% endfor %}
+        </div> <!-- end of <div class="list-group" style="max-height:200px; overflow-y: scroll;" -->
       {% endif %}
     </div>
   </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -239,7 +239,10 @@
 
 {% macro group_panel() %}
   <div class="card panel-default">
-    <div data-toggle='tooltip' class="panel-heading" title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups."><span class="fa fa-users"></span>&nbsp;Group connected cases</div>
+    <div data-toggle='tooltip' class="panel-heading" title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
+      <span class="fa fa-users"></span>&nbsp;Group connected cases
+      <span class="float-sm-right"><a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="text-white"><span class="fas fa-plus text-white mr-3"></span>new group</a></span>
+    </div>
     <div class="card-body">
       {% if case_groups %}
         {% for group_id, case_group in case_groups.items() %}
@@ -280,7 +283,6 @@
           </div>
         {% endfor %}
       {% endif %}
-      <a href="{{ url_for('cases.add_case_group',institute_id=institute._id, case_name=case.display_name) }}" class="btn btn-primary btn-xs text-white"><span class="fa fa-user-plus text-white mr-3"></span>Create new group</a>
     </div>
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -993,7 +993,7 @@ def add_case_group(institute_id, case_name):
 
     controllers.add_case_group(store, current_user, institute_id, case_name, group_id)
 
-    return redirect(request.referrer)
+    return redirect(request.referrer + '#case_groups')
 
 
 @cases_bp.route("/<institute_id>/<case_name>/<case_group>/remove_case_group", methods=["GET"])
@@ -1001,7 +1001,7 @@ def remove_case_group(institute_id, case_name, case_group):
     """Unbind a case group from a case. Remove the group if it is no longer in use."""
     controllers.remove_case_group(store, current_user, institute_id, case_name, case_group)
 
-    return redirect(request.referrer)
+    return redirect(request.referrer + '#case_groups')
 
 
 @cases_bp.route("/<case_group>/case_group_update_label", methods=["POST"])
@@ -1011,7 +1011,7 @@ def case_group_update_label(case_group):
 
     controllers.case_group_update_label(store, case_group, label)
 
-    return redirect(request.referrer)
+    return redirect(request.referrer + '#case_groups')
 
 
 @cases_bp.route("/<institute_id>/<case_name>/download-hpo-genes", methods=["GET"])

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -334,13 +334,21 @@ def test_add_case_group(app, case_obj, institute_obj):
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
 
+        # Given a page referrer (request to add case group starts from case page)
+        referer = url_for(
+            "cases.case",
+            institute_id=institute_obj["internal_id"],
+            case_name=case_obj["display_name"],
+        )
+
         # WHEN we invoke the add group endpoint with GET
         resp = client.get(
             url_for(
                 "cases.add_case_group",
                 institute_id=institute_obj["_id"],
                 case_name=case_obj["display_name"],
-            )
+            ),
+            headers={"referer": referer},
         )
 
         # THEN the response should be a redirect
@@ -360,6 +368,13 @@ def test_remove_case_group(app, case_obj, institute_obj):
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
 
+        # Given a page referrer (request to remove case group starts from case page)
+        referer = url_for(
+            "cases.case",
+            institute_id=institute_obj["internal_id"],
+            case_name=case_obj["display_name"],
+        )
+
         # WHEN we invoke the add group endpoint with GET
         resp = client.get(
             url_for(
@@ -367,7 +382,8 @@ def test_remove_case_group(app, case_obj, institute_obj):
                 institute_id=institute_obj["_id"],
                 case_name=case_obj["display_name"],
                 case_group=group_id,
-            )
+            ),
+            headers={"referer": referer},
         )
 
         # THEN the response should be a redirect


### PR DESCRIPTION
Fix #2418 

Changed
- Added number of group of cases in panel header
- Made a scrollable div so it doesn't expand so much if there are many cases
- Moved the "add new group" button to the panel header (top right corner)
- Made the whole thing more compact
- Every time a change happens the page redirects to the panel as an anchor

Before:

![image](https://user-images.githubusercontent.com/28093618/110500709-c8dbeb80-80f9-11eb-8921-ebfb89c53044.png)


After:

![image](https://user-images.githubusercontent.com/28093618/110500837-e446f680-80f9-11eb-8a28-8a255216c039.png)



**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
