### PR TITLE
Refactor dashboard searches 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dashboard page crashing when filters return no data
 ### Added
 ### Changed
-- Remove option to display stats for all institutes together in dashboard (admin users)
 - Pre-selected fields to run queries with in dashboard page
 
 ## [4.32.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 - Pre-selected fields to run queries with in dashboard page
+- Do not filter by any institute when fist accessing the dashboard
+
 
 ## [4.32.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Changed from deprecated db update method
 - Pre-selected fields to run queries with in dashboard page
-- Do not filter by any institute when fist accessing the dashboard
+- Do not filter by any institute when first accessing the dashboard
 
 ## [4.32.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Fixed
+- Dashboard page crashing when filters return no data
 ### Added
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dashboard page crashing when filters return no data
 ### Added
 ### Changed
+- Remove option to display stats for all institutes together in dashboard (admin users)
+- Pre-selected fields to run queries with in dashboard page
 
 ## [4.32.1]
 ### Fixed

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -71,8 +71,6 @@ def get_dashboard_info(request=None):
         store, institute_id=institute_id, slice_query=slice_query
     )
 
-    flash(general_sliced_info)
-
     total_sliced_cases = general_sliced_info["total_cases"]
     data["total_cases"] = total_sliced_cases
 

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -25,26 +25,25 @@ def institute_select_choices():
     return institute_choices
 
 
-def dashboard_form(request_form):
+def dashboard_form(request_form=None):
     """Retrieve data to be displayed on dashboard page"""
     form = DashboardFilterForm(request_form)
     form.search_institute.choices = institute_select_choices()
     return form
 
 
-def compose_slice_query(request):
+def compose_slice_query(search_type, search_term):
     """Extract a filter query given a form search term and search type
 
     Args:
-        request(flask.request): request data received by dashboard page
+        search_type(str): example -> "case:"
+        search_term(str): example -> "17867"
 
     Returns:
         slice_query(str): example case:17867
     """
     slice_query = None
-    search_type = request.form.get("search_type")
-    search_term = request.form.get("search_term")
-
+    flash(search_type)
     if search_term and search_type:
         slice_query = "".join([search_type, search_term])
 
@@ -64,7 +63,9 @@ def prepare_data(request):
     if institute_id == "None":
         institute_id = None
     data = {"dashboard_form": dashboard_form(request.form)}
-    slice_query = compose_slice_query(request)
+    slice_query = compose_slice_query(
+        request.form.get("search_type"), request.form.get("search_term")
+    )
     get_dashboard_info(store, data, institute_id, slice_query)
     return data
 

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -17,9 +17,9 @@ def institute_select_choices():
     Returns:
         institute_choices(list). Example:[(cust000, "Institute 1"), ..]
     """
-    institute_choices = [("All", "All institutes")] if current_user.is_admin else []
+    institute_choices = []
     # Collect only institutes available to the user
-    institute_objs = list(user_institutes(store, current_user))
+    institute_objs = user_institutes(store, current_user)
     for inst in institute_objs:
         institute_choices.append((inst["_id"], inst["display_name"]))
     return institute_choices
@@ -67,9 +67,6 @@ def prepare_data(request):
     if institute_id and institute_id not in allowed_insititutes:
         flash("Your user is not allowed to visualize this data", "warning")
         redirect(url_for("dashboard.index"))
-
-    if institute_id == "All":
-        institute_id = None
 
     data = {"dashboard_form": dashboard_form(request.form)}
     slice_query = compose_slice_query(

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -21,7 +21,7 @@ def institute_select_choices():
     # Collect only institutes available to the user
     institute_objs = list(user_institutes(store, current_user))
     for inst in institute_objs:
-        institute_choices.append((inst["internal_id"], inst["display_name"]))
+        institute_choices.append((inst["_id"], inst["display_name"]))
     return institute_choices
 
 

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import flash, redirect, request
+from flask import redirect, request
 from flask_login import current_user
 
 from scout.server.extensions import store
@@ -43,7 +43,6 @@ def compose_slice_query(search_type, search_term):
         slice_query(str): example case:17867
     """
     slice_query = None
-    flash(search_type)
     if search_term and search_type:
         slice_query = "".join([search_type, search_term])
 

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -59,6 +59,8 @@ def get_dashboard_info(request=None):
         data(dict): Dictionary with relevant information
     """
     institute_id = request.form.get("search_institute")
+    if institute_id == "None":
+        institute_id = None
     data = {"dashboard_form": dashboard_form(request.form)}
 
     slice_query = compose_slice_query(request)

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -58,9 +58,12 @@ def prepare_data(request):
     Returns:
         data(dict): data to be diplayed in the template
     """
-    institute_id = request.form.get("search_institute")
-
     allowed_insititutes = [inst[0] for inst in institute_select_choices()]
