### PR TITLE
chr pos split js safer for STR view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Typo in case controllers displaying an error every time a patient is matched against external MatchMaker nodes
 - Do not crash while attemping an update for variant documents that are too big (> 16 MB)
 - Old STR causatives (and other variants) may not have HGNC symbols - fix sort lambda
+- ChrPos split js not needed on STR page yet
 ### Changed
 - Remove parsing of case `genome_version`, since it's not used anywhere downstream
 - Introduce deprecation warning for Loqus configs that are not dictionaries

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -2,7 +2,11 @@
 function populateCytobands(cytobands){
   var chromPosPattern = new RegExp("^(?:chr)?([1-9]|1[0-9]|2[0-2]|X|Y|MT)$");
   var chrom = document.forms["filters_form"].elements["chrom"].value;
-  var chromPos = document.forms["filters_form"].elements["chrom_pos"].value;
+  var chromPos = "";
+  if (typeof document.forms["filters_form"].elements["chrom_pos"] != "undefined") {
+  	chromPos=document.forms["filters_form"].elements["chrom_pos"].value;
+	}
+
   var chromosome = "";
   console.log("Populate cytobands")
   var matchedChrName = chromPos.match(chromPosPattern)

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -3,7 +3,7 @@ function populateCytobands(cytobands){
   var chromPosPattern = new RegExp("^(?:chr)?([1-9]|1[0-9]|2[0-2]|X|Y|MT)$");
   var chrom = document.forms["filters_form"].elements["chrom"].value;
   var chromPos = "";
-  if (typeof document.forms["filters_form"].elements["chrom_pos"] != "undefined") {
+  if (typeof document.forms["filters_form"].elements["chrom_pos"] !== "undefined") {
   	chromPos=document.forms["filters_form"].elements["chrom_pos"].value;
 	}
 

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -152,7 +152,6 @@
 
     window.onload=function() {
       populateCytobands({{cytobands|safe}});
-
       {{ update_stash_filter_button_status(current_user, filters) }}
     }
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Some issues remained / arose with filter lock with the new release candidate.

1. A js error on the STR filters (no chr_pos to split) disabled both populating chr and filter lock

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
