### PR TITLE
Feature: Make Phenomodels subpanels collapsible (#2338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display gene splice junctions data in sashimi plots
 - Update case individuals with splice junctions tracks
 - Simple Docker compose for development with local build
+- Make Phenomodels subpanels collapsible
 ### Fixed
 - Show other causative once, even if several events point to it
 - Filtering variants by mitochondrial chromosome for cases with genome build=38

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -172,9 +172,12 @@
     {% for subpanel_id, subpanel in phenomodel.subpanels.items()%}
       <div class="card">
         <div class="card-header">
-          <strong>{{subpanel.title}}</strong>&nbsp;&nbsp;<text class="text-muted">{{subpanel.subtitle}}</text>
+          <a href="#" onclick="toggleDiv('{{subpanel_id}}')">
+            <strong>{{subpanel.title}}</strong>
+          </a>
+          &nbsp;&nbsp;<text class="text-muted">{{subpanel.subtitle}}</text>
         </div>
-        <div class="card-body">
+        <div class="card-body" id="{{ subpanel_id }}">
 
           <div class="row">
             {% if "checkboxes" in subpanel %}

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -177,7 +177,7 @@
           </a>
           &nbsp;&nbsp;<text class="text-muted">{{subpanel.subtitle}}</text>
         </div>
-        <div class="card-body" id="{{ subpanel_id }}">
+        <div class="card-body" style="display: none;" id="{{ subpanel_id }}">
 
           <div class="row">
             {% if "checkboxes" in subpanel %}


### PR DESCRIPTION
This PR adds functionality to make Phenomodels subpanels collapsible

**How to test**:
1. Download branch feature/2338
2. Go to the tab Phenomodels
3. Click on a panel

**Expected outcome**:
- [x] All panels should be clickable and collapse/expand when clicked

**Review:**
- [x] code approved by CR
- [x] tests executed by JH & MOD
