### PR TITLE
Rename and fix style of `All SNVs and INDELs` institute sidebar element 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.
 - Expand list of refseq trancripts in ClinVar submission form
+- Renamed `All SNVs and INDELs` institute sidebar element to `Search SNVs and INDELs` and fixed its style.
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
@@ -20,7 +20,7 @@
           </a>
 
           <!-- snvs and indeld menu item -->
-          <a href="{{ url_for('overview.gene_variants', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
+          <a href="{{ url_for('overview.gene_variants', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start h-100">
               <div class="d-flex w-100 justify-content-start align-items-center">
                   <span class="fa fa-search mr-3"></span>
                   <span class="menu-collapsed">Search SNVs and INDEL</span>

--- a/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
@@ -23,7 +23,7 @@
           <a href="{{ url_for('overview.gene_variants', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start h-100">
               <div class="d-flex w-100 justify-content-start align-items-center">
                   <span class="fa fa-search mr-3"></span>
-                  <span class="menu-collapsed">Search SNVs and INDEL</span>
+                  <span class="menu-collapsed">Search SNVs and INDELs</span>
               </div>
           </a>
 

--- a/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
@@ -23,7 +23,7 @@
           <a href="{{ url_for('overview.gene_variants', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
               <div class="d-flex w-100 justify-content-start align-items-center">
                   <span class="fa fa-search mr-3"></span>
-                  <span class="menu-collapsed">All SNVs and INDELs</span>
+                  <span class="menu-collapsed">Search SNVs and INDEL</span>
               </div>
           </a>
 


### PR DESCRIPTION
Fix #2708

Fix style and rename one sidebar element on Institute page. 

From this:
![image](https://user-images.githubusercontent.com/28093618/121639821-63e3b900-ca8d-11eb-8319-478ae86b4cb1.png)

To this:
![image](https://user-images.githubusercontent.com/28093618/122565776-25c73600-d047-11eb-9667-403439af1e02.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by MOD
- [x] tests executed by CR
