### PR TITLE
Institutes api v1 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display filter badges in cancer variants list
 - Update genes from pre-downloaded file resources
 - On login, OS, browser version and screen size are saved anonymously to understand how users are using Scout
+- API returning institutes data for a given user
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -9,7 +9,7 @@ from anytree.exporter import DictExporter
 from flask import flash
 from flask_login import current_user
 
-from scout.constants import CASE_STATUSES
+from scout.constants import CASE_STATUSES, PHENOTYPE_GROUPS
 from scout.parse.clinvar import clinvar_submission_header, clinvar_submission_lines
 from scout.server.blueprints.genes.controllers import gene
 from scout.server.blueprints.variant.utils import predictions
@@ -21,6 +21,35 @@ from .forms import CaseFilterForm
 
 # Do not assume all cases have a valid track set
 TRACKS = {None: "Rare Disease", "rare": "Rare Disease", "cancer": "Cancer"}
+
+
+def institutes():
+    """Returns institutes info available for a user
+    Returns:
+        data(list): a list of institute dictionaries
+    """
+
+    institute_objs = user_institutes(store, current_user)
+    institutes = []
+    for ins_obj in institute_objs:
+        sanger_recipients = []
+        for user_mail in ins_obj.get("sanger_recipients", []):
+            user_obj = store.user(user_mail)
+            if not user_obj:
+                continue
+            sanger_recipients.append(user_obj["name"])
+        institutes.append(
+            {
+                "display_name": ins_obj["display_name"],
+                "internal_id": ins_obj["_id"],
+                "coverage_cutoff": ins_obj.get("coverage_cutoff", "None"),
+                "sanger_recipients": sanger_recipients,
+                "frequency_cutoff": ins_obj.get("frequency_cutoff", "None"),
+                "phenotype_groups": ins_obj.get("phenotype_groups", PHENOTYPE_GROUPS),
+                "case_count": sum(1 for i in store.cases(collaborator=ins_obj["_id"])),
+            }
+        )
+    return institutes
 
 
 def institute(store, institute_id):

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -31,7 +31,7 @@ blueprint = Blueprint(
 )
 
 
-@blueprint.route("/api/v1/secure/institutes", methods=["GET"])
+@blueprint.route("/api/v1/institutes", methods=["GET"])
 def api_institutes():
     """API endpoint that returns institutes data"""
     data = dict(institutes=controllers.institutes())

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -3,7 +3,7 @@ import logging
 
 import pymongo
 from bson import ObjectId
-from flask import Blueprint, Response, flash, redirect, render_template, request, url_for
+from flask import Blueprint, Response, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user
 from werkzeug.datastructures import Headers
 
@@ -13,7 +13,6 @@ from scout.constants import (
     CASE_SEARCH_TERMS,
     CASEDATA_HEADER,
     CLINVAR_HEADER,
-    PHENOTYPE_GROUPS,
 )
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, templated, user_institutes
@@ -32,31 +31,17 @@ blueprint = Blueprint(
 )
 
 
+@blueprint.route("/api/v1/secure/institutes", methods=["GET"])
+def api_institutes():
+    """API endpoint that returns institutes data"""
+    data = dict(institutes=controllers.institutes())
+    return jsonify(data)
+
+
 @blueprint.route("/overview")
 def institutes():
     """Display a list of all user institutes."""
-    institute_objs = user_institutes(store, current_user)
-    institutes = []
-    for ins_obj in institute_objs:
-        sanger_recipients = []
-        for user_mail in ins_obj.get("sanger_recipients", []):
-            user_obj = store.user(user_mail)
-            if not user_obj:
-                continue
-            sanger_recipients.append(user_obj["name"])
-        institutes.append(
-            {
-                "display_name": ins_obj["display_name"],
-                "internal_id": ins_obj["_id"],
-                "coverage_cutoff": ins_obj.get("coverage_cutoff", "None"),
-                "sanger_recipients": sanger_recipients,
-                "frequency_cutoff": ins_obj.get("frequency_cutoff", "None"),
-                "phenotype_groups": ins_obj.get("phenotype_groups", PHENOTYPE_GROUPS),
-                "case_count": sum(1 for i in store.cases(collaborator=ins_obj["_id"])),
-            }
-        )
-
-    data = dict(institutes=institutes)
+    data = dict(institutes=controllers.institutes())
     return render_template("overview/institutes.html", **data)
 
 

--- a/tests/server/blueprints/institutes/test_institute_api.py
+++ b/tests/server/blueprints/institutes/test_institute_api.py
@@ -1,0 +1,15 @@
+from flask import json, url_for
+
+
+def test_api_institutes(app):
+    """Test retrieving institutes data"""
+
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+
+        # sending a GET request to the institutes API should return content
+        response = client.get("/api/v1/institutes")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data


### PR DESCRIPTION
- Creates an API endpoint to retrieve the list of available institutes for a logged user
- Moved some content of institutes flask endpoint from views to controllers 

**How to test**:
1. Install locally 
2. Using the demo scout instance navigate to the list of institutes and make sure the page looks normal
3. While being logged in Scout, type in your browser the following url: `http://localhost:5000/api/v1/institutes`. It should return json data
4. Log out from Scout and run the same request. You should be redirected to the login page.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by EM
- [x] tests executed by CR
