### PR TITLE
Bugfix: XML Query Replies not Percent Encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Renamed `All SNVs and INDELs` institute sidebar element to `Search SNVs and INDELs` and fixed its style.
 - Add missing parameters to case load-config documentation
 - Allow creating/editing gene panels and dynamic gene panels with genes present in genome build 38
+- Bugfix broken Pytests
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/utils/ensembl_rest_clients.py
+++ b/scout/utils/ensembl_rest_clients.py
@@ -221,7 +221,7 @@ class EnsemblBiomartClient:
             xml_lines.append("\t\t" + line)
         xml_lines += ["\t</Dataset>", "</Query>"]
 
-        return "\n".join(xml_lines)
+        return "".join(xml_lines)
 
     @staticmethod
     def xml_filters(filters):

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -1,6 +1,7 @@
 """Tests for ensembl rest api"""
 
 from urllib.parse import quote, urlencode
+
 import responses
 from requests.exceptions import HTTPError, MissingSchema
 

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -1,8 +1,8 @@
 """Tests for ensembl rest api"""
 
+from urllib.parse import quote, urlencode
 import responses
 from requests.exceptions import HTTPError, MissingSchema
-from urllib.parse import urlencode, quote
 
 from scout.utils import ensembl_rest_clients
 

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -2,6 +2,7 @@
 
 import responses
 from requests.exceptions import HTTPError, MissingSchema
+from urllib.parse import urlencode, quote
 
 from scout.utils import ensembl_rest_clients
 
@@ -176,7 +177,8 @@ def test_test_query_biomart_38_xml(ensembl_biomart_xml_query):
     """
     # GIVEN client with a xml query for a gene
     build = "38"
-    url = "".join([ensembl_rest_clients.BIOMART_38, ensembl_biomart_xml_query])
+    # percent encode query before concatenating with url
+    url = "".join([ensembl_rest_clients.BIOMART_38, quote(ensembl_biomart_xml_query)])
     response = (
         b"ACTR3\tENST00000263238\n"
         b"ACTR3\tENST00000443297\n"
@@ -201,24 +203,27 @@ def test_test_query_biomart_38_xml(ensembl_biomart_xml_query):
 
 
 @responses.activate
-def test_test_query_biomart_37_no_xml():
-    """Prepare a test xml document for the biomart service build 37 and
+def test_test_query_biomart_38_no_xml():
+    """Prepare a test xml document for the biomart service build 38 and
     query the service using it
     """
     # GIVEN defined biomart filters and attributes
     filters = {"ensembl_gene_id": "ENSG00000115091"}
     attributes = ["hgnc_symbol", "ensembl_transcript_id"]
-    url = """http://ensembl.org/biomart/martservice?query=<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Query>
-<Query  virtualSchemaName = "default" formatter = "TSV" header = "0" uniqueRows = "0" count = "" \
-datasetConfigVersion = "0.6" completionStamp = "1">
 
-\t<Dataset name = "hsapiens_gene_ensembl" interface = "default" >
-\t\t<Filter name = "ensembl_gene_id" value = "ENSG00000115091"/>
-\t\t<Attribute name = "hgnc_symbol" />
-\t\t<Attribute name = "ensembl_transcript_id" />
-\t</Dataset>
-</Query>"""
+    query = '<?xml version="1.0" encoding="UTF-8"?>\
+<!DOCTYPE Query>\
+<Query  virtualSchemaName = "default" formatter = "TSV" header = "0" uniqueRows = "0" count = "" \
+datasetConfigVersion = "0.6" completionStamp = "1">\
+\t<Dataset name = "hsapiens_gene_ensembl" interface = "default" >\
+\t\t<Filter name = "ensembl_gene_id" value = "ENSG00000115091"/>\
+\t\t<Attribute name = "hgnc_symbol" />\
+\t\t<Attribute name = "ensembl_transcript_id" />\
+\t</Dataset>\
+</Query>'
+
+    # percent encode query before concatenating with url
+    url = "".join([ensembl_rest_clients.BIOMART_38, quote(query)])
 
     response = (
         b"ACTR3\tENST00000263238\n"

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -171,7 +171,7 @@ def test_xml_attributes(ensembl_biomart_client_37):
 
 
 @responses.activate
-def test_test_query_biomart_38_xml(ensembl_biomart_xml_query):
+def test_query_biomart_38_xml(ensembl_biomart_xml_query):
     """Prepare a test xml document for the biomart service build 38
     and query the service using it
     """
@@ -203,7 +203,7 @@ def test_test_query_biomart_38_xml(ensembl_biomart_xml_query):
 
 
 @responses.activate
-def test_test_query_biomart_38_no_xml():
+def test_query_biomart_38_no_xml():
     """Prepare a test xml document for the biomart service build 38 and
     query the service using it
     """


### PR DESCRIPTION
This bug showed up on Github, but seemed to work locally. Could not find the package that differed -which is my suspected root cause. Reference #2766.

This PR fixes a bug.


**How to test**:
1. how to test it, possibly with real cases/data
Pytests on Github run by Coveralls would fail at `tests/utils/test_ensembl_rest_clients.py::test_test_query_biomart_38_xml`. All test should now pass.

a. Checkout and run `pytest tests/` on your local machine
b. Pytests on Github are started automagically 

**Expected outcome**:
All Pytests pass.


**Review:**
- [ ] code approved by
- [ ] tests executed by
