### PR TITLE
Prevent crashing when updating too large variant documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Speed up user events view
 - Causative view sort out of memory error
 - Use hgnc_id for gene filter query
+- Do not crash while attemping an update for variant documents that are too big (> 16 MB)
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -340,6 +340,8 @@ def parse_variant(
     compounds = variant_obj.get("compounds", [])
 
     if compounds and get_compounds:
+        LOG.error(variant_obj["_id"])
+        LOG.error(compounds)
         # Check if we need to update compound information
         if compounds_need_updating(compounds, case_dismissed_vars):
             new_compounds = store.update_variant_compounds(variant_obj)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -3,6 +3,7 @@ import logging
 import os.path
 from datetime import date
 
+from bson.BSON import encode
 from flask import Response, flash, url_for
 from flask_login import current_user
 from pymongo.errors import DocumentTooLarge
@@ -376,7 +377,8 @@ def parse_variant(
             variant_obj = store.update_variant(variant_obj)
         except DocumentTooLarge:
             flash(
-                f"An error occurred while updating variant: {variant_obj['_id']} --> pymongo_errors.DocumentTooLarge"
+                f"An error occurred while updating variant: {variant_obj['_id']} pymongo_errors.DocumentTooLarge: {len(encode(variant_obj))}",
+                "warning",
             )
 
     variant_obj["comments"] = store.events(

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -3,7 +3,7 @@ import logging
 import os.path
 from datetime import date
 
-from bson.BSON import encode
+import bson
 from flask import Response, flash, url_for
 from flask_login import current_user
 from pymongo.errors import DocumentTooLarge
@@ -377,7 +377,7 @@ def parse_variant(
             variant_obj = store.update_variant(variant_obj)
         except DocumentTooLarge:
             flash(
-                f"An error occurred while updating variant: {variant_obj['_id']} pymongo_errors.DocumentTooLarge: {len(encode(variant_obj))}",
+                f"An error occurred while updating variant: {variant_obj['_id']} pymongo_errors.DocumentTooLarge: {len(bson.BSON.encode(variant_obj))}",
                 "warning",
             )
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -3,9 +3,9 @@ import logging
 import os.path
 from datetime import date
 
-import pymongo_errors
 from flask import Response, flash, url_for
 from flask_login import current_user
+from pymongo.errors import DocumentTooLarge
 from werkzeug.datastructures import Headers, MultiDict
 from xlsxwriter import Workbook
 
@@ -347,7 +347,7 @@ def parse_variant(
                 new_compounds = store.update_variant_compounds(variant_obj)
                 variant_obj["compounds"] = new_compounds
                 has_changed = True
-            except pymongo_errors.DocumentTooLarge:
+            except DocumentTooLarge:
                 flash(
                     f"An error occurred while updating variant: {variant_obj['_id']} --> pymongo_errors.DocumentTooLarge"
                 )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -343,14 +343,9 @@ def parse_variant(
     if compounds and get_compounds:
         # Check if we need to update compound information
         if compounds_need_updating(compounds, case_dismissed_vars):
-            try:
-                new_compounds = store.update_variant_compounds(variant_obj)
-                variant_obj["compounds"] = new_compounds
-                has_changed = True
-            except DocumentTooLarge:
-                flash(
-                    f"An error occurred while updating variant: {variant_obj['_id']} --> pymongo_errors.DocumentTooLarge"
-                )
+            new_compounds = store.update_variant_compounds(variant_obj)
+            variant_obj["compounds"] = new_compounds
+            has_changed = True
 
         # sort compounds on combined rank score
         variant_obj["compounds"] = sorted(
@@ -377,7 +372,12 @@ def parse_variant(
     # We update the variant if some information was missing from loading
     # Or if symbold in reference genes have changed
     if update and has_changed:
-        variant_obj = store.update_variant(variant_obj)
+        try:
+            variant_obj = store.update_variant(variant_obj)
+        except DocumentTooLarge:
+            flash(
+                f"An error occurred while updating variant: {variant_obj['_id']} --> pymongo_errors.DocumentTooLarge"
+            )
 
     variant_obj["comments"] = store.events(
         institute_obj, case=case_obj, variant_id=variant_obj["variant_id"], comments=True

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -377,7 +377,7 @@ def parse_variant(
             variant_obj = store.update_variant(variant_obj)
         except DocumentTooLarge:
             flash(
-                f"An error occurred while updating variant: {variant_obj['_id']} pymongo_errors.DocumentTooLarge: {len(bson.BSON.encode(variant_obj))}",
+                f"An error occurred while updating info for variant: {variant_obj['_id']} (pymongo_errors.DocumentTooLarge: {len(bson.BSON.encode(variant_obj))})",
                 "warning",
             )
 


### PR DESCRIPTION
Fix #2623

Prevent the variantS page to crash when a variant_obj document to be updated is too big (> 16 MB). Display instead a warning message.

I have no idea why this size error occurs tho!

**How to test**:
1. Go on clinical-db stage and try to display the variantS page from this case: https://scout-stage.scilifelab.se/cust003/2015
1. Master branch should crash
2. This branch should display all variants and the problematic variant with a warning

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
