### PR TITLE
Include also genes from dynamic_gene_list in HPO gene list export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [X.X.X]
 ### Added
 - gnomAD annotation field in admin guide
+- Export also dynamic panel genes not associated to an HPO term when downloading the HPO panel
 ### Fixed
 - Replace old docs link www.clinicalgenomics.se/scout with new https://clinical-genomics.github.io/scout
 ### Changed

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -488,7 +488,8 @@ class CaseHandler(object):
             {
                 "$set": {
                     "dynamic_gene_list": dynamic_gene_list,
-                    "dynamic_panel_phenotypes": phenotype_ids or [],
+                    "dynamic_panel_phenotypes": phenotype_ids
+                    or case.get("dynamic_panel_phenotypes", []),
                 }
             },
             return_document=pymongo.ReturnDocument.AFTER,

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -488,8 +488,7 @@ class CaseHandler(object):
             {
                 "$set": {
                     "dynamic_gene_list": dynamic_gene_list,
-                    "dynamic_panel_phenotypes": phenotype_ids
-                    or case.get("dynamic_panel_phenotypes", []),
+                    "dynamic_panel_phenotypes": phenotype_ids or [],
                 }
             },
             return_document=pymongo.ReturnDocument.AFTER,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -655,7 +655,8 @@ def phenotypes_genes(store, case_obj):
 
     if case_obj.get("dynamic_gene_list"):
         gene_list = [
-            gene.get("hgnc_symbol") or gene["hgnc_id"] for gene in case_obj["dynamic_gene_list"]
+            gene.get("hgnc_symbol") or str(gene["hgnc_id"])
+            for gene in case_obj["dynamic_gene_list"]
         ]
         hpo_genes["Case dynamic gene list"] = {
             "description": "custom",

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -630,7 +630,7 @@ def phenotypes_genes(store, case_obj):
     # Loop over the dynamic phenotypes of a case
     for hpo_id in case_obj.get("dynamic_panel_phenotypes", []):
         hpo_term = store.hpo_term(hpo_id)
-        # Check that HPO term exists in dat§abase
+        # Check that HPO term exists in database
         if hpo_term is None:
             LOG.warning(f"Could not find HPO term with ID '{hpo_id}' in database")
             continue

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -660,6 +660,7 @@ def phenotypes_genes(store, case_obj):
             gene.get("hgnc_symbol") or str(gene["hgnc_id"])
             for gene in case_obj["dynamic_gene_list"]
         ]
+        unique_genes = set(gene_list)
         by_phenotype = False
 
     if by_phenotype is False:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -655,6 +655,7 @@ def phenotypes_genes(store, case_obj):
             "genes": ", ".join(sorted(gene_list)),
         }
 
+    # Case where dynamic_panel_phenotypes is empty, perhaps because user has added custom genes to HPO panel
     if not hpo_gene_list and case_obj.get("dynamic_gene_list"):
         gene_list = [
             gene.get("hgnc_symbol") or str(gene["hgnc_id"])

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -626,10 +626,11 @@ def phenotypes_genes(store, case_obj):
     by_phenotype = True  # display genes by phenotype
     unique_genes = set()
     hpo_genes = {}
+
     # Loop over the dynamic phenotypes of a case
     for hpo_id in case_obj.get("dynamic_panel_phenotypes", []):
         hpo_term = store.hpo_term(hpo_id)
-        # Check that HPO term exists in database
+        # Check that HPO term exists in dat§abase
         if hpo_term is None:
             LOG.warning(f"Could not find HPO term with ID '{hpo_id}' in database")
             continue
@@ -649,6 +650,15 @@ def phenotypes_genes(store, case_obj):
 
         hpo_genes[hpo_id] = {
             "description": hpo_term.get("description"),
+            "genes": ", ".join(sorted(gene_list)),
+        }
+
+    if case_obj.get("dynamic_gene_list"):
+        gene_list = [
+            gene.get("hgnc_symbol") or gene["hgnc_id"] for gene in case_obj["dynamic_gene_list"]
+        ]
+        hpo_genes["Case dynamic gene list"] = {
+            "description": "custom",
             "genes": ", ".join(sorted(gene_list)),
         }
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -627,8 +627,10 @@ def phenotypes_genes(store, case_obj):
     unique_genes = set()
     hpo_genes = {}
 
+    hpo_gene_list = case_obj.get("dynamic_panel_phenotypes", [])
+
     # Loop over the dynamic phenotypes of a case
-    for hpo_id in case_obj.get("dynamic_panel_phenotypes", []):
+    for hpo_id in hpo_gene_list:
         hpo_term = store.hpo_term(hpo_id)
         # Check that HPO term exists in database
         if hpo_term is None:
@@ -653,15 +655,12 @@ def phenotypes_genes(store, case_obj):
             "genes": ", ".join(sorted(gene_list)),
         }
 
-    if case_obj.get("dynamic_gene_list"):
+    if not hpo_gene_list and case_obj.get("dynamic_gene_list"):
         gene_list = [
             gene.get("hgnc_symbol") or str(gene["hgnc_id"])
             for gene in case_obj["dynamic_gene_list"]
         ]
-        hpo_genes["Case dynamic gene list"] = {
-            "description": "custom",
-            "genes": ", ".join(sorted(gene_list)),
-        }
+        by_phenotype = False
 
     if by_phenotype is False:
         hpo_genes = {}


### PR DESCRIPTION
fix #2440 

The error was probably due to the fact that only genes from HPO panels created based on HPO terms are exportable. Whenever a user adds a custom gene not associated to a specific HPO term, then this genes is added into case["dynamic_gene_list"], that is not actually contemplated in the export.

This PR fixes this

**How to test**:
1. Add one or more genes to the HPO panel by using the dedicated form:
![image](https://user-images.githubusercontent.com/28093618/111143275-e2f84c80-8585-11eb-8081-4b265eb4efbd.png)

1. Export the panel and see that the genes are written to the export file

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
