### PR TITLE
Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [x.x.x]
+### Added
+### Fixed
+- Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks
+### Changed
+
 ## [4.34]
 ### Added
 - Saved filter lock and unlock

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -69,7 +69,7 @@
                                 {
                                   type: 'wig',
                                   format: "bigwig",
-                                  url: "{{ url_for('alignviewers.unindexed_remote_static', file=track.coverage_wig) }}",
+                                  url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig) }}",
                                 },
                                 {
                                   type: 'spliceJunctions',
@@ -77,8 +77,8 @@
                                   colorBy: 'strand',
                                   thicknessBasedOn: 'numUniqueRead',
                                   labelUniqueReadCount: true,
-                                  url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed) }}",
-                                  indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index) }}",
+                                  url: "{{ url_for('alignviewers.unindexed_remote_static', file=track.splicej_bed) }}",
+                                  indexURL: "{{ url_for('alignviewers.unindexed_remote_static', file=track.splicej_bed_index) }}",
                                   minUniquelyMappedReads: 1
                                 }
                             ]

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -77,10 +77,8 @@
                                   colorBy: 'strand',
                                   thicknessBasedOn: 'numUniqueRead',
                                   labelUniqueReadCount: true,
-                                  url: "{{ url_for('alignviewers.unindexed_remote_static', file=track.splicej_bed) }}",
-                                  {% if track.splicej_bed_index %} // this file should be present but you never know. The track loads more slowly if index is missing
-                                    indexURL: "{{ url_for('alignviewers.unindexed_remote_static', file=track.splicej_bed_index) }}",
-                                  {% endif %}
+                                  url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed) }}",
+                                  indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index) }}",
                                   minUniquelyMappedReads: 1
                                 }
                             ]

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -63,7 +63,6 @@ def remote_cors(remote_url):
 def remote_static():
     """Stream *large* static files with special requirements."""
     file_path = request.args.get("file")
-
     range_header = request.headers.get("Range", None)
     if not range_header and (file_path.endswith(".bam") or file_path.endswith(".cram")):
         return abort(500)

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -501,7 +501,7 @@
         {% if splice_junctions_tracks %}
           <li class="list-group-item">
             <div>{{ splice_junctions_button(institute._id, case.display_name, variant._id) }}</div>
-          <li>
+          </li>
         {% endif %}
       </ul>
       {% if variant.custom %}


### PR DESCRIPTION
Tentative fix #2636

**How to test**:
1. Install on stage and check that tracks from this variant work: https://scout-stage.scilifelab.se/cust003/14022/e4f6bda7d7150a2c455ee12e6a41e2c9

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
