### PR TITLE
Switch off non-clinical gene warnings when filtering research variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks
 ### Changed
-- Switch off non-clinical gene warning when filtering research variants
+- Switch off non-clinical gene warnings when filtering research variants
 
 ## [4.34]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks
 ### Changed
+- Switch off non-clinical gene warning when filtering research variants
 
 ## [4.34]
 ### Added

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -994,7 +994,7 @@ def check_form_gene_symbols(
 
         if hgnc_gene is None:
             not_found_symbols.append(hgnc_symbol)
-        elif is_clinical is False # research
+        elif is_clinical is False:  # research
             updated_hgnc_symbols.append(hgnc_symbol)
         elif is_clinical and hgnc_gene["hgnc_id"] in clinical_hgnc_ids:
             updated_hgnc_symbols.append(hgnc_symbol)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1005,15 +1005,15 @@ def check_form_gene_symbols(
 
     errors = {
         "non_clinical_symbols": {
-            "alert": "Gene not included in clinical list",
+            "alert": "Gene not included in case clinical list",
             "gene_list": non_clinical_symbols,
         },
         "not_found_symbols": {
-            "alert": "HGNC symbol not present in gene collection",
+            "alert": "HGNC symbol not present in genes collection",
             "gene_list": not_found_symbols,
         },
         "not_found_ids": {
-            "alert": "HGNC id not present in gene collection",
+            "alert": "HGNC id not present in genes collection",
             "gene_list": not_found_ids,
         },
         "outdated_symbols": {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -994,15 +994,15 @@ def check_form_gene_symbols(
 
         if hgnc_gene is None:
             not_found_symbols.append(hgnc_symbol)
-        elif is_clinical is False:  # research
+        elif is_clinical is False:  # research variants
             updated_hgnc_symbols.append(hgnc_symbol)
-        elif is_clinical and hgnc_gene["hgnc_id"] in clinical_hgnc_ids:
+        elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
             updated_hgnc_symbols.append(hgnc_symbol)
             if hgnc_symbol not in clinical_symbols:
                 # clinical symbols from gene panels might not be up to date with latest gene names
                 # but their HGNC id would still match
                 outdated_symbols.append(hgnc_symbol)
-        else:
+        else:  # clinical variants
             non_clinical_symbols.append(hgnc_symbol)
 
     errors = {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1000,7 +1000,7 @@ def check_form_gene_symbols(
                 # clinical symbols from gene panels might not be up to date with latest gene names
                 # but their HGNC id would still match
                 outdated_symbols.append(hgnc_symbol)
-        else:
+        elif is_clinical:
             non_clinical_symbols.append(hgnc_symbol)
 
     errors = {
@@ -1008,8 +1008,14 @@ def check_form_gene_symbols(
             "alert": "Gene not included in clinical list",
             "gene_list": non_clinical_symbols,
         },
-        "not_found_symbols": {"alert": "HGNC symbol not found", "gene_list": not_found_symbols},
-        "not_found_ids": {"alert": "HGNC id not found", "gene_list": not_found_ids},
+        "not_found_symbols": {
+            "alert": "HGNC symbol not present in gene collection",
+            "gene_list": not_found_symbols,
+        },
+        "not_found_ids": {
+            "alert": "HGNC id not present in gene collection",
+            "gene_list": not_found_ids,
+        },
         "outdated_symbols": {
             "alert": "Clinical list contains a panel with an outdated symbol for genes",
             "gene_list": outdated_symbols,

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1075,7 +1075,6 @@ def update_form_hgnc_symbols(store, case_obj, form):
 
     # check if supplied gene symbols exist and are clinical
     is_clinical = form.data.get("variant_type", "clinical") == "clinical"
-    flash(f"is_clinical:{is_clinical}")
     updated_hgnc_symbols = check_form_gene_symbols(
         store, case_obj, is_clinical, genome_build, hgnc_symbols, not_found_ids
     )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1002,7 +1002,7 @@ def check_form_gene_symbols(
                 # clinical symbols from gene panels might not be up to date with latest gene names
                 # but their HGNC id would still match
                 outdated_symbols.append(hgnc_symbol)
-        elif is_clinical:
+        else:
             non_clinical_symbols.append(hgnc_symbol)
 
     errors = {
@@ -1075,6 +1075,7 @@ def update_form_hgnc_symbols(store, case_obj, form):
 
     # check if supplied gene symbols exist and are clinical
     is_clinical = form.data.get("variant_type", "clinical") == "clinical"
+    flash(f"is_clinical:{is_clinical}")
     updated_hgnc_symbols = check_form_gene_symbols(
         store, case_obj, is_clinical, genome_build, hgnc_symbols, not_found_ids
     )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -994,6 +994,8 @@ def check_form_gene_symbols(
 
         if hgnc_gene is None:
             not_found_symbols.append(hgnc_symbol)
+        elif is_clinical is False # research
+            updated_hgnc_symbols.append(hgnc_symbol)
         elif is_clinical and hgnc_gene["hgnc_id"] in clinical_hgnc_ids:
             updated_hgnc_symbols.append(hgnc_symbol)
             if hgnc_symbol not in clinical_symbols:

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -383,7 +383,7 @@ def test_update_form_hgnc_symbols_valid_gene_symbol(app, case_obj):
 
     # GIVEN a user trying to filter clinical variants using a valid gene symbol
     form.hgnc_symbols.data = ["POT1"]
-    form.data = {"gene_panels": []}
+    form.data = {"gene_panels": [], "variant_type": "research"}
     updated_form = update_form_hgnc_symbols(store, case_obj, form)
 
     # Form should be updated correctly
@@ -406,7 +406,7 @@ def test_update_form_hgnc_symbols_valid_gene_id(app, case_obj):
 
     # GIVEN a user trying to filter clinical variants using a valid gene ID
     form.hgnc_symbols.data = ["17284"]
-    form.data = {"gene_panels": []}
+    form.data = {"gene_panels": [], "variant_type": "clinical"}
     updated_form = update_form_hgnc_symbols(store, case_obj, form)
 
     # Form should be updated correctly

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -381,7 +381,7 @@ def test_update_form_hgnc_symbols_valid_gene_symbol(app, case_obj):
 
     form = TestForm()
 
-    # GIVEN a user trying to filter clinical variants using a valid gene symbol
+    # GIVEN a user trying to filter research variants using a valid gene symbol
     form.hgnc_symbols.data = ["POT1"]
     form.data = {"gene_panels": [], "variant_type": "research"}
     updated_form = update_form_hgnc_symbols(store, case_obj, form)


### PR DESCRIPTION
Fix #2649

**How to test**:
1. On clinical-db stage go to a case that has research variants
2. From research variants page look for a gene that is not in case clinical list (DNAH14?)
3. Make sure you get no warnings

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
