### PR TITLE
Display validation status badge also for not Sanger-sequenced variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Display validation status badge also for not Sanger-sequenced variants 
 
 ## [4.39]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -319,10 +319,10 @@
 
 
 {% macro variant_validation_badge(variant) %}
-  {% if variant.sanger_ordered and not variant.validation in ['True positive','False positive'] %}
-    <span class="badge badge-default">Verification ordered</span>
+  {% if variant.validation in ['True positive','False positive'] %}
+    <span class="badge badge-success">Validated</span>    
   {% elif variant.sanger_ordered %}
-    <span class="badge badge-success">Validated</span>
+    <span class="badge badge-default">Verification ordered</span>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
Fix #2854

**How to test**:
1. On local demo case, MASTER BRANCH, pin a variant and then go to case page.
2. From case page, mark it as True positive or False positive.
3. Note that no validation badge shows on the side of the variant
![image](https://user-images.githubusercontent.com/28093618/132169037-87950ef0-03db-439c-bd2e-8889caabcde7.png)
4. Switch to this branch and the badge show show.
5. Reset variant validation status (by selecting "Not validated") and the badge should disappear


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
