### PR TITLE
Case index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Warning on overwriting variants with same position was no longer shown
 - Increase the height of the dropdowns to 425px
+- More indices for the case table as it grows, specifically for causatives queries
 ### Changed
 - Clearer warning messages for gene searches in variants filters
 

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -93,7 +93,9 @@ INDEXES = {
     ],
     "event": [
         IndexModel([("category", ASCENDING), ("verb", ASCENDING)], name="category_verb"),
-        IndexModel([("variant_id", ASCENDING)], name="variant_id"),
+        IndexModel(
+            [("variant_id", ASCENDING), ("institute", ASCENDING)], name="variant_id_institute"
+        ),
         IndexModel(
             [
                 ("institute", ASCENDING),

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -118,5 +118,13 @@ INDEXES = {
             background=True,
         )
     ],
-    "case": [IndexModel([("synopsis", TEXT)], default_language="english", name="synopsis_text")],
+    "case": [
+        IndexModel([("synopsis", TEXT)], default_language="english", name="synopsis_text"),
+        IndexModel([("causatives", ASCENDING)], name="causatives"),
+        IndexModel([("collaborators", ASCENDING)], name="collaborators"),
+        IndexModel(
+            [("collaborators", ASCENDING), ("updated_at", ASCENDING)],
+            name="collaborators_updated_at",
+        ),
+    ],
 }

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -84,7 +84,11 @@ INDEXES = {
             background=True,
         ),
         IndexModel([("sanger_ordered", ASCENDING)], name="sanger", background=True, sparse=True),
-        IndexModel([("variant_id", ASCENDING)], name="variant_id", background=True),
+        IndexModel(
+            [("variant_id", ASCENDING), ("institute", ASCENDING)],
+            name="variant_id_institute",
+            background=True,
+        ),
     ],
     "hpo_term": [
         IndexModel([("description", ASCENDING)], name="description"),
@@ -93,9 +97,7 @@ INDEXES = {
     ],
     "event": [
         IndexModel([("category", ASCENDING), ("verb", ASCENDING)], name="category_verb"),
-        IndexModel(
-            [("variant_id", ASCENDING), ("institute", ASCENDING)], name="variant_id_institute"
-        ),
+        IndexModel([("variant_id", ASCENDING)], name="variant_id"),
         IndexModel(
             [
                 ("institute", ASCENDING),

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -126,7 +126,6 @@ INDEXES = {
     "case": [
         IndexModel([("synopsis", TEXT)], default_language="english", name="synopsis_text"),
         IndexModel([("causatives", ASCENDING)], name="causatives"),
-        IndexModel([("collaborators", ASCENDING)], name="collaborators"),
         IndexModel(
             [("collaborators", ASCENDING), ("updated_at", ASCENDING)],
             name="collaborators_updated_at",

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -84,6 +84,7 @@ INDEXES = {
             background=True,
         ),
         IndexModel([("sanger_ordered", ASCENDING)], name="sanger", background=True, sparse=True),
+        IndexModel([("variant_id", ASCENDING)], name="variant_id", background=True),
     ],
     "hpo_term": [
         IndexModel([("description", ASCENDING)], name="description"),


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Attempting to solve #2665 for Lund. Adding back an index for variant_id to the constants, that is used when unrolling the query cursor into a list. An alternative might be to try to recast the positional ids to case id containing document ids, but that will take a bit of error prone logic. Solna still has variant_id in prod, though it was so to speak deprecated, and it is confirmed to take hits on causatives search. It is still slow, but at least one order of magnitude faster than in Lund.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
