### PR TITLE
Filter cases by track, in cases and dashboard pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Autodeploy docs on release
 - Documentation for updating case individuals tracks
+- Filter cases and dashboard stats by analysis track
 ### Changed
 - Changed from deprecated db update method
 - Pre-selected fields to run queries with in dashboard page

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -159,14 +159,12 @@ class CaseHandler(object):
         query_term = name_query[name_query.index(":") + 1 :].strip()
 
         if query_field == "case" and query_term != "":
-            LOG.debug("Case display name query")
             query["$or"] = [
                 {"display_name": {"$regex": query_term}},
                 {"individuals.display_name": {"$regex": query_term}},
             ]
 
         if query_field == "exact_pheno":
-            LOG.debug("Exact HPO phenotype query")
             if query_term != "":
                 query["phenotype_terms.phenotype_id"] = query_term
             else:  # query for cases with no HPO terms
@@ -175,22 +173,21 @@ class CaseHandler(object):
                     {"phenotype_terms": {"$exists": False}},
                 ]
         if query_field == "synopsis":
-            LOG.debug("Case synopsis query")
             if query_term != "":
                 query["$text"] = {"$search": query_term}
             else:
                 query["synopsis"] = ""
 
         if query_field == "panel":
-            LOG.debug("Gene panel query")
             query["panels"] = {"$elemMatch": {"panel_name": query_term, "is_default": True}}
 
         if query_field == "status":
-            LOG.debug("Case status query")
             query["status"] = query_term
 
+        if query_field == "track":
+            query["track"] = query_term
+
         if query_field == "pheno_group":
-            LOG.debug("Phenotye group query")
             if query_term != "":
                 query["phenotype_groups.phenotype_id"] = query_term
             else:
@@ -199,7 +196,6 @@ class CaseHandler(object):
                     {"phenotype_groups": {"$exists": False}},
                 ]
         if query_field == "cohort":
-            LOG.debug("Case cohort query")
             query["cohorts"] = query_term
 
         if query_term != "" and (query_field == "similar_case" or query_field == "similar_pheno"):
@@ -211,7 +207,6 @@ class CaseHandler(object):
             self._set_genes_of_interest_query(query, query_field, query_term)
 
         if query_field == "user":
-            LOG.debug(f"Search for cases with assignee '{query_term}'.")
             query_terms = query_term.split(" ")
             user_query = {
                 "$and": [{"name": {"$regex": term, "$options": "i"}} for term in query_terms]

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -109,6 +109,7 @@ CASE_SEARCH_TERMS = {
     },
     "panel": {"label": "Gene panel", "prefix": "panel:"},
     "status": {"label": "Case status", "prefix": "status:"},
+    "track": {"label": "Analysis track", "prefix": "track:"},
     "pheno_group": {
         "label": "Phenotype group",
         "prefix": "pheno_group:",

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -13,11 +13,11 @@
         {{ dashboard_search_form() }}
         {% if total_cases == 0 %}
           <div class="alert alert-danger">Your search didn't return any results!</div>
+        {% elif total_cases %}
+          {{ general_stats_panels() }}
+          {{ cases_stats_panels() }}
+          {{ variants_stats_panels() }}
         {% endif %}
-
-        {{ general_stats_panels() }}
-        {{ cases_stats_panels() }}
-        {{ variants_stats_panels() }}
       </div>
 
   </div>
@@ -27,23 +27,21 @@
 {% macro dashboard_search_form() %}
 <div class="card">
   <form class="mt-3 ml-3" id='form' class="form-horizontal" method='POST' action="{{ url_for('dashboard.index') }}" accept-charset="utf-8">
-      <input type="hidden" value="{{panel}}" name="panel">
+      <input type="hidden" value="{{panel}}" name="panel" id="panel">
       <div class="form-row align-items-center mb-3">
         <!--Search institute select-->
         <div class="col-2 ml-3">
           {{ dashboard_form.search_institute(class="form-control") }}
         </div>
 
-        {% if panel != "3" %}
-          <!--Search type select field-->
-          <div class="col-3 ml-3">
-            {{ dashboard_form.search_type(class="form-control", id="search_type") }}
-          </div>
-          <!--Search term textfield-->
-          <div class="col-4 ml-3">
-            {{ dashboard_form.search_term(class="form-control", placeholder="Search term", id="search_term") }}
-          </div>
-        {% endif %}
+        <!--Search type select field-->
+        <div class="col-3 ml-3">
+          {{ dashboard_form.search_type(class="form-control", id="search_type") }}
+        </div>
+        <!--Search term textfield-->
+        <div class="col-4 ml-3">
+          {{ dashboard_form.search_term(class="form-control", placeholder="Search term", id="search_term") }}
+        </div>
 
         <!--Search term textfield-->
         <div class="col-1 ml-3">
@@ -161,8 +159,8 @@
   <script src="{{ url_for('dashboard.static', filename='charts.js') }}"></script>
   <script type="text/javascript">
 
-    var sel = document.getElementById("search_type"),
-    text = document.getElementById("search_term");
+    var sel = document.getElementById("search_type");
+    var text = document.getElementById("search_term");
 
     $(document).ready(function(){
       text.disabled = (sel.value == "");
@@ -185,6 +183,18 @@
         var div_el = document.getElementById(panels[index]);
         if (panels[index] == show_div){ //show div
           div_el.style.display = "block";
+          // Assign a new value to hidden panel form field
+          panel_field = document.getElementById("panel");
+          panel_field.value=show_div;
+          // Hide search type select and search term inthe filters if panel=="variants"
+          if (show_div=="variants"){
+            sel.style.display = "none";
+            text.style.display = "none";
+          }
+          else{
+            sel.style.display = "block";
+            text.style.display = "block";
+          }
         }
         else{
           div_el.style.display = "none";

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -186,7 +186,7 @@
           // Assign a new value to hidden panel form field
           panel_field = document.getElementById("panel");
           panel_field.value=show_div;
-          // Hide search type select and search term inthe filters if panel=="variants"
+          // Hide search type select and search term in the filters if panel=="variants"
           if (show_div=="variants"){
             sel.style.display = "none";
             text.style.display = "none";
@@ -196,7 +196,7 @@
             text.style.display = "block";
           }
         }
-        else{
+        else{ // hide the other 2 divs
           div_el.style.display = "none";
         }
       }


### PR DESCRIPTION
- Small fix in dashboard template: see this comment https://github.com/Clinical-Genomics/scout/pull/2551#discussion_r617424400
- Allow filtering by Analysis track both on cases page and dashboard

**How to test**:
1. Install on a local instance of Scout.
2. Check that dashboard page, panels and filter query looks fine.
3. Try filtering cases and dashboard data by analysis track (option should be visible in the select) and the query should work

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
