### PR TITLE
Update and style STR case report table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Documentation for load-configuration rewritten.
 - Add styles to MatchMaker matches table
 - More detailed info on the data shared in MatchMaker submission form
+- Update and style STR case report
 
 ## [4.33.1]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -401,6 +401,8 @@
     {{ sn_variant_content(variant, index) }}
   {% elif variant.category == 'cancer' %}
     {{ sn_variant_content(variant, index) }}
+  {% elif variant.category == 'str' %}
+    {{ str_variant_content(variant, index) }}
   {% else %}
     {{ sv_variant_content(variant, index) }}
   {% endif %}
@@ -421,6 +423,8 @@
             {{ sn_variant_content(variant, loop.index) }}
           {% elif variant.category == 'cancer' %}
             {{ sn_variant_content(variant, loop.index) }}
+          {% elif variant.category == 'str' %}
+            {{ str_variant_content(variant, loop.index) }}
           {% else %}
             {{ sv_variant_content(variant, loop.index) }}
           {% endif %}
@@ -439,12 +443,13 @@
 </div>
 {% endmacro %}
 
+<!-- SNV -->
 {% macro sn_variant_content(variant, index) %} <!--The entire description of a single nucleotide variant, dynamic content -->
   <div class="card" style="border-width: 5px;">
     <div class="card-header">
       <div class="row d-flex align-items-center">
         # <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name[:30]}}</strong></a>&nbsp;
-          <span class="badge badge-pill badge-success">SNV</span>&nbsp;
+          <span class="badge badge-pill badge-success">{{variant.category | upper}}</span>&nbsp;
           {% if variant.sanger_ordered and variant.validation %}
             <span class="badge badge-pill badge-info" title="verif-status">Verification:{{variant.validation}}</span>
           {% elif variant.sanger_ordered %}
@@ -921,12 +926,13 @@
 </div>
 {% endmacro %}
 
+<!-- SV -->
 {% macro sv_variant_content(variant,index) %} <!--The entire description of a structural variant, dynamic contentc -->
 <div class="card" style="border-width: 5px;">
   <div class="card-header">
     <div class="row d-flex align-items-center">
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
-    &nbsp;<span class="badge badge-pill badge-warning">SV</span>
+    &nbsp;<span class="badge badge-pill badge-warning">{{variant.sub_category|upper}}</span>
     </div>
     {% if variant.get('phenotypes') %}
       <div class="row mt-3">
@@ -970,7 +976,7 @@
           {% endif %}
           <td>
             {% for panel_id in variant.panels %}
-              <a href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank">{{ panel_id }}</a><br>
+              <a href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" class="badge badge-secondary">{{ panel_id }}</a><br>
             {% endfor %}
           </td>
           <td>
@@ -1135,6 +1141,178 @@
             </td>
           </tr>
         {% endfor %}