+
+    institute_id = request.form.get(
+        "search_institute", allowed_insititutes[0]
+    )  # GET request has no institute, select the first option of the select
+
     if institute_id and institute_id not in allowed_insititutes:
         flash("Your user is not allowed to visualize this data", "warning")
         redirect(url_for("dashboard.index"))

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -17,7 +17,7 @@ def institute_select_choices():
     Returns:
         institute_choices(list). Example:[(cust000, "Institute 1"), ..]
     """
-    institute_choices = [(None, "All institutes")] if current_user.is_admin else []
+    institute_choices = [("All", "All institutes")] if current_user.is_admin else []
     # Collect only institutes available to the user
     institute_objs = list(user_institutes(store, current_user))
     for inst in institute_objs:
@@ -59,13 +59,14 @@ def prepare_data(request):
         data(dict): data to be diplayed in the template
     """
     institute_id = request.form.get("search_institute")
-    if institute_id == "None":
-        institute_id = None
-    allowed_insititutes = [inst[0] for inst in institute_select_choices()]
 
-    if institute_id not in allowed_insititutes:
+    allowed_insititutes = [inst[0] for inst in institute_select_choices()]
+    if institute_id and institute_id not in allowed_insititutes:
         flash("Your user is not allowed to visualize this data", "warning")
         redirect(url_for("dashboard.index"))
+
+    if institute_id == "All":
+        institute_id = None
 
     data = {"dashboard_form": dashboard_form(request.form)}
     slice_query = compose_slice_query(

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -49,7 +49,7 @@ def compose_slice_query(search_type, search_term):
     return slice_query
 
 
-def prepare_data(request):
+def populate_dashboard_data(request):
     """Prepate data display object to be returned to the view
 
     Args:

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -17,7 +17,7 @@ def institute_select_choices():
     Returns:
         institute_choices(list). Example:[(cust000, "Institute 1"), ..]
     """
-    institute_choices = []
+    institute_choices = [("All", "All institutes")] if current_user.is_admin else []
     # Collect only institutes available to the user
     institute_objs = user_institutes(store, current_user)
     for inst in institute_objs:
@@ -58,6 +58,10 @@ def prepare_data(request):
     Returns:
         data(dict): data to be diplayed in the template
     """
+    data = {"dashboard_form": dashboard_form(request.form)}
+    if request.method == "GET":
+        return data
+
     allowed_insititutes = [inst[0] for inst in institute_select_choices()]
 
     institute_id = request.form.get(
@@ -68,7 +72,9 @@ def prepare_data(request):
         flash("Your user is not allowed to visualize this data", "warning")
         redirect(url_for("dashboard.index"))
 
-    data = {"dashboard_form": dashboard_form(request.form)}
+    if institute_id == "All":
+        institute_id = None
+
     slice_query = compose_slice_query(
         request.form.get("search_type"), request.form.get("search_term")
     )

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask import redirect, request
+from flask import flash, redirect, request, url_for
 from flask_login import current_user
 
 from scout.server.extensions import store
@@ -17,7 +17,7 @@ def institute_select_choices():
     Returns:
         institute_choices(list). Example:[(cust000, "Institute 1"), ..]
     """
-    institute_choices = [(None, "All institutes")]
+    institute_choices = [(None, "All institutes")] if current_user.is_admin else []
     # Collect only institutes available to the user
     institute_objs = list(user_institutes(store, current_user))
     for inst in institute_objs:
@@ -61,6 +61,12 @@ def prepare_data(request):
     institute_id = request.form.get("search_institute")
     if institute_id == "None":
         institute_id = None
+    allowed_insititutes = [inst[0] for inst in institute_select_choices()]
+
+    if institute_id not in allowed_insititutes:
+        flash("Your user is not allowed to visualize this data", "warning")
+        redirect(url_for("dashboard.index"))
+
     data = {"dashboard_form": dashboard_form(request.form)}
     slice_query = compose_slice_query(
         request.form.get("search_type"), request.form.get("search_term")

--- a/scout/server/blueprints/dashboard/forms.py
+++ b/scout/server/blueprints/dashboard/forms.py
@@ -24,4 +24,4 @@ class DashboardFilterForm(FlaskForm):
     )
     search_institute = NonValidatingSelectField("Institute", choices=[])
     search_term = TextField("Search term")
-    search = SubmitField(label="Filter")
+    search = SubmitField(label="Search")

--- a/scout/server/blueprints/dashboard/forms.py
+++ b/scout/server/blueprints/dashboard/forms.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from flask_wtf import FlaskForm
+from wtforms import SelectField, SubmitField, TextField, validators
+
+from scout.constants import CASE_SEARCH_TERMS
+
+CASE_SEARCH_KEY = [("", "")] + [
+    (value["prefix"], value["label"]) for key, value in CASE_SEARCH_TERMS.items()
+]
+
+
+class NonValidatingSelectField(SelectField):
+    """Necessary to skip validation of dynamic selects in form"""
+
+    def pre_validate(self, form):
+        pass
+
+
+class DashboardFilterForm(FlaskForm):
+    """Takes care of cases filtering in cases page"""
+
+    search_type = NonValidatingSelectField(
+        "Search by", [validators.Optional()], choices=CASE_SEARCH_KEY
+    )
+    search_institute = NonValidatingSelectField("Institute", choices=[])
+    search_term = TextField("Search term")
+    search = SubmitField(label="Filter")

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -11,7 +11,7 @@
       <!--filter panel -->
       <div>
         {{ dashboard_search_form() }}
-        {% if total_cases and total_cases == 0 %}
+        {% if total_cases == 0 %}
           <div class="alert alert-danger">Your search didn't return any results!</div>
         {% endif %}
 

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -3,9 +3,9 @@
 {% block content_main %}
   <div class="container-float mt-3">
       <ul class="nav nav-tabs nav-justified">
-        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=1)}}" class="nav-link {% if panel == '1' %}active{% endif %}"><h4>General statistics</h4></a></li>
-        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=2)}}" class="nav-link {% if panel == '2' %}active{% endif %}" ><h4>Case statistics</h4></a></li>
-        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=3)}}" class="nav-link {% if panel == '3' %}active{% endif %}"><h4>Variant statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == '1' %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>General statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == '2' %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>Case statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == '3' %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Variant statistics</h4></a></li>
       </ul>
 
       <!--filter panel -->
