### PR TITLE
Fix human readable variants name in case page for SV variants with start chrom != end chrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Fixed
+- Human readable variants name in case page for variants having start chromosome different from end chromosome
 ### Changed
 
 ## [4.40.1]

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -274,7 +274,6 @@
 {% macro pretty_link_variant(variant, case) %}
 {# Returns human readable links to the corresponding variant page #}
 
-
   {% if variant.category in ("str", "snv", "cancer") %}
     {% if variant.category == "cancer" %}
     <a href="{{ url_for('variant.cancer_variant',
@@ -312,7 +311,7 @@
                               institute_id=variant.institute,
                               case_name=case.display_name,
                               variant_id=variant._id) }}">
-    {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.chromosome }}{{ variant.cytoband_end }})
+    {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.end_chrom }}{{ variant.cytoband_end }})
   {% endif %}
   </a>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -311,7 +311,7 @@
                               institute_id=variant.institute,
                               case_name=case.display_name,
                               variant_id=variant._id) }}">
-    {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.end_chrom }}{{ variant.cytoband_end }})
+    {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}::{{ variant.end_chrom }}{{ variant.cytoband_end }})
   {% endif %}
   </a>
 {% endmacro %}


### PR DESCRIPTION
Fix #2950 

**How to test**:
1. Look for a BND variant in a case on clinical-db stage
2. Confirm bug described in #2950 
3. Install this branch and make sure that the variant naming is correct

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
