### PR TITLE
Reitroduce available igv tracks on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow multiple COSMIC links for a cancer variant
 - Fixed MitoMap and HmtVar links for hg38 cases
 - Do not open new browser tabs when downloading files
+- Selectable IGV tracks on variant page
 ### Changed
 - Improve Javascript performance for displaying Chromograph images
 - Make ClinVar classification more evident in cancer variant page

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -301,7 +301,7 @@
 
     <!--IGV URLS-->
     <div class="h6 ml-4">Alignment</div>
-    {{ alignments(institute, case, variant, current_user, case_groups, config) }}
+    {{ alignments(institute, case, variant, current_user, case_groups, config, igv_tracks) }}
 
     </div>
 {% endmacro %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -62,7 +62,7 @@
   </li>
 {% endmacro %}
 
-{% macro alignments(institute, case, variant, current_user, case_groups, config) %}
+{% macro alignments(institute, case, variant, current_user, case_groups, config, igv_tracks) %}
    <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between">
           <div>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -290,7 +290,7 @@
           {% endfor %}
         </div>
       </ul>
-      {{ alignments(institute, case, variant, current_user, case_groups, config) }}
+      {{ alignments(institute, case, variant, current_user, case_groups, config, igv_tracks) }}
 
       {% if variant.custom %}
       <table class="table table-bordered table-sm">


### PR DESCRIPTION
You were right @dnil, this is very similar to the another bug. They're both resulting from the splitting of the variant page into variant page and cancer variant page. I could have fixed it together with the other bug but when I created the branch I didn't know that it was kind of the same.

Fix #2848

**How to test**:
1. On local demo igv track selection on variant page is broken.
2. On this branch the selection should be working
3. Check variant pages for all types of variants

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