@@ -13,12 +13,10 @@
         {{ dashboard_search_form() }}
         {% if total_cases == 0 %}
           <div class="alert alert-danger">Your search didn't return any results!</div>
-        {% elif panel == "2" %}
-          {{ cases_stats_panels() }}
-        {% elif panel == "3" %}
-          {{ variants_stats_panels() }}
         {% else %}
           {{ general_stats_panels() }}
+          {{ cases_stats_panels() }}
+          {{ variants_stats_panels() }}
         {% endif %}
       </div>
 
@@ -58,7 +56,7 @@
 {% endmacro %}
 
 {% macro general_stats_panels() %}
-<div class="mt-3 text-center">
+<div class="mt-3 text-center" id=1>
   <div class="row">
     <div class="col-md-4">
       <h1>Samples</h1>
@@ -108,7 +106,7 @@
 {% endmacro %}
 
 {% macro cases_stats_panels() %}
-<div class="mt-3">
+<div class="mt-3" id=2>
   <div class="row">
     <div class="col-md-8">
         <canvas id="cases-bar-horiz" height="100"></canvas>
@@ -129,7 +127,7 @@
 
 
 {% macro variants_stats_panels() %}
-<div class="container-float mt-3 text-center">
+<div class="container-float mt-3 text-center" id=3>
   <div class="row">
     <div class="col-md-2"></div>
     <div class="col-md-4 d-flex justify-content-right align-items-center">
@@ -168,6 +166,7 @@
 
     $(document).ready(function(){
       text.disabled = (sel.value == "");
+      hide_div(1)
     });
 
     if(sel){
@@ -176,18 +175,29 @@
       };
     }
 
+    function hide_div(show_div){
+      for (i=1; i<4; i++) {
+        var div_el = document.getElementById(i);
+        if (i==show_div){ //show div
+          div_el.style.display = "block";
+        }
+        else{ //hode other divs
+          div_el.style.display = "none";
+        }
+      }
+    }
 
-    {% if panel == "1" and cases %}
+    {% if cases %}
       //create analysis type chart ===> general stats
       createChart(document.getElementById("ngsType").getContext('2d'), analysisTypeData( {{analysis_types|safe }} ))
       //create cases types chart
       createChart(document.getElementById("casesType").getContext('2d'), casesType( {{cases[1:]|safe}} ))
       //create pedigree info chart
       createChart(document.getElementById("pedigreeTypes").getContext('2d'), pedigreeTypes( {{pedigree|safe}} ))
-    {% elif panel == "2" and cases %}
+
       // create cases detailed stats chart ===> case stats
       createChart(document.getElementById("cases-bar-horiz").getContext('2d'), casesDetailed( {{overview|safe}}, {{cases[0].count}} ))
-    {% elif panel == "3" %}
+
       // create variants detailed stats chart ===> variants stats
       createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))
     {% endif %}

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -11,9 +11,9 @@
       <!--filter panel -->
       <div>
         {{ dashboard_search_form() }}
-        {% if total_cases == 0 %}
+        {% if total_cases and total_cases == 0 %}
           <div class="alert alert-danger">Your search didn't return any results!</div>
-        {% else %}
+        {% elif total_cases %}
           {{ general_stats_panels() }}
           {{ cases_stats_panels() }}
           {{ variants_stats_panels() }}
@@ -143,7 +143,7 @@
         {% endfor %}
       </table>
         <br>
-        <div id="card mt-3" >
+        <div class="card mt-3" >
           <form id="dowload_var_stats" action="{{ url_for('variants.download_verified')}}" method="GET">
             <button type="submit" name="verified_vars" value="verified" class="btn btn-primary btn-md">Download all verified variants for your cases</button>
           </form>

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -31,14 +31,13 @@
   <form class="mt-3 ml-3" id='form' class="form-horizontal" method='POST' action="{{ url_for('dashboard.index') }}" accept-charset="utf-8">
       <input type="hidden" value={{panel}} name="panel">
       <div class="form-row align-items-center mb-3">
-        <!--Search type select field-->
-
         <!--Search institute select-->
         <div class="col-2 ml-3">
           {{ dashboard_form.search_institute(class="form-control") }}
         </div>
-
+  
         {% if panel != "3" %}
+          <!--Search type select field-->
           <div class="col-3 ml-3">
             {{ dashboard_form.search_type(class="form-control", id="search_type") }}
           </div>

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -1,96 +1,62 @@
 {% extends "layout_bs4.html" %}
 
 {% block content_main %}
