### PR TITLE
Rename hide alamut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Added
-- Option to hide Alamut button in app config file
+- Option to hide Alamut button in the app config file
 ### Fixed
 - Library deprecation warning fixed (insert is deprecated. Use insert_one or insert_many instead)
 - Update genes command will not trigger an update of database indices any more

--- a/docs/admin-guide/server.md
+++ b/docs/admin-guide/server.md
@@ -41,6 +41,15 @@ MAIL_PASSWORD = 'mySecretPassw0rd'
 
 TICKET_SYSTEM_EMAIL = 'support@sekvens.nu'
 
+## FEATURE FLAGS
+# Allow users to browse variants marked causative from among all their institutes cases
+SHOW_CAUSATIVES = True
+# Optionally show cards with legacy observed variant frequencies on variant pages
+SHOW_OBSERVED_VARIANT_ARCHIVE = True
+# Optionally hide API link to Alamut Visual. If False or non-existing Scout will show Alamut links.
+HIDE_ALAMUT_LINK = False
+
+
 # emails to send error log message to
 ADMINS = ['robin.andeer@scilifelab.se']
 

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -38,7 +38,7 @@
             {{ igv_button(case, variant, case_groups) }}
           </div>
           <div>
-            {% if variant.alamut_link and config.SHOW_ALAMUT_LINK %}
+            {% if variant.alamut_link %}
               <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary" role="button" target="_blank"
             data-toggle="tooltip" title="Alamut Visual (Plus) - Open variant">Alamut</a>
             {% endif %}
@@ -208,7 +208,7 @@
           <a href="{{ gene.reactome_link }}" class="btn btn-outline-secondary" target="_blank">Reactome</a>
           <a href="{{ gene.expression_atlas_link }}" class="btn btn-outline-secondary" target="_blank">Expr. Atlas</a>
           <a href="{{ gene.clingen_link }}" class="btn btn-outline-secondary" target="_blank">ClinGen</a>
-          {% if config.SHOW_ALAMUT_LINK %}
+          {% if variant.alamut_link %}
             <a href="{{ variant.alamut_link }}" class="btn btn-outline-secondary" target="_blank">Alamut</a>
           {% endif %}
           <a href="{{ gene.ppaint_link }}" class="btn btn-outline-secondary" target="_blank">Protein Paint</a>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -68,7 +68,7 @@ ACCEPT_LANGUAGES = ["en", "sv"]
 # FEATURE FLAGS
 SHOW_CAUSATIVES = True
 SHOW_OBSERVED_VARIANT_ARCHIVE = True
-SHOW_ALAMUT_LINK = True
+HIDE_ALAMUT_LINK = False
 
 # OMIM API KEY: Required for downloading definitions from OMIM (https://www.omim.org/api)
 # OMIM_API_KEY = 'valid_omim_api_key'

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -625,6 +625,9 @@ def alamut_link(
     if build == 38:
         build_str = "(GRCh38)"
 
+    if current_app.config.get("HIDE_ALAMUT_LINK"):
+        return False
+
     url_template = (
         "http://localhost:10000/{search_verb}?{alamut_key_arg}request={this[chromosome]}{build_str}:"
         "{this[position]}{this[reference]}>{this[alternative]}"

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -1,9 +1,11 @@
 """Tests for scout server links"""
 
+from flask import url_for
+
 from scout.server.links import add_gene_links, alamut_link, cbioportal, mycancergenome, snp_links
 
 
-def test_alamut_link(institute_obj, variant_obj):
+def test_alamut_link(app, institute_obj, variant_obj):
     """Test to add a link to alamut browser"""
 
     # GIVEN an institute with settings for Alamut Visual Plus
@@ -13,12 +15,17 @@ def test_alamut_link(institute_obj, variant_obj):
     # GIVEN that genome build 38 is provided
     build = 38
 
-    # WHEN the alamut link is created
-    link_to_alamut = alamut_link(institute_obj, variant_obj, 38)
-    # THEN the link should contain genome build info
-    assert "GRCh38" in link_to_alamut
-    # As well as Alamut Visual Plus API key
-    assert alamut_api_key in link_to_alamut
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        # WHEN the alamut link is created
+        link_to_alamut = alamut_link(institute_obj, variant_obj, 38)
+        # THEN the link should contain genome build info
+        assert "GRCh38" in link_to_alamut
+        # As well as Alamut Visual Plus API key
+        assert alamut_api_key in link_to_alamut
 
 
 def test_add_gene_links():

--- a/tests/server/test_server_utils.py
+++ b/tests/server/test_server_utils.py
@@ -2,29 +2,41 @@
 import tempfile
 
 import pytest
+from flask import url_for
 
 from scout.server.links import get_variant_links
 from scout.server.utils import append_safe, find_index, variant_case
 
 
-def test_get_variant_links(institute_obj, variant_obj):
+def test_get_variant_links(app, institute_obj, variant_obj):
     """Test to get 1000g link"""
     # GIVEN a variant object without links
     assert "thousandg_link" not in variant_obj
+
     # WHEN fetching the variant links
-    links = get_variant_links(institute_obj, variant_obj)
-    # THEN check that links are returned
-    assert "thousandg_link" in links
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        links = get_variant_links(institute_obj, variant_obj)
+        # THEN check that links are returned
+        assert "thousandg_link" in links
 
 
-def test_get_str_variant_links(institute_obj, str_variant_obj):
+def test_get_str_variant_links(app, institute_obj, str_variant_obj):
     """Test adding links to STR variant obj, in particular check source link."""
     # GIVEN a variant object without links
     assert "str_source_link" not in str_variant_obj
     # WHEN fetching the variant links
-    links = get_variant_links(institute_obj, str_variant_obj)
-    # THEN check that links are returned
-    assert "str_source_link" in links
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        links = get_variant_links(institute_obj, str_variant_obj)
+        # THEN check that links are returned
+        assert "str_source_link" in links
 
 
 def test_find_index_bai():


### PR DESCRIPTION
This PR continues on the last PR #2815, renaming the SHOW_ALAMUT_CONFIG introduced there to HIDE_ALAMUT_CONFIG and moving it to links py instead of the jinja code.

**How to test**:
1. how to test it, possibly with real cases/data

![Screenshot 2021-08-25 at 09 53 53](https://user-images.githubusercontent.com/758570/130751358-818f7e64-fa8d-4dad-8d44-7f873ce289f6.png)

![Screenshot 2021-08-25 at 09 54 02](https://user-images.githubusercontent.com/758570/130751363-76288ae1-550e-4428-9775-82b1ebeac223.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
