### PR TITLE
Make ClinVar classification more evident in cancer variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed MitoMap and HmtVar links for hg38 cases
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
+- More eviden ClinVar classification in cancer variant page
 
 ## [4.38]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed MitoMap and HmtVar links for hg38 cases
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
-- More eviden ClinVar classification in cancer variant page
+- Make ClinVar classification more evident in cancer variant page
 
 ## [4.38]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -4,7 +4,7 @@
 {% from "variant/tx_overview.html" import disease_associated, transcripts_overview %}
 {% from "variant/variant_details.html" import frequencies, gtcall_panel, observations_panel, old_observations, mappability_list, severity_list %}
 {% from "variant/buttons.html" import variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button, splice_junctions_button %}
-{% from "variant/components.html" import alignments, panel_classify, compounds_panel, matching_variants, external_links  %}
+{% from "variant/components.html" import alignments, panel_classify, compounds_panel, matching_variants, external_links, clinsig_table  %}
 {% from "variant/sanger.html" import sanger_button, modal_sanger, modal_cancel_sanger %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes %}
 
@@ -260,8 +260,11 @@
         <li class="list-group-item">Rank score: <span class="font-weight-bold">{{ variant.rank_score }}</span>
         </li>
       </ul>
+      <div class="h6 mt-1">
+        {{ clinsig_table(variant) }}
+      </div>
     <!--LINK out resources-->
-      <div class="h6">Databases</div>
+      <div class="h6 mt-1">Databases</div>
       <div>
         <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
         <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
@@ -294,14 +297,6 @@
             data-toggle="tooltip" title="MyCancerGenome">MCG</a>
         {% endif %}
       </div>
-
-      {% if variant.clinsig_human %}
-        {% for clinsig in variant.clinsig_human %}
-          {% if clinsig.accession %}
-            <a class="btn btn-sm btn-info text-white mr-1"  role="button" href="{{ clinsig.link }}" role="button" target="_blank">Clinvar {{ clinsig.accession }}</a>
-          {% endif %}
-        {% endfor %}
-      {% endif %}
     </div>
 
     <!--IGV URLS-->

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -20,10 +20,12 @@
         {% for clinsig in variant.clinsig_human %}
           <tr>
             <td>{{ clinsig.human }}</td>
-            <td>
-              <a href="{{ clinsig.link }}" target="_blank">{{ clinsig.accession }}</a>
-            </td>
-            <td>{{ clinsig.revstat }}</td>
+            {% if clinsig.accession %}
+              <td><a href="{{ clinsig.link }}" target="_blank">{{ clinsig.accession }}</a></td>
+            {% else %}
+              <td>n.a.</td>
+            {% endif %}
+            <td>{{ clinsig.revstat or "n.a." }}</td>
           </tr>
         {% else %}
           <i>No annotations</i>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -4,6 +4,35 @@
 {% from "variant/buttons.html" import igv_button, splice_junctions_button %}
 {% from "variant/utils.html" import igv_track_selection  %}
 
+{% macro clinsig_table(variant) %}
+  {% if variant.clinsig_human %}
+    <table class="table table-bordered table-fixed table-sm">
+      <thead>
+        <thead>
+          <tr class="active">
+            <th>CLINSIG</th>
+            <th>Accession</th>
+            <th>Revstat</th>
+          </tr>
+        </thead>
+      </thead>
+      <tbody>
+        {% for clinsig in variant.clinsig_human %}
+          <tr>
+            <td>{{ clinsig.human }}</td>
+            <td>
+              <a href="{{ clinsig.link }}" target="_blank">{{ clinsig.accession }}</a>
+            </td>
+            <td>{{ clinsig.revstat }}</td>
+          </tr>
+        {% else %}
+          <i>No annotations</i>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endmacro %}
+
 {% macro acmg_classification_item(variant, data) %}
   {% set current_variant = (data.variant_specific == variant._id) %}
   <li class="list-group-item {{ 'list-group-item-info' if current_variant }}">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -5,7 +5,7 @@
 {% from "variant/tx_overview.html" import disease_associated, transcripts_overview %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes, inheritance_panel, autozygosity_panel, genemodels_panel %}
 {% from "variant/variant_details.html" import frequencies, gtcall_panel, old_observations, observations_panel, severity_list, conservations, mappability %}
-{% from "variant/components.html" import alignments, panel_classify, compounds_panel, matching_variants, external_links %}
+{% from "variant/components.html" import alignments, panel_classify, compounds_panel, matching_variants, external_links, clinsig_table %}
 {% from "variant/sanger.html" import sanger_button, modal_sanger, modal_cancel_sanger %}
 
 
@@ -235,32 +235,7 @@
           </tr>
         </tbody>
       </table>
-      {% if variant.clinsig_human %}
-        <table class="table table-bordered table-fixed table-sm">
-          <thead>
-            <thead>
-              <tr class="active">
-                <th>CLINSIG</th>
-                <th>Accession</th>
-                <th>Revstat</th>
-              </tr>
-            </thead>
-          </thead>
-          <tbody>
-            {% for clinsig in variant.clinsig_human %}
-              <tr>
-                <td>{{ clinsig.human }}</td>
-                <td>
-                  <a href="{{ clinsig.link }}" target="_blank">{{ clinsig.accession }}</a>
-                </td>
-                <td>{{ clinsig.revstat }}</td>
-              </tr>
-            {% else %}
-              <i>No annotations</i>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
+      {{ clinsig_table(variant) }}
       {% if variant.mitomap_associated_diseases %}
         <table class="table table-bordered table-fixed table-sm">
           <tbody>


### PR DESCRIPTION
Partial fix to #2835 (point2) **--- NOTE THAT CURRENT CANCER VARIANTS ONLY HAVE clinsig, (#2836) --**

**How to test**:
1. Install on stage or locally
2. Check that ClinVar classification is now well visible on the cancer variant summary

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
