### PR TITLE
Fix flash messages in variants filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Splice junction tracks not centered over variant genes
 - Total number of research variants count
 - Update variants stats in case documents every time new variants are loaded
+- Bug in flashing warning messages when filtering variants
 ### Changed
 - Clearer warning messages for genes and gene/gene-panels searches in variants filters
 

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -154,7 +154,7 @@
   <div class="card panel-default">
     <div class="panel-heading d-flex justify-content-between">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations</a>
-      <span data-toggle="tooltip" title="Nr of observations is the total seen in this loqusdb instance. Missing links on greyed out case names for shared local case variants might be caused by variants not loaded after a rerun or inexact SV matching. Only names of collaborator cases are shown.">?</span>
+      <span data-toggle="tooltip" title="Nr of observations is the total number of occurrences in the loqusdb instance. Missing links on greyed out case names for shared local case variants might be caused by variants not loaded after a rerun or inexact SV matching. Only names of collaborator cases are shown.">?</span>
     </div>
     <div class="card-body">
       <table class="table">

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1007,27 +1007,32 @@ def check_form_gene_symbols(
 
     errors = {
         "non_clinical_symbols": {
-            "info": "Genes not included in gene panel versions in use when loading this case (clinical list).",
+            "message": "Genes not included in gene panel versions in use when loading this case (clinical list).",
             "gene_list": non_clinical_symbols,
+            "label": "info",
         },
         "not_found_symbols": {
-            "alert": "HGNC symbols not present in database genes collection",
+            "message": "HGNC symbols not present in database genes collection",
             "gene_list": not_found_symbols,
+            "label": "warning",
         },
         "not_found_ids": {
-            "alert": "HGNC ids not present in database genes collection",
+            "message": "HGNC ids not present in database genes collection",
             "gene_list": not_found_ids,
+            "label": "warning",
         },
         "outdated_symbols": {
-            "info": "Gene panel versions used for loading variants of this case (clinical list) contain outdated gene symbols. The current HGNC id was found on the clinical list.",
+            "message": "Gene panel versions used for loading variants of this case (clinical list) contain outdated gene symbols. The current HGNC id was found on the clinical list.",
             "gene_list": outdated_symbols,
+            "label": "info",
         },
     }
 
     # warn user if gene symbols are corresponding to any current gene,
-    for error, item in errors.items():
-        if item["gene_list"]:
-            flash(f"{item['alert']}: {item['gene_list']}", "warning")
+    for error in errors.values():
+        if not error["gene_list"]:
+            continue
+        flash(error["message"], error["label"])
 
     return updated_hgnc_symbols
 


### PR DESCRIPTION
Fix bug shown in this comment: https://github.com/Clinical-Genomics/scout/pull/2678#issuecomment-850350252

**How to test**:
1. Filter using HPO genes in settings which would return one of the errors (missing genes etc). Master should crash while this branch not

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
