### PR TITLE
Fix multigene cancer variant summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Link to other causative variants on variant page
 - Allow multiple COSMIC links for a cancer variant
+- Simplified gene info in cancer variant summary
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -198,9 +198,12 @@
     <div class="card-body">
       <li class="list-group-item">
         {% for gene in variant.genes %}
-         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
-           {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
-         </a>
+          {% if gene.hgnc_symbol %}
+           <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5>
+             {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
+           </a>
+          {% else %} <h5>n.a.</h5>
+          {% endif %}
         {% endfor %}
        </li>
        <li class="list-group-item">

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -196,49 +196,13 @@
   <div class="card panel-default">
     <div class="panel-heading">Summary</div>
     <div class="card-body">
-      {% set tmp_gene_info = [] %}
       {% for gene in variant.genes %}
-        {% for transcript in gene.transcripts %}
-          {% if transcript.is_primary %}
-            {% do tmp_gene_info.append(gene) %}
-            {% do tmp_gene_info.append(transcript) %}
-          {% endif %}
-        {% endfor %}
-      {% endfor %}
-      {% if tmp_gene_info | length  == 0 %}
-        {% for gene in variant.genes %}
-          {% for transcript in gene.transcripts %}
-            {% if transcript.refseq_id and transcript.refseq_id.startswith('NM_') %}
-              {% do tmp_gene_info.append(gene) %}
-              {% do tmp_gene_info.append(transcript) %}
-            {% endif %}
-          {% endfor %}
-        {% endfor %}
-      {% endif %}
-      {% set primary_gene = tmp_gene_info[0] %}
-      {% if tmp_gene_info %}
-        {% set primary_transcript = tmp_gene_info[1] %}
-        <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=primary_gene.hgnc_id) }}"><h5 class="card-title">
-          {{ primary_gene.hgnc_symbol }}; {{ primary_gene.description }}
-        </h5></a>
-      {% endif %}
-      <ul class="list-group list-group-flush" style="margin-bottom: 1rem">
-        {% if primary_transcript %}
-          <li class="list-group-item">{{ primary_transcript.refseq_id }}
-        {% endif %}
-        {% if primary_gene and primary_gene.exon %}
-          <span class="text-muted">exon </span><strong>{{ primary_gene.exon }}</strong>
-        {% endif %}
-        {% if primary_transcript and primary_transcript.coding_sequence_name %}
-              {{ primary_transcript.coding_sequence_name | url_decode }}
-        {% endif %}
-        {% if primary_transcript and primary_transcript.protein_sequence_name %}
-          <strong>{{ primary_transcript.protein_sequence_name | url_decode }}</strong>
-        {% endif %}
-        {% if primary_gene and primary_gene.region_annotation %}
-          <div>(<span class="font-weight-bold">{{ primary_gene.functional_annotation|truncate(20, True) }}</span> in <span class="font-weight-bold">{{ primary_gene.region_annotation }} region</span>)</div>
-        {% endif %}
+         <li class="list-group-item">
+           <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
+             {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
+           </a>
         </li>
+      {% endfor %}
        <li class="list-group-item">
           <span class="text-muted">[{{ case.genome_build }}]{{ variant.chromosome }}:g.{{ variant.position }}</span>
           {%- if variant.reference|length > 8 -%}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -196,13 +196,13 @@
   <div class="card panel-default">
     <div class="panel-heading">Summary</div>
     <div class="card-body">
-      {% for gene in variant.genes %}
-         <li class="list-group-item">
-           <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
-             {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
-           </a>
-        </li>
-      {% endfor %}
+      <li class="list-group-item">
+        {% for gene in variant.genes %}
+         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
+           {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
+         </a>
+        {% endfor %}
+       </li>
        <li class="list-group-item">
           <span class="text-muted">[{{ case.genome_build }}]{{ variant.chromosome }}:g.{{ variant.position }}</span>
           {%- if variant.reference|length > 8 -%}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -198,8 +198,8 @@
     <div class="card-body">
       <li class="list-group-item">
         {% for gene in variant.genes %}
-         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h6 class="card-title">
-           {{ gene.hgnc_symbol }}; {{ gene.description }}</h6>
+         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
+           {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
          </a>
         {% endfor %}
        </li>

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -198,8 +198,8 @@
     <div class="card-body">
       <li class="list-group-item">
         {% for gene in variant.genes %}
-         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h5 class="card-title">
-           {{ gene.hgnc_symbol }}; {{ gene.description }}</h5>
+         <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"><h6 class="card-title">
+           {{ gene.hgnc_symbol }}; {{ gene.description }}</h6>
          </a>
         {% endfor %}
        </li>


### PR DESCRIPTION
At the moment cancer variant summary shows the info for a single gene even if the variant hits several genes (fix #2826 and partially fixing #2835).

My fix is perhaps naive since I'm removing most of the info obtained in the jinja parsing (see code) to leave only gene ID and gene name. But I was thinking that:
- Most (if not all) of the jinja parsed info is showed later in the page anyway
- That code is a bit hard to read and to maintain. And the choice of the primary transcript or NM transcript to show with associated exon is a bit arbitrary and could be misleading (see also #2835, first problem) . Perhaps a simpler solutions wound't be so bad..

**How to test**:
1. On clinical-db stage go to a cancer variant hitting multiple genes, esample: https://scout-stage.scilifelab.se/cust000/balsamic-validation-gmsmyeloid-tumor-only-2/cancer/ac4fa05770c2e462ed36d23fe673ea4e?cancer=yes
2. Master branch should show just one gene info in variant summary
3. Install this branch and 2 genes should be shown instead

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
