### PR TITLE
Remove parsing of case `genome_version`, since it's not used anywhere downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 ### Changed
+- Remove parsing of case `genome_version`, since it's not used anywhere downstream
 
 ## [4.33.1]
 ### Fixed

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -692,7 +692,6 @@ class CaseHandler(object):
             - gene_fusion_report: path to the gene fusions report
             - gene_fusion_report_research: path to the research gene fusions report
             - genome_build: If there is a new genome build
-            - genome_version: - || -
             - has_strvariants: If there are new strvariants
             - has_svvariants: If there are new svvariants
             - individuals: There could be new individuals
@@ -759,7 +758,6 @@ class CaseHandler(object):
                     "gene_fusion_report": case_obj.get("gene_fusion_report"),
                     "gene_fusion_report_research": case_obj.get("gene_fusion_report_research"),
                     "genome_build": case_obj.get("genome_build", "37"),
-                    "genome_version": case_obj.get("genome_version"),
                     "has_strvariants": case_obj.get("has_strvariants"),
                     "has_svvariants": case_obj.get("has_svvariants"),
                     "individuals": case_obj["individuals"],

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -74,7 +74,6 @@ def build_case(case_data, adapter):
         dynamic_gene_list = list, # List of genes
 
         genome_build = str, # This should be 37 or 38
-        genome_version = float, # What version of the build
 
         rank_model_version = str,
         rank_score_threshold = int, # default=8
@@ -196,7 +195,6 @@ def build_case(case_data, adapter):
         ##TODO raise exception if invalid genome build was used
 
     case_obj["genome_build"] = genome_build
-    case_obj["genome_version"] = case_data.get("genome_version")
 
     if case_data.get("rank_model_version"):
         case_obj["rank_model_version"] = str(case_data["rank_model_version"])

--- a/scout/models/case/case.py
+++ b/scout/models/case/case.py
@@ -65,7 +65,6 @@ case = dict(
     gene_fusion_report=str,  # Path to the gene fusions report file
     gene_fusion_report_research=str,  # Path to the gene fusions research report file
     genome_build=str,  # This should be 37 or 38
-    genome_version=float,  # What version of the build
     group=list,  # a list of group ids for cases conceptually grouped together with this
     has_strvariants=bool,  # default=False
     has_svvariants=bool,  # default=False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,7 +389,6 @@ def case_obj(request, parsed_case):
     case["owner"] = parsed_case["owner"]
     case["created_at"] = parsed_case["analysis_date"]
     case["dynamic_gene_list"] = []
-    case["genome_version"] = None
     case["has_svvariants"] = True
 
     case["individuals"][0]["sex"] = "1"


### PR DESCRIPTION
`genome_version` is a field that gets populated every time a case is created from parsing a yaml file. Our prod cases have a None value for this key and the key/value is not used anywhere downstream in the app anyway. Fix #2578

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
