### PR TITLE
A more discrete case group tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing inheritance models and custom inheritance models on newly created gene panels
 - Accept only numbers in managed variants filter as position and end coordinates
 - SNP id format and links in Variant page, ClinVar submission form and general report
+- Case groups tooltip triggered only when mouse is on the panel header
 ### Changed
 - A more compact case groups panel
 - Added landscape orientation CSS style to cancer coverage and QC demo report

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -238,8 +238,8 @@
 {% endmacro %}
 
 {% macro group_panel() %}
-  <div class="card panel-default" id="case_groups" data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups."">
-    <div class="panel-heading">
+  <div class="card panel-default" id="case_groups">
+    <div class="panel-heading" data-toggle='tooltip' title="Group cases to share user variant assessments like comments, classification and dismissal. A case can be in multiple groups.">
       <span>
         <i class="fa fa-users mr-1"></i>Group connected cases ({{case_groups|length}} groups)
       </span>


### PR DESCRIPTION
fix #2476

A tiny fix to the annoying issue of a popover showing whenever the mouse is in the case groups panel (no matter where). 

With this PR it shows only if the mouse is over the panel header. My bad, I should have tested better when I touched this code last!

**How to test:**

Check moving the mouse in the case groups panel

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
