### PR TITLE
Increase serverSelectionTimeoutMS MongoDB params to 30K

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Freeze to WTForms to version < 3
 - Remove the extra files (bed files and madeline.svg) introduced by mistake
 - Cli command loading demo data in docker-compose when case custom images exist and is None
+- Increased MongoDB connection serverSelectionTimeoutMS parameter to 30K (default value according to MongoDB documentation)
 
 ## [4.41.1]
 ### Fixed

--- a/scout/adapter/client.py
+++ b/scout/adapter/client.py
@@ -26,7 +26,7 @@ def get_connection(
     uri=None,
     mongodb=None,
     authdb=None,
-    timeout=30000,  # default in MongoDB documentation
+    timeout=30000,  # default according MongoDB documentation
     *args,
     **kwargs,
 ):

--- a/scout/adapter/client.py
+++ b/scout/adapter/client.py
@@ -26,7 +26,7 @@ def get_connection(
     uri=None,
     mongodb=None,
     authdb=None,
-    timeout=20,
+    timeout=30000,  # default in MongoDB documentation
     *args,
     **kwargs,
 ):


### PR DESCRIPTION
Give Scout more time to connect to the database, by increasing the serverSelectionTimeoutMS to 30K, default value according to the MongoDB documentation (https://docs.mongodb.com/manual/reference/connection-string/#server-selection-and-discovery-options)

**How to test**:
1. Start a default instance of Scout and make sure it's populated with data and pages work as usual.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
 