### PR TITLE
/api/v1/genes queries all genome builds by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - command line crashing when updating an individual not found in database
 - Dashboard page crashing when filters return no data
+- /api/v1/genes now searches for genes in all genome builds by default
 ### Added
 - Autodeploy docs on release
 - Documentation for updating case individuals tracks

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -117,8 +117,8 @@ class GeneHandler(object):
         """
         LOG.debug("Fetching genes with symbol %s" % hgnc_symbol)
         build_query = {}
-        if str(build) in ['37', '38']:
-            build_query['build'] = str(build)
+        if str(build) in ["37", "38"]:
+            build_query["build"] = str(build)
 
         if search:
             # first search for a full match
@@ -127,8 +127,10 @@ class GeneHandler(object):
             if nr_genes != 0:
                 return self.hgnc_collection.find(query_full_match)
 
-            return self.hgnc_collection.find({'aliases': {"$regex": hgnc_symbol, "$options": "i"}, **build_query})
-        return self.hgnc_collection.find({'aliases': hgnc_symbol, **build_query})
+            return self.hgnc_collection.find(
+                {"aliases": {"$regex": hgnc_symbol, "$options": "i"}, **build_query}
+            )
+        return self.hgnc_collection.find({"aliases": hgnc_symbol, **build_query})
 
     def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
         """Find one hgnc genes that match a hgnc symbol. Replaces depricated
@@ -154,7 +156,7 @@ class GeneHandler(object):
                 {"hgnc_id": int(hgnc_symbol) if hgnc_symbol.isdigit() else None},
             ],
         }
-        if build in ['37', '38']:
+        if build in ["37", "38"]:
             query["build"] = str(build)
         return query
 

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -116,6 +116,10 @@ class GeneHandler(object):
             pymongo.cursor
         """
         LOG.debug("Fetching genes with symbol %s" % hgnc_symbol)
+        query = {}
+        if str(build) in ['37', '38']:
+            query['build'] = str(build)
+
         if search:
             # first search for a full match
             query = self.get_query_alias_or_id(hgnc_symbol, build)
@@ -123,13 +127,10 @@ class GeneHandler(object):
             if nr_genes != 0:
                 return self.hgnc_collection.find(query)
 
-            return self.hgnc_collection.find(
-                {
-                    "aliases": {"$regex": hgnc_symbol, "$options": "i"},
-                    "build": str(build),
-                }
-            )
-        return self.hgnc_collection.find({"build": build, "aliases": hgnc_symbol})
+            query['aliases'] = {"$regex": hgnc_symbol, "$options": "i"}
+            return self.hgnc_collection.find(query)
+        query['aliases'] = hgnc_symbol
+        return self.hgnc_collection.find(query)
 
     def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
         """Find one hgnc genes that match a hgnc symbol. Replaces depricated
@@ -154,8 +155,9 @@ class GeneHandler(object):
                 {"aliases": hgnc_symbol},
                 {"hgnc_id": int(hgnc_symbol) if hgnc_symbol.isdigit() else None},
             ],
-            "build": str(build),
         }
+        if build in ['37', '38']:
+            query["build"] = str(build)
         return query
 
     def all_genes(self, build=None, add_transcripts=False, limit=100000):

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -116,21 +116,19 @@ class GeneHandler(object):
             pymongo.cursor
         """
         LOG.debug("Fetching genes with symbol %s" % hgnc_symbol)
-        query = {}
+        build_query = {}
         if str(build) in ['37', '38']:
-            query['build'] = str(build)
+            build_query['build'] = str(build)
 
         if search:
             # first search for a full match
-            query = self.get_query_alias_or_id(hgnc_symbol, build)
-            nr_genes = self.nr_genes(query=query)
+            query_full_match = {**self.get_query_alias_or_id(hgnc_symbol, build), **build_query}
+            nr_genes = self.nr_genes(query=query_full_match)
             if nr_genes != 0:
-                return self.hgnc_collection.find(query)
+                return self.hgnc_collection.find(query_full_match)
 
-            query['aliases'] = {"$regex": hgnc_symbol, "$options": "i"}
-            return self.hgnc_collection.find(query)
-        query['aliases'] = hgnc_symbol
-        return self.hgnc_collection.find(query)
+            return self.hgnc_collection.find({'aliases': {"$regex": hgnc_symbol, "$options": "i"}, **build_query})
+        return self.hgnc_collection.find({'aliases': hgnc_symbol, **build_query})
 
     def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
         """Find one hgnc genes that match a hgnc symbol. Replaces depricated

--- a/scout/server/blueprints/genes/controllers.py
+++ b/scout/server/blueprints/genes/controllers.py
@@ -52,16 +52,16 @@ def gene(store, hgnc_id):
     return res
 
 
-def genes_to_json(store, query):
+def genes_to_json(store, query, build):
     """Fetch matching genes and convert to JSON."""
