### PR TITLE
Include cancer case in Docker demo (docker-compose files)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Saved filter lock and unlock
 - Filters can optionally be marked audited, logging the filter name, user and date on the case events and general report.
 - Added `ClinVar hits` and `Cosmic hits` in cancer SNVs filters
+- Load cancer demo case in docker-compose files (default and demo file)
 ### Fixed
 - Make MitoMap link work for hg38 again
 - Export Variants feature crashing when one of the variants has no primary transcripts

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,7 +17,9 @@ services:
   scout-cli:
     build: .
     container_name: scout-cli
-    command: scout --host mongodb setup demo
+    command: bash -c "
+      scout --host mongodb setup demo
+      && scout --host mongodb --demo load case scout/demo/cancer.load_config.yaml"
     volumes:
       - ./scout:/home/worker/app/scout
       - ./volumes/scout/data:/home/worker/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
   scout-cli:
     image: clinicalgenomics/scout
     container_name: scout-cli
-    command: scout --host mongodb setup demo
+    command: bash -c "
+      scout --host mongodb setup demo
+      && scout --host mongodb --demo load case scout/demo/cancer.load_config.yaml"
     volumes:
       - ./scout:/home/worker/app/scout
       - ./volumes/scout/data:/home/worker/data


### PR DESCRIPTION
Load cancer demo case along with the rare disease case when Scout demo is started using docker-compose (docker-compose and docker-compose dev)

**How to test**:
1. Start scout demo using the default docker-compose: `docker-compose up`
2. Stop the demo and run the development demo: `docker-compose -f docker-compose-dev.yml up`

**Expected outcome**:
Demo institute should contain 2 cases: rare disease case and cancer case

**Review:**
- [ ] code approved by
- [ ] tests executed by
