### PR TITLE
Do not open new browser tabs when downloading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to other causative variants on variant page
 - Allow multiple COSMIC links for a cancer variant
 - Fixed MitoMap and HmtVar links for hg38 cases
+- Do not open new browser tabs when downloading files
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -75,7 +75,7 @@
                 <i class="fa fa-link"></i></a>
         </div>
         <div>
-          <a href="{{ url_for('cases.pdf_case_report', institute_id=institute._id, case_name=case.display_name) }}" target="_blank">
+          <a href="{{ url_for('cases.pdf_case_report', institute_id=institute._id, case_name=case.display_name) }}" download>
                 <i class="fa fa-file-pdf-o"></i></a>
         </div>
       </div>
@@ -516,7 +516,7 @@
     </div>
     <div>
       <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                        case_name=case.display_name, date=date, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
+                        case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
     </div>
   </div>
 </div>
@@ -567,7 +567,7 @@
     </div>
     <div>
       <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
-                        case_name=case.display_name, date=date, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
+                        case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
     </div>
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -135,8 +135,8 @@
           </div>
           <div class="col">
             <div class="row">
-              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}" target="_blank"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>&nbsp;&nbsp;
-              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}" target="_blank"><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel &nbsp;&nbsp</a>
+              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>&nbsp;&nbsp;
+              <a class="btn btn-sm btn-primary mt-1" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel &nbsp;&nbsp</a>
             </div>
           </div>
 

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -157,7 +157,7 @@
               <td>
                 {% if ind.vcf2cytosure %}
                 <a href="{{ url_for('cases.vcf2cytosure', institute_id=institute._id,
-                      case_name=case.display_name, individual_id=ind.individual_id) }}" target="_blank" class="btn">
+                      case_name=case.display_name, individual_id=ind.individual_id) }}" download class="btn">
                   <i class="fa fa-download"></i>
                 </a>
                 {% else %}


### PR DESCRIPTION
Fix #2829. What I've done in this PR is basically replacing all the changes from #2810 (target="_blank") with "download". Looks like it's working on Chrome and Safari.

**How to test**:
1. On a local instance of scout, use Safari as browser.
2. Go to demo case page and download the following files:
-  general report
- delivery report
- coverage qc report (is in the cancer case)
- HPO gene list (2 buttons)
- VCF2Cytosure

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