-    gene_query = store.hgnc_genes(query, search=True)
-    json_terms = [
-        {
+    gene_query = store.hgnc_genes(query, build, search=True)
+    json_terms = {
+        gene["hgnc_id"]: {
             "name": "{} | {} ({})".format(
                 gene["hgnc_id"], gene["hgnc_symbol"], ", ".join(gene["aliases"])
             ),
             "id": gene["hgnc_id"],
         }
         for gene in gene_query
-    ]
-    return json_terms
+    }
+    return list(json_terms.values())

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -50,5 +50,6 @@ def gene(hgnc_id=None, hgnc_symbol=None):
 def api_genes():
     """Return JSON data about genes."""
     query = request.args.get("query")
-    json_out = controllers.genes_to_json(store, query)
+    build = request.args.get("build", "all")
+    json_out = controllers.genes_to_json(store, query, build)
     return jsonify(json_out)

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -240,20 +240,21 @@ def test_get_genes_per_build(real_adapter):
     assert sum(1 for i in res) == 1
 
     ##THEN assert gene is excluded when using genome build is 38
-    res = adapter.hgnc_genes(hgnc_symbol="AA", build='38', search=True)
+    res = adapter.hgnc_genes(hgnc_symbol="AA", build="38", search=True)
     assert sum(1 for i in res) == 0
 
     ##THEN assert that build==37 excludes 38 variants when using regex
-    res = adapter.hgnc_genes(hgnc_symbol="A", build='37', search=True)
+    res = adapter.hgnc_genes(hgnc_symbol="A", build="37", search=True)
     assert sum(1 for i in res) == 2
 
     ##THEN assert that build==38 excludes 37 variants when using regex
-    res = adapter.hgnc_genes(hgnc_symbol="A", build='38', search=True)
+    res = adapter.hgnc_genes(hgnc_symbol="A", build="38", search=True)
     assert sum(1 for i in res) == 1
 
     ##THEN assert that build==all includes both 37 and 38 variants when using regex
-    res = adapter.hgnc_genes(hgnc_symbol="A", build='all', search=True)
+    res = adapter.hgnc_genes(hgnc_symbol="A", build="all", search=True)
     assert sum(1 for i in res) == 3
+
 
 def test_get_all_genes(adapter):
     ##GIVEN a empty adapter

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -204,6 +204,57 @@ def test_get_genes_regex(real_adapter):
     assert sum(1 for i in res) == 3
 
 
+def test_get_genes_per_build(real_adapter):
+    adapter = real_adapter
+    ##GIVEN a empty adapter
+    assert sum(1 for i in adapter.all_genes()) == 0
+
+    ##WHEN inserting two genes and fetching one
+    gene_obj = {
+        "hgnc_id": 1,
+        "hgnc_symbol": "AAA",
+        "build": "37",
+        "aliases": ["AAA", "BCD"],
+    }
+    adapter.load_hgnc_gene(gene_obj)
+
+    gene_obj2 = {
+        "hgnc_id": 2,
+        "hgnc_symbol": "AA",
+        "build": "37",
+        "aliases": ["AA", "AB"],
+    }
+    adapter.load_hgnc_gene(gene_obj2)
+
+    gene_obj3 = {
+        "hgnc_id": 3,
+        "hgnc_symbol": "AB",
+        "build": "38",
+        "aliases": ["C", "AC"],
+    }
+
+    adapter.load_hgnc_gene(gene_obj3)
+
+    ##THEN assert default genome build is 37
+    res = adapter.hgnc_genes(hgnc_symbol="AA", search=True)
+    assert sum(1 for i in res) == 1
+
+    ##THEN assert gene is excluded when using genome build is 38
+    res = adapter.hgnc_genes(hgnc_symbol="AA", build='38', search=True)
+    assert sum(1 for i in res) == 0
+
+    ##THEN assert that build==37 excludes 38 variants when using regex
+    res = adapter.hgnc_genes(hgnc_symbol="A", build='37', search=True)
+    assert sum(1 for i in res) == 2
+
+    ##THEN assert that build==38 excludes 37 variants when using regex
+    res = adapter.hgnc_genes(hgnc_symbol="A", build='38', search=True)
+    assert sum(1 for i in res) == 1
+
+    ##THEN assert that build==all includes both 37 and 38 variants when using regex
+    res = adapter.hgnc_genes(hgnc_symbol="A", build='all', search=True)
+    assert sum(1 for i in res) == 3
+
 def test_get_all_genes(adapter):
     ##GIVEN a empty adapter
     assert sum(1 for i in adapter.all_genes()) == 0


### PR DESCRIPTION
This PR fixes a bug where the user could not search for genes from grch38 in `/genes`

**How to test**:
1. goto `/genes`
2. search for "NOTCH2NLA" (in grch37 and 38)
3. search for "NOTCH2NLC" (in grch38)

**Expected outcome**:
- Genes should be found regardless of genome build
- Should only show one hit per gene, regardless if a gene is present in multiple genome builds

**Review:**
- [x] code approved by
- [x] tests executed by
