### PR TITLE
Print Stacktrace for More Exceptions When Loading

### DIFF
--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -98,7 +98,7 @@ def case(
         )
     except SyntaxError as err:
         LOG.error(
-            "SyntaxError {} missing when loading '{}' {}".format(
+            "SyntaxError {}: missing when loading '{}' {}".format(
                 err, config.name, traceback.format_exc()
             )
         )

--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -97,11 +97,16 @@ def case(
             peddy_check=peddy_check,
         )
     except SyntaxError as err:
-        LOG.warning(err)
+        LOG.error(
+            "SyntaxError {} missing when loading '{}' {}".format(
+                err, config.name, traceback.format_exc()
+            )
+        )
         raise click.Abort()
     except KeyError as err:
-        LOG.error("KEYERROR {} missing when loading '{}'".format(err, config.name))
-        LOG.debug("Stack trace: {}".format(traceback.format_exc()))
+        LOG.error(
+            "KeyError {} when loading '{}' {}".format(err, config.name, traceback.format_exc())
+        )
         raise click.Abort()
 
     if config_data.get("human_genome_build") not in [37, 38, "37", "38"]:

--- a/tests/commands/load/test_load_case_cmd.py
+++ b/tests/commands/load/test_load_case_cmd.py
@@ -87,7 +87,7 @@ def test_load_case_KeyError(mock_app, institute_obj, case_obj, monkeypatch):
 
     # THEN it should trigger KeyError
     assert result.exit_code == 1
-    assert "KEYERROR" in result.output
+    assert "KeyError" in result.output
 
 
 def test_load_case_KeyError2(mock_app, institute_obj, case_obj, monkeypatch):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Print stack trace for even more command line errors. These changes are uniform with #2701.

**How to test**:
1. how to test it, possibly with real cases/data
_I'm having a hard time figuring out a good way to force a failure naturally, but got stuck. Any ideas?_


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.




**Review:**
- [ ] code approved by
- [ ] tests executed by
