### PR TITLE
Sort strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Use hgnc_id for gene filter query
 - Typo in case controllers displaying an error every time a patient is matched against external MatchMaker nodes
 - Do not crash while attemping an update for variant documents that are too big (> 16 MB)
-- Old STR causatives may not have HGNC symbols - fix sort lambda
+- Old STR causatives (and other variants) may not have HGNC symbols - fix sort lambda
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -139,7 +139,7 @@ def causatives(institute_id):
     if variants:
         variants = sorted(
             variants,
-            key=lambda k: str(k.get("hgnc_symbols", [None])[0]) or k.get("str_repid") or "",
+            key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
         )
     all_variants = {}
     all_cases = {}

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -138,7 +138,8 @@ def causatives(institute_id):
     variants = list(store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id))
     if variants:
         variants = sorted(
-            variants, key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid")
+            variants,
+            key=lambda k: str(k.get("hgnc_symbols", [None])[0]) or k.get("str_repid") or "",
         )
     all_variants = {}
     all_cases = {}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fallback for hgnc_symbol-lacking variants for causatives sorted.

![Screenshot 2021-05-18 at 09 48 10](https://user-images.githubusercontent.com/758570/118613479-14c4a400-b7bf-11eb-95b0-e8bf5e1dec90.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
