### PR TITLE
Stop updating database indexes after loading exons via command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Stop updating database indexes after loading exons via command line
 
 ## [4.39]
 ### Added

--- a/scout/commands/load/exons.py
+++ b/scout/commands/load/exons.py
@@ -54,6 +54,4 @@ def exons(build, exons_file):
         LOG.info("Please download a mart dump manually, see instructions in user guide for admins")
         return
 
-    adapter.update_indexes()
-
     LOG.info("Time to load exons: {0}".format(datetime.now() - start))


### PR DESCRIPTION
Fix #2852. We don't want indexes being automatically updated after another cli command. We want to have control on when they should be updated.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
