### PR TITLE
Allow multiple COSMIC links for a cancer variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Improve Javascript performance for displaying Chromograph images
 
 ## [4.38]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
+- Allow multiple COSMIC links for a cancer variant
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 

--- a/scout/server/blueprints/cases/static/case_images.js
+++ b/scout/server/blueprints/cases/static/case_images.js
@@ -54,6 +54,8 @@ function add_image_to_individual_panel(individuals, institute, case_name){
  * genome regions- onto the dashboard.
  */
 function draw_tracks(individual, institute, case_name){
+    // First add all new image elements to a fragment, then lastly add the fragmen to main DOM.
+    var fragment = document.createDocumentFragment();
     const CYT_HEIGHT = 50 ;
     const CYT_WIDTH = 530 ;
     var number_of_columns = $(window).width() < WIDTH_BREAKPOINT? 2:3
@@ -79,71 +81,73 @@ function draw_tracks(individual, institute, case_name){
         var coverage_images = make_names("coverage-");
     }
 
-
     // ideograms always exist
     var ideo_imgPath = static_path_ideograms(institute, case_name, individual, 'ideaograms')
     var ideo_images = make_names('')
-
     var autozygous_imgObj = new Image()
     var upd_regions_imgObj = new Image()
     var coverage_imgObj = new Image()
-
-
     var chromspecs_list = get_chromosomes(individual.sex)
+    const chromspecs_list_length = chromspecs_list.length
 
-    for(i = 0; i< chromspecs_list.length; i++){
-        // autozygous_imgObj.src = autozygous_imgPath + autozygous_images[i]
-        // upd_regions_imgObj.src = upd_regions_imgPath + upd_regions_images[i]
+    for(i = 0; i< chromspecs_list_length; i++){
         x_pos = i % number_of_columns == 0? 0 : CYT_WIDTH * (i% number_of_columns) + OFFSET_X + 5
         y_pos =  Math.floor( i/number_of_columns ) * 140;
-
+        var graphics_fragment = document.createDocumentFragment();
         var g = document.createElementNS('http://www.w3.org/2000/svg','g');
         var ideo_image = make_svgimage(ideo_imgPath + ideo_images[i],
                                        x_pos+15,
                                        y_pos,
                                        "25px", "500px", );
 
-
         var t = chromosome_text(CHROMOSOMES[i], x_pos, y_pos);
         var clipPath = make_clipPath(CHROMSPECS_LIST[i], x_pos, y_pos)
         path_ideo = make_ideogram_shape(CHROMSPECS_LIST[i], x_pos, y_pos)
+
         ideo_image.setAttributeNS(null, 'clip-path', "url(#clip-chr"+CHROMSPECS_LIST[i].name +")")
+        graphics_fragment.appendChild(ideo_image);
+
         // add polygon to outline ideogram
         var border_path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         border_path.setAttributeNS(null, 'd', path_ideo)
         border_path.setAttributeNS(null, 'style', "stroke:black;stroke-width:1")
         border_path.setAttributeNS(null, 'fill-opacity', '0.0')
 
+        graphics_fragment.appendChild(clipPath);
+        graphics_fragment.appendChild(t);
+        graphics_fragment.appendChild(border_path)
 
-        g.appendChild(ideo_image);
-        g.appendChild(clipPath);
-        g.appendChild(t);
-        g.appendChild(border_path)
 	if(individual.chromograph_images.upd_regions){
-            var upd_regions_image = make_svgimage(upd_regions_imgPath + upd_regions_images[i],
-                                          x_pos+15,
-                                          y_pos + 90,
-                                          "25px", "500px", );
-            g.appendChild(upd_regions_image);
+            var upd_img = ideo_image.cloneNode()
+            upd_img = update_svgimage(upd_img, upd_regions_imgPath + upd_regions_images[i],
+                                      x_pos+15,
+                                      y_pos + 90,
+                                      "25px", "500px", );
+            graphics_fragment.appendChild(upd_img);
         }
 
         if(individual.chromograph_images.autozygous){
-            var autozygous_image = make_svgimage(autozygous_imgPath + autozygous_images[i],
-                                          x_pos + 0+15,  //
-                                          y_pos + 30 , // place below UPD
-                                          "25px", "500px", );
-            g.appendChild(autozygous_image);
+            var auto_img = ideo_image.cloneNode()
+            auto_img = update_svgimage(auto_img, autozygous_imgPath + autozygous_images[i],
+                                       x_pos + 0+15,  //
+                                       y_pos + 30 , // place below UPD
+                                       "25px", "500px", );
+            graphics_fragment.appendChild(auto_img);
         }
 
         if(individual.chromograph_images.coverage){
-            var coverage_image = make_svgimage(coverage_imgPath + coverage_images[i],
-                                          x_pos + 0+15, //
-                                          y_pos + 60 , // place below UPD
-                                          "25px", "500px", );
-            g.appendChild(coverage_image);
+            var cov_img = ideo_image.cloneNode()
+            cov_img = update_svgimage(cov_img, coverage_imgPath + coverage_images[i],
+                                      x_pos + 0+15, //
+                                      y_pos + 60 , // place below UPD
+                                      "25px", "500px", );
+            graphics_fragment.appendChild(cov_img);
         }
-       svg_element.append(g)
+
+        g.appendChild(graphics_fragment)
+        fragment.append(g)
     }
+    svg_element.append(fragment)
 }
 
 
@@ -208,7 +212,8 @@ function static_path_ideograms(institute, case_name, individual, dir_name){
  */
 function make_names(prefix){
     var names = [];
-    for (var i = 0; i < CHROMOSOMES.length; i++){
+    const chrom_length = CHROMOSOMES.length
+    for (var i = 0; i < chrom_length; i++){
         id = CHROMOSOMES[i];
         names[i] = prefix+id+".png";
     }
@@ -350,12 +355,21 @@ function calc_centromere_lower(pos){
 function make_svgimage(src, x, y, height, width){
     var svgimg = document.createElementNS('http://www.w3.org/2000/svg','image');
     svgimg.setAttributeNS('http://www.w3.org/1999/xlink','href', src);
-    svgimg.setAttributeNS(null, 'x', String(x));
-    svgimg.setAttributeNS(null, 'y', String(y));
-    svgimg.setAttributeNS(null, 'height', String(height));
-    svgimg.setAttributeNS(null, 'width', String(width));
+    svgimg.setAttribute('x', String(x));
+    svgimg.setAttribute('y', String(y));
+    svgimg.setAttribute('height', String(height));
+    svgimg.setAttribute('width', String(width));
+    return svgimg;
+}
 
-    // svgimg.setAttributeNS(null, 'clip-path', "url(#left)");
+
+function update_svgimage(svgimg, src, x, y, height, width){
+    svgimg.setAttributeNS('http://www.w3.org/1999/xlink','href', src);
+    svgimg.setAttribute('x', String(x));
+    svgimg.setAttribute('y', String(y));
+    svgimg.setAttribute('height', String(height));
+    svgimg.setAttribute('width', String(width));
+    svgimg.setAttribute('clip-path', null);
     return svgimg;
 }
 

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -263,8 +263,8 @@
     <!--LINK out resources-->
       <div class="h6">Databases</div>
       <div>
-        <a class="btn btn-sm btn-info mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
-        <a class="btn btn-sm btn-info mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
+        <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
+        <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
         {% if variant.cosmic_links %} <!-- This is a list of tuples : [(id1, link1), (id2, link2), ..] -->
           {% for cosmic_link in variant.cosmic_links %}
             <a data-toggle="tooltip" title="COSMIC" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{cosmic_link[1]}}" target="_blank">{{cosmic_link[0]}}</a>

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -262,35 +262,35 @@
       </ul>
     <!--LINK out resources-->
       <div class="h6">Databases</div>
-      <div class="d-flex align-items-center">
-        <a class="btn btn-sm btn-info" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
-        <a class="btn btn-sm btn-info" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
-        {% if variant.cosmic_links %}
+      <div>
+        <a class="btn btn-sm btn-info mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
+        <a class="btn btn-sm btn-info mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
+        {% if variant.cosmic_links %} <!-- This is a list of tuples : [(id1, link1), (id2, link2), ..] -->
           {% for cosmic_link in variant.cosmic_links %}
-            <a data-toggle="tooltip" title="{{cosmic_link.split('search?q=')[1]}}" class="btn btn-sm btn-info text-white" role="button" href="{{cosmic_link}}" target="_blank">COSMIC</a>
+            <a data-toggle="tooltip" title="COSMIC" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{cosmic_link[1]}}" target="_blank">{{cosmic_link[0]}}</a>
           {% endfor %}
         {% endif %}
         {% if variant.dbsnp_id %}
           {% for snp in variant.dbsnp_id.split(';') %}
-            <a class="btn btn-sm btn-info text-white" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
+            <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
           {% endfor %}
         {% endif %}
       </div>
       <div class="btn-group">
         {% if primary_transcript and primary_transcript.varsome_link %}
-        <a href="{{ primary_transcript.varsome_link }}" class="btn btn-sm btn-info text-white" role="button" target="_blank"
+        <a href="{{ primary_transcript.varsome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
           data-toggle="tooltip" title="Varsome">V</a>
         {% endif %}
         {% if primary_transcript and primary_transcript.tp53_link %}
-          <a href="{{ primary_transcript.tp53_link }}" class="btn btn-sm btn-info text-white" role="button" target="_blank"
+          <a href="{{ primary_transcript.tp53_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
             data-toggle="tooltip" title="MutanTP53">TP53</a>
         {% endif %}
         {% if primary_transcript and primary_transcript.cbioportal_link %}
-          <a href="{{ primary_transcript.cbioportal_link }}" class="btn btn-sm btn-info text-white" role="button" target="_blank"
+          <a href="{{ primary_transcript.cbioportal_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
             data-toggle="tooltip" title="cBioPortal">CBP</a>
         {% endif %}
         {% if primary_transcript and primary_transcript.mycancergenome_link %}
-          <a href="{{ primary_transcript.mycancergenome_link }}" class="btn btn-sm btn-info text-white" role="button" target="_blank"
+          <a href="{{ primary_transcript.mycancergenome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
             data-toggle="tooltip" title="MyCancerGenome">MCG</a>
         {% endif %}
       </div>
@@ -298,7 +298,7 @@
       {% if variant.clinsig_human %}
         {% for clinsig in variant.clinsig_human %}
           {% if clinsig.accession %}
-            <a class="btn btn-sm btn-info text-white"  role="button" href="{{ clinsig.link }}" role="button" target="_blank">Clinvar {{ clinsig.accession }}</a>
+            <a class="btn btn-sm btn-info text-white mr-1"  role="button" href="{{ clinsig.link }}" role="button" target="_blank">Clinvar {{ clinsig.accession }}</a>
           {% endif %}
         {% endfor %}
       {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -262,16 +262,19 @@
       </ul>
     <!--LINK out resources-->
       <div class="h6">Databases</div>
-      <div class="btn-group"><a class="btn btn-sm btn-info" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
-      <a class="btn btn-sm btn-info" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
-      {% if variant.cosmic_link %}
-          <a class="btn btn-sm btn-info text-white" role="button" href="{{ variant.cosmic_link }}" target="_blank">COSMIC</a>
-      {% endif %}
-      {% if variant.dbsnp_id %}
-        {% for snp in variant.dbsnp_id.split(';') %}
-          <a class="btn btn-sm btn-info text-white" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
-        {% endfor %}
-      {% endif %}
+      <div class="d-flex align-items-center">
+        <a class="btn btn-sm btn-info" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
+        <a class="btn btn-sm btn-info" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
+        {% if variant.cosmic_links %}
+          {% for cosmic_link in variant.cosmic_links %}
+            <a data-toggle="tooltip" title="{{cosmic_link.split('search?q=')[1]}}" class="btn btn-sm btn-info text-white" role="button" href="{{cosmic_link}}" target="_blank">COSMIC</a>
+          {% endfor %}
+        {% endif %}
+        {% if variant.dbsnp_id %}
+          {% for snp in variant.dbsnp_id.split(';') %}
+            <a class="btn btn-sm btn-info text-white" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
+          {% endfor %}
+        {% endif %}
       </div>
       <div class="btn-group">
         {% if primary_transcript and primary_transcript.varsome_link %}

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -30,7 +30,7 @@ from scout.constants import (
 from scout.constants.variants_export import EXPORT_HEADER, VERIFIED_VARIANTS_HEADER
 from scout.export.variant import export_verified_variants
 from scout.server.blueprints.variant.utils import clinsig_human, predictions
-from scout.server.links import cosmic_link, str_source_link
+from scout.server.links import cosmic_links, str_source_link
 from scout.server.utils import case_append_alignments, institute_and_case, user_institutes
 
 from .forms import CancerFiltersForm, FiltersForm, StrFiltersForm, SvFiltersForm, VariantFiltersForm
@@ -409,7 +409,7 @@ def parse_variant(
         variant_obj["end_chrom"] = variant_obj["chromosome"]
 
     # variant level links shown on variants page
-    variant_obj["cosmic_link"] = cosmic_link(variant_obj)
+    variant_obj["cosmic_links"] = cosmic_links(variant_obj)
     variant_obj["str_source_link"] = str_source_link(variant_obj)
     # Format clinvar information
     variant_obj["clinsig_human"] = clinsig_human(variant_obj) if variant_obj.get("clnsig") else None

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -488,7 +488,7 @@ def cosmic_links(variant_obj):
         variant_obj(scout.models.Variant)
 
     Returns:
-        url_template(str): Link to COSMIC database if cosmic id is present
+        cosmic_links(list): a list of tuples : [(id1, link1), (id2, link2), ..]
     """
     cosmic_ids = variant_obj.get("cosmic_ids")
     if not cosmic_ids:
@@ -502,7 +502,7 @@ def cosmic_links(variant_obj):
             url_template = "https://cancer.sanger.ac.uk/cosmic/search?q={}"
         else:
             url_template = "https://cancer.sanger.ac.uk/cosmic/mutation/overview?id={}"
-        cosmic_links.append(url_template.format(cosmic_id))
+        cosmic_links.append((cosmic_id, url_template.format(cosmic_id)))
 
     return cosmic_links
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -496,14 +496,14 @@ def cosmic_links(variant_obj):
 
     cosmic_links = []
 
-    for id in cosmic_ids:
-        cosmic_id = str(cosmic_ids[0])
+    for c_id in cosmic_ids:
+        cosmic_id = str(c_id)
         if cosmic_id.startswith("COS"):
             url_template = "https://cancer.sanger.ac.uk/cosmic/search?q={}"
         else:
             url_template = "https://cancer.sanger.ac.uk/cosmic/mutation/overview?id={}"
-
         cosmic_links.append(url_template.format(cosmic_id))
+
     return cosmic_links
 
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -367,7 +367,7 @@ def get_variant_links(institute_obj, variant_obj, build=None):
         exac_link=exac_link(variant_obj),
         gnomad_link=gnomad_link(variant_obj, build),
         swegen_link=swegen_link(variant_obj),
-        cosmic_link=cosmic_link(variant_obj),
+        cosmic_links=cosmic_links(variant_obj),
         beacon_link=beacon_link(variant_obj, build),
         ucsc_link=ucsc_link(variant_obj, build),
         decipher_link=decipher_link(variant_obj, build),
@@ -481,7 +481,7 @@ def swegen_link(variant_obj):
     return url_template.format(this=variant_obj)
 
 
-def cosmic_link(variant_obj):
+def cosmic_links(variant_obj):
     """Compose link to COSMIC Database.
 
     Args:
@@ -490,20 +490,21 @@ def cosmic_link(variant_obj):
     Returns:
         url_template(str): Link to COSMIC database if cosmic id is present
     """
-
     cosmic_ids = variant_obj.get("cosmic_ids")
-
     if not cosmic_ids:
         return None
 
-    cosmic_id = str(cosmic_ids[0])
+    cosmic_links = []
 
-    if cosmic_id.startswith("COS"):
-        url_template = "https://cancer.sanger.ac.uk/cosmic/search?q={}"
-    else:
-        url_template = "https://cancer.sanger.ac.uk/cosmic/mutation/overview?id={}"
+    for id in cosmic_ids:
+        cosmic_id = str(cosmic_ids[0])
+        if cosmic_id.startswith("COS"):
+            url_template = "https://cancer.sanger.ac.uk/cosmic/search?q={}"
+        else:
+            url_template = "https://cancer.sanger.ac.uk/cosmic/mutation/overview?id={}"
 
-    return url_template.format(cosmic_id)
+        cosmic_links.append(url_template.format(cosmic_id))
+    return cosmic_links
 
 
 def beacon_link(variant_obj, build=None):


### PR DESCRIPTION
Partial fix for #2826, issue n.3. COSMIC IDs are correctly saved to database for cancer variants but just one ID is used to create links to cosmic

**How to test**:
1. Locally on master branch go to the first variant of demo cancer case, TP53 (you should load demo cancer case first)
2. Make sure that it contains only one link to COSMIC
3. Switch to this branch and you should be able to see 4 COSMIC links for 4 different cosmic IDs (hover on the buttons to see the actual id). These links should work.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by mikaell
