### PR TITLE
Fix #2510 - cancer case variants button names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 
 ## [4.36]
 ### Added

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -30,6 +30,15 @@ samples:
 vcf_cancer: scout/demo/cancer_test.vcf.gz
 vcf_cancer_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
 
+vcf_snv: scout/demo/cancer_test.vcf.gz
+vcf_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+
+vcf_snv_research: scout/demo/cancer_test.vcf.gz
+vcf_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+
+vcf_cancer_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+vcf_cancer_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+
 delivery_report: scout/demo/delivery_report.html
 cnv_report: scout/demo/cancer_cnv_report.pdf
 coverage_qc_report: scout/demo/cancer_coverage_qc_report.html

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -183,17 +183,17 @@
   {% if case.is_research%}
   <div class="form-group">
     <div class="btn-group">
-    {% if case.vcf_files.vcf_cancer_research %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic SNV and INDELs</a>
-    {% endif %}
-    {% if case.vcf_files.vcf_cancer_sv_research %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic structural variants</a>
-    {% endif %}
     {% if case.vcf_files.vcf_snv_research %}
       <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research {% if case.track=="cancer" %}germline {% endif %}SNV and INDELs</a>
     {% endif %}
     {% if case.vcf_files.vcf_sv_research %}
       <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research {% if case.track=="cancer" %}germline {% endif %}structural variants</a>
+    {% endif %}
+    {% if case.vcf_files.vcf_cancer_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic SNV and INDELs</a>
+    {% endif %}
+    {% if case.vcf_files.vcf_cancer_sv_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic structural variants</a>
     {% endif %}
     </div>
   </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -159,10 +159,10 @@
 {% macro variants_buttons() %}
   <div class="form-group">
     {% if case.vcf_files.vcf_snv %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical SNV and INDELs</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical {% if case.track=="cancer" %}germline {% endif %}SNV and INDELs</a>
     {% endif %}
     {% if case.vcf_files.vcf_sv %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical structural variants</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical {% if case.track=="cancer" %}germline {% endif %}structural variants</a>
     {% endif %}
     {% if case.vcf_files.vcf_str %}
       <a class="btn btn-outline-dark" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical STR variants</a>
@@ -171,10 +171,10 @@
       <a class="btn btn-outline-dark" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">SMN CN</a>
     {% endif %}
     {% if case.vcf_files.vcf_cancer %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical SNV and INDELs</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical {% if case.track=="cancer" %}somatic {% endif %}SNV and INDELs</a>
     {% endif %}
     {% if case.vcf_files.vcf_cancer_sv %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical structural variants</a>
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">Clinical {% if case.track=="cancer" %}somatic {% endif %}structural variants</a>
     {% endif %}
     {% if gens_info.display %}
       <a class="btn btn-outline-dark" target="_blank" href="http://{{gens_info.host}}/{{case.display_name}}?&hg_type={{case.genome_build}}">View CN profile</a>
@@ -183,12 +183,17 @@
   {% if case.is_research%}
   <div class="form-group">
     <div class="btn-group">
-    {% if case.track=="cancer" %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
-    {% else %}
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
-      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research structural variants</a>
+    {% if case.vcf_files.vcf_cancer_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic SNV and INDELs</a>
+    {% endif %}
+    {% if case.vcf_files.vcf_cancer_sv_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research somatic structural variants</a>
+    {% endif %}
+    {% if case.vcf_files.vcf_snv_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research {% if case.track=="cancer" %}germline {% endif %}SNV and INDELs</a>
+    {% endif %}
+    {% if case.vcf_files.vcf_sv_research %}
+      <a class="btn btn-outline-dark" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='research') }}">Research {% if case.track=="cancer" %}germline {% endif %}structural variants</a>
     {% endif %}
     </div>
   </div>


### PR DESCRIPTION
This PR adds a functionality: rename cancer clinical variants button more clearly to indicate the cancer (somatic) and constitutional (germline) variants.

**How to test**:
1. add variants files to regular, cancer and research to a cancer track case e.g. in `scout/demo/cancer.load_config.yaml`
```
vcf_cancer: scout/demo/cancer_test.vcf.gz
vcf_cancer_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz

vcf_snv: scout/demo/cancer_test.vcf.gz
vcf_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz

vcf_snv_research: scout/demo/cancer_test.vcf.gz
vcf_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz

vcf_cancer_research: scout/demo/cancer_test.vcf.gz
vcf_cancer_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
```
Also check an RD case to make sure things look as before there.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.
![Screenshot 2021-06-01 at 09 11 28](https://user-images.githubusercontent.com/758570/120281654-7bff4f80-c2b9-11eb-8b08-18bd529a6f49.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
