### PR TITLE
Adjust some margins, rearr gt and omim cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed automatic spaces after punctuation in comments
 - Remove the hardcoded number of total individuals from the variant's old observations panel
 - Send delete requests to a connected Beacon using the DELETE method
-- Layout of the variant page
+- Layout of the SNV and SV variant page - move frequency up
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed automatic spaces after punctuation in comments
 - Remove the hardcoded number of total individuals from the variant's old observations panel
 - Send delete requests to a connected Beacon using the DELETE method
+- Layout of the variant page
 ### Changed
 - Stop updating database indexes after loading exons via command line
 - Display validation status badge also for not Sanger-sequenced variants

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -6,7 +6,7 @@
 
 {% macro clinsig_table(variant) %}
   {% if variant.clinsig_human %}
-    <table class="table table-bordered table-fixed table-sm">
+    <table class="table table-bordered table-fixed table-sm" id="clinsig_table">
       <thead>
         <thead>
           <tr class="active">

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -6,7 +6,7 @@
 
 {% macro clinsig_table(variant) %}
   {% if variant.clinsig_human %}
-    <table class="table table-bordered table-fixed table-sm" id="clinsig_table">
+    <table id='clinsig_table' class="table table-bordered table-sm">
       <thead>
         <thead>
           <tr class="active">

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -8,13 +8,11 @@
   {% if variant.clinsig_human %}
     <table id='clinsig_table' class="table table-bordered table-sm">
       <thead>
