### PR TITLE
Popup to explain why there are missing links in Loqus observations panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.x]
 ### Added
 - Parse and save splice junction tracks from case config file
+- Tooltip in observations panel, explaining that case variants with no link might be old variants, not uploaded after a case rerun
 ### Fixed
 - Warning on overwriting variants with same position was no longer shown
 ### Changed

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -401,6 +401,11 @@
   <script src="//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 
   <script>
+
+    $(document).ready(function(){
+        $('[data-toggle="tooltip"]').tooltip();
+    });
+
     function set_scrolly_table(table_id) {
     if (document.getElementById(table_id).rows.length > 5) {
       $('#' + table_id).DataTable({

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -152,8 +152,9 @@
 
 {% macro observations_panel(variant, observations, case) %}
   <div class="card panel-default">
-    <div class="panel-heading">
+    <div class="panel-heading d-flex justify-content-between">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations</a>
+      <span data-toggle="tooltip" title="Missing links to case variants might be caused by variants not loaded after a rerun">?</span>
     </div>
     <div class="card-body">
       <table class="table">
@@ -182,7 +183,7 @@
             {% elif data.variant and data.variant.category == "sv"%}
               <a class="ml-3" href="{{ url_for('variant.sv_variant', institute_id=data.case.owner, case_name=data.case.display_name, variant_id=data.variant._id) }}">{{ data.case.display_name }}</a>
             {% else %}
-              <span class="text-muted ml-3">{{ data.case.display_name }}</span>
+              <span class="text-muted ml-3" >{{ data.case.display_name }}</span>
             {% endif %}
           {% endfor %}
           {% if observations['cases']|length >= 10 %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -154,7 +154,7 @@
   <div class="card panel-default">
     <div class="panel-heading d-flex justify-content-between">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations</a>
-      <span data-toggle="tooltip" title="Missing links to case variants might be caused by variants not loaded after a rerun">?</span>
+      <span data-toggle="tooltip" title="Nr of observations is the total seen in this loqusdb instance. Missing links on greyed out case names for shared local case variants might be caused by variants not loaded after a rerun or inexact SV matching. Only names of collaborator cases are shown.">?</span>
     </div>
     <div class="card-body">
       <table class="table">


### PR DESCRIPTION
Fix #2663.

Hover on the popup and you'll see this:

![image](https://user-images.githubusercontent.com/28093618/119500514-2fbb8900-bd68-11eb-854e-30f888946dfe.png)


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
