### PR TITLE
Improved check if case was rerunned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed a bug in variants pages caused by MT variants without alt_frequency
 - Tests for CADD score parsing function
 - Fixed the look of IGV settings on SNV variant page
+- Cases analyzed once shown as `rerun`
 ### Changed
 - Refactor according to CodeFactor - mostly reuse of duplicated code
 - Phenomodels language adjustment

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -171,7 +171,14 @@ def cases(store, case_query, prioritized_cases_query=None, limit=100):
         case_obj["assignees"] = [
             store.user(user_email) for user_email in case_obj.get("assignees", [])
         ]
-        case_obj["is_rerun"] = len(case_obj.get("analyses", [])) > 0
+        # Check if case was re-runned
+        analyses = case_obj.get("analyses", [])
+        now = datetime.datetime.now()
+        case_obj["is_rerun"] = (
+            len(analyses) > 1
+            or analyses
+            and analyses[0].get("date", now) < case_obj.get("analysis_date", now)
+        )
         case_obj["clinvar_variants"] = store.case_to_clinVars(case_obj["_id"])
         case_obj["display_track"] = TRACKS[case_obj.get("track", "rare")]
         return case_obj


### PR DESCRIPTION
Fix #2534 

The database document of a real rerunned case looks like this (example: https://scout.scilifelab.se/cust003/15029):

![image](https://user-images.githubusercontent.com/28093618/114828673-7b266300-9dca-11eb-8034-768688e9f56a.png)

A non-rerunned case that gets the same `rerun` label looks like this (example: https://scout.scilifelab.se/cust003/46):

![image](https://user-images.githubusercontent.com/28093618/114829076-f12aca00-9dca-11eb-94cb-ecec611fcf7b.png)

This PR is fixing this behavior.

**How to test**:
- Locally, on master branch, load a case and re-create the database situation shown in the second figure above.
- Make sure that this branch doesn't show the case as rerun in the case list page.


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
