### PR TITLE
Fix #2575 - unset causative is undefined and crashes other causative …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Include markdown for release autodeploy docs
 - Use standard inheritance model in CLinVar (https://ftp.ncbi.nlm.nih.gov/pub/GTR/standard_terms/Mode_of_inheritance.txt)
+- Fix issue crash with variants that have been unflagged causative not being avaliable in other causatives
 ### Added
 ### Changed
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -596,11 +596,11 @@ class VariantHandler(VariantLoader):
             # link contains other variant ID
             other_causative_id = other_link.split("/")[-1]
 
+            if other_causative_id in yielded_other_causative_ids:
+                continue
+
             # if variant is still causative for that case:
-            if (
-                other_causative_id in other_case_causatives
-                and other_causative_id not in yielded_other_causative_ids
-            ):
+            if other_causative_id in other_case_causatives:
                 other_causative = {
                     "_id": other_causative_id,
                     "case_id": other_case["_id"],

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -597,13 +597,15 @@ class VariantHandler(VariantLoader):
             other_causative_id = other_link.split("/")[-1]
 
             # if variant is still causative for that case:
-            if other_causative_id in other_case_causatives:
+            if (
+                other_causative_id in other_case_causatives
+                and other_causative_id not in yielded_other_causative_ids
+            ):
                 other_causative = {
                     "_id": other_causative_id,
                     "case_id": other_case["_id"],
                     "case_display_name": other_case["display_name"],
                 }
-            if other_causative_id not in yielded_other_causative_ids:
                 yielded_other_causative_ids.append(other_causative_id)
                 yield other_causative
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -591,15 +591,13 @@ class VariantHandler(VariantLoader):
                 # User doesn't have access to this case/variant
                 continue
 
-            other_case_causatives = other_case.get("causatives", [])
             other_link = var_event["link"]
             # link contains other variant ID
             other_causative_id = other_link.split("/")[-1]
-
             if other_causative_id in yielded_other_causative_ids:
                 continue
 
-            # if variant is still causative for that case:
+            other_case_causatives = other_case.get("causatives", [])
             if other_causative_id in other_case_causatives:
                 other_causative = {
                     "_id": other_causative_id,


### PR DESCRIPTION
…view

This PR adds a functionality or fixes a bug.

**How to test**:
1. load two cases sharing a variant, eg `scout --demo load case scout/demo/643595.config.yaml`.
2. mark a variant causative in one case, then flag it down (un-causative)
3. go to the variant in the other case on master branch- notice crash
4. apply fix, and notice how the page works, correctly not showing the previous marked causative
 
**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by
