### PR TITLE
Restore ACMG classification history in a scrollable div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 - Update genes command will not trigger an update of database indices any more
 - Missing resources in temporary downloading directory when updating genes using the command line
+- Restore previous variant ACMG classification in a scrollable div
 ### Changed
 
 

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -70,7 +70,7 @@
     {{ matching_variants(managed_variant, causatives, variant.matching_tiered) }}
     <div class="row">
       <div class="col-sm-3">
-        {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) }}
+        {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}
       </div>
       <div class="col-sm-4">{{ panel_summary() }}</div>
       <div class="col-sm-3">

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -68,7 +68,7 @@
         {% endif %}
       </div>
       {% if evaluations %} <!-- scrollable previous ACMG evaluations div-->
-        <div class="list-group mt-3" style="height:200px;overflow-y: scroll;">
+        <div class="list-group mt-3" style="max-height:200px;overflow-y: scroll;">
           {% for evaluation in evaluations %}
             {{ acmg_classification_item(variant, evaluation) }}
           {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -2,7 +2,7 @@
 {% from "variants/utils.html" import compounds_table %}
 {% from "variant/variant_details.html" import severity_list %}
 
-{% macro acmg_classification_item(data) %}
+{% macro acmg_classification_item(variant, data) %}
   {% set current_variant = (data.variant_specific == variant._id) %}
   <li class="list-group-item {{ 'list-group-item-info' if current_variant }}">
     <div class="d-flex">
@@ -44,7 +44,7 @@
 {% endmacro %}
 
 
-{% macro panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) %}
+{% macro panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) %}
   <div class="card panel-default">
     <div class="panel-heading">Classify</div>
     <div class="card-body">
@@ -67,10 +67,10 @@
           <a href="{{ url_for('overview.clinvar_submissions', institute_id=institute._id) }}" class="btn btn-outline-secondary form-control">Modify clinvar submission</a>
         {% endif %}
       </div>
-      {% if evaluations %}
-        <div class="list-group mt-3">
+      {% if evaluations %} <!-- scrollable previous ACMG evaluations div-->
+        <div class="list-group mt-3" style="height:200px;overflow-y: scroll;">
           {% for evaluation in evaluations %}
-            {{ acmg_classification_item(evaluation) }}
+            {{ acmg_classification_item(variant, evaluation) }}
           {% endfor %}
         </div>
       {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -71,7 +71,7 @@
     <div class="row">
       <div class="col-sm-12">{{ matching_variants(managed_variant, causatives) }}</div>
       <div class="col-sm-4">
-        {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options) }}
+        {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}
         {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
         {{ omim_phenotypes(variant) }}
       </div>


### PR DESCRIPTION
Fix #2811 

**How to test**:
1. Apply ACMG classifications many times to a RD variant and/or cancer variant. 
2. Make sure that all these classifications are shown in a field under the "Classify" button

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
