### PR TITLE
Export primary HGNC transcript in variantS export file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [X.X.X]
 ### Added
 - gnomAD annotation field in admin guide
+- Primary HGNC transcript info in variant export files
 ### Fixed
 - Replace old docs link www.clinicalgenomics.se/scout with new https://clinical-genomics.github.io/scout
 ### Changed

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -6,8 +6,8 @@ EXPORT_HEADER = [
     "Position_Change",
     "HGNC_id",
     "Gene_name",
-    "Canonical_transcript|HGVS|protein_change",
-    "Primary_transcript|HGVS|protein_change",
+    "Canonical_transcript/HGVS/protein_change",
+    "Primary_transcript/HGVS/protein_change",
 ]
 
 MT_EXPORT_HEADER = [

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -6,9 +6,8 @@ EXPORT_HEADER = [
     "Position_Change",
     "HGNC_id",
     "Gene_name",
-    "Canonical_transcript",
-    "Canonical_transcript_HGVS",
-    "Canonical_transcript_protein_change",
+    "Canonical_transcript | HGVS |protein_change",
+    "Primary_transcript | HGVS | protein_change",
 ]
 
 MT_EXPORT_HEADER = [

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -6,8 +6,8 @@ EXPORT_HEADER = [
     "Position_Change",
     "HGNC_id",
     "Gene_name",
-    "Canonical_transcript | HGVS | protein_change",
-    "Primary_transcript | HGVS | protein_change",
+    "Canonical_transcript|HGVS|protein_change",
+    "Primary_transcript|HGVS|protein_change",
 ]
 
 MT_EXPORT_HEADER = [

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -6,7 +6,7 @@ EXPORT_HEADER = [
     "Position_Change",
     "HGNC_id",
     "Gene_name",
-    "Canonical_transcript | HGVS |protein_change",
+    "Canonical_transcript | HGVS | protein_change",
     "Primary_transcript | HGVS | protein_change",
 ]
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -514,7 +514,7 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         primary_txs += gene_primary_txs
 
     for item in [gene_ids, gene_names, canonical_txs, primary_txs]:
-        gene_info.append(";".join(str(x) for x in item))
+        gene_info.append("-".join(str(x) for x in item))
 
     return gene_info
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -475,11 +475,11 @@ def match_gene_txs_variant_txs(variant_gene, hgnc_gene):
 
             # collect info from primary transcripts
             if tx_refseq in hgnc_gene.get("primary_transcripts"):
-                primary_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+                primary_txs.append("/".join([tx_refseq or tx_id, hgvs, pt_change]))
 
             # collect info from canonical transcript
-            if tx_id == variant_gene.get("canonical_transcript"):
-                canonical_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+            if var_tx.get("is_canonical") is True:
+                canonical_txs.append("/".join([tx_refseq or tx_id, hgvs, pt_change]))
 
     return canonical_txs, primary_txs
 
@@ -514,7 +514,7 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         primary_txs += gene_primary_txs
 
     for item in [gene_ids, gene_names, canonical_txs, primary_txs]:
-        gene_info.append("-".join(str(x) for x in item))
+        gene_info.append(" | ".join(str(x) for x in item))
 
     return gene_info
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -382,7 +382,7 @@ def download_variants(store, case_obj, variant_objs):
     headers.add(
         "Content-Disposition",
         "attachment",
-        filename=str(case_obj["display_name"]) + "-filtered_sv-variants.csv",
+        filename=str(case_obj["display_name"]) + "-filtered-variants.csv",
     )
     # return a csv with the exported variants
     return Response(

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -467,15 +467,19 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         if decorated_gene is None:
             continue
         gene_names.append(decorated_gene.get("hgnc_symbol"))
+        # collect only primary of refseq trancripts
+        filtered_decorated_genes_txs = [
+            tx
+            for tx in decorated_gene.get("transcripts", [])
+            if tx.get("refseq_identifiers") or tx.get("is_primary")
+        ]
 
-        for tx in decorated_gene.get("transcripts", []):
-            # collect only primary of refseq trancripts
-            if not tx.get("refseq_identifiers") and tx.get("is_primary") is False:
-                continue
+        for tx in filtered_decorated_genes_txs:
             tx_id = tx["ensembl_transcript_id"]
 
-            # collect specific info (hgvs and pt_change) for the transcript
+            # collect specific info (hgvs and pt_change) from the variant gene transcript
             for var_tx in gene_obj.get("transcripts", []):
+
                 if var_tx["transcript_id"] != tx_id:
                     continue
                 tx_refseq = tx.get("refseq_id")

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -478,9 +478,7 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         for tx in filtered_gene_txs:
             tx_id = tx["ensembl_transcript_id"]
 
-            var_tx = variant_txs_dict.get(tx_id)
-            if var_tx is None:
-                continue
+            var_tx = variant_txs_dict.get(tx_id) or {}
 
             tx_refseq = tx.get("refseq_id")
             hgvs = var_tx.get("coding_sequence_name") or "-"

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -29,7 +29,6 @@ from scout.constants import (
 from scout.constants.acmg import ACMG_CRITERIA
 from scout.constants.variants_export import EXPORT_HEADER, VERIFIED_VARIANTS_HEADER
 from scout.export.variant import export_verified_variants
-from scout.server.blueprints.genes.controllers import gene
 from scout.server.blueprints.variant.utils import predictions, clinsig_human
 from scout.server.links import str_source_link, ensembl, cosmic_link
 from scout.server.utils import (

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -444,6 +444,47 @@ def variant_export_lines(store, case_obj, variants_query):
     return export_variants
 
 
+def _match_gene_txs_variant_txs(variant_gene, decorated_gene, variant_txs_dict):
+    """Match gene transcript with variant transcript to extract primary and canonical tx info
+
+    Args:
+        variant_gene(dict): A gene dictionary with limited info present in variant.genes.
+                        contains info on which transcript is canonical, hgvs and protein changes
+        decorated_gene(dict): A gene object obtained from the database containing a complete list of transcripts.
+        variant_txs_dict(dict): dictionary with all transcripts obtained from the variant gene, with tx IDs as keys
+
+    Returns:
+        canonical_txs, primary_txs(tuple): columns containing canonical and primary transcript info
+    """
+    canonical_txs = []
+    primary_txs = []
+
+    for tx in decorated_gene.get("transcripts", []):
+        tx_id = tx["ensembl_transcript_id"]
+
+        # collect only primary of refseq trancripts from decorated gene
+        if not tx.get("refseq_identifiers") and tx.get("is_primary") is False:
+            continue
+
+        var_tx = variant_txs_dict.get(tx_id) or {}
+        if var_tx is None:
+            continue
+
+        tx_refseq = tx.get("refseq_id")
+        hgvs = var_tx.get("coding_sequence_name") or "-"
+        pt_change = var_tx.get("protein_sequence_name") or "-"
+
+        # collect info from primary transcripts
+        if tx_refseq in decorated_gene.get("primary_transcripts"):
+            primary_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+
+        # collect info from canonical transcript
+        if tx_id == variant_gene.get("canonical_transcript"):
+            canonical_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+
+    return canonical_txs, primary_txs
+
+
 def variant_export_genes_info(store, gene_list, genome_build="37"):
     """Adds gene info to a list of fields corresponding to a variant to be exported.
 
@@ -467,30 +508,14 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         if decorated_gene is None:
             continue
         gene_names.append(decorated_gene.get("hgnc_symbol"))
-        # collect only primary of refseq trancripts from decorated gene
-        filtered_gene_txs = [
-            tx
-            for tx in decorated_gene.get("transcripts", [])
-            if tx.get("refseq_identifiers") or tx.get("is_primary")
-        ]
         variant_txs_dict = {tx["transcript_id"]: tx for tx in gene_obj.get("transcripts", [])}
 
-        for tx in filtered_gene_txs:
-            tx_id = tx["ensembl_transcript_id"]
+        gene_canonical_txs, gene_primary_txs = _match_gene_txs_variant_txs(
+            gene_obj, decorated_gene, variant_txs_dict
+        )
 
-            var_tx = variant_txs_dict.get(tx_id) or {}
-
-            tx_refseq = tx.get("refseq_id")
-            hgvs = var_tx.get("coding_sequence_name") or "-"
-            pt_change = var_tx.get("protein_sequence_name") or "-"
-
-            # collect info from primary transcripts
-            if tx_refseq in decorated_gene.get("primary_transcripts"):
-                primary_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
-
-            # collect info from canonical transcript
-            if tx_id == gene_obj.get("canonical_transcript"):
-                canonical_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+        canonical_txs += gene_canonical_txs
+        primary_txs += gene_primary_txs
 
     for item in [gene_ids, gene_names, canonical_txs, primary_txs]:
         gene_info.append(";".join(str(x) for x in item))

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -467,32 +467,32 @@ def variant_export_genes_info(store, gene_list, genome_build="37"):
         if decorated_gene is None:
             continue
         gene_names.append(decorated_gene.get("hgnc_symbol"))
-        # collect only primary of refseq trancripts
-        filtered_decorated_genes_txs = [
+        # collect only primary of refseq trancripts from decorated gene
+        filtered_gene_txs = [
             tx
             for tx in decorated_gene.get("transcripts", [])
             if tx.get("refseq_identifiers") or tx.get("is_primary")
         ]
+        variant_txs_dict = {tx["transcript_id"]: tx for tx in gene_obj.get("transcripts", [])}
 
-        for tx in filtered_decorated_genes_txs:
+        for tx in filtered_gene_txs:
             tx_id = tx["ensembl_transcript_id"]
 
-            # collect specific info (hgvs and pt_change) from the variant gene transcript
-            for var_tx in gene_obj.get("transcripts", []):
+            var_tx = variant_txs_dict.get(tx_id)
+            if var_tx is None:
+                continue
 
-                if var_tx["transcript_id"] != tx_id:
-                    continue
-                tx_refseq = tx.get("refseq_id")
-                hgvs = var_tx.get("coding_sequence_name") or "-"
-                pt_change = var_tx.get("protein_sequence_name") or "-"
+            tx_refseq = tx.get("refseq_id")
+            hgvs = var_tx.get("coding_sequence_name") or "-"
+            pt_change = var_tx.get("protein_sequence_name") or "-"
 
-                # collect info from primary transcripts
-                if tx_refseq in decorated_gene.get("primary_transcripts"):
-                    primary_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+            # collect info from primary transcripts
+            if tx_refseq in decorated_gene.get("primary_transcripts"):
+                primary_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
 
-                # collect info from canonical transcript
-                if tx_id == gene_obj.get("canonical_transcript"):
-                    canonical_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
+            # collect info from canonical transcript
+            if tx_id == gene_obj.get("canonical_transcript"):
+                canonical_txs.append("|".join([tx_refseq or tx_id, hgvs, pt_change]))
 
     for item in [gene_ids, gene_names, canonical_txs, primary_txs]:
         gene_info.append(";".join(str(x) for x in item))

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -239,12 +239,12 @@ def test_match_gene_txs_variant_txs():
 
     variant_gene = {
         "hgnc_id": 17284,
-        "canonical_transcript": "ENST00000357628",
         "transcripts": [
             {
                 "transcript_id": "ENST00000357628",  # canonical
                 "coding_sequence_name": "c.903G>T",
                 "protein_sequence_name": "p.Gln301His",
+                "is_canonical": True,
             },
             {
                 "transcript_id": "ENST00000393329",  # primary

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -272,8 +272,8 @@ def test_match_gene_txs_variant_txs():
     }
 
     canonical_txs, primary_txs = match_gene_txs_variant_txs(variant_gene, hgnc_gene)
-    assert canonical_txs == ["NM_015450|c.903G>T|p.Gln301His"]
-    assert primary_txs == ["NM_001042594|c.510G>T|p.Gln170His"]
+    assert canonical_txs == ["NM_015450/c.903G>T/p.Gln301His"]
+    assert primary_txs == ["NM_001042594/c.510G>T/p.Gln170His"]
 
 
 def test_variant_csv_export(real_variant_database, case_obj):


### PR DESCRIPTION
This PR adds a functionality:
- merges 3 columns relative to the canonical transcript into one: `Canonical_transcript|HGVS|protein_change`
- creates another column for the primary transcript:  `Primary_transcript|HGVS|protein_change`
- Fixes a bug caused by using default genome build 37 when exporting these info from variants page

Partial fix #2398 and possible fix #2429 

**How to test**:
1. Go to variantS page, filter and export variants.
2. Check exported transcripts against transcripts specified on each variant's page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
