### PR TITLE
Fix Typo In Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added GMS and Lund university hospital logos to login page
 - Made display of Swedac logo configurable
 - Support for displaying custom images in case view
+- Fix typo in index documentation
 
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels

--- a/docs/admin-guide/indexes.md
+++ b/docs/admin-guide/indexes.md
@@ -4,4 +4,4 @@ The indexes that are used is displayed in `scout/constants/indexes.md`. If index
 
 To update indexes simply run the cli command `scout index`.
 
-Existing indexes can be viewed by `scout view indexes`.
+Existing indexes can be viewed by `scout view index`.


### PR DESCRIPTION
This PR  fixes a bug.

The documentation for indexes referred to a non-existing command.
<img width="1157" alt="Screenshot 2021-08-04 at 09 54 07" src="https://user-images.githubusercontent.com/1150065/128143851-fd4f9fc5-1a3b-4536-96b2-24025c4460f7.png">


```
% scout view indexes
2021-08-04 09:50:20 newmexico.local scout.commands.base[98102] INFO Running scout version 4.36
2021-08-04 09:50:20 newmexico.local scout.commands.base[98102] DEBUG Debug logging enabled.
Usage: scout view [OPTIONS] COMMAND [ARGS]...
Try 'scout view --help' for help.

Error: No such command 'indexes'.
```

This is now corrected:
```
% scout view index
2021-08-04 09:51:01 newmexico.local scout.commands.base[98122] INFO Running scout version 4.36
2021-08-04 09:51:01 newmexico.local scout.commands.base[98122] DEBUG Debug logging enabled.
2021-08-04 09:51:01 newmexico.local scout.commands.view.index[98122] INFO Running scout view index
collection	index
2021-08-04 09:51:01 newmexico.local scout.commands.view.index[98122] INFO No indexes found
```


**How to test**:
1. how to test it, possibly with real cases/data

Open `docs/admin-guide/indexes.md`. Copy paste the command for viewing indexes into your terminal. 


**Expected outcome**:
Executing the command for viewing indexes should print a list of current indexes to terminal output.


**Review:**
- [ ] code approved by
- [ ] tests executed by
