### PR TITLE
Explain that only genes with same case build can be added to dynamic HPO list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Individual-specific HPO terms
 - Optional alamut_key in institute settings for Alamut Plus software
 - Case report API endpoint
+- Tooltip in case explaining that genes with genome build different than case genome build will not be added to dynamic HPO panel.
 ### Fixed
 - Updated IGV to v2.8.5 to solve missing gene labels on some zoom levels
 - Demo cancer case config file to load somatic SNVs and SVs only.

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -222,7 +222,7 @@
 
         <div class="row d-flex justify-content-between mt-3">
           <div class="col-4">
-            <div data-toggle='tooltip' title="Manually add a gene to the dynamic (HPO) panel.
+            <div data-toggle='tooltip' title="Manually add a gene (must have the same genome build as case analysis) to the dynamic HPO panel.
             To remove, use the HPO panel button to regenerate a list without them.">
                 Add gene to the dynamic panel
             </div>


### PR DESCRIPTION
Fix #2789. Perhaps not the best fix ever, but it's an easy one.

The problem in flashing an error message is that the `case build `vs `gene build` is done in the adapter, here: https://github.com/Clinical-Genomics/scout/blob/1aefda23ee6c595c6047be140b8db407fd20527f/scout/adapter/mongo/case.py#L449

and from there it is a bit difficult to flash message to the web page..

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