-{% set panel = panel|int %}
   <div class="container-float mt-3">
-      <ul class="nav nav-tabs" id="myTab" role="tablist">
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 1 %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>General statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 2 %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>Case statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == 3 %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Variant statistics</h4></a></li>
+      <ul class="nav nav-tabs nav-justified">
+        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=1)}}" class="nav-link {% if panel == '1' %}active{% endif %}"><h4>General statistics</h4></a></li>
+        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=2)}}" class="nav-link {% if panel == '2' %}active{% endif %}" ><h4>Case statistics</h4></a></li>
+        <li class="nav-item"><a href="{{url_for('dashboard.index', panel=3)}}" class="nav-link {% if panel == '3' %}active{% endif %}"><h4>Variant statistics</h4></a></li>
       </ul>
-    <div class="tab-content" id="tabs">
-      <div class="tab-pane" id="1">
-        {{ basic_stats() }}
-      </div>
-      <div class="tab-pane" id="2">
-        {{ cases_stats() }}
-      </div>
-      <div class="tab-pane" id="3">
-        {{ variants_stats() }}
-      </div>
-    </div>
-  </div>
 
-{% endblock %}
-
-{% macro basic_stats() %}
-<div class="card">
-  <div class="card-body">
-    {{ dashboard_search_form(1) }}
-    {{ general_stats_panels() }}
-  </div>
-</div>
-{% endmacro %}
-
-{% macro cases_stats() %}
-<div class="card">
-  <div class="card-body">
-    {{ dashboard_search_form(2) }}
-    {{ cases_stats_panels() }}
-  </div>
-</div>
-{% endmacro %}
-
-{% macro variants_stats() %}
-<div class="card">
-  <div class="card-body">
-    {{ dashboard_search_form(3) }}<br><br>
-    {{ variants_stats_panels() }}
-  </div>
-</div>
-{% endmacro %}
-
-{% macro dashboard_search_form(pane) %}
-<br>
-<form id='form' class="form-horizontal" method='POST' action="{{ url_for('dashboard.index') }}" accept-charset="utf-8">
-    <input type="hidden" value={{pane}} name="pane_id" id="pane_id">
-    <div class="row text-center">
-      <div class="col-md-4 col-sm-4">
-        {% if pane in (1,2) %}
-          <div class="input-group">
-            <span class="input-group-addon">
-              <span class="glyphicon glyphicon-search"></span>
-            </span>
-            <input type="search" class="form-control" value="{{ query if query }}" name="query" id="query" placeholder="Enter query to filter cases summarized below" onchange="update_select({% if current_user.is_admin %}true{% else %}false{% endif %})"></input>
-          </div>
+      <!--filter panel -->
+      <div>
+        {{ dashboard_search_form() }}
+        {% if total_cases == 0 %}
+          <div class="alert alert-danger">Your search didn't return any results!</div>
+        {% elif panel == "2" %}
+          {{ cases_stats_panels() }}
+        {% elif panel == "3" %}
+          {{ variants_stats_panels() }}
+        {% else %}
+          {{ general_stats_panels() }}
         {% endif %}
       </div>
-      <div class="col-md-4 col-sm-2">
-      <select name="institute" class="form-control" id="institute" onchange="this.form.submit()">
-        {% for inst in institutes %}
-          {% if inst.display_name == 'All institutes' and query and not current_user.is_admin %}
-            <option value="{{ inst._id }}" disabled>{{ inst.display_name }}</option>
-          {% else %}
-            <option value="{{ inst._id }}" {{ "selected" if inst._id == choice }} >{{ inst.display_name }}</option>
-          {% endif %}
-        {% endfor %}
-      </select>
-      </div>
-      <div class="col-md-2 col-sm-2">
-        <button type="submit" class="form-control">Search</input>
-      </div>
-    </div>
-    {% if pane in (1,2) %}
-    <br>
-    <div class="bottom-align-text">
-      Query examples:
-      {% for elem in ["case:18201", "exact_pheno:HP:0001166", "synopsis:epilepsy", "panel:NMD", "pheno_group:HP:0001250", "status:active", "cohort:pedhep", "similar_case:1820", "similar_pheno:HP:0001166,HP:0001250", "pinned:POT1", "causative:POT1", "user:Kent"]%}
-        <span class="badge badge-info">{{elem}}</span>
-      {% endfor %}
-    </div>
-    {% endif %}
-  </form>
-  <br>
+
+  </div>
+{% endblock %}
+
+
+{% macro dashboard_search_form() %}
+<div class="card">
+  <form class="mt-3 ml-3" id='form' class="form-horizontal" method='POST' action="{{ url_for('dashboard.index') }}" accept-charset="utf-8">
+      <input type="hidden" value={{panel}} name="panel">
+      <div class="form-row align-items-center mb-3">
+        <!--Search type select field-->
+
+        <!--Search institute select-->
+        <div class="col-2 ml-3">
+          {{ dashboard_form.search_institute(class="form-control") }}
+        </div>
+
+        {% if panel != "3" %}
+          <div class="col-3 ml-3">
+            {{ dashboard_form.search_type(class="form-control", id="search_type") }}
+          </div>
+          <!--Search term textfield-->
+          <div class="col-4 ml-3">
+            {{ dashboard_form.search_term(class="form-control", placeholder="Search term", id="search_term") }}
+          </div>
+
+        {% endif %}
+
+        <!--Search term textfield-->
+        <div class="col-1 ml-3">
+          {{ dashboard_form.search(class="form-control") }}
+        </div>
+
+      </div> <!--end of class="form-row align-items-center"-->
+    </form>
+  </div>
 {% endmacro %}
 
 {% macro general_stats_panels() %}
