### PR TITLE
Remove padding from (Matching causatives from other cases) panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make MitoMap link work for hg38 again
 - Export Variants feature crashing when one of the variants has no primary transcripts
 - Redirect to last visited variantS page when dismissing variants from variants list
+- Remove padding from the list inside (Matching causatives from other cases) panel
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 - Grey background for dismissed compounds in variants list and variant page

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -221,7 +221,7 @@
       <div class="card-body">
         <ul class="list-group list-group-flush">
           {% for other_variant in causatives %}
-            <li class="list-group-item">
+            <li class="list-group-item" style="padding: 0;">
               <a href="{{ url_for('variant.variant',
                                   institute_id=institute._id,
                                   case_name=other_variant.case_display_name,


### PR DESCRIPTION
This PR fixes the padding inside (matching causatives, matching managed variants) panels #2542 

I mocked data locally and it works as it should.

![Screen Shot 2021-05-10 at 17 00 05](https://user-images.githubusercontent.com/41540288/117681142-16381000-b1b2-11eb-830d-9e58b14eaef4.png)


**How to test**:
1. After deploying to stage
2. Go to: https://scout-stage.scilifelab.se/cust002/F0016354/9a045de2b8925769a83dcbf638910f5b

**Expected outcome**:
The text on both panels (Matching causatives, Matching managed variants) should align like the screenshot.

**Review:**
- [ ] code approved by
- [ ] tests executed by
