### PR TITLE
Add a Pedigree panel in STR page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 - A new index for hgnc_symbol in hgnc gene collection
+- A Pedigree panel in STR page
 ### Fixed
 - Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks
 ### Changed

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -1,5 +1,5 @@
 {% extends "layout_bs4.html" %}
-{% from "utils.html" import comments_table %}
+{% from "utils.html" import comments_table, pedigree_panel %}
 {% from "variants/components.html" import gene_cell, frequency_cell_general %}
 {% from "variants/utils.html" import cell_rank, dismiss_variants_block, filter_form_footer, update_stash_filter_button_status, pagination_footer, pagination_hidden_div, str_filters %}
 {% from "variant/buttons.html" import igv_button %}
@@ -120,6 +120,13 @@
 </div> <!-- end of class="container-float"> -->
 <div class="container-fluid">
   {{ pagination_footer(more_variants, page) }}
+</div>
+<!--  Pedigree_panel -->
+<div class="row">
+  {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
+  {% if has_pedigree %}
+    <div class="col-md-4">{{ pedigree_panel(case) }}</div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -124,10 +124,10 @@
 <!--  Pedigree_panel -->
 {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
 {% if has_pedigree %}
-<div class="row">
+  <div class="row">
     <div class="col-md-4">{{ pedigree_panel(case) }}</div>
-  {% endif %}
-</div>
+  </div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -122,9 +122,9 @@
   {{ pagination_footer(more_variants, page) }}
 </div>
 <!--  Pedigree_panel -->
+{% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
+{% if has_pedigree %}
 <div class="row">
-  {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
-  {% if has_pedigree %}
     <div class="col-md-4">{{ pedigree_panel(case) }}</div>
   {% endif %}
 </div>


### PR DESCRIPTION
This PR adds:
A Pedigree panel on the STR page when the length of (case.madeline_info & case.individuals) > 1

![Screen Shot 2021-05-20 at 14 03 01](https://user-images.githubusercontent.com/41540288/118978763-fe157d00-b977-11eb-9d48-e08c565a271f.png)


**Review:**
- [x] code approved by DN
- [x] tests executed by MOD
