### PR TITLE
Fix #2655 - dont populate deleted pinned/causatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display Tier I and II variants in case view causatives card for cancer cases
 ### Fixed
 - Send partial file data to igv.js when visualizing sashimi plots with splice junction tracks
+- Do not attempt to populate annotations for not loaded pinned/causatives
 ### Changed
 - Switch off non-clinical gene warnings when filtering research variants
 - Don't display OMIM disease card in case view for cancer cases

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -232,10 +232,12 @@ def case(store, institute_obj, case_obj):
 
 def _populate_acmg(evaluated_variants):
     """
-    Add ACMG classification options for display of ACMG badges to variants
+    Add ACMG classification options for display of ACMG badges to variants.
+    The list of variant objects can contain plain variant_id strings for deleted / no longer loaded variants.
+    These should not be populated.
 
     Args:
-        evaluated_variants:
+        evaluated_variants: list(variant_obj or str)
 
     Returns:
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -240,8 +240,10 @@ def _populate_acmg(evaluated_variants):
     Returns:
 
     """
+
     for variant in evaluated_variants:
-        if isinstance(variant.get("acmg_classification"), int):
+
+        if not isinstance(variant, str) and isinstance(variant.get("acmg_classification"), int):
             classification = ACMG_MAP.get(variant["acmg_classification"])
             for option in ACMG_OPTIONS:
                 if option["code"] == classification:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. For a case with pinned or causative deleted / no longer loaded variants, Scout should no longer crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

![Screenshot 2021-05-24 at 13 29 53](https://user-images.githubusercontent.com/758570/119341524-2bbe3700-bc94-11eb-92da-71018bc9bd33.png)


**Review:**
- [ ] code approved by
- [ ] tests executed by
