### PR TITLE
Fix #2614 - always use hgnc_id for gene filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove padding from the list inside (Matching causatives from other cases) panel
 - Pass None to get_app function in CLI base since passing script_info to app factory functions was deprecated in Flask 2.0
 - Fixed failing tests due to Flask update to version 2.0
+- Use hgnc_id for gene filter query
 ### Added
 - Add link to HmtVar for mitochondrial variants (if VCF is annotated with HmtNote)
 - Grey background for dismissed compounds in variants list and variant page

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -113,7 +113,7 @@ class CaseHandler(object):
         """
         hgnc_id = self.hgnc_id(hgnc_symbol=query_term)
         if hgnc_id is None:
-            LOG.debug(f"No gene with the HGNC symbol {hgnc_id} found.")
+            LOG.debug(f"No gene with the HGNC symbol {query_term} found.")
             query["_id"] = {"$in": []}  # No result should be returned by query
 
         unwind = "$causatives"

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -159,6 +159,7 @@ class VariantHandler(VariantLoader):
         nr_of_variants=10,
         skip=0,
         sort_key="variant_rank",
+        build="37",
     ):
         """Returns variants specified in question for a specific case.
 
@@ -172,7 +173,7 @@ class VariantHandler(VariantLoader):
             nr_of_variants(int): if -1 return all variants
             skip(int): How many variants to skip
             sort_key: ['variant_rank', 'rank_score', 'position']
