### PR TITLE
Expand list of refseq trancripts in ClinVar submission form to reflect those in variant tx overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.
+- Expand list of refseq trancripts in ClinVar submission form
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -159,8 +159,10 @@
                           {% for gene in pinned.genes %}
                             {% for transcript in gene.transcripts %}
                               {% if transcript.refseq_id and transcript.coding_sequence_name %}
-                                <input type="radio" id="{{pinned._id+"_"+transcript.refseq_id}}" name="ref_seq@{{pinned._id}}" value="{{transcript.refseq_id+"|"+transcript.coding_sequence_name}}" {% if transcript.is_primary == True %} checked {% endif %}>
-                                <label for="{{pinned._id+"_"+transcript.refseq_id}}">{{transcript.refseq_id}} | {{transcript.coding_sequence_name}}</label><br>
+                                {% for refseq in transcript.refseq_identifiers %}
+                                <input type="radio" id="{{pinned._id+"_"+refseq}}" name="ref_seq@{{pinned._id}}" value="{{refseq+"|"+transcript.coding_sequence_name}}" {% if transcript.is_primary == True %} checked {% endif %}>
+                                <label for="{{pinned._id+"_"+refseq}}">{{refseq}} | {{transcript.coding_sequence_name}}</label><br>
+                                {% endfor %}
                               {% endif %}
                             {% endfor %}
                           {% endfor %} <!--end of gene-->


### PR DESCRIPTION
Fix #2520

Transcript list on ClinVar submission should show the same refseq transcripts that are shown in variant overview

**How to test: local instance of Scout**:
1. Marster branch, take this variant: http://localhost:5000/cust000/643594/0f630f3e151fa6a29513814688174a36
2. Pin the variant and go to the clinVar submission page: 
![image](https://user-images.githubusercontent.com/28093618/122202761-a34f4280-ce9d-11eb-8abe-7a57befbda58.png)
3. You'll notice that variant tx overview in variant page (count the number of distinct Refseq IDs, second column):
![image](https://user-images.githubusercontent.com/28093618/122202878-c1b53e00-ce9d-11eb-95bb-bc27df710f2c.png)
and variant ClinVar transcrips in the ClinVar form:
![image](https://user-images.githubusercontent.com/28093618/122203307-312b2d80-ce9e-11eb-9bae-770c8209ffa8.png)
are different in number.

4. Switch to this branch and number of transcripts should be the same

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MOD
- [x] tests executed by CR
