### PR TITLE
Fix mme match external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed failing tests due to Flask update to version 2.0
 - Speed up user events view
 - Causative view sort out of memory error
+- Typo in case controllers displaying an error every time a patient is matched against external MatchMaker nodes
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1218,7 +1218,7 @@ def matchmaker_match(request, match_type, institute_id, case_name):
             nodes = [node["id"] for node in matchmaker.connected_nodes]
             for node in nodes:
                 json_resp = matchmaker.match_external(patient_id, node)
-                if json_resp.get("status") != 200:
+                if json_resp.get("status_code") != 200:
                     flash(
                         f"An error occurred while matching patient against external node: '{node}' : {json_resp.get('message')}",
                         "danger",


### PR DESCRIPTION
Fix #2618 

Fix a typo causing the display of an error every time a patient is matched against external MatchMaker nodes. It's not really a bug in the matching (which occurs), it's just saying an error occurred.

**How to test**:
1. Install the branch on scout stage (clinical-db)
2. Go to any case as a user that has MatchMaker permissions (grant yourself permissions using the command line if you are not one)
3. Add a case with variant and/or phenotypes to matchmaker and match it again one or more external nodes
4. The matching should not return error

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