@@ -142,7 +108,6 @@
   </div> <!-- end of class="row"-->
 </div>
 {% endmacro %}
-
 
 {% macro cases_stats_panels() %}
 <div class="mt-3">
@@ -200,6 +165,17 @@
   <script src="{{ url_for('dashboard.static', filename='charts.js') }}"></script>
   <script type="text/javascript">
 
+    var sel = document.getElementById("search_type"),
+    text = document.getElementById("search_term");
+
+    $(document).ready(function(){
+      text.disabled = (sel.value == "");
+    });
+
+    sel.onchange = function(e) {
+      text.disabled = (sel.value == "");
+    };
+
     //create analysis type chart ===> general stats
     createChart(document.getElementById("ngsType").getContext('2d'), analysisTypeData( {{analysis_types|safe }} ))
 
@@ -215,35 +191,5 @@
     // create variants detailed stats chart ===> variants stats
     createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))
 
-    $(document).ready(function() {
-      hide_div({{panel}})
-    });
-
-    function hide_div(show_div){
-      for (i=1; i<4; i++) {
-        var div_el = document.getElementById(i);
-        if (i==show_div){ //show div
-          div_el.style.display = "block";
-        }
-        else{ //hode other divs
-          div_el.style.display = "none";
-        }
-      }
-    }
-
-    function update_select(admin_user){
-      var query_text = document.getElementById("query").value;
-      var sel = document.getElementById("institute");
-      if(query_text && !admin_user) {
-        sel.children[0].disabled = "disabled";
-        if(sel.options[0].selected) {
-          sel.options[0].selected = false;
-          sel.options[1].selected = true;
-        }
-      }
-      else{
-        sel.children[0].disabled = "";
-      }
-    }
   </script>
 {% endblock %}

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -35,7 +35,7 @@
         <div class="col-2 ml-3">
           {{ dashboard_form.search_institute(class="form-control") }}
         </div>
-  
+
         {% if panel != "3" %}
           <!--Search type select field-->
           <div class="col-3 ml-3">
@@ -170,9 +170,12 @@
       text.disabled = (sel.value == "");
     });
 
-    sel.onchange = function(e) {
-      text.disabled = (sel.value == "");
-    };
+    if(sel){
+      sel.onchange = function(e) {
+        text.disabled = (sel.value == "");
+      };
+    }
+
 
     {% if panel == "1" and cases %}
       //create analysis type chart ===> general stats
@@ -182,9 +185,8 @@
       //create pedigree info chart
       createChart(document.getElementById("pedigreeTypes").getContext('2d'), pedigreeTypes( {{pedigree|safe}} ))
     {% elif panel == "2" and cases %}
-    // create cases detailed stats chart ===> case stats
-    createChart(document.getElementById("cases-bar-horiz").getContext('2d'), casesDetailed( {{overview|safe}}, {{cases[0].count}} ))
-
+      // create cases detailed stats chart ===> case stats
+      createChart(document.getElementById("cases-bar-horiz").getContext('2d'), casesDetailed( {{overview|safe}}, {{cases[0].count}} ))
     {% elif panel == "3" %}
       // create variants detailed stats chart ===> variants stats
       createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -46,7 +46,6 @@
           <div class="col-4 ml-3">
             {{ dashboard_form.search_term(class="form-control", placeholder="Search term", id="search_term") }}
           </div>
-
         {% endif %}
 
         <!--Search term textfield-->
@@ -176,20 +175,21 @@
       text.disabled = (sel.value == "");
     };
 
-    //create analysis type chart ===> general stats
-    createChart(document.getElementById("ngsType").getContext('2d'), analysisTypeData( {{analysis_types|safe }} ))
-
-    {% if cases|length >0 %}
-    //create cases types chart
-    createChart(document.getElementById("casesType").getContext('2d'), casesType( {{cases[1:]|safe}} ))
+    {% if panel == "1" %}
+      //create analysis type chart ===> general stats
+      createChart(document.getElementById("ngsType").getContext('2d'), analysisTypeData( {{analysis_types|safe }} ))
+      //create cases types chart
+      createChart(document.getElementById("casesType").getContext('2d'), casesType( {{cases[1:]|safe}} ))
+      //create pedigree info chart
+      createChart(document.getElementById("pedigreeTypes").getContext('2d'), pedigreeTypes( {{pedigree|safe}} ))
+    {% elif panel == "2" %}
     // create cases detailed stats chart ===> case stats
     createChart(document.getElementById("cases-bar-horiz").getContext('2d'), casesDetailed( {{overview|safe}}, {{cases[0].count}} ))
-    {% endif %}
-    //create pedigree info chart
-    createChart(document.getElementById("pedigreeTypes").getContext('2d'), pedigreeTypes( {{pedigree|safe}} ))
 
