### PR TITLE
Open variant in a new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Refactor according to CodeFactor - mostly reuse of duplicated code
 - Phenomodels language adjustment
-- Open variants in a new window from variants list
+- Open variants in a new window (from variants page)
+- Open overlapping and compund variants in a new window (from variant page)
 
 ## [4.31.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Refactor according to CodeFactor - mostly reuse of duplicated code
 - Phenomodels language adjustment
 - Open variants in a new window (from variants page)
-- Open overlapping and compund variants in a new window (from variant page)
+- Open overlapping and compound variants in a new window (from variant page)
 
 ## [4.31.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests for CADD score parsing function
 ### Changed
 - Refactor according to CodeFactor - mostly reuse of duplicated code
+- Open variants in a new window from variants list
 
 
 ## [4.31.1]

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -80,12 +80,12 @@
               <td>
                 {% if overlapping_variant.category in ("sv", "cancer_sv") %}
                   <a href="{{url_for('variant.sv_variant', institute_id=institute._id,
-                                   case_name=case.display_name, variant_id=overlapping_variant._id)}}">
+                                   case_name=case.display_name, variant_id=overlapping_variant._id)}}" target="_blank">
                     {{ overlapping_variant.display_name|truncate(20, True) }}
                   </a>
                 {% else %}
                   <a href="{{url_for('variant.variant', institute_id=institute._id,
-                                 case_name=case.display_name, variant_id=overlapping_variant._id)}}">
+                                 case_name=case.display_name, variant_id=overlapping_variant._id)}}" target="_blank">
                     {{ overlapping_variant.display_name|truncate(20, True) }}
                   </a>
                 {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -701,11 +701,11 @@
 {% if variant.category in ("sv", "cancer_sv") %}
   <a class="variants-row-item flex-small layout"
       href="{{ url_for('variant.sv_variant', institute_id=institute._id,
-                       case_name=case.display_name, variant_id=variant._id) }}" target="_blank">
+                       case_name=case.display_name, variant_id=variant._id) }}" target='_blank'>
 {% else %}
   <a class="variants-row-item flex-small layout"
      href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
-                      variant_id=variant._id) }}" target="_blank">
+                      variant_id=variant._id) }}" target='_blank'>
 {% endif %}
   {{ variant.variant_rank }}&nbsp;</a>
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -701,11 +701,11 @@
 {% if variant.category in ("sv", "cancer_sv") %}
   <a class="variants-row-item flex-small layout"
       href="{{ url_for('variant.sv_variant', institute_id=institute._id,
-                       case_name=case.display_name, variant_id=variant._id) }}">
+                       case_name=case.display_name, variant_id=variant._id) }}" target="_blank">
 {% else %}
   <a class="variants-row-item flex-small layout"
      href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name,
-                      variant_id=variant._id) }}">
+                      variant_id=variant._id) }}" target="_blank">
 {% endif %}
   {{ variant.variant_rank }}&nbsp;</a>
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -70,7 +70,7 @@
               <a href='{{ url_for("variant.variant",
                                  institute_id=institute._id,
                                  case_name=case.display_name,
-                                 variant_id=compound.variant) }}'>
+                                 variant_id=compound.variant) }}' target="_blank">
                 {{ compound.display_name|truncate(20, True) }}
               </a>
             {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -70,7 +70,7 @@
               <a href='{{ url_for("variant.variant",
                                  institute_id=institute._id,
                                  case_name=case.display_name,
-                                 variant_id=compound.variant) }}' target="_blank">
+                                 variant_id=compound.variant) }}' target='_blank'>
                 {{ compound.display_name|truncate(20, True) }}
               </a>
             {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -85,7 +85,7 @@
                   {% if variant.chromosome in ["MT","M"] %}
                     {{ mark_heteroplasmic_mt(case.individuals, variant.samples) }}
                   {% endif %}
-		</td>
+		            </td>
                 <td>{{ gene_cell(variant) }}</td>
                 <td class="text-right">{{ frequency_cell(variant) }}</td>
                 <td class="text-right">{{ cell_cadd(variant) }}</td>


### PR DESCRIPTION
- Open variants in new a new window (from variants page) . Fix #2512 
- Open overlapping variants (SNVs and SVs) in a new window, when clicked on a variant page.

**How to test**:
1. From variantS page (snvs, svs, strs, cancer vars), when a user clicks on variant link, the variant page is opened in a new window.
2. Check that overlapping variants in variant page (SNVs and SVs) open correctly in a new window. This will be better tested on clinical-db

**Expected outcome**:
- Try to open variants from all types.

**Review:**
- [ ] code approved by
- [ ] tests executed by
