### PR TITLE
Fixed MitoMap and HmtVar links for hg38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Link to other causative variants on variant page
 - Allow multiple COSMIC links for a cancer variant
+- Fixed MitoMap and HmtVar links for hg38 cases
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update look of variants page navigation buttons
 ### Changed
 
-
-
 ## [4.37]
 ### Added
 - Highlight and show version number for RefSeq MANE transcripts.

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -154,10 +154,12 @@ def variant(
         genome_build = "37"
 
     # is variant located on the mitochondria
-    variant_obj['is_mitochondrial'] = any([
-        (genome_build == "38" and variant_obj['chromosome'] == 'M'),
-        (genome_build == "37" and variant_obj['chromosome'] == 'MT')
-    ])
+    variant_obj["is_mitochondrial"] = any(
+        [
+            (genome_build == "38" and variant_obj["chromosome"] == "M"),
+            (genome_build == "37" and variant_obj["chromosome"] == "MT"),
+        ]
+    )
 
     # add default panels extra gene information
     panels = default_panels(store, case_obj)

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -153,6 +153,12 @@ def variant(
     if genome_build not in ["37", "38"]:
         genome_build = "37"
 
+    # is variant located on the mitochondria
+    variant_obj['is_mitochondrial'] = any([
+        (genome_build == "38" and variant_obj['chromosome'] == 'M'),
+        (genome_build == "37" and variant_obj['chromosome'] == 'MT')
+    ])
+
     # add default panels extra gene information
     panels = default_panels(store, case_obj)
     variant_obj = add_gene_info(store, variant_obj, gene_panels=panels, genome_build=genome_build)

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -212,8 +212,11 @@
             <a href="{{ variant.alamut_link }}" class="btn btn-outline-secondary" target="_blank">Alamut</a>
           {% endif %}
           <a href="{{ gene.ppaint_link }}" class="btn btn-outline-secondary" target="_blank">Protein Paint</a>
-          {% if variant.chromosome == 'MT' %}
+          {% if variant.is_mitochondrial %}
             <a href="{{ variant.mitomap_link }}" class="btn btn-outline-secondary" target="_blank">MitoMap</a>
+          {% endif %}
+          {% if variant.hmtvar_variant_id %}
+            <a href="{{ variant.hmtvar_link }}" class="btn btn-outline-secondary" target="_blank">HmtVar</a>
           {% endif %}
           {% if gene.tp53_link %}
             <a href="{{ gene.tp53_link }}" class="btn btn-outline-secondary" target="_blank">MutanTP53</a>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -377,7 +377,7 @@
           <input type="hidden" name="stop" value="{{ initial_view.end }}">
         {% endif %}
 
-        {% if variant.chromosome == "MT" and case.mt_bams %}
+        {% if variant.is_mitochondrial and case.mt_bams %}
           <input type="hidden" name="mt_bam" value="{{case.mt_bams|join(',')}}">
           <input type="hidden" name="mt_bai" value="{{case.mt_bais|join(',')}}">
           - Alignment:


### PR DESCRIPTION
This fixes that MitoMap and HmtVar links are being displayed when using hg38 genome build. The issue was accidentally introduced in v4.37.
