### PR TITLE
Fix #2547

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Fixed
 - iSort lint check only
+- Institute cases page crashing when a case has track:None
 
 ## [4.32]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Fixed
 - iSort lint check only
-- Institute cases page crashing when a case has track:None
+- Institute cases page crashing when a case has track:Null
 
 ## [4.32]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -779,7 +779,7 @@ class CaseHandler(object):
                     "smn_tsv": case_obj.get("smn_tsv"),
                     "status": case_obj.get("status"),
                     "sv_rank_model_version": case_obj.get("sv_rank_model_version"),
-                    "track": case_obj.get("track"),
+                    "track": case_obj.get("track", "rare"),
                     "updated_at": updated_at,
                     "variants_stats": case_obj.get("variants_stats"),
                     "vcf_files": case_obj.get("vcf_files"),

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -20,6 +20,7 @@ from scout.utils.md5 import generate_md5_key
 
 from .forms import CaseFilterForm
 
+# Do not assume all cases have a valid track set
 TRACKS = {None: "Rare Disease", "rare": "Rare Disease", "cancer": "Cancer"}
 
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -20,7 +20,7 @@ from scout.utils.md5 import generate_md5_key
 
 from .forms import CaseFilterForm
 
-TRACKS = {"rare": "Rare Disease", "cancer": "Cancer"}
+TRACKS = {None: "Rare Disease", "rare": "Rare Disease", "cancer": "Cancer"}
 
 
 def institute(store, institute_id):


### PR DESCRIPTION
Fix the bug causing the institute caseS page crashing when at least one case has track set to Null (None). It also prevents the track to be set to Null when some event triggers a case update for a case that has no "track" key saved in database

**How to test**:
=== Test 1 ===
1. With local instance of Scout open mongodb compass and set demo case track to Null:
![image](https://user-images.githubusercontent.com/28093618/115009565-b4370400-9eac-11eb-8533-51897e7daf0d.png)

2. Go to Cases page and check the difference between master branch and this branch

=== Test 2 ===
1. Load demo case
2. Remove the track key completely from case document
3. From master branch, visit a variant of this case and check the database: the track of the case should be set to Null
4. Repeat from this branch and check that instead track is set to "rare"

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
