### PR TITLE
Collect COSMIC IDs from CSQ field named COSMIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow multiple COSMIC links for a cancer variant
 - Fixed MitoMap and HmtVar links for hg38 cases
 - Do not open new browser tabs when downloading files
+- Missing COSMIC IDs collected from CSQ field named `COSMIC`
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 - Make ClinVar classification more evident in cancer variant page

--- a/scout/parse/variant/transcript.py
+++ b/scout/parse/variant/transcript.py
@@ -229,12 +229,18 @@ def parse_transcripts(raw_transcripts, allele=None):
         transcript["dbsnp"] = []
         transcript["cosmic"] = []
         variant_ids = entry.get("EXISTING_VARIATION")
+
         if variant_ids:
             for variant_id in variant_ids.split("&"):
                 if variant_id.startswith("rs"):
                     transcript["dbsnp"].append(variant_id)
                 elif variant_id.startswith("COSM") or variant_id.startswith("COSV"):
                     transcript["cosmic"].append(variant_id)
+
+        cosmic_ids = entry.get("COSMIC")
+        if cosmic_ids:
+            for cosmic_id in cosmic_ids.split("&"):
+                transcript["cosmic"].append(cosmic_id)
 
         yield transcript
 

--- a/tests/parse/test_parse_transcripts.py
+++ b/tests/parse/test_parse_transcripts.py
@@ -1,6 +1,26 @@
 from scout.parse.variant.transcript import parse_transcripts
 
 
+def test_parse_cosmic_csq_cosmic():
+    """Test parsing cosmic IDs from 'COSMIC' CSQ entry"""
+
+    cosmic_id = "COSV99072206"
+
+    # GIVEN a CSQ entry containing a specific 'COSMIC' key
+    csq_header = "Consequence|COSMIC|COSMIC_CDS|COSMIC_GENE|COSMIC_STRAND|COSMIC_CNT|COSMIC_AA"
+    csq_entry = "missense_variant|{0}|c.913T>G|POLQ||2|p.S305A".format(cosmic_id)
+
+    header = [word.upper() for word in csq_header.split("|")]
+    raw_transcripts = [dict(zip(header, entry.split("|"))) for entry in csq_entry.split(",")]
+
+    # WHEN parsing the transcripts
+    transcripts = parse_transcripts(raw_transcripts)
+
+    # THEN the COSMIC annotation should be parsed correctly
+    for transcript in transcripts:
+        assert transcript["cosmic"] == [cosmic_id]
+
+
 def test_parse_transcripts():
     ## GIVEN some transcript information and a vep header
     csq_entry = "A|missense_variant|MODERATE|ABCC2|ENSG00000023839|Transcript|ENST00000370449|protein_coding|10/32||ENST00000370449.4:c.1249G>A|ENSP00000359478.4:p.Val417Ile|1362|1249|417|V/I|Gtt/Att|||1||HGNC|53|YES|||CCDS7484.1|ENSP00000359478|Q92887||UPI000013D6CA||Ensembl|G|G||tolerated|benign|PROSITE_profiles:PS50929&hmmpanther:PTHR24223&hmmpanther:PTHR24223:SF176&TIGRFAM_domain:TIGR00957&Pfam_domain:PF00664&Gene3D:2hydA01&Superfamily_domains:SSF90123||||||12.834|9.654|8.373|10.218|-7.208|1.111|-6.097|-6.097|-12.417|-1.215|-9.514|-13.633||||5.48|-10.3|0.54096|0.000000|-0.327000|0.0978|0.00|255992|Benign|255992|criteria_provided&_multiple_submitters&_no_conflicts|,A|missense_variant|MODERATE|ABCC2|1244|Transcript|NM_000392.3|protein_coding|10/32||NM_000392.3:c.1249G>A|NP_000383.1:p.Val417Ile|1388|1249|417|V/I|Gtt/Att|||1||EntrezGene|53|YES||||NP_000383.1|||||RefSeq|G|G||tolerated|benign|||||||12.834|9.654|8.373|10.218|-7.208|1.111|-6.097|-6.097|-12.417|-1.215|-9.514|-13.633||||5.48|-10.3|0.54096|0.000000|-0.327000|0.0978|0.00|255992|Benign|255992|criteria_provided&_multiple_submitters&_no_conflicts|,A|missense_variant|MODERATE|ABCC2|1244|Transcript|NM_000392.4|protein_coding|10/32||NM_000392.4:c.1249G>A|NP_000383.1:p.Val417Ile|1496|1249|417|V/I|Gtt/Att|||1||EntrezGene|53|YES||||NP_000383.1||||rseq_mrna_nonmatch&rseq_cds_mismatch|RefSeq|G|G|OK|tolerated|benign|||||||12.834|9.654|8.373|10.218|-7.208|1.111|-6.097|-6.097|-12.417|-1.215|-9.514|-13.633||||5.48|-10.3|0.54096|0.000000|-0.327000|0.0978|0.00|255992|Benign|255992|criteria_provided&_multiple_submitters&_no_conflicts|"


### PR DESCRIPTION
Fix #2844 

COSMIC IDs for this variant are stored in a CSQ key named `COSMIC` (at the transcript level) and not together with the SNPs ID with the key `EXISTING_VARIATION`

**How to test**:
1. Load on stage a case containing this structure of CSQ (the test case from the issue would be perfect)
2. Check that the variant from the issue has a COSMIC ID

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
