### PR TITLE
Import and use standard models of inheritance defined in ClinVar constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Fixed
+- Use standard inheritance model in CLinVar(https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt)
 ### Added
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.x]
 ### Fixed
-- Use standard inheritance model in CLinVar(https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt)
+- Use standard inheritance model in CLinVar (https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt)
 ### Added
 ### Changed
 

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -22,7 +22,7 @@ from .case_tags import (
     SEX_MAP,
     VERBS_MAP,
 )
-from .clinvar import CASEDATA_HEADER, CLINVAR_HEADER
+from .clinvar import CASEDATA_HEADER, CLINVAR_HEADER, INHERITANCE_MODELS
 from .clnsig import CLINSIG_MAP, REV_CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
 from .file_types import FILE_TYPE_MAP
 from .gene_tags import (

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -22,7 +22,7 @@ from .case_tags import (
     SEX_MAP,
     VERBS_MAP,
 )
-from .clinvar import CASEDATA_HEADER, CLINVAR_HEADER, INHERITANCE_MODELS
+from .clinvar import CASEDATA_HEADER, CLINVAR_HEADER, CLINVAR_INHERITANCE_MODELS
 from .clnsig import CLINSIG_MAP, REV_CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
 from .file_types import FILE_TYPE_MAP
 from .gene_tags import (

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -102,3 +102,27 @@ REVSTAT_TERMS = {
     "practice_guideline",
     "reviewed_by_expert_panel",
 }
+
+# Models of inheritance are defined here:
+# https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt
+INHERITANCE_MODELS = [
+    "Autosomal dominant inheritance",
+    "Autosomal dominant inheritance with maternal imprinting",
+    "Autosomal dominant inheritance with paternal imprinting",
+    "Autosomal recessive inheritance",
+    "Autosomal unknown",
+    "Codominant",
+    "Genetic anticipation",
+    "Mitochondrial inheritance",
+    "Multifactorial inheritance",
+    "Oligogenic inheritance",
+    "Other",
+    "Sex-limited autosomal dominant",
+    "Somatic mutation",
+    "Sporadic",
+    "Unknown mechanism",
+    "X-linked dominant inheritance",
+    "X-linked inheritance",
+    "X-linked recessive inheritance",
+    "Y-linked inheritance",
+]

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -105,7 +105,7 @@ REVSTAT_TERMS = {
 
 # Models of inheritance are defined here:
 # https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt
-INHERITANCE_MODELS = [
+CLINVAR_INHERITANCE_MODELS = [
     "Autosomal dominant inheritance",
     "Autosomal dominant inheritance with maternal imprinting",
     "Autosomal dominant inheritance with paternal imprinting",

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -12,9 +12,9 @@ from scout.constants import (
     CALLERS,
     CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
     CANCER_TIER_OPTIONS,
+    CLINVAR_INHERITANCE_MODELS,
     DISMISS_VARIANT_OPTIONS,
     IGV_TRACKS,
-    INHERITANCE_MODELS,
     MANUAL_RANK_OPTIONS,
     MOSAICISM_OPTIONS,
     VERBS_MAP,
@@ -458,5 +458,5 @@ def clinvar_export(store, institute_id, case_name, variant_id):
         case=case_obj,
         variant=variant_obj,
         pinned_vars=pinned,
-        inheritance_models=INHERITANCE_MODELS,
+        inheritance_models=CLINVAR_INHERITANCE_MODELS,
     )

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -14,6 +14,7 @@ from scout.constants import (
     CANCER_TIER_OPTIONS,
     DISMISS_VARIANT_OPTIONS,
     IGV_TRACKS,
+    INHERITANCE_MODELS,
     MANUAL_RANK_OPTIONS,
     MOSAICISM_OPTIONS,
     VERBS_MAP,
@@ -457,4 +458,5 @@ def clinvar_export(store, institute_id, case_name, variant_id):
         case=case_obj,
         variant=variant_obj,
         pinned_vars=pinned,
+        inherirance_models=INHERITANCE_MODELS,
     )

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -458,5 +458,5 @@ def clinvar_export(store, institute_id, case_name, variant_id):
         case=case_obj,
         variant=variant_obj,
         pinned_vars=pinned,
-        inherirance_models=INHERITANCE_MODELS,
+        inheritance_models=INHERITANCE_MODELS,
     )

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -176,7 +176,7 @@
                       <td>
                         <select id="Mode of inheritance_{{pinned._id}}" name="inheritance_mode@{{pinned._id}}">
                           <option value="" selected>-</option>
-                          {% for model in inherirance_models %}
+                          {% for model in inheritance_models %}
                             <option value="{{model}}">{{model}}</option>
                           {% endfor %}
                         </select>

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -175,56 +175,10 @@
                       </td>
                       <td>
                         <select id="Mode of inheritance_{{pinned._id}}" name="inheritance_mode@{{pinned._id}}">
-                          {% if 'AR_hom' in pinned.genetic_models or 'AR_hom_dn' in pinned.genetic_models or 'AR_comp' in pinned.genetic_models or 'AR_comp_d' in pinned.genetic_models %}
-                            <option value="Autosomal recessive inheritance" selected>Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance">X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant">Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance">Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance">Y-linked inheritance</option>
-                          {% elif 'XR' in pinned.genetic_models or 'XR_dn' in pinned.genetic_models %}
-                            <option value="Autosomal recessive inheritance">Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance" selected>X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant">Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance">Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance">Y-linked inheritance</option>
-                          {% elif 'XD' in pinned.genetic_models or 'XD_dn' in pinned.genetic_models %}
-                            <option value="Autosomal recessive inheritance">Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance">X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant" selected>Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance">Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance">Y-linked inheritance</option>
-                          {% elif pinned.chromosome == 'MT' %}
-                            <option value="Autosomal recessive inheritance">Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance">X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant">Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance" selected>Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance">Y-linked inheritance</option>
-                          {% elif pinned.chromosome == 'Y' %}
-                            <option value="Autosomal recessive inheritance">Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance">X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant">Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance">Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance" selected>Y-linked inheritance</option>
-                          {% else %}
-                            <option value="Autosomal recessive inheritance" selected>Autosomal recessive inheritance</option>
-                            <option value="Autosomal dominant">Autosomal dominant inheritance</option>
-                            <option value="X-linked inheritance">X-linked inheritance</option>
-                            <option value="Sex-limited autosomal dominant">Sex-limited autosomal dominant</option>
-                            <option value="Mitochondrial inheritance">Mitochondrial inheritance</option>
-                            <option value="Y-linked inheritance">Y-linked inheritance</option>
-                          {% endif %}
-                          <option value="Autosomal unknown">Autosomal unknown</option>
-                          <option value="Codominant">Codominant</option>
-                          <option value="Genetic anticipation">Genetic anticipation</option>
-                          <option value="Oligogenic">Oligogenic</option>
-                          <option value="Somatic mutation">Somatic mutation</option>
-                          <option value="Sporadic">Sporadic</option>
-                          <option value="Other">Other</option>
+                          <option value="" selected>-</option>
+                          {% for model in inherirance_models %}
+                            <option value="{{model}}">{{model}}</option>
+                          {% endfor %}
                         </select>
                       </td>
                     </tr>


### PR DESCRIPTION
Fix #2570.

Description of ClinVar data fields is here: https://www.ncbi.nlm.nih.gov/projects/clinvar/ClinVarDataDictionary.pdf
In this document they mention that the models of inheritance to be used are in this document: https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt

**How to test**:
1. Pin a variant and check that the inheritance model field is displayed correctly in the ClinVar form.
2. Save submission and export it to file.
3. Check that inheritance model is correct on exported file or that is missing if no model was selected

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
