### PR TITLE
Remove mitochondrial and coverage report from cancer cases sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [X.X.X]
 ### Added
+### Changed
+- Remove mitochondrial and coverage report from cancer cases sidebar
 
 ## [4.31]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -81,9 +81,7 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">MultiQC</span>
-          <a href="{{ url_for('cases.multiqc', institute_id=institute._id,
-                              case_name=case.display_name) }}" target="_blank">
-                              <i class="fa fa-link"></i></a>
+          <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
         </div>
       </div>
     {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -87,7 +87,7 @@
         </div>
       </div>
     {% endif %}
-    {% if config.SQLALCHEMY_DATABASE_URI %}
+    {% if config.SQLALCHEMY_DATABASE_URI and case.track == "rare" %}
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">Coverage</span>
@@ -99,6 +99,7 @@
         </div>
       </div>
     {% endif %}
+    {% if case.track == "rare" %}
     <div href="#" class="bg-dark list-group-item text-white">
       <div class="d-flex flex-row flex-fill bd-highlight">
         <div>
@@ -109,6 +110,7 @@
         </div>
       </div>
     </div>
+    {% endif %}
     {% if case.cnv_report %}
       {{ cnv_report(institute._id, case) }}
     {% endif %}


### PR DESCRIPTION
Remove 2 reports from the sidebar of cancer cases: "mtDNA report" and "Coverage" report
- fix #2480 and fix #2482 

**How to test**:
1. Install this branch on clinical-db stage and go to a cancer case. 
2. See the difference in the available reports for the case between master branch and this branch

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