-    // create variants detailed stats chart ===> variants stats
-    createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))
+    {% else %}
+      // create variants detailed stats chart ===> variants stats
+      createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))
+    {% endif %}
 
   </script>
 {% endblock %}

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -175,18 +175,18 @@
       text.disabled = (sel.value == "");
     };
 
-    {% if panel == "1" %}
+    {% if panel == "1" and cases %}
       //create analysis type chart ===> general stats
       createChart(document.getElementById("ngsType").getContext('2d'), analysisTypeData( {{analysis_types|safe }} ))
       //create cases types chart
       createChart(document.getElementById("casesType").getContext('2d'), casesType( {{cases[1:]|safe}} ))
       //create pedigree info chart
       createChart(document.getElementById("pedigreeTypes").getContext('2d'), pedigreeTypes( {{pedigree|safe}} ))
-    {% elif panel == "2" %}
+    {% elif panel == "2" and cases %}
     // create cases detailed stats chart ===> case stats
     createChart(document.getElementById("cases-bar-horiz").getContext('2d'), casesDetailed( {{overview|safe}}, {{cases[0].count}} ))
 
-    {% else %}
+    {% elif panel == "3" %}
       // create variants detailed stats chart ===> variants stats
       createChart(document.getElementById("var-validations").getContext('2d'), varValidations( {{variants|safe }}))
     {% endif %}

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -3,9 +3,9 @@
 {% block content_main %}
   <div class="container-float mt-3">
       <ul class="nav nav-tabs nav-justified">
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == '1' %}active{% endif %}" data-toggle="tab" onclick="hide_div(1)"><h4>General statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == '2' %}active{% endif %}" data-toggle="tab" onclick="hide_div(2)"><h4>Case statistics</h4></a></li>
-        <li class="nav-item"><a href="#" class="nav-link {% if panel == '3' %}active{% endif %}" data-toggle="tab" onclick="hide_div(3)"><h4>Variant statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == 'general' %}active{% endif %}" data-toggle="tab" onclick="hide_div('general')"><h4>General statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == 'cases' %}active{% endif %}" data-toggle="tab" onclick="hide_div('cases')"><h4>Case statistics</h4></a></li>
+        <li class="nav-item"><a href="#" class="nav-link {% if panel == 'variants' %}active{% endif %}" data-toggle="tab" onclick="hide_div('variants')"><h4>Variant statistics</h4></a></li>
       </ul>
 
       <!--filter panel -->
@@ -13,11 +13,11 @@
         {{ dashboard_search_form() }}
         {% if total_cases and total_cases == 0 %}
           <div class="alert alert-danger">Your search didn't return any results!</div>
-        {% elif total_cases %}
-          {{ general_stats_panels() }}
-          {{ cases_stats_panels() }}
-          {{ variants_stats_panels() }}
         {% endif %}
+
+        {{ general_stats_panels() }}
+        {{ cases_stats_panels() }}
+        {{ variants_stats_panels() }}
       </div>
 
   </div>
@@ -27,7 +27,7 @@
 {% macro dashboard_search_form() %}
 <div class="card">
   <form class="mt-3 ml-3" id='form' class="form-horizontal" method='POST' action="{{ url_for('dashboard.index') }}" accept-charset="utf-8">
-      <input type="hidden" value={{panel}} name="panel">
+      <input type="hidden" value="{{panel}}" name="panel">
       <div class="form-row align-items-center mb-3">
         <!--Search institute select-->
         <div class="col-2 ml-3">
@@ -56,7 +56,7 @@
 {% endmacro %}
 
 {% macro general_stats_panels() %}
-<div class="mt-3 text-center" id=1>
+<div class="mt-3 text-center" id="general">
   <div class="row">
     <div class="col-md-4">
       <h1>Samples</h1>
@@ -106,7 +106,7 @@
 {% endmacro %}
 
 {% macro cases_stats_panels() %}
-<div class="mt-3" id=2>
+<div class="mt-3" id="cases">
   <div class="row">
     <div class="col-md-8">
         <canvas id="cases-bar-horiz" height="100"></canvas>
@@ -127,7 +127,7 @@
 
 
 {% macro variants_stats_panels() %}
-<div class="container-float mt-3 text-center" id=3>
+<div class="container-float mt-3 text-center" id="variants">
   <div class="row">
     <div class="col-md-2"></div>
     <div class="col-md-4 d-flex justify-content-right align-items-center">
