### PR TITLE
Feature/assign button/210825 ref #2804

### DIFF
--- a/scout/server/blueprints/cases/static/case_styles.css
+++ b/scout/server/blueprints/cases/static/case_styles.css
@@ -26,3 +26,8 @@
 .btn-header {
   margin-left: 1rem;
 }
+
+.no-hover{
+    pointer-events: none;
+}
+

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -562,6 +562,23 @@ function SidebarCollapse () {
     $('#collapse-icon').toggleClass('fa-angle-double-left fa-angle-double-right');
 }
 
+
+function toggleClickableButtons(button, select_field) {
+    const selection = document.getElementById(select_field)
+
+    if (selection.value.length > 0) {
+       document.getElementById(button).classList.remove('btn-outline-secondary');
+       document.getElementById(button).classList.remove('no-hover');
+       document.getElementById(button).classList.add('btn-secondary');
+    }
+    else { 
+       document.getElementById(button).classList.remove('btn-secondary');
+       document.getElementById(button).classList.add('no-hover');
+       document.getElementById(button).classList.add('btn-outline-secondary');
+    }
+  }
+
+
 // Hide submenus
 $('#body-row .collapse').collapse('hide');
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -239,7 +239,7 @@
            {{ case.synopsis|markdown if case.synopsis else 'Nothing written yet...' }}
           </div>
           <div class="col-2">
-            <button type="button" class="btn btn-outline-secondary form-control" data-toggle="modal" data-target="#edit-synopsis">
+            <button type="button" class="btn btn-secondary form-control" data-toggle="modal" data-target="#edit-synopsis">
               Edit
             </button>
           </div>

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -36,7 +36,7 @@
               {% endfor %}
             </select>
           </div>
-            <button class="btn btn-outline-secondary form-control" type="submit">Add</button>
+            <button class="btn btn-secondary form-control" type="submit">Add</button>
             <a href="{{ url_for('overview.institute_settings', institute_id=institute._id) }}">Add more selectable options</a>
         </div>
       </form>
@@ -91,7 +91,7 @@
         {% endif %}
       </div>
       <div class="col-md-2">
-        <button class="btn btn-outline-secondary form-control" type="submit" name="{{ type }}">
+        <button class="btn btn-secondary form-control" type="submit" name="{{ type }}">
           Add
         </button>
       </div>
@@ -137,7 +137,7 @@
             </select>
           </div>
           <div>
-            <button class="btn btn-outline-secondary form-control" type="submit">Add</button>
+            <button class="btn btn-secondary form-control" type="submit">Add</button>
             <a href="{{ url_for('overview.institute_settings', institute_id=institute._id) }}">Add options</a>
           </div>
         </div>
@@ -173,7 +173,7 @@
     <form method="POST" action="{{ url_for('cases.phenotypes', institute_id=institute._id, case_name=case.display_name) }}">
       <div class="row">
         <div class="col-4">
-          <input name="hpo_term" class="typeahead_hpo form-control" data-provide="typeahead" autocomplete="off" required placeholder="Search...">
+          <input name="hpo_term" id="hpo_term" class="typeahead_hpo form-control" data-provide="typeahead" autocomplete="off" required placeholder="Search..." oninput="toggleClickableButtons('assign-phenotype-button', 'hpo_term');">
         </div>
         <div class="col-4">
           <select name="phenotype_inds" multiple class="selectpicker">
@@ -185,7 +185,7 @@
           </select>
         </div>
         <div class="col-3">
-          <button class="btn btn-outline-secondary btn-sm form-control">Assign phenotype</button>
+          <button class="btn no-hover btn-outline-secondary btn-sm form-control"  id="assign-phenotype-button">Assign phenotype</button>
         </div>
       </div>
     </form>

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -175,7 +175,7 @@
         <div class="col-4">
           <input name="hpo_term" id="hpo_term" class="typeahead_hpo form-control" data-provide="typeahead" autocomplete="off" required placeholder="Search..." oninput="toggleClickableButtons('assign-phenotype-button', 'hpo_term');">
         </div>
-        <div class="col-4">
+        <div class="col-3">
           <select name="phenotype_inds" multiple class="selectpicker">
             {% for ind in case.individuals %}
               <option value="{{ind.individual_id}}|{{ind.display_name}}" {{"selected" if ind.phenotype==2 }}>
@@ -184,8 +184,8 @@
             {% endfor %}
           </select>
         </div>
-        <div class="col-3">
-          <button class="btn no-hover btn-outline-secondary btn-sm form-control"  id="assign-phenotype-button">Assign phenotype</button>
+        <div class="col-5">
+          <button class="btn no-hover btn-outline-secondary btn-sm form-control"  id="assign-phenotype-button">Assign Phenotype</button>
         </div>
       </div>
     </form>
@@ -196,18 +196,18 @@
 
       <!-- Display and remove added HPO terms -->
       <div class="row mt-3">
-        <div class="col-10 ml-3">
+        <div class="col-12 ml-3">
           {% for hpo_term in case.phenotype_terms %}
             {{ hpo_item(hpo_term, case.individuals) }}
           {% else %}
             <span class="text-mute">No phenotypes added yet</span>
           {% endfor %}
         </div>
-        <div class="col-1">
-          <button data-toggle='tooltip' title="Remove selected HPO terms" class="btn btn-danger btn fa fa-trash float-left" type="submit" name="action" value="DELETE"></button>
+        <div class="col-12">
+          <button data-toggle='tooltip' title="Remove selected HPO terms" class="btn btn-danger btn fa fa-trash float-right" type="submit" name="action" value="DELETE"></button>
         </div>
       </div>
-
+      <hr>
       <div id="phenotypes_panel" class="mt-3">
         <div class="row d-flex justify-content-between">
           <div class="col-12">

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -86,7 +86,7 @@
             </div>
           {% endif %}
           <div class="col-sm-{{ 6 if variant_id else 12 }}">
-            <button class="btn btn-outline-secondary form-control" type="submit">Comment</button>
+            <button class="btn btn-secondary form-control" type="submit">Comment</button>
           </div>
         </div>
       </form>


### PR DESCRIPTION
This PR adds a functionality: Adjust GUI button size, increase affordance by color synchronising clickable buttons and minor US enhancements.

* I have tried to unify usage of button colors on the case page, making clickable buttons dark gray, and unclickable lighter. This used to be a muddle.
* The size of Divs in the phenotype box did not add up to twelve, this is fixed and the button "Assign Phenotype" has been given more real estate (still, with a too narrow window the elements will render in strange ways)
* Added a horizontal ruler below phenotypes to clearer separate subelements.


**How to test**:
1. how to test it, possibly with real cases/data

Install this branch `feature/assign-button/210825` and go to case page.


**Expected outcome**:
The functionality should be working and the view should look like attached pictures. If phenotype terms input box is empty, the button "Assign Phenotypes" will be in a lighter gray color. When writing in the box it will turn darker gray.

![image](https://user-images.githubusercontent.com/1150065/130796081-b3ac6705-bce1-49e6-997c-b05b096953e9.png)
![image](https://user-images.githubusercontent.com/1150065/130796165-03e0f658-9dcc-4ae1-b6c0-b602802b83f6.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
