### PR TITLE
Removed padding after punctuation in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Added pagination to phenotype API
 ### Fixed
 - Command to load the OMIM gene panel (`scout load panel --omim`)
+- Removed automatic spaces after punctuation in comments
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -197,11 +197,6 @@ def register_filters(app):
         return cosmicId
 
     @app.template_filter()
-    def fix_punctuation(text):
-        """Adds a white space after puntuation"""
-        return re.sub(r"(?<=[.,:;?!])(?=[^\s])", r" ", text)
-
-    @app.template_filter()
     def count_cursor(pymongo_cursor):
         """Count numer of returned documents (deprecated pymongo.cursor.count())"""
         # Perform operations on a copy of the cursor so original does not move

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1159,7 +1159,7 @@
           {% for comment in variant.comments %}
             <tr>
               <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
-              <td class="text-break"><strong>{{ comment.content | fix_punctuation}}</strong></td>
+              <td class="text-break"><strong>{{ comment.content }}</strong></td>
             </tr>
           {% endfor %}
         </tbody>
@@ -1327,7 +1327,7 @@
           {% for comment in variant.comments %}
             <tr>
               <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
-              <td class="text-break"><strong>{{ comment.content | fix_punctuation}}</strong></td>
+              <td class="text-break"><strong>{{ comment.content }}</strong></td>
             </tr>
           {% endfor %}
         </tbody>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -199,7 +199,7 @@
 	                    {% for comment in comments %}
 	                      <tr>
 	                        <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
-	                        <td class="text-break"><strong>{{ comment.content | fix_punctuation }}</strong></td>
+	                        <td class="text-break"><strong>{{ comment.content }}</strong></td>
 	                      </tr>
 	                    {% endfor %}
 	                    </table>
@@ -742,7 +742,7 @@
                 {% for comment in variant.comments %}
                   <tr>
                     <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
-                    <td class="text-break"><strong>{{ comment.content | fix_punctuation }}</strong></td>
+                    <td class="text-break"><strong>{{ comment.content }}</strong></td>
                   </tr>
                 {% endfor %}
                 </table>

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -42,7 +42,7 @@
     <style>.odd { background-color: #d5e8f0 }</style>
     {% for comment in comments %}
       <div class="row ml-1 alert {% if loop.index0 % 2 %}even{% else %}odd{% endif %}">
-          <div class="col-7 text-break">{{ comment.content|fix_punctuation }}</div>
+          <div class="col-7 text-break">{{ comment.content }}</div>
           <div class="col-5 text-right">
             <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
               <small>


### PR DESCRIPTION
This removes the automatic insertion of a space after a punctuation mark in comments. (fix #2891)

**How to test**:
1.  write the following comment "foo!doo?moo.crow,flow"

**Expected outcome**:
The displayed comment should be "foo!doo?moo.crow,flow"

**Review:**
- [ ] code approved by
- [ ] tests executed by
