### PR TITLE
Change Female/Male symbols to letters (F,M)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.
+- Changing the (Female, Male) symbols to (F/M) letters in individuals_table and case-sma.
 
 
 ## [4.36]

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -113,12 +113,16 @@
                   class="bg-warning"
                 {% endif %}>
               <td>{{ ind.display_name }}</td>
-              <td>
+              <td style="font-weight: bold;">
                 {% if ind.sex_human in ['female','male'] %}
-                  <i class="fa fa-{{ind.sex_human}}" aria-hidden="true"></i>
-                {% else %}
-                  {{ind.sex_human}}
-                {% endif %}
+                    {% if ind.sex_human == 'female' %}
+                      F
+                    {% elif ind.sex_human == 'male' %}
+                      M
+                    {% else %}
+                      {{ind.sex_human}}
+                    {% endif %}
+                  {% endif %}
                 {% if ind.confirmed_sex %}
                   <i class="fa fa-check"></i>
                 {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -116,11 +116,15 @@
                   <option {% if ind.sex_human == "female" %} selected {% endif %} value="female">Female</option>
                   <option {% if not ind.sex_human in ["female", "male"] %} selected= {% endif %} value="unknown">Unknown</option>
                 </select>
-                <div class="sex-display">
+                <div class="sex-display" style="font-weight: bold;">
                   {% if ind.sex_human in ['female','male'] %}
-                    <i class="fa fa-{{ind.sex_human}}" aria-hidden="true"></i>
-                  {% else %}
-                    {{ind.sex_human}}
+                    {% if ind.sex_human == 'female' %}
+                      F
+                    {% elif ind.sex_human == 'male' %}
+                      M
+                    {% else %}
+                      {{ind.sex_human}}
+                    {% endif %}
                   {% endif %}
                   {% if ind.confirmed_sex %}
                     <i class="fa fa-check"></i>


### PR DESCRIPTION
This PR fixes.
Change the sex symbols into letters (F/M):
![Screen Shot 2021-06-09 at 15 17 31](https://user-images.githubusercontent.com/41540288/121365292-cecfab80-c938-11eb-8153-84745a8cded0.png)
![Screen Shot 2021-06-09 at 15 17 20](https://user-images.githubusercontent.com/41540288/121365281-cd05e800-c938-11eb-93bb-82c558eb1d42.png)


**How to test**:
1. Run Scout locally (symbols-female-male) branch
2. Open a case


**Expected outcome**:
1. In the Individuals table: Sexs should be with letters (F,M)
2. Open SMN CN: Sexs should be with letters (F,M) in SMN Copy Number status - Individuals table

**Review:**
- [x] code approved by CR
- [x] tests executed by MOD
