### PR TITLE
Update requirements to use flask-ldap3-login>=0.9.17 instead of freezing WTForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Enforce same individual ids, display names and affected status when updating a case
 - Display and download HPO gene panels' gene in italics
 - Improved documentation for connecting to loqusdb instances (including loqusdbapi)
+- Update requirements to use flask-ldap3-login>=0.9.17 instead of freezing WTForm
 ### Fixed
 - Use of deprecated TextField after the upgrade of WTF to v3.0
 - Freeze to WTForms to version < 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Flask-Bootstrap
 Flask-CORS
 path.py
 Flask-Markdown
-WTForms<3 # Remove this dependency after flask_ldap3_login issue #75 is fixed
 Flask-WTF
 Flask-Mail
 Flask-WeasyPrint
@@ -26,7 +25,7 @@ cryptography<3.4
 
 # webapp login
 authlib
-flask_ldap3_login
+flask_ldap3_login>=0.9.17
 flask_login
 
 # Parsing


### PR DESCRIPTION
flask-ldap3-login was just released to fix [this dependency issue](https://github.com/nickw444/flask-ldap3-login/issues/75#issuecomment-970715102) caused by the upgrade of WTForm to v3.0. This is a better fix than what we have for [the issue in Scout](https://github.com/Clinical-Genomics/scout/issues/2961) I think!

**How to test**:
1. Tested here: https://github.com/nickw444/flask-ldap3-login/issues/75#issuecomment-970385810

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
