### PR TITLE
gnomAD 2 --> 3 for MT variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests for CADD score parsing function
 ### Changed
 - Refactor according to CodeFactor - mostly reuse of duplicated code
+- gnomAD link points to gnomAD v.3 (build GRCh38) for mitochondrial variants.
 
 
 ## [4.31.1]

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -457,20 +457,16 @@ def exac_link(variant_obj):
 
 
 def gnomad_link(variant_obj, build=37):
-    """Compose link to gnomAD website."""
+    """Compose link to gnomAD website for a variant."""
+    url_template = (
+        "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
+        "{this[position]}-{this[reference]}-{this[alternative]}"
+    ).format(this=variant_obj)
 
     if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
-        url_template = (
-            "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
-            "{this[position]}-{this[reference]}-{this[alternative]}?dataset=gnomad_r3"
-        )
-    else:
-        url_template = (
-            "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
-            "{this[position]}-{this[reference]}-{this[alternative]}"
-        )
+        url_template += "?dataset=gnomad_r3"
 
-    return url_template.format(this=variant_obj)
+    return url_template
 
 
 def swegen_link(variant_obj):

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -459,7 +459,7 @@ def exac_link(variant_obj):
 def gnomad_link(variant_obj, build=37):
     """Compose link to gnomAD website."""
 
-    if build == 38:
+    if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
         url_template = (
             "http://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
             "{this[position]}-{this[reference]}-{this[alternative]}?dataset=gnomad_r3"


### PR DESCRIPTION
Fix #2479 --> Change the link from gnomAD v.2 (build 37) to gnomAD 3 (GRCh38) for mitochondrial variants from cases sequenced in build 37. Since MT variants are not aligned using genome build 37, but 38 (kindof).

**How to test**:
1. Locally or on clinical-db. 
2. On master, under frequency, notice that all MT variants contain links to gnomAD and that this link doesn't work (it tells you that `Mitochondrial variants are not available in gnomAD v2.1.1`
3. Switch to this branch and see that the gnomAD link works because it points to gnomAD 3 instead of gnomAD 2.1.1

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
