### PR TITLE
Added sort icon to all tables with sortable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Load case with missing panels in config files, but show warning.
 - Changing the (Female, Male) symbols to (F/M) letters in individuals_table and case-sma.
 - Print stacktrace if load command fails
+- Added sort icon and a pointer to the cursor to all tables with sortable fields
 
 ## [4.36]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -4,10 +4,10 @@
           <div class="table-responsive fixed-panel">
       <table id="panel-table" class="table" style="width:100%">
         <thead>
-          <tr>
-            <th>Panel</th>
-            <th>Version</th>
-            <th>Genes</th>
+          <tr style="cursor: pointer; white-space: nowrap">
+            <th>Panel <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'panel'"></i></th>
+            <th>Version <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'version'"></i></th>
+            <th>Genes <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'genes'"></i></th>
           </tr>
         </thead>
         <tbody>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -6,7 +6,7 @@
         <thead>
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-toggle="tooltip" title="Sort by gene panel name"></i></th>
-            <th>Version <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'version'"></i></th>
+            <th>Version <i class="fas fa-sort" data-toggle="tooltip" title="Sort by panel version"></i></th>
             <th>Genes <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'genes'"></i></th>
           </tr>
         </thead>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -7,7 +7,7 @@
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-toggle="tooltip" title="Sort by gene panel name"></i></th>
             <th>Version <i class="fas fa-sort" data-toggle="tooltip" title="Sort by panel version"></i></th>
-            <th>Genes <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'genes'"></i></th>
+            <th>Genes <i class="fas fa-sort" data-toggle="tooltip" title="Sort by number of genes"></i></th>
           </tr>
         </thead>
         <tbody>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -5,7 +5,7 @@
       <table id="panel-table" class="table" style="width:100%">
         <thead>
           <tr style="cursor: pointer; white-space: nowrap">
-            <th>Panel <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'panel'"></i></th>
+            <th>Panel <i class="fas fa-sort" data-toggle="tooltip" title="Sort by gene panel name"></i></th>
             <th>Version <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'version'"></i></th>
             <th>Genes <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'genes'"></i></th>
           </tr>

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -35,7 +35,7 @@
         <thead class="thead-light">
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by gene name"></i></th>
-            <th>Refseq IDs <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'refseq IDs'"></i></th>
+            <th>Refseq IDs <i class="fas fa-sort" data-toggle="tooltip" title="Sort by Refseq ID"></i></th>
             <th>ID <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ID'"></i></th>
             <th>HGVS Description <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'HGVS Description'"></i></th>
             <th>Links <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'links'"></i></th>

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -33,12 +33,12 @@
     <div class=card-body>
       <table id="transcript_overview_table" class="table table-bordered table-hover table-sm">
         <thead class="thead-light">
-          <tr>
-            <th>Gene</th>
-            <th>Refseq IDs</th>
-            <th>ID</th>
-            <th>HGVS Description</th>
-            <th>Links</th>
+          <tr style="cursor: pointer; white-space: nowrap">
+            <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'gene'"></i></th>
+            <th>Refseq IDs <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'refseq IDs'"></i></th>
+            <th>ID <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ID'"></i></th>
+            <th>HGVS Description <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'HGVS Description'"></i></th>
+            <th>Links <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'links'"></i></th>
           </tr>
         </thead>
         <tbody>

--- a/scout/server/blueprints/variant/templates/variant/tx_overview.html
+++ b/scout/server/blueprints/variant/templates/variant/tx_overview.html
@@ -34,7 +34,7 @@
       <table id="transcript_overview_table" class="table table-bordered table-hover table-sm">
         <thead class="thead-light">
           <tr style="cursor: pointer; white-space: nowrap">
-            <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'gene'"></i></th>
+            <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by gene name"></i></th>
             <th>Refseq IDs <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'refseq IDs'"></i></th>
             <th>ID <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ID'"></i></th>
             <th>HGVS Description <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'HGVS Description'"></i></th>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -287,7 +287,7 @@
           <th>Protein <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'protein'"></i></th>
           <th>SWISS PROT <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'SWISS PROT'"></i></th>
           <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Sift'"></i></th>
-          <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
+          <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Polyphen'"></i></th>
           <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Pfam'"></i></th>
           <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ProSite'"></i></th>
           <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Smart'"></i></th>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -290,7 +290,7 @@
           <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
           <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Pfam'"></i></th>
           <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'proSite'"></i></th>
-          <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'smart'"></i></th>
+          <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Smart'"></i></th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -286,7 +286,7 @@
           <th>Transcript <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'transcript'"></i></th>
           <th>Protein <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'protein'"></i></th>
           <th>SWISS PROT <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'SWISS PROT'"></i></th>
-          <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'sift'"></i></th>
+          <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Sift'"></i></th>
           <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
           <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'pfam'"></i></th>
           <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'proSite'"></i></th>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -289,7 +289,7 @@
           <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Sift'"></i></th>
           <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
           <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Pfam'"></i></th>
