### PR TITLE
Fix causatives view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove padding from the list inside (Matching causatives from other cases) panel
 - Speed up user events view
 - Causative view sort out of memory error
-- Temporarily freeze Flask <2.0.0 due to unmitigated deprecation
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,19 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added `ClinVar hits` to variants filter (rare disease track)
 - Load cancer demo case in docker-compose files (default and demo file)
 - Inclusive-language check using [woke](https://github.com/get-woke/woke) github action
+- Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
+- Grey background for dismissed compounds in variants list and variant page
+- Pin badge for pinned compounds in variants list and variant page
+- Support LoqusDB REST API queries
 ### Fixed
 - Make MitoMap link work for hg38 again
 - Export Variants feature crashing when one of the variants has no primary transcripts
 - Redirect to last visited variantS page when dismissing variants from variants list
 - Improved matching of SVs Loqus occurrences in other cases
 - Remove padding from the list inside (Matching causatives from other cases) panel
-### Added
-- Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
-- Grey background for dismissed compounds in variants list and variant page
-- Pin badge for pinned compounds in variants list and variant page
-- Support LoqusDB REST API queries
+- Speed up user events view
+- Causative view sort out of memory error
+- Temporarily freeze Flask <2.0.0 due to unmitigated deprecation
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 BeautifulSoup4
 werkzeug
-Flask>=0.10
+Flask>=0.10,<2
 Flask-DebugToolbar
 Flask-Bootstrap
 path.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 BeautifulSoup4
 werkzeug
-Flask>=0.10,<2
+Flask>=0.10
 Flask-DebugToolbar
 Flask-Bootstrap
 path.py

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -89,6 +89,16 @@ INDEXES = {
     "event": [
         IndexModel([("category", ASCENDING), ("verb", ASCENDING)], name="category_verb"),
         IndexModel([("variant_id", ASCENDING)], name="variant_id"),
+        IndexModel(
+            [
+                ("institute", ASCENDING),
+                ("case", ASCENDING),
+                ("category", ASCENDING),
+                ("verb", ASCENDING),
+            ],
+            name="case_verb",
+        ),
+        IndexModel([("user_id", ASCENDING)], name="user_events"),
     ],
     "transcript": [
         IndexModel(

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -84,7 +84,7 @@ INDEXES = {
     "hpo_term": [
         IndexModel([("description", ASCENDING)], name="description"),
         IndexModel([("description", TEXT)], default_language="english", name="description_text"),
-        IndexModel([("hpo_number", ASCENDING)], name="number"),
+        IndexModel([("hpo_number", ASCENDING)], name="number", background=True),
     ],
     "event": [
         IndexModel([("category", ASCENDING), ("verb", ASCENDING)], name="category_verb"),
@@ -114,6 +114,5 @@ INDEXES = {
             background=True,
         )
     ],
-    "hpo_term": [IndexModel([("hpo_number", ASCENDING)], name="number", background=True)],
     "case": [IndexModel([("synopsis", TEXT)], default_language="english", name="synopsis_text")],
 }

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -135,9 +135,9 @@ def causatives(institute_id):
         except ValueError:
             flash("Provided gene info could not be parsed!", "warning")
 
-    variants = store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id)
+    variants = list(store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id))
     if variants:
-        variants.sort("hgnc_symbols", pymongo.ASCENDING)
+        variants = sorted(variants, key=lambda k: k["hgnc_symbols"])
     all_variants = {}
     all_cases = {}
     for variant_obj in variants:

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -37,7 +37,6 @@ def event_rank(count):
 def users(store):
     """Display a list of all users and which institutes they belong to."""
     user_objs = list(store.users())
-    total_events = sum([1 for event in store.user_events()])
     for user_obj in user_objs:
         user_institutes = user_obj.get("institutes")
         if user_institutes:
@@ -48,5 +47,4 @@ def users(store):
         user_obj["events_rank"] = event_rank(user_obj["events"])
     return dict(
         users=sorted(user_objs, key=lambda user: -user["events"]),
-        total_events=total_events,
     )

--- a/tests/server/blueprints/login/test_controllers.py
+++ b/tests/server/blueprints/login/test_controllers.py
@@ -66,6 +66,5 @@ def test_event_rank_6000():
 def test_users_controller(user_adapter):
     """Test the uses controller"""
     res = users(user_adapter)
-    assert res["total_events"] == 0
     user = res["users"][0]
     assert user["events_rank"] == "aspirant"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

To apply to an existing installation, one will also need to
```
scout index --update
```

I haven't checked yet, but something reminds me that perhaps it is best just to add the same indices manually to prod when the time comes. We should perhaps also take a quick peek at current indices before running an update on stage. These ones should be fine, but there could be some other pending change that will slow things down more for a bit. Over the long weekend would actually not be at all bad for that.

**How to test**:
1. test user events view
2. test causatives view
3. test a case_verb intense view, like hovering over compounds to shade for dismissed ones

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