+      </tbody>
+    </table>
+
+
+    {% if variant.comments | count_cursor > 0  %}
+      <br>
+      <table id="panel-table" class="table table-sm" style="background-color: transparent">
+        <thead>
+          <tr>
+            <td colspan=3><strong>Variant-related comments</strong></td>
+          </tr>
+        </thead>
+        <tbody>
+          {% for comment in variant.comments %}
+            <tr>
+              <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
+              <td class="text-break"><strong>{{ comment.content | fix_punctuation}}</strong></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}
+
+<!-- STR -->
+{% macro str_variant_content(variant,index) %} 
+<div class="card" style="border-width: 5px;">
+  <div class="card-header">
+    <div class="row d-flex align-items-center">
+    # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.str_repid}}:{{ variant.alternative|replace("<", "")|replace(">", "") }} - {{variant.str_display_ru or variant.str_ru}} - {{ variant.str_status| upper |replace("_", " ") }}</strong></a>
+    &nbsp;<span class="badge badge-pill badge-info">{{variant.category | upper}}</span>
+    </div>
+    {% if variant.get('phenotypes') %}
+      <div class="row mt-3">
+        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+          OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
+          HPO terms:&nbsp;
+          {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
+            {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
+          {%- endfor -%}
+        </h6>
+      </div>
+    {% endif %}
+  </div>
+  <div class="card-body">
+    <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent">
+      <thead>
+        <tr class="table-secondary">
+          <th>Variant type</th>
+          <th>length</td>
+          <th>Coordinates</th>
+          <th>Cytoband</th>
+          <th>Gene panels</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="badge badge-info">{{variant.category | upper}}</span></td>
+          <td>{{ variant.length }}</td>
+          <td>
+            {% if variant.chromosome == variant.end_chrom %}
+              chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
+            {% else %}
+              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}
+            {% endif %}
+          </td>
+          {% if variant.cytoband_start and variant.cytoband_end %}
+            <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
+          {% else %}
+            <td>-</td>
+          {% endif %}
+          <td>
+            {% for panel_id in variant.panels %}
+              <a href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" class="badge badge-secondary">{{ panel_id }}</a><br>
+            {% endfor %}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table id="panel-table" class="table table-sm" style="background-color: transparent">
+      <tr>
+          <table id="panel-table" class="table table-bordered " style="background-color: transparent">
+            <thead>
+              <tr class="table-secondary">
+                <th rowspan="2">Sample</th>
+                  <th rowspan="2">Genotype (GT)</th>
+                  <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
+                  <!-- <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th> -->
+                  <th rowspan="2" colspan="1">ExpansionHunter support</th>
+                </tr>
+                <tr class="table-secondary">
+                  <th>Reference</th>
+                  <th>Alternative</th>
+                </tr>
+              </tr>
+            </thead>
+            <tbody>
+              {% for sample in variant.samples %}
+                <tr {% if sample.display_name in affected %} class="table-danger" {% endif %}>
+                  <td>{{ sample.display_name }}</td>
+                  <td class="text-center">{{ sample.genotype_call }}</td>
+                  {% if sample.allele_depths %}
+                      {% for number in sample.allele_depths %}
+                        <td class="text-right">
+                          {% if number == -1 %}
+                            <small>N/A</small>
+                          {% else %}
+                            {{ number }}
+                          {% endif %}
+                        </td>
+                      {% endfor %}
+                  {% else %}
+                      <td class="text-right"><small>N/A</small></td>
+                      <td class="text-right"><small>N/A</small></td>
+                  {% endif %}
+                    <!-- <td class="text-right">{{ sample.genotype_quality }}</td> -->
+                    <td><small>{{ sample.so }}</small></td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </td>
+      </tr>
+    </table>
+    <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent">
+      <thead>
+        <tr class="table-secondary">
+          <th>Scout Rank</th>
+          <th>Scout score</th>
+          <th>Manual rank</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{variant.variant_rank}}</td>
+          <td>{{variant.rank_score}}</td>
+          <td>
+          {% if variant.manual_rank %}
+            <span class="badge badge-pill badge-secondary" title="Manual rank">{{ manual_rank_options[variant.manual_rank]['label'] }}</span>
+          {% endif %}
+          {% if variant.cancer_tier %}
+            <span class="badge badge-pill badge-secondary" title="Tier">{{ cancer_rank_options[variant.cancer_tier]['label'] }}</span>
+          {% endif %}
+          {% if not (variant.manual_rank or variant.cancer_tier) %}
+            <span class="text-center">-</span>
+          {% endif %}
+          </td>
+      </tbody>
+    </table>
+
+    <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent">
+      <thead>
+        <tr class="table-secondary">
+          <th>Disease</th>
+          <th>Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {% if variant.str_disease %}
+            <td>{{ variant.str_disease }} ({{ variant.str_inheritance_mode }})</td>
+          {% else %}
+            <td>Disease information not provided with locus. Consider updating to a new version of Stranger.</td>
+          {% endif %}
+          {% if variant.str_source is defined %}
+            <td>{{ variant.str_source.display }}</td>
+          {% else %}
+            <td>-</td>
+          {% endif %}
+          </tr>
       </tbody>
     </table>
 

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1192,7 +1192,7 @@
       <thead>
         <tr class="table-secondary">
           <th>Variant type</th>
