### PR TITLE
Bugfix 2503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Show other causative once, even if several events point to it
 - Filtering variants by mitochondrial chromosome for cases with genome build=38
+- Fixed a bug in variants pages caused by MT variants without alt_frequency
 ### Changed
 ### Fixed
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -4,7 +4,7 @@
 {% macro mark_heteroplasmic_mt(individuals, samples) %}
   {% for ind in individuals if ind.phenotype == 2 %}
     {% for gt in samples|selectattr("sample_id", "equalto", ind.individual_id) %}
-      {% if gt.alt_frequency < 0.9 and gt.alt_frequency != -1 %}
+      {% if gt.alt_frequency and gt.alt_frequency < 0.9 and gt.alt_frequency != -1 %}
         <a data-toggle="tooltip" data-html="true" title="<div>Heteroplasmy: {{ (100*gt.alt_frequency)|round(3) }}%</div>">
         <span class="badge badge-warning">{{ (100*gt.alt_frequency)|round(1) }}%</span>
       {% endif %}


### PR DESCRIPTION
Current master contains a bug that caused the page to crash when filtering by SNV variants that don't contain the key `alt_frequency`

Fix #2503 

**How to test -> locally**:
1. From master branch, load demo variants with the command:  `scout setup demo`
2. start the app (from master branch): `scout --demo serve`
3. Go to variantS page (SNV variants) and filter by chromosome (MT chromosome)
4. Notice that the page crashes
5. Switch to this branch and repeat the search, the page should NOT crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [ ] tests executed by
