### PR TITLE
Fix previously tiered style in variantS and display again previously tiered and matching causatives in cancer variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed standard docker-compose with scout demo data and database
 - Clinical variant assessments not present for pinned and causative variants on case page.
 - MatchMaker matching one node at the time only
+- Remove link from previously tiered variants badge in cancer variants page
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -67,8 +67,7 @@
     </div>
     {% endif %}
 
-    {{ matching_variants(managed_variant) }}
-    
+    {{ matching_variants(managed_variant, variant.matching_tiered) }}
     <div class="row">
       <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) }}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -67,7 +67,7 @@
     </div>
     {% endif %}
 
-    {{ matching_variants(managed_variant, variant.matching_tiered) }}
+    {{ matching_variants(managed_variant, causatives, variant.matching_tiered) }}
     <div class="row">
       <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) }}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -68,6 +68,7 @@
     {% endif %}
 
     {{ matching_variants(managed_variant) }}
+    
     <div class="row">
       <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) }}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -79,7 +79,7 @@
 {% endmacro %}
 
 
-{% macro matching_variants(managed_variant, causatives) %}
+{% macro matching_variants(managed_variant, causatives, matching_tiered=None) %}
   {% if causatives %}
     <div class="card panel-default">
       <div class="panel-heading">Matching causatives from other cases</div>
@@ -121,6 +121,24 @@
       </div> <!--end of card body-->
     </div><!--end of card-->
   {% endif%}
+  {% if matching_tiered %}
+    <div class="col">
+      Matching tiered:
+      {% for tier, tiered_info in matching_tiered.items() %}
+        <a class="btn btn-{{tiered_info.label}} btn-xs" data-toggle="collapse" href="#collapse_{{tier}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+          {{tier}} ({{tiered_info.links|length}}x)
+        </a>
+        <div class="collapse" id="collapse_{{tier}}">
+          <div>
+            {{tier}}:
+            {% for link in tiered_info["links"] %}
+              {% set match_case = link.split('/') %}
+                <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
+            {% endfor %}
+          </div>
+        </div>
+    </div>
+  {% endfor %}
 {% endmacro %}
 
 {% macro compounds_panel(institute, case, variant) %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -137,8 +137,9 @@
             {% endfor %}
           </div>
         </div>
+      {% endfor %}
     </div>
-  {% endfor %}
+  {% endif %}
 {% endmacro %}
 
 {% macro compounds_panel(institute, case, variant) %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -81,28 +81,24 @@
 
 {% macro matching_variants(managed_variant, causatives, matching_tiered=None) %}
   {% if causatives %}
-    <div class="card panel-default">
-      <div class="panel-heading">Matching causatives from other cases</div>
-      <div class="card-body">
-        <ul class="list-group list-group-flush">
-          {% for other_variant in causatives %}
-            <li class="list-group-item" style="padding: 0;">
-              <a href="{{ url_for('variant.variant',
-                                  institute_id=other_variant.owner,
-                                  case_name=other_variant.case_display_name,
-                                  variant_id=other_variant._id) }}">
-                {{ other_variant.case_display_name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
+    <div class="card mt-3">
+      <div class="card-body mt-1 ml-3 mb-1" style="padding: 0;">
+        Matching causatives from other cases:&nbsp;
+        {% for other_variant in causatives %}
+          <a href="{{ url_for('variant.variant',
+                              institute_id=other_variant.owner,
+                              case_name=other_variant.case_display_name,
+                              variant_id=other_variant._id) }}">
+            {{ other_variant.case_display_name }}
+          </a>&nbsp;
+        {% endfor %}
       </div> <!--end of card body-->
     </div><!--end of card-->
   {% endif %}
   {% if managed_variant %}
-    <div class="card panel-default">
-      <div class="panel-heading">Matching managed variant</div>
-      <div class="card-body">
+    <div class="card mt-3">
+      <div class="card-body mt-1 ml-3 mb-1">
+        Matching managed variant:
         <div class="row">
           <div class="col-2">
             {{ managed_variant.display_id }}
@@ -121,23 +117,26 @@
       </div> <!--end of card body-->
     </div><!--end of card-->
   {% endif%}
+
   {% if matching_tiered %}
-    <div class="col">
-      Matching tiered:
-      {% for tier, tiered_info in matching_tiered.items() %}
-        <a class="btn btn-{{tiered_info.label}} btn-xs" data-toggle="collapse" href="#collapse_{{tier}}" role="button" aria-expanded="false" aria-controls="collapseExample">
-          {{tier}} ({{tiered_info.links|length}}x)
-        </a>
-        <div class="collapse" id="collapse_{{tier}}">
-          <div>
-            {{tier}}:
-            {% for link in tiered_info["links"] %}
-              {% set match_case = link.split('/') %}
-                <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
-            {% endfor %}
+    <div class="card">
+      <div class="card-body mt-1 ml-3 mb-1 d-flex align-items-center" style="padding: 0;">
+        Matching tiered:&nbsp;
+        {% for tier, tiered_info in matching_tiered.items() %}
+          <a class="btn btn-{{tiered_info.label}} btn-xs" data-toggle="collapse" href="#collapse_{{tier}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+            {{tier}} ({{tiered_info.links|length}}x)
+          </a>
+          <div class="collapse" id="collapse_{{tier}}">
+            <div>
+              {{tier}}:
+              {% for link in tiered_info["links"] %}
+                {% set match_case = link.split('/') %}
+                  <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
+              {% endfor %}
+            </div>
           </div>
-        </div>
-      {% endfor %}
+        {% endfor %}
+      </div>
     </div>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -41,13 +41,13 @@
 
 {% macro other_tiered_variants(variant) %}
   {% if variant.matching_tiered %}
-    <a href="#" role="button" class="btn popovers" data-toggle="popover" data-html="true" title=""
+    <span class="popovers badge badge-dark" data-toggle="popover" data-html="true" title=""
         data-content="
           {% for tier, tiered_info in variant.matching_tiered.items() %}
             <span class='badge badge-{{tiered_info.label}}'>{{tier}} ({{tiered_info.links|length}}x)</span>
           {% endfor %}
         "
-       data-original-title="Previously tiered as"><span class="badge badge-dark">T</span></a>
+       data-original-title="Previously tiered as">T</span>
   {% endif %} <!-- end of if variant.matching_tiered -->
 {% endmacro %}
 


### PR DESCRIPTION
Fix #2794 and fix #2796

**How to test**:
1. Check content of issues mentioned above
1. Check the behavior of [this variant](https://scout-stage.scilifelab.se/cust000/20190327_cancer/cancer/fa6eed9d98cb537ec1220df514c005eb?cancer=yes) in master branch and this branch.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
