### PR TITLE
Clearer warnings in variants filters, gene search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Warning on overwriting variants with same position was no longer shown
 ### Changed
+- Clearer warning messages for gene searches in variants filters
 
 ## [4.35]
 ### Added

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1007,19 +1007,19 @@ def check_form_gene_symbols(
 
     errors = {
         "non_clinical_symbols": {
-            "alert": "Gene not included in case clinical list",
+            "info": "Genes not included in case gene panels",
             "gene_list": non_clinical_symbols,
         },
         "not_found_symbols": {
-            "alert": "HGNC symbol not present in genes collection",
+            "alert": "HGNC symbols not present in database genes collection",
             "gene_list": not_found_symbols,
         },
         "not_found_ids": {
-            "alert": "HGNC id not present in genes collection",
+            "alert": "HGNC id not present in database genes collection",
             "gene_list": not_found_ids,
         },
         "outdated_symbols": {
-            "alert": "Clinical list contains a panel with an outdated symbol for genes",
+            "alert": "Case gene panels contains an outdated symbol for genes",
             "gene_list": outdated_symbols,
         },
     }

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1019,7 +1019,7 @@ def check_form_gene_symbols(
             "gene_list": not_found_ids,
         },
         "outdated_symbols": {
-            "alert": "Case gene panels contains an outdated symbol for genes",
+            "alert": "Case gene panels contain an outdated symbol for genes",
             "gene_list": outdated_symbols,
         },
     }

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1015,7 +1015,7 @@ def check_form_gene_symbols(
             "gene_list": not_found_symbols,
         },
         "not_found_ids": {
-            "alert": "HGNC id not present in database genes collection",
+            "alert": "HGNC ids not present in database genes collection",
             "gene_list": not_found_ids,
         },
         "outdated_symbols": {


### PR DESCRIPTION
Fix #2664.

- Change color of message of the warning message when gene is not in gene panels to blue
- Clearer warning messages in general

**How to test**:
1. Install on stage or locally and do filter variants using the HPO list, gene names and gene HGNC Ids

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