-          <th>length</td>
+          <th>Estimated size</th>
           <th>Coordinates</th>
           <th>Cytoband</th>
           <th>Gene panels</th>
@@ -1201,7 +1201,7 @@
       <tbody>
         <tr>
           <td><span class="badge badge-info">{{variant.category | upper}}</span></td>
-          <td>{{ variant.length }}</td>
+          <td>{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
           <td>
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1304,8 +1304,6 @@
         <tr>
           {% if variant.str_disease %}
             <td>{{ variant.str_disease }} ({{ variant.str_inheritance_mode }})</td>
-          {% else %}
-            <td>Disease information not provided with locus. Consider updating to a new version of Stranger.</td>
           {% endif %}
           {% if variant.str_source is defined %}
             <td>{{ variant.str_source.display }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1230,7 +1230,6 @@
                 <th rowspan="2">Sample</th>
                   <th rowspan="2">Genotype (GT)</th>
                   <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                  <!-- <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th> -->
                   <th rowspan="2" colspan="1">ExpansionHunter support</th>
                 </tr>
                 <tr class="table-secondary">
@@ -1258,7 +1257,6 @@
                       <td class="text-right"><small>N/A</small></td>
                       <td class="text-right"><small>N/A</small></td>
                   {% endif %}
-                    <!-- <td class="text-right">{{ sample.genotype_quality }}</td> -->
                     <td><small>{{ sample.so }}</small></td>
                 </tr>
               {% endfor %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -280,7 +280,7 @@
                    case_name=case.display_name,
                    variant_id=variant._id) }}">
   {% if variant.category in "str" %}
-  {{ variant.str_repid }} {{ variant.alternative }}
+  {{ variant.str_repid }} {{ variant.alternative | replace("<", " ") | replace(">", "")}}
   {% elif variant.category in ("snv", "cancer") %}
   {% set display_genes = [] %}
     {% for gene in variant.genes %}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -59,7 +59,11 @@
               </a>
             </td>
             <td><span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
-                {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
+                {% if group_variant.category in 'str' %}
+                    {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
+                {% else %}
+                    {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) }}
+                {% endif%}                
               </span>
             </td>
             <td><span class="badge badge-secondary">{{ variant.category|upper }}</span></td>

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -59,7 +59,6 @@
               </a>
             </td>
             <td><span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