-          <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'proSite'"></i></th>
+          <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ProSite'"></i></th>
           <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Smart'"></i></th>
         </tr>
       </thead>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -288,7 +288,7 @@
           <th>SWISS PROT <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'SWISS PROT'"></i></th>
           <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Sift'"></i></th>
           <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
-          <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'pfam'"></i></th>
+          <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'Pfam'"></i></th>
           <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'proSite'"></i></th>
           <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'smart'"></i></th>
         </tr>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -192,10 +192,10 @@
   <div class="card panel-default">
     <table class="table table-bordered table-sm">
       <thead>
-        <tr>
-          <th>Gene</th>
-          <th>Ensembl ID</th>
-          <th>Description</th>
+        <tr style="cursor: pointer; white-space: nowrap">
+          <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'gene'"></i></th>
+          <th>Ensembl ID <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'ensembl ID'"></i></th>
+          <th>Description <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'description'"></i></th>
         </tr>
       </thead>
       <tbody>
@@ -225,17 +225,17 @@
   <div class="card panel-default table-responsive fixed-panel">
     <table id="transcripts_panel_table" class="table table-bordered card-sm">
       <thead>
-        <tr>
-          <th>Gene</th>
-          <th>Transcript</th>
-          <th>RefSeq</th>
-          <th>Biotype</th>
-          <th>Mutation type</th>
-          <th>Strand</th>
-          <th>Exon</th>
-          <th>Intron</th>
-          <th>cDNA</th>
-          <th>Amino acid</th>
+        <tr style="cursor: pointer; white-space: nowrap">
+          <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'gene'"></i></th>
+          <th>Transcript <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'transcript'"></i></th>
+          <th>RefSeq <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'refSeq'"></i></th>
+          <th>Biotype <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'biotype'"></i></th>
+          <th>Mutation type <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'mutation type'"></i></th>
+          <th>Strand <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'strand'"></i></th>
+          <th>Exon <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'exon'"></i></th>
+          <th>Intron <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'intron'"></i></th>
+          <th>cDNA <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'cDNA'"></i></th>
+          <th>Amino acid <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'amino acid'"></i></th>
         </tr>
       </thead>
       <tbody>
@@ -281,16 +281,16 @@
   <div class="panel panel-default table-responsive">
     <table id="proteins_panel_table" class="table table-bordered">
       <thead>
-        <tr>
-          <th>Gene</th>
-          <th>Transcript</th>
-          <th>Protein</th>
-          <th>SWISS PROT</th>
-          <th>Sift</th>
-          <th>Polyphen</th>
-          <th>Pfam</th>
-          <th>ProSite</th>
-          <th>Smart</th>
+        <tr style="cursor: pointer; white-space: nowrap">
+          <th>Gene <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'gene'"></i></th>
+          <th>Transcript <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'transcript'"></i></th>
+          <th>Protein <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'protein'"></i></th>
+          <th>SWISS PROT <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'SWISS PROT'"></i></th>
+          <th>Sift <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'sift'"></i></th>
+          <th>Polyphen <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'polyphen'"></i></th>
+          <th>Pfam <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'pfam'"></i></th>
+          <th>ProSite <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'proSite'"></i></th>
+          <th>Smart <i class="fas fa-sort" data-toggle="tooltip" title="Sort by 'smart'"></i></th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
This PR adds:
- Sort icon to all tables with sortable fields
- A tooltip to all sort icons with a title
- Change the cursor to a pointer when hovering over the sortable fileds

**How to test**:
1. On the branch sortable-filelds#1641
2. Open a case to test Gene panels 
3. Open variant page to test (RefSeq transcripts, Genes, Transcripts, Proteins)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

<img width="1023" alt="Screen Shot 2021-06-11 at 14 39 34" src="https://user-images.githubusercontent.com/41540288/121694049-0457ce80-caca-11eb-9bb6-18c032d92ff9.png">
<img width="1413" alt="Screen Shot 2021-06-11 at 14 39 44" src="https://user-images.githubusercontent.com/41540288/121694053-0588fb80-caca-11eb-8ef0-545446ef27b2.png">
<img width="1413" alt="Screen Shot 2021-06-11 at 14 39 52" src="https://user-images.githubusercontent.com/41540288/121694061-06219200-caca-11eb-851f-7903d6cd2d47.png">
<img width="910" alt="Screen Shot 2021-06-11 at 14 40 01" src="https://user-images.githubusercontent.com/41540288/121694065-06ba2880-caca-11eb-8df8-b5e778634fdc.png">
<img width="548" alt="Screen Shot 2021-06-11 at 14 40 17" src="https://user-images.githubusercontent.com/41540288/121694068-0752bf00-caca-11eb-8c85-673ac9fdfdce.png">


**Review:**
- [x] code approved by CR
- [x] tests executed by MOD
