### PR TITLE
Avoid case reports triggering the loading spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 - Update genes command will not trigger an update of database indices any more
 - Missing resources in temporary downloading directory when updating genes using the command line
-- Loading spinner not stopping after downloading general report or delivery report
+- Loading spinner not stopping after downloading PDF case reports
 ### Changed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 - Update genes command will not trigger an update of database indices any more
 - Missing resources in temporary downloading directory when updating genes using the command line
+- Loading spinner not stopping after downloading general report or delivery report
 ### Changed
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update genes command will not trigger an update of database indices any more
 - Missing resources in temporary downloading directory when updating genes using the command line
 - Restore previous variant ACMG classification in a scrollable div
-- Loading spinner not stopping after downloading PDF case reports
+- Loading spinner not stopping after downloading PDF case reports and variant list export
 ### Changed
 
 

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -567,7 +567,7 @@
     </div>
     <div>
       <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
-                        case_name=case.display_name, date=date, format='pdf') }}"><i class="fa fa-file-pdf-o"></i></a>
+                        case_name=case.display_name, date=date, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
     </div>
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -75,7 +75,7 @@
                 <i class="fa fa-link"></i></a>
         </div>
         <div>
-          <a href="{{ url_for('cases.pdf_case_report', institute_id=institute._id, case_name=case.display_name) }}">
+          <a href="{{ url_for('cases.pdf_case_report', institute_id=institute._id, case_name=case.display_name) }}" target="_blank">
                 <i class="fa fa-file-pdf-o"></i></a>
         </div>
       </div>
@@ -516,7 +516,7 @@
     </div>
     <div>
       <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                        case_name=case.display_name, date=date, format='pdf') }}"><i class="fa fa-file-pdf-o"></i></a>
+                        case_name=case.display_name, date=date, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
     </div>
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -135,8 +135,8 @@
           </div>
           <div class="col">
             <div class="row">
-              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>&nbsp;&nbsp;
-              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel &nbsp;&nbsp</a>
+              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}" target="_blank"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>&nbsp;&nbsp;
+              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}" target="_blank"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel &nbsp;&nbsp</a>
             </div>
           </div>
 

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -157,7 +157,7 @@
               <td>
                 {% if ind.vcf2cytosure %}
                 <a href="{{ url_for('cases.vcf2cytosure', institute_id=institute._id,
-                      case_name=case.display_name, individual_id=ind.individual_id) }}" class="btn">
+                      case_name=case.display_name, individual_id=ind.individual_id) }}" target="_blank" class="btn">
                   <i class="fa fa-download"></i>
                 </a>
                 {% else %}

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -111,6 +111,9 @@ function validateForm(){
       alert("Padding must be greater than zero!")
     }
   }
+
+  $(window).unbind('beforeunload');
+  
   return true;
 }
 

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -112,8 +112,9 @@ function validateForm(){
     }
   }
 
+  // Avoid page spinner being stuck on Filter and export variants option
   $(window).unbind('beforeunload');
-  
+
   return true;
 }
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block content_main %}
-  <form method="POST" id="filters_form" action="{{url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name)}}">
+  <form method="POST" id="filters_form" action="{{url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name)}}" onsubmit="return validateForm()">
   <div class="container-float">
     {{ pagination_hidden_div(page) }}
     <div class="card panel-default" id="accordion">


### PR DESCRIPTION
Fix #2806

**How to test**:
- Locally, on master branch case page, try to download the PDF delivery report or the PDF general report (RD case) or the Coverage & QC report (cancer case). After they are downloaded the loading spinner won't stop spinning on case page
- Switch to this branch and the loading spinner won't be triggered by the file download

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
