### PR TITLE
Tentative fix #2580

### DIFF
--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -330,7 +330,7 @@ def observations(store, loqusdb, case_obj, variant_obj):
         LOG.debug("Could not find any observations for %s", composite_id)
         obs_data["total"] = loqusdb.case_count(
             variant_category=variant_obj["category"]
-        )  # count only case having the specifuc type of variant (snv/sv)
+        )  # count only cases having the specific type of variant (snv/sv)
         return obs_data
 
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -352,7 +352,7 @@ def observations(store, loqusdb, case_obj, variant_obj):
             # If the user does not have access to the information we skip it
             continue
 
-        other_variant = store.variant(document_id=variant_obj[""])
+        other_variant = store.variant(document_id=variant_obj["variant_id"])
         # If the other variant is not loaded we skip it
         if not other_variant:
             continue

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -352,7 +352,9 @@ def observations(store, loqusdb, case_obj, variant_obj):
             # If the user does not have access to the information we skip it
             continue
 
-        other_variant = store.variant(document_id=variant_obj["variant_id"])
+        other_variant = store.variant(
+            case_id=other_case["_id"], document_id=variant_obj["variant_id"]
+        )
         # If the other variant is not loaded we skip it
         if not other_variant:
             continue

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -328,7 +328,9 @@ def observations(store, loqusdb, case_obj, variant_obj):
     obs_data = loqusdb.get_variant(variant_query, loqusdb_id=institute_obj.get("loqusdb_id")) or {}
     if not obs_data:
         LOG.debug("Could not find any observations for %s", composite_id)
-        obs_data["total"] = loqusdb.case_count()
+        obs_data["total"] = loqusdb.case_count(
+            variant_category=variant_obj["category"]
+        )  # count only case having the specifuc type of variant (snv/sv)
         return obs_data
 
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import date
 
-from flask import url_for
+from flask import flash, url_for
 from flask_login import current_user
 
 from scout.constants import (
@@ -335,6 +335,7 @@ def observations(store, loqusdb, case_obj, variant_obj):
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])
 
     obs_data["cases"] = []
+    flash(obs_data)
     for i, case_id in enumerate(obs_data.get("families", [])):
         if i > 10:
             break

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import date
 
-from flask import flash, url_for
+from flask import url_for
 from flask_login import current_user
 
 from scout.constants import (
@@ -19,7 +19,6 @@ from scout.constants import (
     MOSAICISM_OPTIONS,
     VERBS_MAP,
 )
-from scout.parse.variant.ids import parse_document_id
 from scout.server.extensions import cloud_tracks, gens
 from scout.server.links import ensembl, get_variant_links
 from scout.server.utils import (
@@ -335,7 +334,6 @@ def observations(store, loqusdb, case_obj, variant_obj):
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])
 
     obs_data["cases"] = []
-    flash(obs_data)
     for i, case_id in enumerate(obs_data.get("families", [])):
         if i > 10:
             break
@@ -353,8 +351,8 @@ def observations(store, loqusdb, case_obj, variant_obj):
         if user_institutes_ids.isdisjoint(other_institutes):
             # If the user does not have access to the information we skip it
             continue
-        document_id = parse_document_id(chrom, str(pos), ref, alt, var_type, case_id)
-        other_variant = store.variant(document_id=document_id)
+
+        other_variant = store.variant(document_id=variant_obj[""])
         # If the other variant is not loaded we skip it
         if not other_variant:
             continue

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -236,7 +236,7 @@ class LoqusDB:
         except AttributeError:
             raise ConfigError("LoqusDB id not found: {}".format(loqusdb_id))
 
-    def case_count(self):
+    def case_count(self, variant_category="snv"):
         """Returns number of cases in loqus instance
 
         Returns:
@@ -244,7 +244,7 @@ class LoqusDB:
         """
         nr_cases = 0
         case_call = self.get_command()
-        case_call.extend(["cases", "--count"])
+        case_call.extend(["cases", "--count", "-t", variant_category])
         output = ""
         try:
             output = execute_command(case_call)


### PR DESCRIPTION
- Skip calling parse_document_id to create a variant["variant_id] to look for the same variant in other cases, since the other variants share the same document_id with the variant in question.
- A more precise Loqus case counter, that when counting total cases takes into account only cases having that specific type of variant (snv/sv).

A bit complicated to test on stage, since it's running queries to loqus prod, but at least the stats for SNVs seem to work!

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
