### PR TITLE
Show a warning if case config file has missing panels, do not crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Load case with missing panels in config files. Show warning instead.
 
 ## [4.36]
 ### Added

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -188,6 +188,9 @@ def build_case(case_data, adapter):
             panel["is_default"] = False
         panels.append(panel)
 
+    if not panels:
+        raise IntegrityError("At least an existing gene panel must be associated to this case.")
+
     case_obj["panels"] = panels
 
     case_obj["dynamic_gene_list"] = []

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -189,7 +189,7 @@ def build_case(case_data, adapter):
         panels.append(panel)
 
     if not panels:
-        raise IntegrityError("At least an existing gene panel must be associated to this case.")
+        raise IntegrityError("At least one existing gene panel must be associated to this case.")
 
     case_obj["panels"] = panels
 

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -169,7 +169,11 @@ def build_case(case_data, adapter):
     for panel_name in case_panels:
         panel_obj = adapter.gene_panel(panel_name)
         if not panel_obj:
-            raise IntegrityError("Panel %s does not exist in database" % panel_name)
+            LOG.warning(
+                "Panel %s does not exist in database and will not be saved in case document."
+                % panel_name
+            )
+            continue
         panel = {
             "panel_id": panel_obj["_id"],
             "panel_name": panel_obj["panel_name"],

--- a/scout/build/case.py
+++ b/scout/build/case.py
@@ -188,9 +188,6 @@ def build_case(case_data, adapter):
             panel["is_default"] = False
         panels.append(panel)
 
-    if not panels:
-        raise IntegrityError("At least one existing gene panel must be associated to this case.")
-
     case_obj["panels"] = panels
 
     case_obj["dynamic_gene_list"] = []

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1012,12 +1012,12 @@ def check_form_gene_symbols(
             "label": "info",
         },
         "not_found_symbols": {
-            "message": "HGNC symbols not present in database genes collection",
+            "message": "HGNC symbols not present in database's genes collection",
             "gene_list": not_found_symbols,
             "label": "warning",
         },
         "not_found_ids": {
-            "message": "HGNC ids not present in database genes collection",
+            "message": "HGNC ids not present in database's genes collection",
             "gene_list": not_found_ids,
             "label": "warning",
         },

--- a/tests/build/test_build_case.py
+++ b/tests/build/test_build_case.py
@@ -118,14 +118,13 @@ def test_build_case_non_existing_owner(adapter, institute_obj):
         case_obj = build_case(case_info, adapter)
 
 
-def test_build_case_no_valid_panel():
+def test_build_case_no_valid_panel(adapter, institute_obj):
     """Test loading a case containing a non-valid gene panel"""
 
-    def test_build_minimal_case(adapter, institute_obj):
-        adapter.institute_collection.insert_one(institute_obj)
-        # GIVEN a case without case id
-        case_info = {"case_id": "test-case", "owner": "cust000", "panel": ["FOO"]}
-        # WHEN case is built
-        case_obj = build_case(case_info, adapter)
-        # THEN assert that it worked
-        assert case_obj["_id"] == case_info["case_id"]
+    adapter.institute_collection.insert_one(institute_obj)
+    # GIVEN a case without case id
+    case_info = {"case_id": "test-case", "owner": "cust000", "panel": ["FOO"]}
+    # WHEN case is built
+    case_obj = build_case(case_info, adapter)
+    # THEN assert that it worked
+    assert case_obj["_id"] == case_info["case_id"]

--- a/tests/build/test_build_case.py
+++ b/tests/build/test_build_case.py
@@ -127,4 +127,4 @@ def test_build_case_no_valid_panel(adapter, institute_obj):
     # WHEN case is built
     case_obj = build_case(case_info, adapter)
     # THEN assert that it worked
-    assert case_obj["_id"] == case_info["case_id"]
+    assert case_obj["panels"] == []

--- a/tests/build/test_build_case.py
+++ b/tests/build/test_build_case.py
@@ -122,9 +122,9 @@ def test_build_case_no_valid_panel(adapter, institute_obj):
     """Test loading a case containing a non-valid gene panel"""
 
     adapter.institute_collection.insert_one(institute_obj)
-    # GIVEN a case without case id
+    # GIVEN a case without a valid gene panel
     case_info = {"case_id": "test-case", "owner": "cust000", "panel": ["FOO"]}
     # WHEN case is built
     case_obj = build_case(case_info, adapter)
-    # THEN assert that it worked
+    # THEN assert that case is loaded and panel will not be saved in case document
     assert case_obj["panels"] == []

--- a/tests/build/test_build_case.py
+++ b/tests/build/test_build_case.py
@@ -118,7 +118,14 @@ def test_build_case_non_existing_owner(adapter, institute_obj):
         case_obj = build_case(case_info, adapter)
 
 
-# def test_build_case_config(parsed_case):
-#     case_obj = build_case(parsed_case)
-#     print(case_obj.to_json())
-#     assert False
+def test_build_case_no_valid_panel():
+    """Test loading a case containing a non-valid gene panel"""
+
+    def test_build_minimal_case(adapter, institute_obj):
+        adapter.institute_collection.insert_one(institute_obj)
+        # GIVEN a case without case id
+        case_info = {"case_id": "test-case", "owner": "cust000", "panel": ["FOO"]}
+        # WHEN case is built
+        case_obj = build_case(case_info, adapter)
+        # THEN assert that it worked
+        assert case_obj["_id"] == case_info["case_id"]


### PR DESCRIPTION
Fix #2608

**How to test**:
1. Edit demo case config file with a gene panel that doesn't exist (example: `gene_panels: [panel1, hello]`)
2. Load the case with `scout setup demo` command or load it manually with `scout --demo load case scout/demo/643594.config.yaml --update`
3. Master branch should crash, this branch should load the case with a warning.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
