### PR TITLE
Show variant QUAL in summary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [X.X.X]
 ### Added
 - gnomAD annotation field in admin guide
+- Show variant quality (QUAL field from vcf) in the variant summary
 ### Fixed
 - Replace old docs link www.clinicalgenomics.se/scout with new https://clinical-genomics.github.io/scout
 ### Changed

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -392,6 +392,16 @@
                 {% endif %}
               </strong></span>
             </td>
+            <td>
+              QUAL
+              <span><strong>
+                {% if variant.quality %}
+                  {{ variant.quality|int }}
+                {% else %}
+                  -
+                {% endif %}
+              </strong></span>
+            </td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
As part of https://github.com/Clinical-Genomics/scout/issues/2324 this PR adds the QUAL value to the "variant summary" section of the variants detail page.

![bild](https://user-images.githubusercontent.com/11991860/111318598-7eacba00-8665-11eb-9440-d5dd86d556f6.png)

At least for Sentieon DNAscope this value is much more informative than GQ, which is always 99...

