### PR TITLE
Fixed layout of the RD variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed automatic spaces after punctuation in comments
 - Remove the hardcoded number of total individuals from the variant's old observations panel
 - Send delete requests to a connected Beacon using the DELETE method
+- Layout of the variant page
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -68,30 +68,32 @@
     </div>
     {% endif %}
 
+    <div class="row">{{ matching_variants(managed_variant, causatives) }}</div>
+
     <div class="row">
-      <div class="col-sm-12">{{ matching_variants(managed_variant, causatives) }}</div>
-      <div class="col-sm-4">
+      <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}
+      </div>
+      <div class="col-sm-4">
+        {{ panel_summary() }}
+      </div>
+      <div class="col-sm-3">
+        {{ frequencies(variant) }}
+        {% if config['LOQUSDB_SETTINGS'] %}
+          {{ observations_panel(variant, observations, case) }}
+        {% endif %}
+        {{  old_observations(variant) }}
+      </div>
+      <div class="col-sm-2">
+        {{ severity_list(variant) }}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-4">
         {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
         {{ omim_phenotypes(variant) }}
       </div>
       <div class="col-sm-8">
-        <div class="row">
-          <div class="col-sm-6">{{ panel_summary() }}</div>
-          <div class="col-sm-6">
-            <div class="row">
-              {{ frequencies(variant) }}
-              {{ severity_list(variant) }}
-            </div>
-            <div class="row">
-              {% if config['LOQUSDB_SETTINGS'] %}
-                {{ observations_panel(variant, observations, case) }}
-              {% endif %}
-              {{  old_observations(variant) }}
-            </div>
-          </div>
-
-        </div>
         {% if variant.disease_associated_transcripts %}
           <div class="col-sm-12">{{ disease_associated(variant) }}</div>
         {% endif %}


### PR DESCRIPTION
This PR fixes the layout of the RD variant page, making it like the cancer variant page. 

Current master:  
![image](https://user-images.githubusercontent.com/28093618/137259378-5559dc0e-5b75-4b6c-844f-372de0ce1385.png)

This branch:  
![image](https://user-images.githubusercontent.com/28093618/137259332-8528d665-c6ce-42f2-9b5e-53f8d680b4e9.png)


**How to test**:
1. Install on clinical-db stage and check the difference from current master

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by mikaell
- [x] tests executed by CR
