### PR TITLE
Remove Deprecation Warning: mongo.insert -> insert_many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
-- Library deprecation warning fixed
+- Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 ### Changed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
+- Library deprecation warning fixed
 ### Changed
 
 

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -77,7 +77,7 @@ def test_phenotype_genes_matching_phenotypes(gene_database, case_obj, hpo_term, 
         "description": "Encephalopathy",
         "genes": gene_list[:3],  # this term has last 3 genes overlapping with term 1
     }
-    assert adapter.hpo_term_collection.insert([hpo_term, hpo_term2])
+    assert adapter.hpo_term_collection.insert_many([hpo_term, hpo_term2])
     # And a case with that dynamic phenotype and gene list
     case_obj["dynamic_panel_phenotypes"] = ["HP:0001250", "HP:0001298"]
     case_obj["dynamic_gene_list"] = [{"hgnc_id": gene_id} for gene_id in gene_list[:3]]


### PR DESCRIPTION
This PR adds a functionality, removes a deprecation warning:

```
tests/server/blueprints/cases/test_cases_controllers.py::test_phenotype_genes_matching_phenotypes
1079
  /home/runner/work/scout/scout/tests/server/blueprints/cases/test_cases_controllers.py:80: DeprecationWarning: insert is deprecated. Use insert_one or insert_many instead.
```


**How to test**:
1. how to test it, possibly with real cases/data
Install

**Expected outcome**:
Deprecation warning for `/test_cases_controllers.py:80` is removed.


**Review:**
- [ ] code approved by
- [ ] tests executed by
