### PR TITLE
Display a loading icon until the page loads completely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added integration to a rerunner service for toggling reanalysis with updated pedigree information
 - SpliceAI display and parsing from VEP CSQ
 - Display matching tiered variants for cancer variants
+- Display a loading icon (spinner) until the page loads completely
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.

--- a/scout/server/templates/bootstrap4.html
+++ b/scout/server/templates/bootstrap4.html
@@ -14,9 +14,46 @@
   {% endblock %}
 	<!-- Adding support for Font Awesome icons version 6 -->
 	<script src="https://kit.fontawesome.com/bff7dad824.js" crossorigin="anonymous"></script>
+
+	<style>
+
+		.spinner {
+			height: 100vh;
+			width: 100vw;
+			overflow: hidden;
+			position: absolute;
+		}
+
+		.spinner>div {
+			height: 60px;
+			width: 60px;
+			border: 5px solid #1182b22c;
+			border-top-color: #1181B2;
+			position: absolute;
+			margin: auto;
+			top: 0;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			border-radius: 50%;
+			animation: spin 0.5s infinite linear;
+			z-index: 100;
+		}
+
+		@keyframes spin {
+			100%{
+				transform: rotate(360deg);
+			}
+		}
+
+	</style>
 </head>
 
 <body>
+	<!-- Loading spinner -->
+	<div class="spinner">
+		<div></div>
+	</div>
 	{% block body %}
   {% block navbar%}
   {% endblock navbar%}
@@ -35,3 +72,13 @@
 
 </body>
 </html>
+
+<script>
+$(window).on('beforeunload', function(){
+	$('.spinner').show();
+});
+
+$(document).ready (function() {
+	  $('.spinner').hide();
+})
+</script>

--- a/scout/server/templates/bootstrap4.html
+++ b/scout/server/templates/bootstrap4.html
@@ -25,8 +25,8 @@
 		}
 
 		.spinner>div {
-			height: 60px;
-			width: 60px;
+			height: 90px;
+			width: 90px;
 			border: 5px solid #1182b22c;
 			border-top-color: #1181B2;
 			position: absolute;


### PR DESCRIPTION
This PR adds:
A loading spinner to all pages when the page is loading.

**How to test**:
1. Install on clinical-db stage
2. Navigate from one page to another.


**Expected outcome**:
A loading spinner should appear until the page loads completely.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR & MOD
