### PR TITLE
Fix demo case load config file to show available VCF fields and load only somatic SNVs and SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Highlight and show version number for RefSeq MANE transcripts.
 - Added integration to a rerunner service for toggling reanalysis with updated pedigree information
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
+- Demo cancer case config file to load somatic SNVs and SVs only.
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -30,14 +30,14 @@ samples:
 vcf_cancer: scout/demo/cancer_test.vcf.gz
 vcf_cancer_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
 
-vcf_snv: scout/demo/cancer_test.vcf.gz
-vcf_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+#vcf_snv: scout/demo/cancer_test.vcf.gz
+#vcf_sv: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
 
-vcf_snv_research: scout/demo/cancer_test.vcf.gz
-vcf_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+#vcf_snv_research: scout/demo/cancer_test.vcf.gz
+#vcf_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
 
-vcf_cancer_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
-vcf_cancer_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+#vcf_cancer_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
+#vcf_cancer_sv_research: scout/demo/manta_vep_94_annotated_sv_cancer_file.vcf.gz
 
 delivery_report: scout/demo/delivery_report.html
 cnv_report: scout/demo/cancer_cnv_report.pdf


### PR DESCRIPTION
When the demo cancer case is loaded in current master loads the somatic variants as germline variants and the somatic variants lists are empty

**How to test**:
1. In a local Scout instance, master branch, load the cancer demo case and make sure that the loaded variants are not somatic
2. Remove the case and load it again using this branch. The variants loaded should be shown as somatic variants

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
