### PR TITLE
Revert "Clearer warnings in variants filters, gene search (#2667)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Warning on overwriting variants with same position was no longer shown
 ### Changed
-- Clearer warning messages for gene searches in variants filters
 
 ## [4.35]
 ### Added

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1007,19 +1007,19 @@ def check_form_gene_symbols(
 
     errors = {
         "non_clinical_symbols": {
-            "info": "Genes not included in case gene panels",
+            "alert": "Gene not included in case clinical list",
             "gene_list": non_clinical_symbols,
         },
         "not_found_symbols": {
-            "alert": "HGNC symbols not present in database genes collection",
+            "alert": "HGNC symbol not present in genes collection",
             "gene_list": not_found_symbols,
         },
         "not_found_ids": {
-            "alert": "HGNC ids not present in database genes collection",
+            "alert": "HGNC id not present in genes collection",
             "gene_list": not_found_ids,
         },
         "outdated_symbols": {
-            "alert": "Case gene panels contain an outdated symbol for genes",
+            "alert": "Clinical list contains a panel with an outdated symbol for genes",
             "gene_list": outdated_symbols,
         },
     }


### PR DESCRIPTION
This reverts commit 80cac58c8b724ce850a8ba0211c1041229244e66.

This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
