### PR TITLE
Fix bug causing exported variants to crash when one of the variants has no primary transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Fixed
 - Make MitoMap link work for hg38 again
-- Variants page crashing when one of the variants has no primary transcripts
+- Export Variants feature crashing when one of the variants has no primary transcripts
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Fixed
 - Make MitoMap link work for hg38 again
+- Variants page crashing when one of the variants has no primary transcripts
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 ### Changed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -483,7 +483,7 @@ def match_gene_txs_variant_txs(variant_gene, hgnc_gene):
             pt_change = var_tx.get("protein_sequence_name") or "-"
 
             # collect info from primary transcripts
-            if tx_refseq in hgnc_gene.get("primary_transcripts"):
+            if tx_refseq in hgnc_gene.get("primary_transcripts", []):
                 primary_txs.append("/".join([tx_refseq or tx_id, hgvs, pt_change]))
 
             # collect info from canonical transcript


### PR DESCRIPTION
fix #2585  

This bug is caused by an error in the code that handles the loop through the primaty transcripts of a variant. When the variant has no primary transcripts the page crashes.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