-        <thead>
-          <tr class="active">
-            <th>CLINSIG</th>
-            <th>Accession</th>
-            <th>Revstat</th>
-          </tr>
-        </thead>
+        <tr class="active">
+          <th>CLINSIG</th>
+          <th>Accession</th>
+          <th>Revstat</th>
+        </tr>
       </thead>
       <tbody>
         {% for clinsig in variant.clinsig_human %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -25,7 +25,7 @@
             {% else %}
               <td>n.a.</td>
             {% endif %}
-            <td>{{ clinsig.revstat or "n.a." }}</td>
+            <td><div class="text-break">{{ clinsig.revstat or "n.a." }}</div></td>
           </tr>
         {% else %}
           <i>No annotations</i>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -87,7 +87,9 @@
 
   <div class="row">
     <div class="col-md-6">
-      {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
+       <div class="card panel-default">
+        {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
+       </div>
     </div>
     <div class="col-md-6">
       {{ omim_phenotypes(variant) }}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -248,7 +248,9 @@
           </tr>
         </tbody>
       </table>
+      <div style="overflow-y: scroll;">
       {{ clinsig_table(variant) }}
+      </div>
       {% if variant.mitomap_associated_diseases %}
         <table class="table table-bordered table-fixed table-sm">
           <tbody>
@@ -381,10 +383,9 @@
     if (document.getElementById(table_id).rows.length > 5) {
       $('#' + table_id).DataTable({
         scrollY: pixels,
-        overflow-y: scroll,
         stripeClasses: [],
         scrollCollapse: true,
-        paging: false,
+        paging: true,
         searching: false,
         ordering: true,
         info: false})

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -381,6 +381,7 @@
     if (document.getElementById(table_id).rows.length > 5) {
       $('#' + table_id).DataTable({
         scrollY: pixels,
+        overflow-y: scroll,
         stripeClasses: [],
         scrollCollapse: true,
         paging: false,

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -248,7 +248,7 @@
           </tr>
         </tbody>
       </table>
-      <div style="overflow-y: scroll; max-height: 120px; !important"> 
+      <div style="overflow-y: scroll; max-height: 140px; !important">
       {{ clinsig_table(variant) }}
       </div>
       {% if variant.mitomap_associated_diseases %}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -399,6 +399,7 @@
     set_scrolly_table('proteins_panel_table')
     set_scrolly_table('transcripts_panel_table')
 
+    set_scrolly_table('clinsig_table')
 
     $(document).ready(function(){
         $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -248,7 +248,7 @@
           </tr>
         </tbody>
       </table>
-      <div style="overflow-y: scroll;">
+      <div style="overflow-y: scroll; max-height: 120px; !important"> 
       {{ clinsig_table(variant) }}
       </div>
       {% if variant.mitomap_associated_diseases %}
@@ -400,8 +400,6 @@
     set_scrolly_table('transcript_overview_table', 350)
     set_scrolly_table('proteins_panel_table', 350)
     set_scrolly_table('transcripts_panel_table', 350)
-
-    set_scrolly_table('clinsig_table', 100)
 
     $(document).ready(function(){
         $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -385,7 +385,7 @@
         scrollY: pixels,
         stripeClasses: [],
         scrollCollapse: true,
-        paging: true,
+        paging: false,
         searching: false,
         ordering: true,
         info: false})

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -377,10 +377,10 @@
   <script src="//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 
   <script>
-    function set_scrolly_table(table_id) {
+    function set_scrolly_table(table_id, pixels) {
     if (document.getElementById(table_id).rows.length > 5) {
       $('#' + table_id).DataTable({
-        scrollY: 350,
+        scrollY: pixels,
         stripeClasses: [],
         scrollCollapse: true,
         paging: false,
@@ -395,11 +395,11 @@
       .columns.adjust()
     });
 
-    set_scrolly_table('transcript_overview_table')
-    set_scrolly_table('proteins_panel_table')
-    set_scrolly_table('transcripts_panel_table')
+    set_scrolly_table('transcript_overview_table', 350)
+    set_scrolly_table('proteins_panel_table', 350)
+    set_scrolly_table('transcripts_panel_table', 350)
 
-    set_scrolly_table('clinsig_table')
+    set_scrolly_table('clinsig_table', 100)
 
     $(document).ready(function(){
         $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -68,30 +68,32 @@
     </div>
     {% endif %}
 
+    <div class="row">{{ matching_variants(managed_variant, causatives) }}</div>
+
     <div class="row">
-      <div class="col-sm-12">{{ matching_variants(managed_variant, causatives) }}</div>
-      <div class="col-sm-4">
+      <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}
+      </div>
+      <div class="col-sm-4">
+        {{ panel_summary() }}
+      </div>
+      <div class="col-sm-3">
+        {{ frequencies(variant) }}
+        {% if config['LOQUSDB_SETTINGS'] %}
+          {{ observations_panel(variant, observations, case) }}
+        {% endif %}
+        {{  old_observations(variant) }}
+      </div>
+      <div class="col-sm-2">
+        {{ severity_list(variant) }}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-4">
         {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
         {{ omim_phenotypes(variant) }}
       </div>
       <div class="col-sm-8">
-        <div class="row">
-          <div class="col-sm-6">{{ panel_summary() }}</div>
-          <div class="col-sm-6">
-            <div class="row">
-              {{ frequencies(variant) }}
-              {{ severity_list(variant) }}
-            </div>
-            <div class="row">
-              {% if config['LOQUSDB_SETTINGS'] %}
-                {{ observations_panel(variant, observations, case) }}
-              {% endif %}
-              {{  old_observations(variant) }}
-            </div>
-          </div>
-
-        </div>
         {% if variant.disease_associated_transcripts %}
           <div class="col-sm-12">{{ disease_associated(variant) }}</div>
         {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -105,16 +105,19 @@
         <div class="row"><div class="col-12">{{ transcripts_overview(variant) }}</div></div>
           <div class="row">
             <div class="col-4">
-              {{ mappability(variant) }}
+
               {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
               {% if has_pedigree %}
                 {{ pedigree_panel(case) }}
               {% endif %}
-              {% if variant.azlength %}
-                    {{ autozygosity_panel(variant) }}
-              {% endif %}
               {{ conservations(variant) }}</div>
-            <div class="col-8">{{ gtcall_panel(variant) }}</div>
+            <div class="col-8">
+              {{ gtcall_panel(variant) }}
+              {{ mappability(variant) }}
+              {% if variant.azlength %}
+                {{ autozygosity_panel(variant) }}
+              {% endif %}
+            </div>
           </div>
         </div>
       </div>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -248,9 +248,7 @@
           </tr>
         </tbody>
       </table>
-      <div style="overflow-y: scroll; max-height: 140px; !important">
       {{ clinsig_table(variant) }}
-      </div>
       {% if variant.mitomap_associated_diseases %}
         <table class="table table-bordered table-fixed table-sm">
           <tbody>
@@ -379,10 +377,10 @@
   <script src="//cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
 
   <script>
-    function set_scrolly_table(table_id, pixels) {
+    function set_scrolly_table(table_id) {
     if (document.getElementById(table_id).rows.length > 5) {
       $('#' + table_id).DataTable({
-        scrollY: pixels,
+        scrollY: 350,
         stripeClasses: [],
         scrollCollapse: true,
         paging: false,
@@ -397,9 +395,9 @@
       .columns.adjust()
     });
 
-    set_scrolly_table('transcript_overview_table', 350)
-    set_scrolly_table('proteins_panel_table', 350)
-    set_scrolly_table('transcripts_panel_table', 350)
+    set_scrolly_table('transcript_overview_table')
+    set_scrolly_table('proteins_panel_table')
+    set_scrolly_table('transcripts_panel_table')
 
     $(document).ready(function(){
         $('[data-toggle="tooltip"]').tooltip();

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -68,7 +68,7 @@
     </div>
     {% endif %}
 
-    <div class="row">{{ matching_variants(managed_variant, causatives) }}</div>
+    <div class="row"><div class="col-12">{{ matching_variants(managed_variant, causatives) }}</div></div>
 
     <div class="row">
       <div class="col-sm-3">
@@ -90,39 +90,36 @@
     </div>
     <div class="row">
       <div class="col-sm-4">
-        {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
+        <div class="card panel-default">
+          {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
+        </div>
         {{ omim_phenotypes(variant) }}
+        {{ genemodels_panel(variant) }}
+        {{ inheritance_panel(variant) }}
+
       </div>
       <div class="col-sm-8">
         {% if variant.disease_associated_transcripts %}
-          <div class="col-sm-12">{{ disease_associated(variant) }}</div>
+          <div class="row"><div class="col-12">{{ disease_associated(variant) }}</div></div>
         {% endif %}
-        <div class="col-sm-12">{{ transcripts_overview(variant) }}</div>
-        <div class="row">
-          <div class="col-sm-6">
-            {{ genemodels_panel(variant) }}
-          </div>
-          <div class="col-sm-6">
-            {{ inheritance_panel(variant) }}
-            {% if variant.azlength %}
-              {{ autozygosity_panel(variant) }}
-            {% endif %}
+        <div class="row"><div class="col-12">{{ transcripts_overview(variant) }}</div></div>
+          <div class="row">
+            <div class="col-4">
+              {{ mappability(variant) }}
+              {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
+              {% if has_pedigree %}
+                {{ pedigree_panel(case) }}
+              {% endif %}
+              {% if variant.azlength %}
+                    {{ autozygosity_panel(variant) }}
+              {% endif %}
+              {{ conservations(variant) }}</div>
+            <div class="col-8">{{ gtcall_panel(variant) }}</div>
           </div>
         </div>
       </div>
     </div>
 
-    <div class="row">
-      {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
-      {% if has_pedigree %}
-        <div class="col-sm-3">{{ pedigree_panel(case) }}</div>
-      {% endif %}
-      <div class="col-sm-5">{{ gtcall_panel(variant) }}</div>
-      <div class="col-sm">
-        {{ conservations(variant) }}
-        {{ mappability(variant) }}
-      </div>
-    </div>
     {% if variant.compounds %}
       <div class="row">
         <div class="col-12">{{ compounds_panel(institute, case, variant) }}</div>


### PR DESCRIPTION
This PR mildly rearranges the variant(s) pages

![Screenshot 2021-10-14 at 13 35 30](https://user-images.githubusercontent.com/758570/137310458-1a7be7cc-dd75-4c66-8afe-1be502ca3e42.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
