### PR TITLE
Made Alamut button optional and moved it on the side of igv button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Added
+- Option to hide Alamut button in app config file
 ### Fixed
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 - Update genes command will not trigger an update of database indices any more
 - Missing resources in temporary downloading directory when updating genes using the command line
 ### Changed
+- Moved Alamut button close to igv button
 
 
 ## [4.37]

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -303,7 +303,10 @@
     <div class="h6 ml-4">Alignment</div>
     <table class="table table-sm ml-3">
       <tr>
-        <td style="width:20%;">
+        <td class="d-flex flex-row align-items-center">
+          {% if config.SHOW_ALAMUT_LINK %}
+            <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary mr-3" target="_blank">Alamut</a>
+          {% endif %}
           {{ igv_button(case, variant, case_groups) }}
         </td>
         {% if config.SQLALCHEMY_DATABASE_URI %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -170,7 +170,6 @@
           <a href="{{ gene.reactome_link }}" class="btn btn-outline-secondary" target="_blank">Reactome</a>
           <a href="{{ gene.expression_atlas_link }}" class="btn btn-outline-secondary" target="_blank">Expr. Atlas</a>
           <a href="{{ gene.clingen_link }}" class="btn btn-outline-secondary" target="_blank">ClinGen</a>
-          <a href="{{ variant.alamut_link }}" class="btn btn-outline-secondary" target="_blank">Alamut</a>
           <a href="{{ gene.ppaint_link }}" class="btn btn-outline-secondary" target="_blank">Protein Paint</a>
           {% if variant.chromosome == 'MT' %}
             <a href="{{ variant.mitomap_link }}" class="btn btn-outline-secondary" target="_blank">MitoMap</a>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -317,7 +317,10 @@
       </ul>
       <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between">
-          <div>
+          <div class="d-flex flex-row align-items-center">
+            {% if config.SHOW_ALAMUT_LINK %}
+              <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary mr-3" target="_blank">Alamut</a>
+            {% endif %}
             {{ igv_button(case, variant, case_groups) }}
           </div>
 

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -68,6 +68,7 @@ ACCEPT_LANGUAGES = ["en", "sv"]
 # FEATURE FLAGS
 SHOW_CAUSATIVES = True
 SHOW_OBSERVED_VARIANT_ARCHIVE = True
+SHOW_ALAMUT_LINK = True
 
 # OMIM API KEY: Required for downloading definitions from OMIM (https://www.omim.org/api)
 # OMIM_API_KEY = 'valid_omim_api_key'


### PR DESCRIPTION
Fix #2805 
- Created a config settings option to hide Alamut button (not all centers have this software)
- If SHOW_ALAMUT_LINK is set to True, show it on the side of the igv button.

![image](https://user-images.githubusercontent.com/28093618/130604325-a4958826-1475-47a6-b064-669bda09171b.png)


**How to test**:
1. Locally or on stage on both RD and cancer variants.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
