### PR TITLE
 Redirect to last visited variantS page when dismissing variants from variants list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Make MitoMap link work for hg38 again
 - Export Variants feature crashing when one of the variants has no primary transcripts
+- Redirect to last visited variantS page when dismissing variants from variants list
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 - Grey background for dismissed compounds in variants list and variant page

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -31,7 +31,7 @@
 </div>
 {% endmacro %}
 
-{% macro dismiss_variants_block(dismiss_variant_options, institute, case) %}
+{% macro dismiss_variants_block(dismiss_variant_options, institute, case, page) %}
 <div class="row d-flex align-items-center mb-2 ml-1">
   <div class="col-2 ">Dismiss selected variants:</div>
   <div class="col-4 align-items-start">
@@ -735,6 +735,7 @@
     <input type="submit" name="page" id="paginate-first" value=1 hidden="true">
     <input type="submit" name="page" id="paginate-previous" value={{page-1}} hidden="true">
     <input type="submit" name="page" id="paginate-next" value={{page+1}} hidden="true">
+    <input type="hidden" name="page" value="{{page}}"> <!-- In order to work, this input should be placed AFTER the submit form items with the same name -->
   </div>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -31,7 +31,7 @@
 </div>
 {% endmacro %}
 
-{% macro dismiss_variants_block(dismiss_variant_options, institute, case, page) %}
+{% macro dismiss_variants_block(dismiss_variant_options, institute, case) %}
 <div class="row d-flex align-items-center mb-2 ml-1">
   <div class="col-2 ">Dismiss selected variants:</div>
   <div class="col-4 align-items-start">


### PR DESCRIPTION
Fix #2588

**How to test**:
1. Go to variantS page 2 and dismiss some variants. When page redirects you should still be on variantS page 2

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
