### PR TITLE
Update genes command will not trigger an update of database indices any more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
+- Update genes command will not trigger an update of database indices any more
 ### Changed
 
 

--- a/scout/commands/update/genes.py
+++ b/scout/commands/update/genes.py
@@ -181,6 +181,4 @@ def genes(build, downloads_folder, api_key):
 
         load_transcripts(adapter, ensembl_tx_res, genome_build, ensembl_genes_dict)
 
-    adapter.update_indexes()
-
     LOG.info("Genes and transcripts loaded")


### PR DESCRIPTION
Removed a line in update genes command that triggers also the update indices command

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
