### PR TITLE
Fix #2927 - general report inconsistent inheritance pattern none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
+- Variants dismissed with inconsistent inheritance pattern can again be shown in general case report
 ### Changed
 
 ## [4.40]

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -873,11 +873,14 @@
                         </table>
                       {% elif reason == '7' %} <!-- Inheritance pattern not relevant -->
                       <br>
-                        ({% for model in variant.genetic_models|sort %}
-                          <span class="badge badge-info" title="{{genetic_models[model]}}">{{model}}</span>
+
+                        ({% if variant.genetic_models %}
+                          {% for model in variant.genetic_models|sort %}
+                            <span class="badge badge-info" title="{{genetic_models[model]}}">{{model}}</span>
+                          {% endfor %}
                         {% else %}
                           No models followed
-                        {% endfor %})
+                        {% endif %})
                         <br>
                       {% elif reason== '23' %} <!-- inherited from unaffected -->
                         <table id="panel-table" class="table-borderless table-sm" >
@@ -1094,11 +1097,13 @@
           </td>
           <td>
             <span class="float-left">
-              {% for model in variant.genetic_models|sort %}
-                <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
+              {% if variant.genetic_models %}
+                {% for model in variant.genetic_models|sort %}
+                  <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
+                {% endfor %}
               {% else %}
                 <span class="badge badge-warning">No models followed</span>
-              {% endfor %}
+              {% endif %}
             </span>
           </td>
           <td>


### PR DESCRIPTION
This PR adds a fixes a bug, see #2927.

**How to test**:
1. Dismiss a variant without an inheritance pattern, with the reason "inconsistent inheritance pattern"
2. Try to generate a general report, and note it failing with current master
3. Apply fix, and see report working:
![Screenshot 2021-10-15 at 16 42 45](https://user-images.githubusercontent.com/758570/137506109-92748eed-6819-48c0-8e42-5848229a7158.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
