### PR TITLE
More reactive steps on variant page - fix #2934 tentatively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Fixed
 ### Changed
+- Rearrange variant page again, moving severity predictions down.
+- More reactive layout width steps on variant page
 
 ## [4.40.1]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -71,25 +71,22 @@
     <div class="row"><div class="col-12">{{ matching_variants(managed_variant, causatives) }}</div></div>
 
     <div class="row">
-      <div class="col-sm-3">
+      <div class="col-lg-3 col-md-6">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}
       </div>
-      <div class="col-sm-4">
+      <div class="col-lg-5 col-md-6">
         {{ panel_summary() }}
       </div>
-      <div class="col-sm-3">
+      <div class="col-lg-4">
         {{ frequencies(variant) }}
         {% if config['LOQUSDB_SETTINGS'] %}
           {{ observations_panel(variant, observations, case) }}
         {% endif %}
         {{  old_observations(variant) }}
       </div>
-      <div class="col-sm-2">
-        {{ severity_list(variant) }}
-      </div>
     </div>
     <div class="row">
-      <div class="col-sm-4">
+      <div class="col-lg-4 col-md-12">
         <div class="card panel-default">
           {{ comments_panel(institute, case, current_user, variant.comments, variant_id=variant._id) }}
         </div>
@@ -98,25 +95,34 @@
         {{ inheritance_panel(variant) }}
 
       </div>
-      <div class="col-sm-8">
+      <div class="col-lg-8 col-md-12">
         {% if variant.disease_associated_transcripts %}
           <div class="row"><div class="col-12">{{ disease_associated(variant) }}</div></div>
         {% endif %}
         <div class="row"><div class="col-12">{{ transcripts_overview(variant) }}</div></div>
           <div class="row">
-            <div class="col-4">
-
-              {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
-              {% if has_pedigree %}
+            {% set has_pedigree = case.madeline_info and case.individuals|length > 1 %}
+            {% if has_pedigree %}
+              <div class="col-lg-4">
                 {{ pedigree_panel(case) }}
-              {% endif %}
-              {{ conservations(variant) }}</div>
-            <div class="col-8">
+              </div>
+            {% endif %}
+            <div class="col-lg-8">
               {{ gtcall_panel(variant) }}
-              {{ mappability(variant) }}
-              {% if variant.azlength %}
+            </div>
+            <div class="col-lg-4">
+              {{ severity_list(variant) }}
+            </div>
+            <div class="col-lg-4 col-md-6">
+              {{ conservations(variant) }}
+            </div>
+            {% if variant.azlength %}
+              <div class="col-lg-4 col-md-6">
                 {{ autozygosity_panel(variant) }}
-              {% endif %}
+              </div>
+            {% endif %}
+            <div class="col-lg-4 col-md-6">
+              {{ mappability(variant) }}
             </div>
           </div>
         </div>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -231,11 +231,13 @@
       <ul class="list-group">
         <li class="list-group-item">
           <a href="https://sift.bii.a-star.edu.sg/www/SIFT_help.html" target="_blank">SIFT</a>
-          {% if variant.sift_predictions  %}
-           <br> {{ variant.sift_predictions|join(', ') }}
-          {% else %}
-             <span class="float-right">{{ "-" }}</span>
-          {% endif %}
+          <span class="float-right">
+            {% if variant.sift_predictions  %}
+              {{ variant.sift_predictions|join(', ') }}</span>
+            {% else %}
+               {{ "-" }}
+            {% endif %}
+          </span>
         </li>
         <li class="list-group-item">
           <a href="https://sites.google.com/site/revelgenomics/about" target="_blank">REVEL</a>
@@ -249,11 +251,13 @@
         </li>
         <li class="list-group-item">
           <a href="http://genetics.bwh.harvard.edu/pph2/" target="_blank">Polyphen</a>
+          <span class="float-right">
           {% if variant.polyphen_predictions %}
-            <br> {{ variant.polyphen_predictions|join(', ') }}
+            {{ variant.polyphen_predictions|join(', ') }}
           {% else %}
-             <span class="float-right">{{ "-" }}</span>
+             {{ "-" }}
           {% endif %}
+          </span>
         </li>
         <li class="list-group-item">
           SPIDEX


### PR DESCRIPTION
This PR adresses a layout issue with the variant page.

I have (re)added a couple of reactive steps, going from single to two- or three-column design. Severity predictions have been moved down on the page, reflecting their relatively smaller contribution to the total variant assessment, and placed closer to the conservation card.


![Screenshot 2021-10-20 at 16 49 38](https://user-images.githubusercontent.com/758570/138116797-cee1f2ed-1cca-4704-92cd-165386ae5cb8.png)
![Screenshot 2021-10-20 at 16 49 55](https://user-images.githubusercontent.com/758570/138116818-4bad1198-e156-44aa-9d58-2151e9d708f9.png)
![Screenshot 2021-10-20 at 16 50 02](https://user-images.githubusercontent.com/758570/138116817-c20bef26-4c08-45a3-9c43-ec2c4c0078b6.png)

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
