### PR TITLE
fix bug #2491

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 - Remove mitochondrial and coverage report from cancer cases sidebar
+### Fixed
+- ClinVar page when dbSNP id is None
 
 ## [4.31]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -229,10 +229,10 @@
                       </td>
                     </tr>
                     {% if pinned.category == 'snv'%}
-                    {% set dbsnp_ids = pinned.dbsnp_id.split(';') if pinned.dbsnp_id else [] %}
+                    {% set dbsnp_ids = pinned.dbsnp_id.split(';') if pinned.dbsnp_id else [''] %}
                       <tr>
                         <td>var. identifier</td>
-                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{ dbsnp_ids[0] if pinned.dbsnp_id and 'rs' in dbsnp_ids[0] else ''}}" size=14 pattern="rs[0-9]+" ></td>
+                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{ dbsnp_ids[0] }}" size=14 pattern="rs[0-9]+" ></td>
                       </tr>
                     {% endif %}
                     <tr>

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -229,10 +229,10 @@
                       </td>
                     </tr>
                     {% if pinned.category == 'snv'%}
-                    {% set dbsnp_ids = pinned.dbsnp_id.split(';') %}
+                    {% set dbsnp_ids = pinned.dbsnp_id.split(';') if pinned.dbsnp_id else [] %}
                       <tr>
                         <td>var. identifier</td>
-                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{ dbsnp_ids[0] if 'rs' in dbsnp_ids[0] else ''}}" size=14 pattern="rs[0-9]+" ></td>
+                        <td><input type="text" id="Variation identifiers_{{pinned._id}}" name="variations_ids@{{pinned._id}}" value="{{ dbsnp_ids[0] if pinned.dbsnp_id and 'rs' in dbsnp_ids[0] else ''}}" size=14 pattern="rs[0-9]+" ></td>
                       </tr>
                     {% endif %}
                     <tr>


### PR DESCRIPTION
Fix #2491, that is a result if my latest changes in the ClinVar page (PR #2474). The other pages I've changed in that PR are fine, because the code first checks if the variant has a dbsnp id before splitting it.

**How to test**:
1. try to add a variant with no dbsnp id to a ClinVar submission in Scout

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
