### PR TITLE
Paginate hpo search api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - A .cff citation file
 - Phenotypes search API endpoint
+- Added pagination to phenotypes API
 ### Fixed
 - Command to load the OMIM gene panel (`scout load panel --omim`)
 ### Changed
@@ -15,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display validation status badge also for not Sanger-sequenced variants
 - Moved Frequencies, Severity and Local observations panels up in RD variants page
 - Enabled Flask CORS to communicate CORS status to js apps
-- Moved the code preparing the transcripts overview to the backend 
+- Moved the code preparing the transcripts overview to the backend
 
 ## [4.39]
 ### Added

--- a/scout/adapter/mongo/hpo.py
+++ b/scout/adapter/mongo/hpo.py
@@ -58,7 +58,7 @@ class HpoHandler(object):
 
         return self.hpo_term_collection.find_one({"_id": hpo_id})
 
-    def hpo_terms(self, query=None, hpo_term=None, text=None, limit=None):
+    def hpo_terms(self, query=None, hpo_term=None, text=None, limit=None, skip=None):
         """Return all HPO terms
 
         If a query is sent hpo_terms will try to match with regex on term or
@@ -68,6 +68,7 @@ class HpoHandler(object):
             query(str): Part of a hpoterm or description
             hpo_term(str): Search for a specific hpo term
             limit(int): the number of desired results
+            skip(int): the number of results to skip
 
         Returns:
             result(pymongo.Cursor): A cursor with hpo terms
@@ -97,8 +98,10 @@ class HpoHandler(object):
             search_term = hpo_term
 
         limit = limit or 0
+        skip = skip or 0
         res = (
             self.hpo_term_collection.find(query_dict)
+            .skip(skip)
             .limit(limit)
             .sort("hpo_number", pymongo.ASCENDING)
         )

--- a/scout/server/blueprints/phenotypes/controllers.py
+++ b/scout/server/blueprints/phenotypes/controllers.py
@@ -19,9 +19,9 @@ def hpo_terms(store, query=None, limit=None, page=None):
         limit = int(limit)
 
     if page and limit:
-        page=int(page)
+        page = int(page)
         if page > 0:
-            skip = (page - 1)*limit
+            skip = (page - 1) * limit
         else:
             skip = 0
     if query:

--- a/scout/server/blueprints/phenotypes/controllers.py
+++ b/scout/server/blueprints/phenotypes/controllers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-def hpo_terms(store, query=None):
+def hpo_terms(store, query=None, limit=None, page=None):
     """Retrieves a list of HPO terms from scout database
 
     Args:
@@ -13,8 +13,19 @@ def hpo_terms(store, query=None):
 
     """
     hpo_phenotypes = {}
+
+    skip = None
+    if limit:
+        limit = int(limit)
+
+    if page and limit:
+        page=int(page)
+        if page > 0:
+            skip = (page - 1)*limit
+        else:
+            skip = 0
     if query:
-        hpo_phenotypes["phenotypes"] = list(store.hpo_terms(query=query))
+        hpo_phenotypes["phenotypes"] = list(store.hpo_terms(query=query, limit=limit, skip=skip))
     else:
-        hpo_phenotypes["phenotypes"] = list(store.hpo_terms())
+        hpo_phenotypes["phenotypes"] = list(store.hpo_terms(limit=limit, skip=skip))
     return hpo_phenotypes

--- a/scout/server/blueprints/phenotypes/views.py
+++ b/scout/server/blueprints/phenotypes/views.py
@@ -22,11 +22,18 @@ def hpo_terms():
 def api_hpo_terms():
     """Public API for HPO phenotype terms: retrieve all HPO terms
 
+    Request get args:
+        limit:  max number of phenotypes to return
+        page: the page in multiples of limit to return
+
     Returns:
         data(dict): dict with key "phenotypes" set to an array of all phenotype terms
     """
 
-    data = controllers.hpo_terms(store=store)
+    limit = request.args.get("limit", None)
+    page = request.args.get("page", None)
+
+    data = controllers.hpo_terms(store=store, limit=limit, page=page)
     return jsonify(data)
 
 
@@ -35,9 +42,15 @@ def api_hpo_terms():
 def api_hpo_term_search(search_string):
     """Public API for HPO phenotype term: search for a HPO terms matching a string
 
+    Args:
+        search_string(str): match HPO terms containing this string
+    Request get args:
+        limit:  max number of phenotypes to return
+        page: the page in multiples of limit to return
     Returns:
         data(dict): result dict with key "phenotypes" set to an array of all matching phenotype terms
     """
-
-    data = controllers.hpo_terms(store=store, query=search_string)
+    limit=request.args.get("limit", None)
+    page=request.args.get("page", None)
+    data = controllers.hpo_terms(store=store, query=search_string, limit=limit, page=page)
     return jsonify(data)

--- a/scout/server/blueprints/phenotypes/views.py
+++ b/scout/server/blueprints/phenotypes/views.py
@@ -50,7 +50,7 @@ def api_hpo_term_search(search_string):
     Returns:
         data(dict): result dict with key "phenotypes" set to an array of all matching phenotype terms
     """
-    limit=request.args.get("limit", None)
-    page=request.args.get("page", None)
+    limit = request.args.get("limit", None)
+    page = request.args.get("page", None)
     data = controllers.hpo_terms(store=store, query=search_string, limit=limit, page=page)
     return jsonify(data)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The HPO phenotypes bulk return and search API now has pagination options. Add an argument `limit` to the `GET` to set the max number of returned HPO terms, and `page` to continue displaying from that page, assuming `limit` number of terms per page.

**How to test**:
1. phrase a few queries to the phenotypes API and note that page and limit are used after the branch is installed

**Expected outcome**:
The functionality should be working.

<img width="1176" alt="Screenshot 2021-09-16 at 20 00 28" src="https://user-images.githubusercontent.com/758570/133662004-4c3066e2-0f34-4774-83d4-50ec4ed86b97.png">

Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
