### PR TITLE
Fix typo in SHOW_OBSERVED_VARIANT_ARCHIVE config param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changing the (Kind) drop-down according to (Category) drop-down in Managed variant add variant
 - Moved Gens button to individuals table
 - Check resource files availability before starting updating OMIM diagnoses
+- Config parameter `SHOW_ARCHIVED_OBSERVATIONS` to hide archived local observations panel when set to False
 
 ## [4.36]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changing the (Kind) drop-down according to (Category) drop-down in Managed variant add variant
 - Moved Gens button to individuals table
 - Check resource files availability before starting updating OMIM diagnoses
-- Config parameter `SHOW_ARCHIVED_OBSERVATIONS` to hide archived local observations panel when set to False
+- Fix typo in `SHOW_OBSERVED_VARIANT_ARCHIVE` config param
 
 ## [4.36]
 ### Added

--- a/scout/server/blueprints/public/views.py
+++ b/scout/server/blueprints/public/views.py
@@ -29,7 +29,6 @@ def index():
 
     badge_name = current_app.config.get("ACCREDITATION_BADGE")
     flash(f"badge_name----->{badge_name}")
-    flash(f"config file:{current_app.config}")
     if badge_name and not Path(public_bp.static_folder, badge_name).is_file():
         LOG.warning(f'No file with name "{badge_name}" in {public_bp.static_folder}')
         badge_name = None

--- a/scout/server/blueprints/public/views.py
+++ b/scout/server/blueprints/public/views.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from flask import Blueprint, current_app, flash, render_template, send_from_directory
+from flask import Blueprint, current_app, render_template, send_from_directory
 from flask_ldap3_login.forms import LDAPLoginForm
 
 from scout import __version__
@@ -28,7 +28,6 @@ def index():
         form = LDAPLoginForm()
 
     badge_name = current_app.config.get("ACCREDITATION_BADGE")
-    flash(f"badge_name----->{badge_name}")
     if badge_name and not Path(public_bp.static_folder, badge_name).is_file():
         LOG.warning(f'No file with name "{badge_name}" in {public_bp.static_folder}')
         badge_name = None

--- a/scout/server/blueprints/public/views.py
+++ b/scout/server/blueprints/public/views.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 
-from flask import Blueprint, current_app, render_template, send_from_directory
+from flask import Blueprint, current_app, flash, render_template, send_from_directory
 from flask_ldap3_login.forms import LDAPLoginForm
 
 from scout import __version__
@@ -28,6 +28,7 @@ def index():
         form = LDAPLoginForm()
 
     badge_name = current_app.config.get("ACCREDITATION_BADGE")
+    flash(f"badge_name----->{badge_name}")
     if badge_name and not Path(public_bp.static_folder, badge_name).is_file():
         LOG.warning(f'No file with name "{badge_name}" in {public_bp.static_folder}')
         badge_name = None

--- a/scout/server/blueprints/public/views.py
+++ b/scout/server/blueprints/public/views.py
@@ -29,6 +29,7 @@ def index():
 
     badge_name = current_app.config.get("ACCREDITATION_BADGE")
     flash(f"badge_name----->{badge_name}")
+    flash(f"config file:{current_app.config}")
     if badge_name and not Path(public_bp.static_folder, badge_name).is_file():
         LOG.warning(f'No file with name "{badge_name}" in {public_bp.static_folder}')
         badge_name = None

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -79,9 +79,7 @@
         {% if config['LOQUSDB_SETTINGS'] %}
           {{ observations_panel(variant, observations, case) }}
         {% endif %}
-        {% if config['SHOW_OBERVED_VARIANT_ARCHIVE'] %}
-          {{  old_observations(variant) }}
-        {% endif %}
+        {{  old_observations(variant) }}
 
       </div>
       <div class="col-sm-2">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -94,9 +94,7 @@
       {% if config['LOQUSDB_SETTINGS'] %}
         {{ observations_panel(variant, observations, case) }}
       {% endif %}
-      {% if config['SHOW_OBERVED_VARIANT_ARCHIVE'] %}
-        {{  old_observations(variant) }}
-      {% endif %}
+      {{  old_observations(variant) }}
       {{ severity_list(variant) }}
       {{ conservations(variant) }}
       {{ mappability(variant) }}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -197,7 +197,7 @@
 {% endmacro %}
 
 {% macro old_observations(variant, obs_date) %}
