### PR TITLE
Created a MongoDB 4.4 replicaset docker-compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - A .cff citation file
 - Phenotype search API endpoint
 - Added pagination to phenotype API
+- Development docker-compose file for connecting to a MongoDB 4.4 replicaset with 3 nodes
 ### Fixed
 - Command to load the OMIM gene panel (`scout load panel --omim`)
 - Unify style of pinned and causative variants' badges on case page

--- a/containers/development/docker-compose-mongo-replicaset.yml
+++ b/containers/development/docker-compose-mongo-replicaset.yml
@@ -1,60 +1,45 @@
-# Howto (from this fantastic tutorial:https://gist.github.com/asoorm/7822cc742831639c93affd734e97ce4f):
+# Howto (from this fantastic tutorial: https://github.com/UpSync-Dev/docker-compose-mongo-replica-set):
 # 1) From Scout main folder, run:
 # docker-compose -f containers/development/docker-compose-mongo-replicaset.yml up (-d)
 #
-# 2) In another terminal (or the same, if you used the -d param in the command above), exec into one of the mongos:
-# docker exec -it localmongo1 /bin/bash
+# 2) Modify /etc/hosts by adding the following lines ():
+# Added to enable connections to a local, containerized MongoDB replicaset
+# 127.0.0.1       mongo1
+# 127.0.0.1       mongo2
+# 127.0.0.1       mongo3
 #
-# 3) Access the mongo console:
-#  mongo
+# 3) The connection to the replicaset has the following string (wait a few seconds before connecing):
+# mongo mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/scout?replicaSet=rs0
 #
-# 4) Configure replica set by pasting the following command:
-#rs.initiate(
-#  {
-#    _id : 'rs0',
-#    members: [
-#      { _id : 0, host : "mongo1:27017" },
-#      { _id : 1, host : "mongo2:27017" },
-#      { _id : 2, host : "mongo3:27017" }
-#    ]
-#  }
-#)
-#
-# 5) The connection to the replicaset has the following string:
-# mongodb://localhost:27011,localhost:27012,localhost:27013/DB_NAME?replicaSet=scout-rs
-#
-# 6) Remove used images, containers and volumes by running:
+# 7) Remove used images, containers and volumes by running:
 # docker-compose down
+# (docker system prune)
+# (docker volume prune)
 
-version: "3"
+version: "3.8"
+
 services:
   mongo1:
-    hostname: mongo1
-    container_name: localmongo1
     image: mongo:4.4.9
-    expose:
-    - 27017
+    container_name: mongo1
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27011"]
     ports:
-      - 27011:27017
-    restart: always
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]
+      - 27011:27011
+    healthcheck:
+      test: test $$(echo "rs.initiate({_id:'rs0',members:[{_id:0,host:\"mongo1:27011\"},{_id:1,host:\"mongo2:27012\"},{_id:2,host:\"mongo3:27013\"}]}).ok || rs.status().ok" | mongo --port 27011 --quiet) -eq 1
+      interval: 10s
+      start_period: 30s
+
   mongo2:
-    hostname: mongo2
-    container_name: localmongo2
     image: mongo:4.4.9
-    expose:
-    - 27017
+    container_name: mongo2
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27012"]
     ports:
-    - 27012:27017
-    restart: always
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]
+      - 27012:27012
+
   mongo3:
-    hostname: mongo3
-    container_name: localmongo3
     image: mongo:4.4.9
-    expose:
-    - 27017
+    container_name: mongo3
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27013"]
     ports:
-    - 27013:27017
-    restart: always
-    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]
+      - 27013:27013

--- a/containers/development/docker-compose-mongo-replicaset.yml
+++ b/containers/development/docker-compose-mongo-replicaset.yml
@@ -1,0 +1,60 @@
+# Howto (from this fantastic tutorial:https://gist.github.com/asoorm/7822cc742831639c93affd734e97ce4f):
+# 1) From Scout main folder, run:
+# docker-compose -f containers/development/docker-compose-mongo-replicaset.yml up (-d)
+#
+# 2) In another terminal (or the same, if you used the -d param in the command above), exec into one of the mongos:
+# docker exec -it localmongo1 /bin/bash
+#
+# 3) Access the mongo console:
+#  mongo
+#
+# 4) Configure replica set by pasting the following command:
+#rs.initiate(
+#  {
+#    _id : 'rs0',
+#    members: [
+#      { _id : 0, host : "mongo1:27017" },
+#      { _id : 1, host : "mongo2:27017" },
+#      { _id : 2, host : "mongo3:27017" }
+#    ]
+#  }
+#)
+#
+# The connection to the replicaset has the following string:
+# mongodb://localhost:27011,localhost:27012,localhost:27013/DB_NAME?replicaSet=scout-rs
+#
+# Remove used images, containers and volumes by running:
+# docker-compose down
+
+version: "3"
+services:
+  mongo1:
+    hostname: mongo1
+    container_name: localmongo1
+    image: mongo:4.4.9
+    expose:
+    - 27017
+    ports:
+      - 27011:27017
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]
+  mongo2:
+    hostname: mongo2
+    container_name: localmongo2
+    image: mongo:4.4.9
+    expose:
+    - 27017
+    ports:
+    - 27012:27017
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]
+  mongo3:
+    hostname: mongo3
+    container_name: localmongo3
+    image: mongo:4.4.9
+    expose:
+    - 27017
+    ports:
+    - 27013:27017
+    restart: always
+    entrypoint: [ "/usr/bin/mongod", "--bind_ip_all", "--replSet", "scout-rs" ]

--- a/containers/development/docker-compose-mongo-replicaset.yml
+++ b/containers/development/docker-compose-mongo-replicaset.yml
@@ -20,10 +20,10 @@
 #  }
 #)
 #
-# The connection to the replicaset has the following string:
+# 5) The connection to the replicaset has the following string:
 # mongodb://localhost:27011,localhost:27012,localhost:27013/DB_NAME?replicaSet=scout-rs
 #
-# Remove used images, containers and volumes by running:
+# 6) Remove used images, containers and volumes by running:
 # docker-compose down
 
 version: "3"

--- a/containers/development/docker-compose-mongo-replicaset.yml
+++ b/containers/development/docker-compose-mongo-replicaset.yml
@@ -11,7 +11,7 @@
 # 3) The connection to the replicaset has the following string (wait a few seconds before connecing):
 # mongo mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/scout?replicaSet=rs0
 #
-# 7) Remove used images, containers and volumes by running:
+# 4) Remove used images, containers and volumes by running:
 # docker-compose down
 # (docker system prune)
 # (docker volume prune)


### PR DESCRIPTION
This PR adds a functionality addresses #2906 (point1):
- Creates a dockerized MongoDB (v4.4.9) replicaset that can be accessed from localhost with the syntax: mongo mongo_connection_string

**How to test**:
1. Switch to this branch and follow the instructions contained in the new docker-compose file to launch the mongos. **NOTE THAT STEP 2 IS VITAL FOR CONNECTING**, don't skip it.
2. From another terminal, to check the status of the replicaset, execute the mongo shell from one of the 3 containers
```
docker exec -it mongo1 mongo --port 27011
```
And then type `rs.status()` . It should display some replicaset metrics.
3) Exit from the mongo shell and that container and from the terminal try to connect to the replicaset (you should have mongo installed locally): 
```
mongo mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/SOME_DB?replicaSet=rs0
```
4) Bonus test --> connect from PyMongo. From a python 3 shell:
```
from pymongo import MongoClient
client = MongoClient("mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/SOME_DB?replicaSet=rs0")
client.server_info()
```

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
