### PR TITLE
Unify style of pinned and causative variants' badges on case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added pagination to phenotype API
 ### Fixed
 - Command to load the OMIM gene panel (`scout load panel --omim`)
+- Unify style of pinned and causative variants' badges on case page
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -320,7 +320,7 @@
 
 {% macro variant_validation_badge(variant) %}
   {% if variant.validation in ['True positive','False positive'] %}
-    <span class="badge badge-success">Validated</span>    
+    <span class="badge badge-success">Validated</span>
   {% elif variant.sanger_ordered %}
     <span class="badge badge-default">Verification ordered</span>
   {% endif %}
@@ -359,13 +359,13 @@
           <li class="list-group-item list-group-item-action">
             {% if variant._id %}
               {% do already_displayed_variant_ids.append( variant._id ) %}
-              <div class="row align-items-between align-items-center">
+              <div class="row">
                 <div class="col">
                   {{ pretty_link_variant(variant, case) }}
                   {{ variant_validation_badge(variant) }}
+                  {{ clinical_assessments_badge(variant) }}
+                  {{ tumor_allele_freq(variant) }}
                 </div>
-                {{ clinical_assessments_badge(variant) }}
-                {{ tumor_allele_freq(variant) }}
                 <div class="col-1">
                   {{ remove_form(url_for('cases.mark_causative',
                                          institute_id=institute._id,
@@ -512,21 +512,19 @@
           {% if variant._id %}
             <div class="row">
               <div class="col">
-                <div class="form-group row align-items-center">
-                  <div class="ml-3">
-                    {{ pretty_link_variant(variant, case) }}
-                  </div>
-                  <div style="padding: 0 10px 3px">
+                <div class="row align-items-between">
+                  <div class="col">
+                    {{ pretty_link_variant(variant, case)}}
                     {{ clinical_assessments_badge(variant) }}
                     {{ variant_validation_badge(variant) }}
+                    {{ tumor_allele_freq(variant) }}
                     {% if variant.mosaic_tags %}
                       <span class="badge badge-info">mosaic</span>
                     {% endif %}
                   </div>
                 </div>
               </div>
-              {{ tumor_allele_freq(variant) }}
-              <div class="col-4">
+              <div class="col-5">
               <form action="{{ url_for('cases.mark_validation',
                                          institute_id=variant.institute,
                                          case_name=case.display_name,


### PR DESCRIPTION
Fix #2884 

Unifies the styles of pinned and causative variants on case page

**How to test**:
1. Classify a variant with ACMG criteria (for example pathogenic)
2. Pin it
3. Mark it as causative
4. Go on variant page both on master branch and this branch and see the difference

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by mikaell
- [x] tests executed by mikael
