### PR TITLE
Gene panel dropdown height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add styles to MatchMaker matches table
 - More detailed info on the data shared in MatchMaker submission form
 - Update and style STR case report
-- Add max-height to all dropdowns in Clinical SNV and INDELs view
+- Add max-height to all dropdowns in filters
 
 ## [4.33.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Documentation for load-configuration rewritten.
 - Add styles to MatchMaker matches table
 - More detailed info on the data shared in MatchMaker submission form
+- Add max-height to all dropdowns in Clinical SNV and INDELs view
 
 ## [4.33.1]
 ### Fixed

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -137,7 +137,7 @@
   <div class="row">
     <div class="col-2">
       {{ form.gene_panels.label(class="control-label", data_toggle="tooltip", data_placement="left", title="This list can be modified from the institute settings page. Latest panel version is used in variants filtering.") }}
-      {{ form.gene_panels(class="selectpicker", size="5") }}
+      {{ form.gene_panels(class="selectpicker") }}
     </div>
     <div class="col-2">
       {{ form.symbol_file.label(class="control-label", data_toggle="tooltip", data_placement="left", title="Load an HGNC gene symbol list file; a text file with one gene symbol starting each row. Extra columns separated with tab are ignored. Comment rows starting with # are ignored.") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -137,7 +137,7 @@
   <div class="row">
     <div class="col-2">
       {{ form.gene_panels.label(class="control-label", data_toggle="tooltip", data_placement="left", title="This list can be modified from the institute settings page. Latest panel version is used in variants filtering.") }}
-      {{ form.gene_panels(class="selectpicker") }}
+      {{ form.gene_panels(class="selectpicker", size="5") }}
     </div>
     <div class="col-2">
       {{ form.symbol_file.label(class="control-label", data_toggle="tooltip", data_placement="left", title="Load an HGNC gene symbol list file; a text file with one gene symbol starting each row. Extra columns separated with tab are ignored. Comment rows starting with # are ignored.") }}

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -240,7 +240,12 @@
         the_form.submit();
       };
 
+      // max-height to all dropdowns in this view
+      $(".dropdown-menu").css("max-height","400px");
+
     });
+
+
    </script>
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -55,7 +55,7 @@
          <thead>
             <tr>
               <th style="width:3%"></th>
-              <th style="width:12%" title="Rank position">Rank </th>
+              <th style="width:12%" title="Rank position">Rank</th>
               <th style="width:6%" title="Rank score">Score</th>
               <th style="width:6%" title="Chromosome">Chr.</th>
               <th style="width:8%" title="HGNC symbols">Gene</th>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -239,10 +239,6 @@
         var the_form = document.forms['filters_form'];
         the_form.submit();
       };
-
-      // max-height to all dropdowns in this view
-      $(".dropdown-menu").css("max-height","400px");
-
     });
 
 

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -342,7 +342,7 @@ option {
 }
 
 .dropdown-menu {
-  max-height: 420px !important;
+  max-height: 130px !important;
 }
 
 

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -91,7 +91,7 @@ table.dataTable {margin-bottom: 0rem}
  .navbar-nav>.active, .navbar-default,
  .navbar-inverse>.active, .navbar-nav li.active > a {
   color:white;
-  background-color: #343a40; !important;
+  background-color: #343a40 !important;
 }
 
 .dropdown {
@@ -341,6 +341,10 @@ option {
    content: "\e114";
    float: right;
    transition: all 0.5s;
+}
+
+.dropdown-menu {
+  max-height: 420px !important;
 }
 
 

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -15,8 +15,6 @@
 }
 
 .btn-custom-select {
-  color: white;
-  background-color: white;
   width: 100%;
   color: #495057;
   background-color: #fff;
@@ -60,7 +58,7 @@ table.dataTable {margin-bottom: 0rem}
 /* Custom navbar theme */
 .navbar{
   background-color:#1181B2;
-  padding: 0px 0px;
+  padding: 0;
   height: 50px;
 }
 
@@ -72,7 +70,7 @@ table.dataTable {margin-bottom: 0rem}
 
 .float-top-secondary {
 	position: fixed;
-	top: 0px;
+	top: 0;
 	left: 0;
 	right: 0;
 	padding: 1rem;
@@ -95,7 +93,7 @@ table.dataTable {margin-bottom: 0rem}
 }
 
 .dropdown {
-  margin-top: 0px;
+  margin-top: 0;
 }
 
 .panel-default {
@@ -302,8 +300,8 @@ input[type="checkbox"].ios8-switch + label:after {
     content: "";
     position: absolute;
     display: block;
-    left: 0px;
-    top: 0px;
+    left: 0;
+    top: 0;
     width: 24px; /* x*3 */
     height: 24px; /* x*3 */
     border-radius: 16px; /* x*2 */

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -39,7 +39,7 @@
   width: 100%;
 }
 
-table.dataTable {margin-bottom: 0rem}
+table.dataTable {margin-bottom: 0}
 
 .dataTables_scrollBody {
   border-bottom-left-radius: 15px;


### PR DESCRIPTION
This PR adds:
Fix the height of all dropdowns in Clinical SNV and INDELs view to be able to select an option from a dropdown in search without the new "bar" (static position)  overlap the dropdown.

I tested it on (Region Annotations, Functional Annotations), and its works as it should.

<img width="1431" alt="Screen Shot 2021-05-21 at 10 59 45" src="https://user-images.githubusercontent.com/41540288/119112807-c6b0da00-ba24-11eb-9928-bf4b401b68d5.png">




**Review:**
- [ ] code approved by
- [x] tests executed by MOD
