### PR TITLE
Fix splice junction tracks not centered over genes when variants are in gene build 37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Warning on overwriting variants with same position was no longer shown
 - Increase the height of the dropdowns to 425px
+- Splice junction tracks not centered over variant genes
 ### Changed
 - Clearer warning messages for gene searches in variants filters
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -35,7 +35,7 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
 
     # Check if variant coordinates are in genome build 38
     # Otherwise do variant coords liftover
-    if not build in str(case_obj.get("genome_build")):
+    if build not in str(case_obj.get("genome_build")):
         client = EnsemblRestApiClient()
         mapped_coords = client.liftover(
             case_obj.get("genome_build"),

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -49,7 +49,7 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
             locus_start_coords.append(mapped_start)
             locus_end_coords.append(mapped_end)
 
-    # Use original coordinates only genome build was 38 from the beginning of liftover didn't work
+    # Use original coordinates only genome build was already 38 or liftover didn't work
     if not locus_start_coords:
         locus_start_coords.append(variant_obj.get("position"))
     if not locus_end_coords:

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -25,7 +25,7 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
         display_obj(dict): A display object containing case name, list of genes, lucus and tracks
     """
     build = "38"  # This feature is only available for RNA tracks in build 38
-    # Collect locus coordinates. Take into account that variant can hit multiple genes
+
     variant_obj = store.variant(document_id=variant_id)
     _, case_obj = institute_and_case(store, institute_id, case_name)
 
@@ -52,8 +52,8 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
         locus_start_coords.append(variant_obj.get("position"))
         locus_end_coords.append(variant_obj.get("end"))
 
+    # Collect locus coordinates. Take into account that variant can hit multiple genes
     variant_genes_ids = [gene["hgnc_id"] for gene in variant_obj.get("genes", [])]
-
     gene_symbols = []
     for gene_id in variant_genes_ids:
         gene_obj = store.hgnc_gene(hgnc_identifier=gene_id, build=build)

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -8,12 +8,13 @@ from flask_login import current_user
 from scout.constants import CASE_SPECIFIC_TRACKS, HUMAN_REFERENCE, IGV_TRACKS
 from scout.server.extensions import cloud_tracks, store
 from scout.server.utils import institute_and_case
+from scout.utils.ensembl_rest_clients import EnsemblRestApiClient
 
 LOG = logging.getLogger(__name__)
 CUSTOM_TRACK_NAMES = ["Genes", "ClinVar", "ClinVar CNVs"]
 
 
-def make_sashimi_tracks(institute_id, case_name, variant_id, build="38"):
+def make_sashimi_tracks(institute_id, case_name, variant_id):
     """Create a dictionary containing the required tracks for a splice junction plot
 
     Accepts:
@@ -23,13 +24,36 @@ def make_sashimi_tracks(institute_id, case_name, variant_id, build="38"):
     Returns:
         display_obj(dict): A display object containing case name, list of genes, lucus and tracks
     """
-
+    build = "38"  # This feature is only available for RNA tracks in build 38
     # Collect locus coordinates. Take into account that variant can hit multiple genes
     variant_obj = store.variant(document_id=variant_id)
-    variant_genes_ids = [gene["hgnc_id"] for gene in variant_obj.get("genes", [])]
+    _, case_obj = institute_and_case(store, institute_id, case_name)
+
     # Initialize locus coordinates it with variant coordinates so it won't crash if variant gene(s) no longer exist in database
-    locus_start_coords = [variant_obj.get("position")]
-    locus_end_coords = [variant_obj.get("end")]
+    locus_start_coords = []
+    locus_end_coords = []
+
+    # Check if variant coordinates are in genome build 38
+    # Otherwise do variant coords liftover
+    if not build in str(case_obj.get("genome_build")):
+        client = EnsemblRestApiClient()
+        mapped_coords = client.liftover(
+            case_obj.get("genome_build"),
+            variant_obj.get("chromosome"),
+            variant_obj.get("position"),
+            variant_obj.get("end"),
+        )
+        if mapped_coords:
+            mapped_start = mapped_coords[0]["mapped"].get("start")
+            mapped_end = mapped_coords[0]["mapped"].get("end") or mapped_start
+            locus_start_coords.append(mapped_start)
+            locus_end_coords.append(mapped_end)
+    else:
+        locus_start_coords.append(variant_obj.get("position"))
+        locus_end_coords.append(variant_obj.get("end"))
+
+    variant_genes_ids = [gene["hgnc_id"] for gene in variant_obj.get("genes", [])]
+
     gene_symbols = []
     for gene_id in variant_genes_ids:
         gene_obj = store.hgnc_gene(hgnc_identifier=gene_id, build=build)
@@ -41,6 +65,7 @@ def make_sashimi_tracks(institute_id, case_name, variant_id, build="38"):
 
     locus_start = min(locus_start_coords)
     locus_end = max(locus_end_coords)
+
     locus = f"{variant_obj['chromosome']}:{locus_start}-{locus_end}"  # Locus will span all genes the variant falls into
     display_obj = {"locus": locus, "tracks": [], "genes": gene_symbols}
 
@@ -48,7 +73,6 @@ def make_sashimi_tracks(institute_id, case_name, variant_id, build="38"):
     set_common_tracks(display_obj, build)
 
     # Populate tracks for each individual with splice junction track data
-    _, case_obj = institute_and_case(store, institute_id, case_name)
     for ind in case_obj.get("individuals", []):
         if not all([ind.get("splice_junctions_bed"), ind.get("rna_coverage_bigwig")]):
             continue

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -57,12 +57,10 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
 
     # Collect locus coordinates. Take into account that variant can hit multiple genes
     variant_genes_ids = [gene["hgnc_id"] for gene in variant_obj.get("genes", [])]
-    gene_symbols = []
     for gene_id in variant_genes_ids:
         gene_obj = store.hgnc_gene(hgnc_identifier=gene_id, build=build)
         if gene_obj is None:
             continue
-        gene_symbols.append(gene_obj.get("hgnc_symbol") or gene_obj["hgnc_id"])
         locus_start_coords.append(gene_obj["start"])
         locus_end_coords.append(gene_obj["end"])
 
@@ -70,7 +68,7 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
     locus_end = max(locus_end_coords)
 
     locus = f"{variant_obj['chromosome']}:{locus_start}-{locus_end}"  # Locus will span all genes the variant falls into
-    display_obj = {"locus": locus, "tracks": [], "genes": gene_symbols}
+    display_obj = {"locus": locus, "tracks": []}
 
     # Add Genes and reference tracks to display object
     set_common_tracks(display_obj, build)

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -48,8 +48,11 @@ def make_sashimi_tracks(institute_id, case_name, variant_id):
             mapped_end = mapped_coords[0]["mapped"].get("end") or mapped_start
             locus_start_coords.append(mapped_start)
             locus_end_coords.append(mapped_end)
-    else:
+
+    # Use original coordinates only genome build was 38 from the beginning of liftover didn't work
+    if not locus_start_coords:
         locus_start_coords.append(variant_obj.get("position"))
+    if not locus_end_coords:
         locus_end_coords.append(variant_obj.get("end"))
 
     # Collect locus coordinates. Take into account that variant can hit multiple genes

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -57,6 +57,7 @@
                             displayMode: "{{ custTrack.displayMode }}",
                             visibilityWindow: 300000000,
                             order: Number.MAX_VALUE,
+                            searchable: true
                           },
                         {% endif %}
                       {% endfor %}

--- a/scout/utils/ensembl_rest_clients.py
+++ b/scout/utils/ensembl_rest_clients.py
@@ -117,7 +117,6 @@ class EnsemblRestApiClient:
                 f"{assembly2}?content-type=application/json",
             ]
         )
-        LOG.error(url)
         result = self.send_request(url)
         if isinstance(result, dict):
             return result.get("mappings")

--- a/scout/utils/ensembl_rest_clients.py
+++ b/scout/utils/ensembl_rest_clients.py
@@ -91,6 +91,39 @@ class EnsemblRestApiClient:
             data = err
         return data
 
+    def liftover(self, build, chrom, start, end=None):
+        """Perform variant liftover using Ensembl REST API
+
+        Args:
+            build(str): genome build: "37" or "38"
+            chrom(str): 1-22,X,Y,MT,M
+            start(int): start coordinate
+            stop(int): stop coordinate or None
+
+        Returns:
+            mappings(list of dict): example:
+                example: https://rest.ensembl.org/map/human/GRCh37/X:1000000..1000100:1/GRCh38?content-type=application/json
+        """
+
+        build = "GRCh38" if "38" in str(build) else "GRCh37"
+
+        assembly2 = "GRCh38"
+        if build == "GRCh38":
+            assembly2 = "GRCh37"
+
+        url = "/".join(
+            [
+                self.server,
+                "map/human",
+                build,
+                f"{chrom}:{start}..{end or start}",  # End variant provided is not required
+                f"{assembly2}?content-type=application/json",
+            ]
+        )
+        result = self.send_request(url)
+        if isinstance(result, dict):
+            return result.get("mappings")
+
     def __repr__(self):
         return f"EnsemblRestApiClient:server:{self.server}"
 

--- a/scout/utils/ensembl_rest_clients.py
+++ b/scout/utils/ensembl_rest_clients.py
@@ -106,10 +106,7 @@ class EnsemblRestApiClient:
         """
 
         build = "GRCh38" if "38" in str(build) else "GRCh37"
-
-        assembly2 = "GRCh38"
-        if build == "GRCh38":
-            assembly2 = "GRCh37"
+        assembly2 = "GRCh38" if build == "GRCh37" else "GRCh37"
 
         url = "/".join(
             [
@@ -120,6 +117,7 @@ class EnsemblRestApiClient:
                 f"{assembly2}?content-type=application/json",
             ]
         )
+        LOG.error(url)
         result = self.send_request(url)
         if isinstance(result, dict):
             return result.get("mappings")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,6 +201,34 @@ def ensembl_genes(request, gene_bulk):
     return _ensembl_genes
 
 
+@pytest.fixture
+def ensembl_liftover_reasponse():
+    """Returns a  response from ensembl liftover api"""
+    _response = {
+        "mappings": [
+            {
+                "mapped": {
+                    "assembly": "GRCh38",
+                    "seq_region_name": "X",
+                    "end": 1039365,
+                    "start": 1039265,
+                    "coord_system": "chromosome",
+                    "strand": 1,
+                },
+                "original": {
+                    "strand": 1,
+                    "coord_system": "chromosome",
+                    "start": 1000000,
+                    "seq_region_name": "X",
+                    "end": 1000100,
+                    "assembly": "GRCh37",
+                },
+            }
+        ]
+    }
+    return _response
+
+
 @pytest.fixture(scope="function")
 def gene_bulk(genes):
     """Return a list with HgncGene objects"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -202,7 +202,7 @@ def ensembl_genes(request, gene_bulk):
 
 
 @pytest.fixture
-def ensembl_liftover_reasponse():
+def ensembl_liftover_response():
     """Returns a  response from ensembl liftover api"""
     _response = {
         "mappings": [

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -9,7 +9,7 @@ from scout.server.extensions import cloud_tracks, store
 
 
 def test_make_sashimi_tracks_variant_38(app, case_obj):
-    """Test function that creates splice junction tracks for a variant with genome build 37"""
+    """Test function that creates splice junction tracks for a variant with genome build 38"""
 
     # GIVEN a case with genome build 38
     store.case_collection.find_one_and_update(

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -6,7 +6,6 @@ from flask_login import current_user
 from scout.commands.update.individual import individual as ind_cmd
 from scout.server.blueprints.alignviewers import controllers
 from scout.server.extensions import cloud_tracks, store
-from tests.utils.conftest import ensembl_liftover_reasponse
 
 
 @responses.activate

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -47,7 +47,7 @@ def test_make_sashimi_tracks(app, case_obj):
 
         # THEN it should return the expected data
         display_obj = controllers.make_sashimi_tracks(
-            case_obj["owner"], case_obj["display_name"], test_variant["_id"], "37"
+            case_obj["owner"], case_obj["display_name"], test_variant["_id"]
         )
         assert display_obj["case"] == case_obj["display_name"]
         assert display_obj["genes"] == ["POT1"]

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -1,38 +1,35 @@
 # -*- coding: utf-8 -*-
+import responses
 from flask import url_for
 from flask_login import current_user
 
 from scout.commands.update.individual import individual as ind_cmd
 from scout.server.blueprints.alignviewers import controllers
 from scout.server.extensions import cloud_tracks, store
+from tests.utils.conftest import ensembl_liftover_reasponse
 
 
-def test_make_sashimi_tracks(app, case_obj):
+@responses.activate
+def test_make_sashimi_tracks_variant(app, case_obj, ensembl_liftover_reasponse):
     """Test function that creates splice junction tracks"""
+
+    # WHEN the gene splice junction track is created for any variant in a gene
+    test_variant = store.variant_collection.find_one({"hgnc_symbols": ["POT1"]})
+
+    # GIVEN a patched response from Ensembl liftover API
+    url = f'http://grch37.rest.ensembl.org/map/human/GRCh37/{test_variant["chromosome"]}:{test_variant["position"]}..{test_variant["end"]}/GRCh38?content-type=application/json'
+    responses.add(
+        responses.GET,
+        url,
+        json=ensembl_liftover_reasponse,
+        status=200,
+    )
+
     # GIVEN a case's affected individual
     affected_name = "NA12882"
 
     # GIVEN a case with an individual containing splice junction data:
-    runner = app.test_cli_runner()
-    runner.invoke(
-        ind_cmd,
-        [
-            "--case-id",
-            case_obj["_id"],
-            "--ind",
-            affected_name,
-            "rna_coverage_bigwig",
-            "test.bigWig",
-        ],
-        input="y",
-    )
-    runner.invoke(
-        ind_cmd,
-        ["--case-id", case_obj["_id"], "--ind", affected_name, "splice_junctions_bed", "test.bed"],
-        input="y",
-    )
-    updated_case = store.case_collection.find_one()
-    for ind in updated_case["individuals"]:
+    for ind in case_obj["individuals"]:
         if ind["display_name"] == affected_name:
             assert ind["rna_coverage_bigwig"]
             assert ind["splice_junctions_bed"]
@@ -42,20 +39,17 @@ def test_make_sashimi_tracks(app, case_obj):
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200
 
-        # WHEN the gene splice junction track is created for any variant in a gene
-        test_variant = store.variant_collection.find_one({"hgnc_symbols": ["POT1"]})
-
         # THEN it should return the expected data
         display_obj = controllers.make_sashimi_tracks(
             case_obj["owner"], case_obj["display_name"], test_variant["_id"]
         )
         assert display_obj["case"] == case_obj["display_name"]
-        assert display_obj["genes"] == ["POT1"]
+        # assert display_obj["genes"] == ["POT1"]
         assert display_obj["locus"]
         assert display_obj["tracks"][0]["name"] == affected_name
-        assert display_obj["tracks"][0]["coverage_wig"] == "test.bigWig"
-        assert display_obj["tracks"][0]["splicej_bed"] == "test.bed"
-        assert display_obj["tracks"][0]["splicej_bed_index"] is None
+        assert display_obj["tracks"][0]["coverage_wig"]
+        assert display_obj["tracks"][0]["splicej_bed"]
+        assert display_obj["tracks"][0]["splicej_bed_index"]
         assert display_obj["reference_track"]  # Reference genome track
         assert display_obj["custom_tracks"]  # Custom tracks include gene track in the right build
 

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -39,7 +39,7 @@ def test_make_sashimi_tracks_variant_38(app, case_obj):
 
 
 @responses.activate
-def test_make_sashimi_tracks_variant_37(app, case_obj, ensembl_liftover_reasponse):
+def test_make_sashimi_tracks_variant_37(app, case_obj, ensembl_liftover_response):
     """Test function that creates splice junction tracks for a variant with genome build 37"""
 
     # WHEN the gene splice junction track is created for any variant in a gene

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -50,7 +50,7 @@ def test_make_sashimi_tracks_variant_37(app, case_obj, ensembl_liftover_reaspons
     responses.add(
         responses.GET,
         url,
-        json=ensembl_liftover_reasponse,
+        json=ensembl_liftover_response,
         status=200,
     )
 

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -93,34 +93,6 @@ def ensembl_rest_client_38():
 
 
 @pytest.fixture
-def ensembl_liftover_reasponse():
-    """Returns a  response from ensembl liftover api"""
-    _response = {
-        "mappings": [
-            {
-                "mapped": {
-                    "assembly": "GRCh38",
-                    "seq_region_name": "X",
-                    "end": 1039365,
-                    "start": 1039265,
-                    "coord_system": "chromosome",
-                    "strand": 1,
-                },
-                "original": {
-                    "strand": 1,
-                    "coord_system": "chromosome",
-                    "start": 1000000,
-                    "seq_region_name": "X",
-                    "end": 1000100,
-                    "assembly": "GRCh37",
-                },
-            }
-        ]
-    }
-    return _response
-
-
-@pytest.fixture
 def ensembl_gene_response():
     """Return a response from ensembl gene api"""
     _response = [

--- a/tests/utils/conftest.py
+++ b/tests/utils/conftest.py
@@ -93,6 +93,34 @@ def ensembl_rest_client_38():
 
 
 @pytest.fixture
+def ensembl_liftover_reasponse():
+    """Returns a  response from ensembl liftover api"""
+    _response = {
+        "mappings": [
+            {
+                "mapped": {
+                    "assembly": "GRCh38",
+                    "seq_region_name": "X",
+                    "end": 1039365,
+                    "start": 1039265,
+                    "coord_system": "chromosome",
+                    "strand": 1,
+                },
+                "original": {
+                    "strand": 1,
+                    "coord_system": "chromosome",
+                    "start": 1000000,
+                    "seq_region_name": "X",
+                    "end": 1000100,
+                    "assembly": "GRCh37",
+                },
+            }
+        ]
+    }
+    return _response
+
+
+@pytest.fixture
 def ensembl_gene_response():
     """Return a response from ensembl gene api"""
     _response = [

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -44,7 +44,7 @@ def test_ping_ensemble_38(ensembl_rest_client_38):
 
 
 @responses.activate
-def test_liftover(ensembl_rest_client_37, ensembl_liftover_reasponse):
+def test_liftover(ensembl_rest_client_37, ensembl_liftover_response):
     """Test send request for coordinates liftover"""
     # GIVEN a patched response from Ensembl
     url = "http://grch37.rest.ensembl.org/map/human/GRCh37/X:1000000..1000100/GRCh38?content-type=application/json"

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -46,7 +46,7 @@ def test_ping_ensemble_38(ensembl_rest_client_38):
 @responses.activate
 def test_liftover(ensembl_rest_client_37, ensembl_liftover_reasponse):
     """Test send request for coordinates liftover"""
-    # GIVEN a patched response from Ensmbl
+    # GIVEN a patched response from Ensembl
     url = "http://grch37.rest.ensembl.org/map/human/GRCh37/X:1000000..1000100/GRCh38?content-type=application/json"
     responses.add(
         responses.GET,

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -44,6 +44,23 @@ def test_ping_ensemble_38(ensembl_rest_client_38):
 
 
 @responses.activate
+def test_liftover(ensembl_rest_client_37, ensembl_liftover_reasponse):
+    """Test send request for coordinates liftover"""
+    # GIVEN a patched response from Ensmbl
+    url = "http://grch37.rest.ensembl.org/map/human/GRCh37/X:1000000..1000100/GRCh38?content-type=application/json"
+    responses.add(
+        responses.GET,
+        url,
+        json=ensembl_liftover_reasponse,
+        status=200,
+    )
+    client = ensembl_rest_client_37
+    # WHEN sending the liftover request the function should return a mapped locus
+    mapped_coords = client.liftover("37", "X", 1000000, 1000100)
+    assert mapped_coords[0]["mapped"]
+
+
+@responses.activate
 def test_send_gene_request(ensembl_gene_response, ensembl_rest_client_37):
     """Test send request with correct params and endpoint"""
     url = "https://grch37.rest.ensembl.org/overlap/id/ENSG00000103591?feature=gene"

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -51,7 +51,7 @@ def test_liftover(ensembl_rest_client_37, ensembl_liftover_reasponse):
     responses.add(
         responses.GET,
         url,
-        json=ensembl_liftover_reasponse,
+        json=ensembl_liftover_response,
         status=200,
     )
     client = ensembl_rest_client_37


### PR DESCRIPTION
While working on another bug I've realized that when you click on the splice junctions, the igv view is not centered over the gene (the gene is there, but generally relegated to a small part of the view):

Master branch:

![image](https://user-images.githubusercontent.com/28093618/119639689-24c03180-be18-11eb-86b4-469ab82d93d8.png)


This branch fixes this bug and the gene view becomes like this:

![image](https://user-images.githubusercontent.com/28093618/119639332-cbf09900-be17-11eb-8280-91000ca5dabe.png)


**How to test**:
1. Run` scout setup demo` and check the splice junctions of any variant

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