-                <!-- 🚧 untested code ahead 🚧 -->
                 {% if group_variant.category in 'str' %}
                     {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
                 {% else %}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -59,6 +59,7 @@
               </a>
             </td>
             <td><span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
+                <!-- 🚧 untested code ahead 🚧 -->
                 {% if group_variant.category in 'str' %}
                     {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
                 {% else %}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -59,7 +59,7 @@
               </a>
             </td>
             <td><span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
-                {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) }}
+                {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
               </span>
             </td>
             <td><span class="badge badge-secondary">{{ variant.category|upper }}</span></td>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -275,24 +275,29 @@
               </span>
             </td>
             <td>
+              <!-- 🚧 untested code ahead 🚧 -->
+              {% if not variant.str_repid %}
               Change
               <span>
-                {%- if variant.reference|length > 8 -%}
-                  <strong>{{ variant.reference[:1] }}..{{variant.reference[-1:]}}</strong><button type="button" class="fa fa-file-text btn-xs js-tooltip js-copy"
-                    style="background-color: Transparent;outline:none; border: none;" data-toggle="tooltip" data-placement="bottom" data-copy="{{variant.reference}}" title="Copy to clipboard">
-                  </button>
-                {%- else -%}
-                  <strong>{{ variant.reference }}</strong>
-                {%- endif -%}
-                  →
-                {%- if variant.alternative|length > 8 -%}
-                  <strong>{{ variant.alternative[:1] }}..{{variant.alternative[-1:]}}</strong><button type="button" class="fa fa-file-text btn-xs js-tooltip js-copy"
-                    style="background-color: Transparent;outline:none; border: none;" data-toggle="tooltip" data-placement="bottom" data-copy="{{variant.alternative}}" title="Copy to clipboard">
+                  {%- if variant.reference|length > 8 -%}
+                    <strong>{{ variant.reference[:1] }}..{{variant.reference[-1:]}}</strong><button type="button" class="fa fa-file-text btn-xs js-tooltip js-copy"
+                      style="background-color: Transparent;outline:none; border: none;" data-toggle="tooltip" data-placement="bottom" data-copy="{{variant.reference}}" title="Copy to clipboard">
                     </button>
+                  {%- else -%}
+                    <strong>{{ variant.reference }}</strong>
+                  {%- endif -%}
+                    →
+                  {%- if variant.alternative|length > 8 -%}
+                    <strong>{{ variant.alternative[:1] }}..{{variant.alternative[-1:]}}</strong><button type="button" class="fa fa-file-text btn-xs js-tooltip js-copy"
+                      style="background-color: Transparent;outline:none; border: none;" data-toggle="tooltip" data-placement="bottom" data-copy="{{variant.alternative}}" title="Copy to clipboard">
+                    </button>
+                  {%- else -%}
+                    <strong>{{ variant.alternative }}</strong>
+                  {%- endif -%}
                 {%- else -%}
                   <strong>{{ variant.alternative | replace("<", " ") | replace(">", "")}}</strong>
                 {%- endif -%}
-                </span>
+              </span>
             </td>
           </tr>
           {% if variant.str_repid %}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -275,8 +275,7 @@
               </span>
             </td>
             <td>
-              <!-- 🚧 untested code ahead 🚧 -->
-              {% if not variant.str_repid %}
+              {% if not variant.category == "str" %}
               Change
               <span>
                   {%- if variant.reference|length > 8 -%}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -290,7 +290,7 @@
                     style="background-color: Transparent;outline:none; border: none;" data-toggle="tooltip" data-placement="bottom" data-copy="{{variant.alternative}}" title="Copy to clipboard">
                     </button>
                 {%- else -%}
-                  <strong>{{ variant.alternative }}</strong>
+                  <strong>{{ variant.alternative | replace("<", " ") | replace(">", "")}}</strong>
                 {%- endif -%}
                 </span>
             </td>


### PR DESCRIPTION
This PR adds:
1. Update and style STR case report.

When opening a general report as a web page:
![Screen Shot 2021-05-19 at 11 31 12](https://user-images.githubusercontent.com/41540288/118790859-7146c280-b896-11eb-9033-39959a44ed59.png)

When downloading a general report as a PDF:
![Screen Shot 2021-05-19 at 11 31 36](https://user-images.githubusercontent.com/41540288/118790942-83286580-b896-11eb-9d8c-7491a925dbe5.png)

STR variants pinned & marked causative:
![Screen Shot 2021-05-19 at 11 30 47](https://user-images.githubusercontent.com/41540288/118791691-3d1fd180-b897-11eb-8e39-ad00ead31b69.png)
![Screen Shot 2021-05-19 at 11 30 52](https://user-images.githubusercontent.com/41540288/118791701-3ee99500-b897-11eb-9278-87c76a9f37cd.png)

Variant page (without angle brackets):
![Web 1920 – 1](https://user-images.githubusercontent.com/41540288/118792404-eb2b7b80-b897-11eb-9929-215f87d7a1a9.png)






**Review:**
- [ ] code approved by
- [x] tests executed by MOD
