### PR TITLE
Fixed crash when gene hasnt a primary_transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Typo in case controllers displaying an error every time a patient is matched against external MatchMaker nodes
 - Do not crash while attemping an update for variant documents that are too big (> 16 MB)
 - Old STR causatives may not have HGNC symbols - fix sort lambda
+- Check if gene_obj has primary_transcript before trying to access it
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -69,7 +69,7 @@
                   <td class="d-flex align-items-center">
                     <div> <!-- ID col-->
                       <span class="text"> {{ transcript.transcript_id }}</span>
-                      {% if gene.common and transcript.refseq_id in gene.common.primary_transcripts %}
+                      {% if (primary_transcripts in gene.common) and (gene.common and transcript.refseq_id in gene.common.primary_transcripts) %}
                         <a href="#" data-toggle="tooltip" title="hgnc primary"><span class="badge badge-primary" title="hgnc primary">P</span></a>
                       {% endif %}
                       {% if transcript.mane_select_transcript %}

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -69,7 +69,7 @@
                   <td class="d-flex align-items-center">
                     <div> <!-- ID col-->
                       <span class="text"> {{ transcript.transcript_id }}</span>
-                      {% if (primary_transcripts in gene.common) and (gene.common and transcript.refseq_id in gene.common.primary_transcripts) %}
+                      {% if gene.common and 'primary_transcripts' in gene.common and transcript.refseq_id in gene.common.primary_transcripts %}
                         <a href="#" data-toggle="tooltip" title="hgnc primary"><span class="badge badge-primary" title="hgnc primary">P</span></a>
                       {% endif %}
                       {% if transcript.mane_select_transcript %}


### PR DESCRIPTION
This fixes an issue when the variant view would crash if a gene hasn't a primary transcript

**Review:**
- [x] code approved by CR
- [x] tests executed by MJ
