### PR TITLE
Add lanscape orientation style to demo cancer coverage and QC report HTML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Page formatting issues whenever case and variant comments contain extremely long strings with no spaces
 ### Changed
 - A more compact case groups panel
+- Replaced demo cancer_coverage_qc_report with an up-to-date landscape-oriented one
 
 ## [4.30.2]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Page formatting issues whenever case and variant comments contain extremely long strings with no spaces
 ### Changed
 - A more compact case groups panel
-- Replaced demo cancer_coverage_qc_report with an up-to-date landscape-oriented one
+- Added landscape orientation CSS style to cancer coverage and QC demo report
 
 ## [4.30.2]
 ### Added

--- a/scout/demo/cancer_coverage_qc_report.html
+++ b/scout/demo/cancer_coverage_qc_report.html
@@ -219,20 +219,20 @@
 
 <h1 class="title">Kvalitetsrapport</h1>
 <h1 class="subtitle">Klinisk sekvensering av cancerprover</h1>
-<h3 class="date">rapportdatum: 2021-03-19 17:05</h3>
+<h3 class="date">rapportdatum: 2021-02-02 00:40</h3>
 
 <h1>Provinformation</h1>
 <dl>
 <dt>ProvID</dt>
-<dd>999-99</dd>
+<dd>FS000XXX</dd>
 <dt>Analyspanel</dt>
-<dd>gmck_solid_4.1</dd>
+<dd>gmck-solid </dd>
 <dt>Analyskod</dt>
-<dd>TEST</dd>
+<dd>PAN123456 </dd>
 <dt>Analysdatum</dt>
-<dd>2021-03-19 17:04</dd>
-<dt>Bioinformatisk analys</dt>
-<dd>BALSAMIC version 6.1.2</dd>
+<dd>2021-01-25 08:53</dd>
+<dt>Bioinformatiskanalys:</dt>
+<dd>BALSAMIC version 6.0.4</dd>
 </dl>
 <h1>Sammanfattning</h1>
 <table>
@@ -247,11 +247,18 @@
 </thead>
 <tbody>
 <tr>
+<td align="center">normal</td>
+<td align="center">KS656</td>
+<td align="center">597.0</td>
+<td align="center">1.47</td>
+<td align="center">125.82</td>
+</tr>
+<tr>
 <td align="center">tumor</td>
-<td align="center">999-99</td>
-<td align="center">792.0</td>
-<td align="center">2.03</td>
-<td align="center">253.26</td>
+<td align="center">KS454</td>
+<td align="center">805.0</td>
+<td align="center">1.57</td>
+<td align="center">131.28</td>
 </tr>
 </tbody>
 </table>
@@ -270,13 +277,22 @@
 </thead>
 <tbody>
 <tr>
+<td align="center">normal</td>
+<td align="center">KS656</td>
+<td align="center">99.84 %</td>
+<td align="center">99.5 %</td>
+<td align="center">97.72 %</td>
+<td align="center">67.94 %</td>
+<td align="center">8.52 %</td>
+</tr>
+<tr>
 <td align="center">tumor</td>
-<td align="center">999-99</td>
-<td align="center">99.93 %</td>
-<td align="center">99.9 %</td>
-<td align="center">99.58 %</td>
-<td align="center">83.35 %</td>
-<td align="center">34.01 %</td>
+<td align="center">KS454</td>
+<td align="center">99.86 %</td>
+<td align="center">99.72 %</td>
+<td align="center">98.72 %</td>
+<td align="center">87.46 %</td>
+<td align="center">30.44 %</td>
 </tr>
 </tbody>
 </table>

--- a/scout/demo/cancer_coverage_qc_report.html
+++ b/scout/demo/cancer_coverage_qc_report.html
@@ -7,6 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title> Klinisk sekvensering av cancerprover -  Kvalitetsrapport</title>
   <style type="text/css">
+  @page {
+    size: landscape;
+  }
   body {
     font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;
     max-width: 1000px;
@@ -216,20 +219,20 @@
 
 <h1 class="title">Kvalitetsrapport</h1>
 <h1 class="subtitle">Klinisk sekvensering av cancerprover</h1>
-<h3 class="date">rapportdatum: 2021-02-02 00:40</h3>
+<h3 class="date">rapportdatum: 2021-03-19 17:05</h3>
 
 <h1>Provinformation</h1>
 <dl>
 <dt>ProvID</dt>
-<dd>FS000XXX</dd>
+<dd>999-99</dd>
 <dt>Analyspanel</dt>
-<dd>gmck-solid </dd>
+<dd>gmck_solid_4.1</dd>
 <dt>Analyskod</dt>
-<dd>PAN123456 </dd>
+<dd>TEST</dd>
 <dt>Analysdatum</dt>
-<dd>2021-01-25 08:53</dd>
-<dt>Bioinformatiskanalys:</dt>
-<dd>BALSAMIC version 6.0.4</dd>
+<dd>2021-03-19 17:04</dd>
+<dt>Bioinformatisk analys</dt>
+<dd>BALSAMIC version 6.1.2</dd>
 </dl>
 <h1>Sammanfattning</h1>
 <table>
@@ -244,18 +247,11 @@
 </thead>
 <tbody>
 <tr>
-<td align="center">normal</td>
-<td align="center">KS656</td>
-<td align="center">597.0</td>
-<td align="center">1.47</td>
-<td align="center">125.82</td>
-</tr>
-<tr>
 <td align="center">tumor</td>
-<td align="center">KS454</td>
-<td align="center">805.0</td>
-<td align="center">1.57</td>
-<td align="center">131.28</td>
+<td align="center">999-99</td>
+<td align="center">792.0</td>
+<td align="center">2.03</td>
+<td align="center">253.26</td>
 </tr>
 </tbody>
 </table>
@@ -274,22 +270,13 @@
 </thead>
 <tbody>
 <tr>
-<td align="center">normal</td>
-<td align="center">KS656</td>
-<td align="center">99.84 %</td>
-<td align="center">99.5 %</td>
-<td align="center">97.72 %</td>
-<td align="center">67.94 %</td>
-<td align="center">8.52 %</td>
-</tr>
-<tr>
 <td align="center">tumor</td>
-<td align="center">KS454</td>
-<td align="center">99.86 %</td>
-<td align="center">99.72 %</td>
-<td align="center">98.72 %</td>
-<td align="center">87.46 %</td>
-<td align="center">30.44 %</td>
+<td align="center">999-99</td>
+<td align="center">99.93 %</td>
+<td align="center">99.9 %</td>
+<td align="center">99.58 %</td>
+<td align="center">83.35 %</td>
+<td align="center">34.01 %</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Fix #2442, it wasn't that complicated! Tested on Chome and Safari

**How to test**:
1. Load a demo cancer case via config file into a local scout instance:
```
scout --demo load case scout/demo/cancer.load_config.yaml
```
1. Check how the PDF version of the coverage_qc_report looks on master and this branch

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
