### PR TITLE
Fixes link to other causative variants on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
+- Link to other causative variants on variant page
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -652,6 +652,7 @@ class VariantHandler(VariantLoader):
             if other_causative_id in other_case_causatives:
                 other_causative = {
                     "_id": other_causative_id,
+                    "institute_id": other_case["owner"],
                     "case_id": other_case["_id"],
                     "case_display_name": other_case["display_name"],
                 }

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -124,7 +124,7 @@
         Matching causatives from other cases:&nbsp;
         {% for other_variant in causatives %}
           <a href="{{ url_for('variant.variant',
-                              institute_id=other_variant.owner,
+                              institute_id=other_variant.institute_id,
                               case_name=other_variant.case_display_name,
                               variant_id=other_variant._id) }}">
             {{ other_variant.case_display_name }}


### PR DESCRIPTION
Partial fix to #2826, specifically addressing the first error: link to other causatives not working in variant page

**How to test**:
1. Locally, on master branch, load the other demo case with the command `scout --demo load case scout/demo/643595.config.yaml`
2. Go to case 643595 and mark the POT1 variant as causative
3. Go to case 643594, POT1 variant, you'll see that it has an other causative matching variant, but the link doesn't work
4. Switch to this branch and check that the link works

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved bymikaell
- [x] tests executed by mikaell
