### PR TITLE
Moved Frequencies, Severity and Local observations panels up in RD variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants
+- Moved Frequencies, Severity and Local observations panels up in RD variant page
 
 ## [4.39]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants
-- Moved Frequencies, Severity and Local observations panels up in RD variant page
+- Moved Frequencies, Severity and Local observations panels up in RD variants page
 
 ## [4.39]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -59,13 +59,22 @@
     <div class="alert alert-warning">Showing only first 30 genes!</div>
   {% endif %}
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
       {{ panel_basics() }}
     </div> <!-- end of col -->
 
-    <div class="col-md-6">
+    <div class="col-md-4">
       {{ panel_summary() }}
     </div> <!-- end of col -->
+
+    <div class="col-md-4">
+      {{ frequencies(variant) }}
+      {% if config['LOQUSDB_SETTINGS'] %}
+        {{ observations_panel(variant, observations, case) }}
+        {{ old_observations(variant) }}
+      {% endif %}
+
+    </div>
   </div> <!-- end of row -->
 
   <div class="row">
@@ -83,15 +92,6 @@
     <div class="col-md-6">
       {{ omim_phenotypes(variant) }}
     </div>
-  </div>
-
-  <div class="row">
-    <div class="col-4">{{ frequencies(variant) }}</div>
-    {% if config['LOQUSDB_SETTINGS'] %}
-      <div class="col-4">{{ observations_panel(variant, observations, case) }}</div>
-      <div class="col-4">{{ old_observations(variant) }}</div>
-    {% endif %}
-
   </div>
 
   <div class="row">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -76,28 +76,38 @@
         {{ omim_phenotypes(variant) }}
       </div>
       <div class="col-sm-8">
-        <div class="col-sm-12">{{ panel_summary() }}</div>
+        <div class="row">
+          <div class="col-sm-6">{{ panel_summary() }}</div>
+          <div class="col-sm-6">
+            <div class="row">
+              {{ frequencies(variant) }}
+              {{ severity_list(variant) }}
+            </div>
+            <div class="row">
+              {% if config['LOQUSDB_SETTINGS'] %}
+                {{ observations_panel(variant, observations, case) }}
+              {% endif %}
+              {{  old_observations(variant) }}
+            </div>
+          </div>
+
+        </div>
         {% if variant.disease_associated_transcripts %}
           <div class="col-sm-12">{{ disease_associated(variant) }}</div>
         {% endif %}
         <div class="col-sm-12">{{ transcripts_overview(variant) }}</div>
+        <div class="row">
+          <div class="col-sm-6">
+            {{ genemodels_panel(variant) }}
+          </div>
+          <div class="col-sm-6">
+            {{ inheritance_panel(variant) }}
+            {% if variant.azlength %}
+              {{ autozygosity_panel(variant) }}
+            {% endif %}
+          </div>
+        </div>
       </div>
-    </div>
-
-    <div class="card-columns">
-      {{ genemodels_panel(variant) }}
-      {{ inheritance_panel(variant) }}
-        {% if variant.azlength %}
-          {{ autozygosity_panel(variant) }}
-        {% endif %}
-      {{ frequencies(variant) }}
-      {% if config['LOQUSDB_SETTINGS'] %}
-        {{ observations_panel(variant, observations, case) }}
-      {% endif %}
-      {{  old_observations(variant) }}
-      {{ severity_list(variant) }}
-      {{ conservations(variant) }}
-      {{ mappability(variant) }}
     </div>
 
     <div class="row">
@@ -106,6 +116,10 @@
         <div class="col-sm-3">{{ pedigree_panel(case) }}</div>
       {% endif %}
       <div class="col-sm-5">{{ gtcall_panel(variant) }}</div>
+      <div class="col-sm">
+        {{ conservations(variant) }}
+        {{ mappability(variant) }}
+      </div>
     </div>
     {% if variant.compounds %}
       <div class="row">


### PR DESCRIPTION
Fix #2807.
- Moved  Frequencies, Severity and Local observations panels up in variant page
- Moved Frequencies and Local observations up in SV variant page 

**How to test**:
1. Install the branch on stage and check the difference with master branch for SNV variant and SV variant pages (RD cases).

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by mikaell
- [x] tests executed by mikael
