### PR TITLE
Fix managed vars filters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed standard docker-compose with scout demo data and database
 - Clinical variant assessments not present for pinned and causative variants on case page.
 - MatchMaker matching one node at the time only
+- Managed variants filter form
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -122,7 +122,7 @@ class ManagedVariantHandler(object):
         return managed_variant
 
     def managed_variants(
-        self, category=["snv", "sv", "cancer_snv", "cancer_sv"], build="37", query_options=None
+        self, category=["snv", "sv", "cancer_snv", "cancer_sv"], query_options=None, build=None
     ):
         """Return a cursor to all managed variants of a particular category and build.
 
@@ -138,6 +138,7 @@ class ManagedVariantHandler(object):
 
         query = {"category": {"$in": category}, "build": build}
         query_with_options = self.add_options(query, query_options)
+        LOG.error(query_with_options)
         return self.managed_variant_collection.find(query_with_options)
 
     def count_managed_variants(

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -136,7 +136,7 @@ class ManagedVariantHandler(object):
 
         """
 
-        query = {"category": {"$in": category}, "build": build}
+        query = {"category": {"$in": category}}
         query_with_options = self.add_options(query, query_options)
         LOG.error(query_with_options)
         return self.managed_variant_collection.find(query_with_options)

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -128,7 +128,7 @@ class ManagedVariantHandler(object):
 
         Arguments:
             category(str):
-            sub_category(str):
+            query_options(str):
             build(str):
 
         Returns:
@@ -138,7 +138,6 @@ class ManagedVariantHandler(object):
 
         query = {"category": {"$in": category}}
         query_with_options = self.add_options(query, query_options)
-        LOG.error(query_with_options)
         return self.managed_variant_collection.find(query_with_options)
 
     def count_managed_variants(

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -22,6 +22,23 @@ LOG = logging.getLogger(__name__)
 VARS_PER_PAGE = 50
 
 
+def set_query_coordinates(query_options, request_form):
+    """Set query coordinates based on submitted form
+
+    Args:
+        query_options(dict): managed variants optional params
+        request_form(ImmutableMultiDict): form submitted by user to filter managed variants
+    """
+    chrom = request_form.get("chromosome")
+    if chrom is None:
+        return
+    query_options["chromosome"] = chrom
+    if request_form.get("position"):
+        query_options["position"] = int(request_form.get("position"))
+    if request_form.get("end"):
+        query_options["end"] = int(request_form.get("end"))
+
+
 def managed_variants(request):
     """Create and return managed variants' data
 
@@ -44,10 +61,13 @@ def managed_variants(request):
     categories = request.form.getlist("category") or [cat[0] for cat in CATEGORY_CHOICES]
 
     query_options = {"sub_category": []}
+    # Set variant sub-category in query_options
     for sub_cat in request.form.getlist("sub_category") or [
         subcat[0] for subcat in SUBCATEGORY_CHOICES
     ]:
         query_options["sub_category"].append(sub_cat)
+    # Set requested variant coordinates in query options
+    set_query_coordinates(query_options, request.form)
 
     # Get all variants according to the selected fields in filter form
     managed_variants_query = store.managed_variants(

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -30,7 +30,7 @@ def set_query_coordinates(query_options, request_form):
         request_form(ImmutableMultiDict): form submitted by user to filter managed variants
     """
     chrom = request_form.get("chromosome")
-    if chrom is None:
+    if chrom is None or chrom == "All":
         return
     query_options["chromosome"] = chrom
     if request_form.get("position"):

--- a/scout/server/blueprints/managed_variants/forms.py
+++ b/scout/server/blueprints/managed_variants/forms.py
@@ -29,7 +29,9 @@ class ManagedVariantForm(FlaskForm):
     cytoband_start = SelectField("Cytoband start", choices=[])
     cytoband_end = SelectField("Cytoband end", choices=[])
     description = TextField(label="Description")
-    build = SelectField("Genome build", [validators.Optional()], choices=["37", "38"])
+    build = SelectField(
+        "Genome build", [validators.Optional()], choices=[("37", "37"), ("38", "38")]
+    )
 
 
 class ManagedVariantsFilterForm(ManagedVariantForm):

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -237,13 +237,13 @@
         {{ wtf.form_field(filters_form.build, onchange="setChromosomes()") }}
       </div>
       <div class="col-2">
-        {{ wtf.form_field(filters_form.chromosome, onchange="setCytobands()") }}
+        {{ wtf.form_field(filters_form.chromosome, onchange="setCytobands();set_coords_fields()") }}
       </div>
       <div class="col-2">
-        {{ wtf.form_field(filters_form.position, type="number") }}
+        {{ wtf.form_field(filters_form.position, type="number", disabled=True) }}
       </div>
       <div class="col-2">
-        {{ wtf.form_field(filters_form.end, type="number") }}
+        {{ wtf.form_field(filters_form.end, type="number", disabled=True) }}
       </div>
       <div class="col-2">
         {{ wtf.form_field(filters_form.cytoband_start, onchange="setElemCoordinate('cytoband_start', 'position')") }}
@@ -291,7 +291,10 @@
 
   var cytoStart = document.forms["filters_form"].elements["cytoband_start"]; // filter form
   var cytoEnd = document.forms["filters_form"].elements["cytoband_end"]; // filter form
-  var chromSelect = document.forms["filters_form"].elements["chromosome"]; // filter form
+  var chromSelect = document.forms["filters_form"].elements["chromosome"]; // filter form chromosome
+  var start_coord_field = document.forms["filters_form"].elements["position"]; // filter form start coord
+  var end_coord_field = document.forms["filters_form"].elements["end"]; // filter form end coord
+
 
   // clear option elements from any given select
   function clearSelect(selectElem){
@@ -337,6 +340,20 @@
     })
     populateSelect(chromSelect, chrom_options); // populate chromosome select with chromosome options
     setCytobands(); // Reset cytobands select elements
+  }
+
+  function set_coords_fields(){
+    //Make chromosome coordinates editable if a valid chromsome is selected
+    selectedChrom = chromSelect.value;
+    if (selectedChrom !== 'undefined' && selectedChrom !== "All" ){
+      start_coord_field.disabled = false;
+      end_coord_field.disabled = false;
+    }
+    else {
+      start_coord_field.disabled = true;
+      end_coord_field.disabled = true;
+    }
+
   }
 
   // Set cytobands select options according to selected chrom


### PR DESCRIPTION
Fix #2788

- Attempt at fixing the weird looking chromosome build on managed variants filter form 
- Added the code to be able to filter managed variants by chromosome coordinates
- Deactivate managed variants filter by chromosome build, since build can't be assigned when managed vars are created (yet)

**How to test**:
1. Install on clinical-db stage and try to filter managed variants with different parameters

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