-
+            build(str): genome build
         Returns:
              pymongo.cursor
         """
@@ -188,7 +189,11 @@ class VariantHandler(VariantLoader):
             nr_of_variants = skip + nr_of_variants
 
         mongo_query = self.build_query(
-            case_id, query=query, variant_ids=variant_ids, category=category
+            case_id,
+            query=query,
+            variant_ids=variant_ids,
+            category=category,
+            build=build,
         )
         sorting = []
         if sort_key == "variant_rank":

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -356,7 +356,7 @@ def cancer_variants(institute_id, case_name):
     controllers.populate_chrom_choices(form, case_obj)
 
     form.gene_panels.choices = controllers.gene_panel_choices(institute_obj, case_obj)
-    genome_build = case_obj.get("genome_build")
+    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     variants_query = store.variants(

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -356,10 +356,12 @@ def cancer_variants(institute_id, case_name):
     controllers.populate_chrom_choices(form, case_obj)
 
     form.gene_panels.choices = controllers.gene_panel_choices(institute_obj, case_obj)
+    genome_build = case_obj.get("genome_build")
+    cytobands = store.cytoband_by_chrom(genome_build)
 
-    cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
-
-    variants_query = store.variants(case_obj["_id"], category="cancer", query=form.data)
+    variants_query = store.variants(
+        case_obj["_id"], category="cancer", query=form.data, build=genome_build
+    )
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 
     if request.form.get("export"):

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -61,16 +61,23 @@ def test_gene_symbols_query(adapter, case_obj):
     """Test variants query using HGNC symbol"""
 
     # WHEN hgnc_symbols params is provided to the query builder
-    test_gene = "POT1"
-    query = {"hgnc_symbols": [test_gene], "gene_panels": []}
+    gene_obj = {
+        "hgnc_id": 17284,
+        "hgnc_symbol": "POT1",
+        "build": "37",
+        "aliases": ["POTTA", "POT1"],
+    }
+    adapter.load_hgnc_gene(gene_obj)
+
+    query = {"hgnc_symbols": [gene_obj["hgnc_symbol"]], "gene_panels": []}
     mongo_query = adapter.build_query(case_obj["_id"], query=query)
 
-    # THEN the query should countain the gene
+    # THEN the query should countain the hgnc_id of the gene
     assert mongo_query == {
         "case_id": case_obj["_id"],
         "category": "snv",
         "variant_type": "clinical",
-        "hgnc_symbols": {"$in": [test_gene]},
+        "hgnc_ids": {"$in": [gene_obj["hgnc_id"]]},
     }
 
 
@@ -79,9 +86,14 @@ def test_gene_panel_query(adapter, case_obj):
 
     # GIVEN a database containing a minimal gene panel
     test_gene = "POT1"
-    test_panel = dict(panel_name="POT panel", version=1, genes=[{"symbol": test_gene}])
+    test_gene_hgnc_id = 17284
+
+    test_panel = dict(
+        panel_name="POT panel",
+        version=1,
+        genes=[{"symbol": test_gene, "hgnc_id": test_gene_hgnc_id}],
+    )
     adapter.panel_collection.insert_one(test_panel)
-    ínserted_panel = adapter.panel_collection.find_one()
 
     # WHEN the panel _id is provided to the query builder
     query = {"hgnc_symbols": [], "gene_panels": ["POT panel"]}
@@ -92,7 +104,7 @@ def test_gene_panel_query(adapter, case_obj):
         "case_id": case_obj["_id"],
         "category": "snv",
         "variant_type": "clinical",
-        "hgnc_symbols": {"$in": [test_gene]},
+        "hgnc_ids": {"$in": [test_gene_hgnc_id]},
     }
 
 
@@ -101,17 +113,31 @@ def test_gene_symbol_gene_panel_query(adapter, case_obj):
 
     # GIVEN a database containing a minimal gene panel
     test_gene = "POT1"
-    test_panel = dict(panel_name="POT panel", version=1, genes=[{"symbol": test_gene}])
+    test_gene_hgnc_id = 17284
+    test_panel = dict(
+        panel_name="POT panel",
+        version=1,
+        genes=[{"symbol": test_gene, "hgnc_id": test_gene_hgnc_id}],
+    )
     adapter.panel_collection.insert_one(test_panel)
-    ínserted_panel = adapter.panel_collection.find_one()
+
+    other_gene = "ATM"
+    other_gene_hgnc_id = 795
+    other_gene_obj = {
+        "hgnc_id": other_gene_hgnc_id,
+        "hgnc_symbol": other_gene,
+        "build": "37",
+        "aliases": [test_gene],
+    }
+    adapter.load_hgnc_gene(other_gene_obj)
 
     # WHEN the panel _id is provided to the query builder + a gene symbol for another gene
     query = {"hgnc_symbols": ["ATM"], "gene_panels": ["POT panel"]}
     mongo_query = adapter.build_query(case_obj["_id"], query=query)
 
     # THEN the query should countain both genes in the hgnc_symbols list
-    mongo_query_gene_list = mongo_query["hgnc_symbols"]["$in"]
-    for gene in ["ATM", "POT1"]:
+    mongo_query_gene_list = mongo_query["hgnc_ids"]["$in"]
+    for gene in [test_gene_hgnc_id, other_gene_hgnc_id]:
         assert gene in mongo_query_gene_list
 
 


### PR DESCRIPTION
This PR fixes a bug.

Gene filter since v4.21 used gene panel hgnc symbols for filtering, instead of the panels assigned on load. This harmonises well with gene symbol queries and arbitrary lists. However, if a gene symbol changes, even if hgnc_id stays the same, queries will miss the gene. Manually added search symbols go through validation checks. To avoid similar issues in the future, always gene filter with hgnc_id.

**How to test**:
1. Filter demo case with the test1 panel. Note a gene.
2. Re-symbol the gene in a panel, e.g. 
![Screenshot 2021-05-14 at 18 02 23](https://user-images.githubusercontent.com/758570/118298080-4ac40880-b4df-11eb-8913-4583012c003f.png)
3. Before checking out this branch, filter with the gene of choice and note that you no longer find the gene with the panel, but can find it with manual lookup of its actual hgnc symbol (e.g. "POT1")
4. Apply patch and note that the gene list filter is working again
5. Ideally retest with different scenarios: combine with manual hgnc symbols, use different case builds, hpo panels, possibly different variant categories...
 
**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
