### PR TITLE
Simple Docker compose dev file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO gene list download now has option for clinical and non-clinical genes
 - Display gene splice junctions data in sashimi plots
 - Update case individuals with splice junctions tracks
+- Simple Docker compose for development with local build
 ### Fixed
 - Show other causative once, even if several events point to it
 - Filtering variants by mitochondrial chromosome for cases with genome build=38
@@ -20,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests for CADD score parsing function
 ### Changed
 - Refactor according to CodeFactor - mostly reuse of duplicated code
+
 
 ## [4.31.1]
 ### Added

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,51 @@
+version: '3'
+# usage:
+# (sudo) docker-compose up -d
+# (sudo) docker-compose down
+services:
+
+  mongodb:
+    image: mvertes/alpine-mongo
+    container_name: mongodb
+    ports:
+      - '27017:27017'
+    expose:
+      - '27017'
+    networks:
+      - scout-net
+
+  scout-cli:
+    build: .
+    container_name: scout-cli
+    command: scout --host mongodb setup demo
+    volumes:
+      - ./scout:/home/worker/app/scout
+      - ./volumes/scout/data:/home/worker/data
+    networks:
+      - scout-net
+    depends_on:
+      - mongodb
+
+  scout-web:
+    build: .
+    container_name: scout-web
+    expose:
+      - '5000'
+    ports:
+      - '5000:5000'
+    command: scout --host mongodb --demo serve --host 0.0.0.0
+    volumes:
+      - ./scout:/home/worker/app/scout
+      - ./volumes/scout/data:/home/worker/data
+    networks:
+      - scout-net
+    depends_on:
+      - mongodb
+
+networks:
+  scout-net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.21.0.0/24


### PR DESCRIPTION
This PR adds a simple modified docker compose to use local build dir instead of docker hub images for scout web and cli.

**How to test**:
1. `docker-compose -f docker-compose-dev.yml up`
2. Scout with a demo instance should now be available on port 5000

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