@@ -166,7 +166,11 @@
 
     $(document).ready(function(){
       text.disabled = (sel.value == "");
-      hide_div(1)
+      {% if not total_cases %}
+        hide_div("all");
+      {% else %}
+        hide_div('{{panel}}');
+      {% endif %}
     });
 
     if(sel){
@@ -176,12 +180,13 @@
     }
 
     function hide_div(show_div){
-      for (i=1; i<4; i++) {
-        var div_el = document.getElementById(i);
-        if (i==show_div){ //show div
+      panels = ["general", "cases", "variants"];
+      for (index = 0; index < panels.length; ++index) {
+        var div_el = document.getElementById(panels[index]);
+        if (panels[index] == show_div){ //show div
           div_el.style.display = "block";
         }
-        else{ //hode other divs
+        else{
           div_el.style.display = "none";
         }
       }

--- a/scout/server/blueprints/dashboard/views.py
+++ b/scout/server/blueprints/dashboard/views.py
@@ -1,19 +1,4 @@
-import logging
-import os
-from pprint import pprint as pp
-
-from flask import (
-    Blueprint,
-    abort,
-    current_app,
-    flash,
-    jsonify,
-    redirect,
-    render_template,
-    request,
-    send_from_directory,
-    url_for,
-)
+from flask import Blueprint, render_template, request
 
 from .controllers import get_dashboard_info
 
@@ -24,8 +9,6 @@ blueprint = Blueprint(
     static_folder="static",
     static_url_path="/dashboard/static",
 )
-
-LOG = logging.getLogger(__name__)
 
 
 @blueprint.route("/dashboard", methods=["GET", "POST"])

--- a/scout/server/blueprints/dashboard/views.py
+++ b/scout/server/blueprints/dashboard/views.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request
 
-from .controllers import get_dashboard_info
+from .controllers import prepare_data
 
 blueprint = Blueprint(
     "dashboard",
@@ -14,7 +14,7 @@ blueprint = Blueprint(
 @blueprint.route("/dashboard", methods=["GET", "POST"])
 def index():
     """Display the Scout dashboard."""
-    data = get_dashboard_info(request)
+    data = prepare_data(request)
 
     return render_template(
         "dashboard/dashboard_general.html",

--- a/scout/server/blueprints/dashboard/views.py
+++ b/scout/server/blueprints/dashboard/views.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request
 
-from .controllers import prepare_data
+from .controllers import populate_dashboard_data
 
 blueprint = Blueprint(
     "dashboard",
@@ -14,10 +14,10 @@ blueprint = Blueprint(
 @blueprint.route("/dashboard", methods=["GET", "POST"])
 def index():
     """Display the Scout dashboard."""
-    data = prepare_data(request)
+    data = populate_dashboard_data(request)
 
     return render_template(
         "dashboard/dashboard_general.html",
-        panel=request.form.get("panel", request.args.get("panel", "1")),
+        panel=request.form.get("panel", request.args.get("panel", "general")),
         **data,
     )

--- a/scout/server/blueprints/dashboard/views.py
+++ b/scout/server/blueprints/dashboard/views.py
@@ -14,9 +14,6 @@ from flask import (
     send_from_directory,
     url_for,
 )
-from flask_login import current_user
-
-from scout.server.extensions import store
 
 from .controllers import get_dashboard_info
 
@@ -34,64 +31,10 @@ LOG = logging.getLogger(__name__)
 @blueprint.route("/dashboard", methods=["GET", "POST"])
 def index():
     """Display the Scout dashboard."""
-    accessible_institutes = current_user.institutes
-    if not "admin" in current_user.roles:
-        accessible_institutes = current_user.institutes
-        if not accessible_institutes:
-            flash("Not allowed to see information - please visit the dashboard later!")
-            return redirect(url_for("cases.dahboard_general.html"))
-
-    LOG.debug("User accessible institutes: {}".format(accessible_institutes))
-    institutes = [inst for inst in store.institutes(accessible_institutes)]
-
-    # Insert a entry that displays all institutes in the beginning of the array
-    institutes.insert(0, {"_id": None, "display_name": "All institutes"})
-
-    institute_id = None
-    slice_query = None
-    panel = 1
-    if request.method == "POST":
-        institute_id = request.form.get("institute")
-        slice_query = request.form.get("query")
-        panel = request.form.get("pane_id")
-
-    elif request.method == "GET":
-        institute_id = request.args.get("institute")
-        slice_query = request.args.get("query")
-
-    # User should be restricted to their own institute if:
-    # 1) Their default institute when the page is first loaded
-    # 2) if they ask for an institute that they don't belong to
-    # 3) if they want perform a query on all institutes
-
-    if not institute_id:
-        institute_id = accessible_institutes[0]
-    elif (not current_user.is_admin) and (slice_query and institute_id == "None"):
-        institute_id = accessible_institutes[0]
-    elif (not institute_id in accessible_institutes) and not (institute_id == "None"):
-        institute_id = accessible_institutes[0]
-
-    LOG.info("Fetch all cases with institute: %s", institute_id)
-
-    data = get_dashboard_info(store, institute_id, slice_query)
-    data["institutes"] = institutes
-    data["choice"] = institute_id
-    total_cases = data["total_cases"]
-
-    LOG.info("Found %s cases", total_cases)
-    if total_cases == 0:
-        flash(
-            "no cases found for institute {} (with that query) - please visit the dashboard later!".format(
-                institute_id
-            ),
-            "info",
-        )
-    #        return redirect(url_for('cases.index'))
+    data = get_dashboard_info(request)
 
     return render_template(
         "dashboard/dashboard_general.html",
-        institute=institute_id,
-        query=slice_query,
-        panel=panel,
-        **data
+        panel=request.form.get("panel", request.args.get("panel", "1")),
+        **data,
     )

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -22,9 +22,10 @@ def test_institute_select_choices(user_obj, app):
         select_choices = institute_select_choices()
 
         # It should return the expected list of tuples
-        assert len(select_choices) == len(user_obj["institutes"])
+        assert len(select_choices) == len(user_obj["institutes"]) + 1
+        assert select_choices[0] == ("All", "All institutes")
         user_institute = user_obj["institutes"][0]
-        assert select_choices[0][0] == user_institute
+        assert select_choices[1][0] == user_institute
 
 
 def test_dashboard_form(app):

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -1,6 +1,57 @@
-from pprint import pprint as pp
+from flask import url_for
 
-from scout.server.blueprints.dashboard.controllers import get_dashboard_info
+from scout.server.blueprints.dashboard.controllers import (
+    compose_slice_query,
+    dashboard_form,
+    get_dashboard_info,
+    institute_select_choices,
+)
+from scout.server.blueprints.dashboard.forms import DashboardFilterForm
+from scout.server.extensions import store
+
+
+def test_institute_select_choices(user_obj, app):
+    """Test the function that creates the data for the institute select"""
+
+    # GIVEN an app with a logged user
+    with app.test_client() as client:
+
+        resp = client.get(url_for("auto_login"))
+
+        # WHEN returning the institute institute select choices
+        select_choices = institute_select_choices()
+
+        # It should return the expected list of tuples
+        assert len(select_choices) == len(user_obj["institutes"]) + 1
+        assert select_choices[0] == (None, "All institutes")
+        user_institute = user_obj["institutes"][0]
+        assert select_choices[1][0] == user_institute
+
+
+def test_dashboard_form(app):
+    """Test the function returning the dashboard page form"""
+
+    # GIVEN an app with a logged user
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+
+        # A DashboardFilterForm should be created correctly by dashboard_form
+        df = dashboard_form(None)
+        assert isinstance(df, DashboardFilterForm)
+        assert df.search_type
+        assert df.search_institute
+        assert df.search_term
+        assert df.search
+
+
+def test_compose_slice_query(app):
+    """Test function that combines form fields to create filter query"""
+
+    # GIVEN two parameters provided in the dashboard filter form
+    search_type = "case:"
+    search_term = "test_case"
+    slice_query = compose_slice_query(search_type, search_term)
+    assert slice_query == f"{search_type}{search_term}"
 
 
 def test_empty_database(real_adapter):
@@ -9,7 +60,7 @@ def test_empty_database(real_adapter):
     ## WHEN asking for data
     data = get_dashboard_info(adapter)
     ## THEN assert that the data is empty
-    # assert data.get("total_cases") == 0
+    assert data.get("total_cases") == 0
 
 
 def test_one_case(real_adapter, case_obj):

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -23,7 +23,7 @@ def test_institute_select_choices(user_obj, app):
 
         # It should return the expected list of tuples
         assert len(select_choices) == len(user_obj["institutes"]) + 1
-        assert select_choices[0] == (None, "All institutes")
+        assert select_choices[0] == ("All", "All institutes")
         user_institute = user_obj["institutes"][0]
         assert select_choices[1][0] == user_institute
 

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -9,13 +9,14 @@ def test_empty_database(real_adapter):
     ## WHEN asking for data
     data = get_dashboard_info(adapter)
     ## THEN assert that the data is empty
-    assert data.get("total_cases") == 0
+    # assert data.get("total_cases") == 0
 
 
 def test_one_case(real_adapter, case_obj):
     ## GIVEN an database with one case
     adapter = real_adapter
     adapter._add_case(case_obj)
+
     ## WHEN asking for data
     data = get_dashboard_info(adapter)
     ## THEN assert there is one case in the data

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -22,10 +22,9 @@ def test_institute_select_choices(user_obj, app):
         select_choices = institute_select_choices()
 
         # It should return the expected list of tuples
-        assert len(select_choices) == len(user_obj["institutes"]) + 1
-        assert select_choices[0] == ("All", "All institutes")
+        assert len(select_choices) == len(user_obj["institutes"])
         user_institute = user_obj["institutes"][0]
-        assert select_choices[1][0] == user_institute
+        assert select_choices[0][0] == user_institute
 
 
 def test_dashboard_form(app):


### PR DESCRIPTION
Fix #2550 by refactoring the dashboard filters.

Changes from master:
- When first landing on the dashboard page now, it **takes a long time to load since it's already performing a search** (one that you might not even be interested in). Now you land quickly on a blank page, where you can decide what to search for.
- There is a **bug in current master due to the fact that the user is allowed to perform a free search on the query filter** (try to write "whatevs" in that field and see the result. 
- I'm changing the dashboard web page so that the free text field mentioned above can't give error, since it's used together with a select specifying the type of search for the term.
Basically from this:

![image](https://user-images.githubusercontent.com/28093618/115090432-22afac80-9f15-11eb-8fbd-98971c07a647.png)

To this:

![image](https://user-images.githubusercontent.com/28093618/115090483-47a41f80-9f15-11eb-8d83-30a6c22dccb6.png)

- **Flashing a message when no result is returned instead of crashing**
- Moving to and refactoring the code present in the view in the controllers.

**How to test**:
- Test it on scout stage on clinical-db and see that the stats displayed are the same as in master branch
- Please note that the "All institutes" option might cause page timeout on stage (master branch and this branch), while it still works on prod (might be due to more server resources allocated to the latter instance)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
