### PR TITLE
Reintroduce missing splice junctions button on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow multiple COSMIC links for a cancer variant
 - Fixed MitoMap and HmtVar links for hg38 cases
 - Do not open new browser tabs when downloading files
+- Missing splice junctions button on variant page
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 - Make ClinVar classification more evident in cancer variant page

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -1,5 +1,5 @@
 {% macro splice_junctions_button(institute_id, case_name, variant_id) %}
-  <a class="btn btn-secondary btn-sm text-white mt-1" href="{{url_for('alignviewers.sashimi_igv', institute_id=institute_id, case_name=case_name, variant_id=variant_id)}}" target="_blank"
+  <a class="btn btn-sm btn-secondary text-white" href="{{url_for('alignviewers.sashimi_igv', institute_id=institute_id, case_name=case_name, variant_id=variant_id)}}" target="_blank"
     data-toggle="tooltip" data-placement="top" title="Only available in build GRCh38">RNA splicing</a>
 {% endmacro %}
 

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -301,7 +301,7 @@
 
     <!--IGV URLS-->
     <div class="h6 ml-4">Alignment</div>
-    {{ alignments(institute, case, variant, current_user, case_groups, config) }}
+    {{ alignments(institute, case, variant, current_user, case_groups, config, splice_junctions_tracks) }}
 
     </div>
 {% endmacro %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -62,28 +62,32 @@
   </li>
 {% endmacro %}
 
-{% macro alignments(institute, case, variant, current_user, case_groups, config) %}
+{% macro alignments(institute, case, variant, current_user, case_groups, config, splice_junctions_tracks=False) %}
    <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between">
           <div>
             {{ igv_button(case, variant, case_groups) }}
           </div>
-          <div>
-            {% if variant.alamut_link %}
-              <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary" role="button" target="_blank"
-            data-toggle="tooltip" title="Alamut Visual (Plus) - Open variant">Alamut</a>
-            {% endif %}
-           </div>
+          {% if splice_junctions_tracks %}
+            <div>
+              {{ splice_junctions_button(institute._id, case.display_name, variant._id) }}
+            </div>
+          {% endif %}
+          {% if variant.alamut_link %}
+            <div>
+              <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary" role="button" target="_blank" data-toggle="tooltip" title="Alamut Visual (Plus) - Open variant">Alamut</a>
+            </div>
+          {% endif %}
           {% if config.SQLALCHEMY_DATABASE_URI %}
-          <div class="d-flex flex-wrap">
-            {% for gene in variant.genes %}
-              <span class="ml-5">
-                <a target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
-                  {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-                </a>
-              </span>
-            {% endfor %}
-          </div>
+            <div class="d-flex flex-wrap">
+              {% for gene in variant.genes %}
+                <span class="ml-5">
+                  <a target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
+                    {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+                  </a>
+                </span>
+              {% endfor %}
+            </div>
           {% endif %}
         </li>
         <li class="list-group-item">
@@ -91,11 +95,6 @@
             {{ igv_track_selection(igv_tracks, current_user) }}
           </div>
         </li>
-        {% if splice_junctions_tracks %}
-          <li class="list-group-item">
-            <div>{{ splice_junctions_button(institute._id, case.display_name, variant._id) }}</div>
-          </li>
-        {% endif %}
       </ul>
 {% endmacro %}
 

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -290,7 +290,7 @@
           {% endfor %}
         </div>
       </ul>
-      {{ alignments(institute, case, variant, current_user, case_groups, config) }}
+      {{ alignments(institute, case, variant, current_user, case_groups, config, splice_junctions_tracks) }}
 
       {% if variant.custom %}
       <table class="table table-bordered table-sm">


### PR DESCRIPTION
Fix #2847 

**How to test**:
1. On a local master, note that splice junctions button is not visible on variant page
2. Switch to this branch and the button re-appears

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
