### PR TITLE
remove typo from tooltip title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Clinical variant assessments not present for pinned and causative variants on case page.
 - MatchMaker matching one node at the time only
 - Remove link from previously tiered variants badge in cancer variants page
+- Typo in gene cell on cancer variants page
 ### Changed
 - Better naming for variants buttons on cancer track (somatic, germline). Also show cancer research button if available.
 - Load case with missing panels in config files, but show warning.

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -10,7 +10,7 @@
             <div>
               <strong>Models</strong>: {{ variant.first_rep_gene.inheritance|join(',') }}
             </div>
-          {% endif %}>
+          {% endif %}
         {% if variant.first_rep_gene.phenotypes %}
           <div><strong>OMIM disease</strong>
           {% for disease in variant.first_rep_gene.phenotypes %}


### PR DESCRIPTION
Fix #2797.

There is an extra ">" in the tooltip of the gene cell in cancer variantS page.

Before:
![image](https://user-images.githubusercontent.com/28093618/130196842-4f051ca5-493e-403c-8c5a-c979456ab3e7.png)

After:
![image](https://user-images.githubusercontent.com/28093618/130196906-6a086691-ad13-427b-9915-0dd543844ac2.png)


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [ ] tests executed by
