### PR TITLE
Institute cases api & server.utils.jsonconverter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display filter badges in cancer variants list
 - Update genes from pre-downloaded file resources
 - On login, OS, browser version and screen size are saved anonymously to understand how users are using Scout
-- API returning institutes data for a given user
+- API returning institutes data for a given user: `/api/v1/institutes`
+- API returning case data for a given institute: `/api/v1/institutes/<institute_id>/cases`
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -460,7 +460,8 @@ def update_clinvar_submission_status(store, request_obj, institute_id, submissio
         store.update_clinvar_submission_status(institute_id, submission_id, update_status)
     if update_status == "register_id":  # register an official clinvar submission ID
         result = store.update_clinvar_id(
-            clinvar_id=request_obj.form.get("clinvar_id"), submission_id=submission_id,
+            clinvar_id=request_obj.form.get("clinvar_id"),
+            submission_id=submission_id,
         )
     if update_status == "delete":  # delete a submission
         deleted_objects, deleted_submissions = store.delete_submission(submission_id=submission_id)
@@ -482,7 +483,8 @@ def update_clinvar_sample_names(store, submission_id, case_id, old_name, new_nam
     """
     n_renamed = store.rename_casedata_samples(submission_id, case_id, old_name, new_name)
     flash(
-        f"Renamed {n_renamed} case data individuals from '{old_name}' to '{new_name}'", "info",
+        f"Renamed {n_renamed} case data individuals from '{old_name}' to '{new_name}'",
+        "info",
     )
 
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -445,8 +445,7 @@ def update_clinvar_submission_status(store, request_obj, institute_id, submissio
         store.update_clinvar_submission_status(institute_id, submission_id, update_status)
     if update_status == "register_id":  # register an official clinvar submission ID
         result = store.update_clinvar_id(
-            clinvar_id=request_obj.form.get("clinvar_id"),
-            submission_id=submission_id,
+            clinvar_id=request_obj.form.get("clinvar_id"), submission_id=submission_id,
         )
     if update_status == "delete":  # delete a submission
         deleted_objects, deleted_submissions = store.delete_submission(submission_id=submission_id)
@@ -468,8 +467,7 @@ def update_clinvar_sample_names(store, submission_id, case_id, old_name, new_nam
     """
     n_renamed = store.rename_casedata_samples(submission_id, case_id, old_name, new_name)
     flash(
-        f"Renamed {n_renamed} case data individuals from '{old_name}' to '{new_name}'",
-        "info",
+        f"Renamed {n_renamed} case data individuals from '{old_name}' to '{new_name}'", "info",
     )
 
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -2,6 +2,8 @@
 import datetime
 import logging
 
+from pymongo import ASCENDING, DESCENDING
+
 LOG = logging.getLogger(__name__)
 
 from anytree import Node, RenderTree
@@ -209,9 +211,9 @@ def cases(store, request, institute_id):
     sort_by = request.args.get("sort")
     sort_order = request.args.get("order") or "asc"
     if sort_by:
-        pymongo_sort = pymongo.ASCENDING
+        pymongo_sort = ASCENDING
         if sort_order == "desc":
-            pymongo_sort = pymongo.DESCENDING
+            pymongo_sort = DESCENDING
         if sort_by == "analysis_date":
             all_cases.sort("analysis_date", pymongo_sort)
         elif sort_by == "track":

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -175,12 +175,16 @@ def update_institute_settings(store, institute_obj, form):
     return updated_institute
 
 
-def _get_cases_sort_order(data, request):
+def _sort_cases(data, request, all_cases):
     """Set cases data sorting values in cases data
 
     Args:
         data(dict): dictionary containing cases data
         request(flask.request) request sent by browser to the api_institutes endpoint
+        all_cases(pymongo Cursor)
+
+    Returns:
+        all_cases(pymongo Cursor): Cursor of eventually sorted cases
     """
 
     sort_by = request.args.get("sort")
@@ -198,6 +202,8 @@ def _get_cases_sort_order(data, request):
 
     data["sort_order"] = sort_order
     data["sort_by"] = sort_by
+
+    return all_cases
 
 
 def cases(store, request, institute_id):
@@ -222,6 +228,7 @@ def cases(store, request, institute_id):
     data["name_query"] = name_query
     limit = int(request.args.get("search_limit")) if request.args.get("search_limit") else 100
     skip_assigned = request.args.get("skip_assigned")
+    data["form"] = populate_case_filter_form(request.args)
     data["skip_assigned"] = skip_assigned
     is_research = request.args.get("is_research")
     data["is_research"] = is_research
@@ -232,9 +239,7 @@ def cases(store, request, institute_id):
         skip_assigned=skip_assigned,
         is_research=is_research,
     )
-    data["form"] = populate_case_filter_form(request.args)
-
-    _get_cases_sort_order(data, request)
+    all_cases = _sort_cases(data, request, all_cases)
 
     data["nr_cases"] = store.nr_cases(institute_id=institute_id)
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -187,7 +187,6 @@ def cases(store, request, institute_id):
         data(dict): includes the cases, how many there are and the limit.
     """
     data = {"search_terms": CASE_SEARCH_TERMS}
-    data["search_terms"]
     institute_obj = institute_and_case(store, institute_id)
     data["institute"] = institute_obj
     name_query = None

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -42,8 +42,9 @@ def institutes():
 @blueprint.route("/api/v1/<institute_id>/cases")
 def api_cases(institute_id):
     """API endpoint that returns all cases for a given institute"""
-    data = dict(cases=controllers.cases(store, request, institute_id))
-    return jsonify(data)
+    return "HERE BITCHES"
+    # data = dict(cases=controllers.cases(store, request, institute_id))
+    # return jsonify(data)
 
 
 @blueprint.route("/<institute_id>/cases")
@@ -69,8 +70,7 @@ def causatives(institute_id):
     variants = list(store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id))
     if variants:
         variants = sorted(
-            variants,
-            key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
+            variants, key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
         )
     all_variants = {}
     all_cases = {}

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -42,7 +42,8 @@ def institutes():
 @blueprint.route("/api/v1/<institute_id>/cases")
 def api_cases(institute_id):
     """API endpoint that returns all cases for a given institute"""
-    pass
+    data = dict(cases=controllers.cases(store, request, institute_id))
+    return jsonify(data)
 
 
 @blueprint.route("/<institute_id>/cases")

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -1,4 +1,5 @@
 """Common utilities for the server code"""
+import datetime
 import io
 import logging
 import os
@@ -6,10 +7,22 @@ import pathlib
 import zipfile
 from functools import wraps
 
+from bson.objectid import ObjectId
 from flask import abort, flash, render_template, request
 from flask_login import current_user
 
 LOG = logging.getLogger(__name__)
+
+
+def jsonconverter(obj):
+    """Converts non-serializable onjects into str"""
+    LOG.warning(f"An object of type {type(obj)} is not json-serializable: converting it.")
+    if "Form" in str(type(obj)):
+        return obj.__dict__
+    if isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    if isinstance(obj, ObjectId):
+        return obj.__str__()
 
 
 def templated(template=None):
@@ -133,17 +146,9 @@ def case_append_alignments(case_obj):
         {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
         {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": "no_index"},
         {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": "no_index"},
-        {
-            "path": "upd_regions_bed",
-            "append_to": "upd_regions_beds",
-            "index": "no_index",
-        },
+        {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": "no_index",},
         {"path": "upd_sites_bed", "append_to": "upd_sites_beds", "index": "no_index"},
-        {
-            "path": "tiddit_coverage_wig",
-            "append_to": "tiddit_coverage_wigs",
-            "index": "no_index",
-        },
+        {"path": "tiddit_coverage_wig", "append_to": "tiddit_coverage_wigs", "index": "no_index",},
     ]
 
     for individual in case_obj["individuals"]:

--- a/scout/utils/convert.py
+++ b/scout/utils/convert.py
@@ -3,6 +3,12 @@ import re
 from scout.constants import AMINO_ACID_RESIDUE_3_TO_1
 
 
+def jsonconverter(obj):
+    """Converts non-serializable onjects into str"""
+    if isinstance(obj, datetime.datetime):
+        return obj.__str__()
+
+
 def isfloat(x):
     try:
         a = float(x)

--- a/scout/utils/convert.py
+++ b/scout/utils/convert.py
@@ -3,12 +3,6 @@ import re
 from scout.constants import AMINO_ACID_RESIDUE_3_TO_1
 
 
-def jsonconverter(obj):
-    """Converts non-serializable onjects into str"""
-    if isinstance(obj, datetime.datetime):
-        return obj.__str__()
-
-
 def isfloat(x):
     try:
         a = float(x)

--- a/tests/server/blueprints/institutes/test_institute_api.py
+++ b/tests/server/blueprints/institutes/test_institute_api.py
@@ -2,7 +2,7 @@ from flask import json, url_for
 
 
 def test_api_institutes(app):
-    """Test retrieving institutes data"""
+    """Test retrieving institutes data from the API"""
 
     with app.test_client() as client:
         # GIVEN that the user could be logged in
@@ -10,6 +10,33 @@ def test_api_institutes(app):
 
         # sending a GET request to the institutes API should return content
         response = client.get("/api/v1/institutes")
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data
+
+
+def test_api_cases(app, institute_obj):
+    """Test retrieving institute cases data from the API"""
+
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+
+        # Invoking the API with some args params
+        request_data = {
+            "limit": "100",
+            "skip_assigned": "on",
+            "is_research": "on",
+            "query": "case_id",
+        }
+        response = client.get(
+            url_for(
+                "overview.api_cases",
+                institute_id=institute_obj["internal_id"],
+                params=request_data,
+            )
+        )
+        # WOULD return a data
         assert response.status_code == 200
         data = json.loads(response.data)
         assert data

--- a/tests/server/blueprints/institutes/test_institute_controllers.py
+++ b/tests/server/blueprints/institutes/test_institute_controllers.py
@@ -15,10 +15,7 @@ def test_phenomodel_checkgroups_filter(app, institute_obj, hpo_checkboxes, omim_
     hpo_id1 = hpo_checkboxes[0]["_id"]
     hpo_id2 = hpo_checkboxes[1]["_id"]
     omim_id = omim_checkbox["_id"]
-    checkbox2 = dict(
-        name=hpo_id2,
-        description=hpo_checkboxes[1]["description"],
-    )
+    checkbox2 = dict(name=hpo_id2, description=hpo_checkboxes[1]["description"],)
     checkbox1 = dict(
         name=hpo_id1,
         description=hpo_checkboxes[1]["description"],
@@ -45,51 +42,3 @@ def test_phenomodel_checkgroups_filter(app, institute_obj, hpo_checkboxes, omim_
         assert updated_model["subpanels"]["panel1"]["checkboxes"][hpo_id2]
         assert hpo_id1 not in updated_model["subpanels"]["panel1"]["checkboxes"]
         assert omim_id not in updated_model["subpanels"]["panel1"]["checkboxes"]
-
-
-def test_cases(adapter, case_obj, institute_obj):
-
-    # GIVEN a non prioritized case
-    case = case_obj
-    assert case["status"] == "inactive"
-    adapter.case_collection.insert_one(case)
-
-    # GIVEN a priotized case
-    case2 = copy.deepcopy(case)
-    case2["_id"] = "internal_id2"
-    case2["status"] = "prioritized"
-    adapter.case_collection.insert_one(case2)
-
-    all_cases = adapter.cases(collaborator=institute_obj["_id"])
-    assert len(list(all_cases)) == 2
-
-    prio_cases = adapter.prioritized_cases(institute_id=institute_obj["_id"])
-    assert len(list(prio_cases)) == 1
-
-    all_cases = adapter.cases(collaborator=institute_obj["_id"])
-    prio_cases = adapter.prioritized_cases(institute_id=institute_obj["_id"])
-
-    # WHEN the cases controller is invoked
-    data = cases(store=adapter, case_query=all_cases, prioritized_cases_query=prio_cases, limit=1)
-
-    # THEN 2 cases should be returned
-    assert data["found_cases"] == 2
-
-
-def test_controller_cases(adapter):
-    # GIVEN an adapter with a case
-    test_case = {
-        "case_id": "1",
-        "owner": "cust000",
-        "individuals": [
-            {"analysis_type": "wgs", "sex": 1, "phenotype": 2, "individual_id": "ind1"}
-        ],
-        "status": "inactive",
-    }
-    adapter.case_collection.insert_one(test_case)
-    case_query = adapter.case_collection.find()
-    # WHEN fetching a case with the controller
-    data = cases(adapter, case_query)
-    # THEN
-    assert isinstance(data, dict)
-    assert data["found_cases"] == 1


### PR DESCRIPTION
- Created an API endpoint for institute cases
- Created a jsonconverter function in server utils to be used in all APIs whenever data objects are not json-serializable

**How to test**:
1. On clinical-db, using the browser go to an institute page and make sure it contains the list of cases as usual  (for instance: https://scout-stage.scilifelab.se/cust002/cases)
2. go to the https://scout-stage.scilifelab.se/api/v1/institutes/cust002/cases and make sure it returns the same data, but in json format

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