-{% if "SHOW_ARCHIVED_OBSERVATIONS" not in config or config.SHOW_ARCHIVED_OBSERVATIONS == true %}
+{% if "SHOW_OBSERVED_VARIANT_ARCHIVE" in config and config["SHOW_OBSERVED_VARIANT_ARCHIVE"] == true %}
   <div class="card panel-default">
     <div class="panel-heading">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations (archive {{obs_date or '2017-05-31'}})</a>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -197,7 +197,7 @@
 {% endmacro %}
 
 {% macro old_observations(variant, obs_date) %}
-{% if config.SHOW_ARCHIVED_OBSERVATIONS is not defined or config.SHOW_ARCHIVED_OBSERVATIONS is true%}
+{% if config.SHOW_ARCHIVED_OBSERVATIONS is not defined or config.SHOW_ARCHIVED_OBSERVATIONS == true%}
   <div class="card panel-default">
     <div class="panel-heading">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations (archive {{obs_date or '2017-05-31'}})</a>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -197,6 +197,7 @@
 {% endmacro %}
 
 {% macro old_observations(variant, obs_date) %}
+{% if config.SHOW_ARCHIVED_OBSERVATIONS is not defined or config.SHOW_ARCHIVED_OBSERVATIONS is true%}
   <div class="card panel-default">
     <div class="panel-heading">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations (archive {{obs_date or '2017-05-31'}})</a>
@@ -220,6 +221,7 @@
       </table>
     </div>
   </div>
+{% endif %}
 {% endmacro %}
 
 {% macro severity_list(variant) %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -197,7 +197,7 @@
 {% endmacro %}
 
 {% macro old_observations(variant, obs_date) %}
-{% if config.SHOW_ARCHIVED_OBSERVATIONS is not defined or config.SHOW_ARCHIVED_OBSERVATIONS == true%}
+{% if "SHOW_ARCHIVED_OBSERVATIONS" not in config or config.SHOW_ARCHIVED_OBSERVATIONS == true %}
   <div class="card panel-default">
     <div class="panel-heading">
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations (archive {{obs_date or '2017-05-31'}})</a>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -18,7 +18,7 @@ MAIL_USE_SSL = False
 
 # Filename of accrediation bagde image in server/bluprints/public/static
 # If null no badge is displayed in scout
-ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
+# ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # Configure gens service
 # GENS_HOST = "127.0.0.1"
 # GENS_PORT = 5000

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -18,7 +18,8 @@ MAIL_USE_SSL = False
 
 # Filename of accrediation bagde image in server/bluprints/public/static
 # If null no badge is displayed in scout
-# ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
+ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
+
 # Configure gens service
 # GENS_HOST = "127.0.0.1"
 # GENS_PORT = 5000

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -66,7 +66,7 @@ ACCEPT_LANGUAGES = ["en", "sv"]
 
 # FEATURE FLAGS
 SHOW_CAUSATIVES = True
-SHOW_OBERVED_VARIANT_ARCHIVE = True
+SHOW_ARCHIVED_OBSERVATIONS = False
 
 # OMIM API KEY: Required for downloading definitions from OMIM (https://www.omim.org/api)
 # OMIM_API_KEY = 'valid_omim_api_key'

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -67,7 +67,7 @@ ACCEPT_LANGUAGES = ["en", "sv"]
 
 # FEATURE FLAGS
 SHOW_CAUSATIVES = True
-SHOW_ARCHIVED_OBSERVATIONS = False
+SHOW_OBSERVED_VARIANT_ARCHIVE = True
 
 # OMIM API KEY: Required for downloading definitions from OMIM (https://www.omim.org/api)
 # OMIM_API_KEY = 'valid_omim_api_key'


### PR DESCRIPTION
Fix a typo in SHOW_OBSERVED_VARIANT_ARCHIVE config param

**How to test**:
1. Test locally in the 3 scenarios:
- No SHOW_OBSERVED_VARIANT_ARCHIVE param in config file
- SHOW_OBSERVED_VARIANT_ARCHIVE = True in config file 
- SHOW_OBSERVED_VARIANT_ARCHIVE = False in config file

1. Test on clinical-db stage and you should see archived observations.
2. Test locally and try the scenarios above

**Expected outcome**:
Archived observations panel should be shown when SHOW_OBSERVED_VARIANT_ARCHIVE is present and set to True

**Review:**
- [x] code approved by mikaell
- [x] tests executed by mikaell
