### PR TITLE
Reduce complexity of panels endpoint by moving some code to the panels controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Enforce same individual ids, display names and affected status when updating a case
 - Display and download HPO gene panels' gene in italics
 - Improved documentation for connecting to loqusdb instances (including loqusdbapi)
+- Reduce complexity of `panels` endpoint moving some code to the panels controllers
 ### Fixed
 - Use of deprecated TextField after the upgrade of WTF to v3.0
 - Freeze to WTForms to version < 3

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -3,7 +3,7 @@ import datetime as dt
 import logging
 import operator
 
-from flask import flash, redirect, url_for
+from flask import abort, flash, redirect, url_for
 from flask_login import current_user
 
 from scout.build.panel import build_panel
@@ -12,6 +12,18 @@ from scout.parse.panel import parse_genes
 log = logging.getLogger(__name__)
 
 INHERITANCE_MODELS = ["ar", "ad", "mt", "xr", "xd", "x", "y"]
+
+
+def shall_display_panel(panel_obj, user):
+    """Check if panel shall be displayed based on display status and user previleges."""
+    is_visible = not panel_obj.get("hidden", False)
+    return is_visible or panel_write_granted(panel_obj, user)
+
+
+def panel_write_granted(panel_obj, user):
+    return any(
+        ["maintainer" not in panel_obj, user.is_admin, user._id in panel_obj.get("maintainer")]
+    )
 
 
 def panel_create_or_update(store, request):

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -34,7 +34,7 @@ def panel_create_or_update(store, request):
         request(flask.request) request sent by browser form to the /panels endpoint
 
     """
-    # Try to read the csv file containing genes info
+    # Try to read the csv or txt file containing genes info
     csv_file = request.files["csv_file"]
     content = csv_file.stream.read()
     lines = None

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -13,6 +13,72 @@ log = logging.getLogger(__name__)
 INHERITANCE_MODELS = ["ar", "ad", "mt", "xr", "xd", "x", "y"]
 
 
+def panel_create_or_update(store, request):
+    """Process a user request to create a new gene panel
+
+    Args:
+        store(scout.adapter.MongoAdapter)
+        request(flask.request) request sent by browser form to the /panels endpoint
+
+    Returns:
+    """
+    # Try to read the csv file containing genes info
+    csv_file = request.files["csv_file"]
+    content = csv_file.stream.read()
+    lines = None
+    try:
+        if b"\n" in content:
+            lines = content.decode("utf-8-sig", "ignore").split("\n")
+        else:
+            lines = content.decode("windows-1252").split("\r")
+    except Exception as err:
+        flash(
+            "Something went wrong while parsing the panel CSV file! ({})".format(err),
+            "danger",
+        )
+        return redirect(request.referrer)
+
+    # check if a new panel should be created or the user is modifying an existing one
+    new_panel_name = request.form.get("new_panel_name")
+    if new_panel_name:  # create a new panel
+        new_panel_id = controllers.new_panel(
+            store=store,
+            institute_id=request.form["institute"],
+            panel_name=new_panel_name,
+            display_name=request.form["display_name"] or new_panel_name.replace("_", " "),
+            csv_lines=lines,
+            maintainer=[current_user._id],
+            description=request.form["description"],
+        )
+        if new_panel_id is None:
+            return redirect(request.referrer)
+
+        flash("new gene panel added, {}!".format(new_panel_name), "success")
+        return redirect(url_for("panels.panel", panel_id=new_panel_id))
+
+    # modify an existing panel
+    update_option = request.form["modify_option"]
+
+    panel_obj = store.gene_panel(request.form["panel_name"], include_hidden=current_user.is_admin)
+    if panel_obj is None:
+        return abort(404, "gene panel not found: {}".format(request.form["panel_name"]))
+
+    if panel_write_granted(panel_obj, current_user):
+        panel_obj = controllers.update_panel(
+            store=store,
+            panel_name=request.form["panel_name"],
+            csv_lines=lines,
+            option=update_option,
+        )
+    else:
+        flash(
+            "Permission denied: please ask a panel maintainer or admin for help.",
+            "danger",
+        )
+
+    return redirect(url_for("panels.panel", panel_id=panel_obj["_id"]))
+
+
 def panel(store, panel_obj):
     """Preprocess a panel of genes."""
     panel_obj["institute"] = store.institute(panel_obj["institute"])

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -31,14 +31,12 @@ def panels():
             "panel_name"
         )
     ]
-
     panel_versions = {}
     for name in panel_names:
         panels = store.gene_panels(panel_id=name, include_hidden=True)
         panel_versions[name] = [
             panel_obj for panel_obj in panels if shall_display_panel(panel_obj, current_user)
         ]
-
     panel_groups = []
     for institute_obj in institutes:
         institute_panels = (
@@ -47,7 +45,6 @@ def panels():
             if shall_display_panel(panel_obj, current_user)
         )
         panel_groups.append((institute_obj, institute_panels))
-
     return dict(
         panel_groups=panel_groups,
         panel_names=panel_names,

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -22,66 +22,6 @@ def panels():
     """Show all panels for a user"""
     if request.method == "POST":
         controllers.panel_create_or_update(store, request)
-        """
-        # update an existing panel
-        csv_file = request.files["csv_file"]
-        content = csv_file.stream.read()
-        lines = None
-        try:
-            if b"\n" in content:
-                lines = content.decode("utf-8-sig", "ignore").split("\n")
-            else:
-                lines = content.decode("windows-1252").split("\r")
-        except Exception as err:
-            flash(
-                "Something went wrong while parsing the panel CSV file! ({})".format(err),
-                "danger",
-            )
-            return redirect(request.referrer)
-
-        new_panel_name = request.form.get("new_panel_name")
-        if new_panel_name:  # create a new panel
-            new_panel_id = controllers.new_panel(
-                store=store,
-                institute_id=request.form["institute"],
-                panel_name=new_panel_name,
-                display_name=request.form["display_name"] or new_panel_name.replace("_", " "),
-                csv_lines=lines,
-                maintainer=[current_user._id],
-                description=request.form["description"],
-            )
-            if new_panel_id is None:
-                return redirect(request.referrer)
-
-            flash("new gene panel added, {}!".format(new_panel_name), "success")
-            return redirect(url_for("panels.panel", panel_id=new_panel_id))
-
-
-        # modify an existing panel
-        update_option = request.form["modify_option"]
-
-        panel_obj = store.gene_panel(
-            request.form["panel_name"], include_hidden=current_user.is_admin
-        )
-        if panel_obj is None:
-            return abort(404, "gene panel not found: {}".format(request.form["panel_name"]))
-
-        if panel_write_granted(panel_obj, current_user):
-            panel_obj = controllers.update_panel(
-                store=store,
-                panel_name=request.form["panel_name"],
-                csv_lines=lines,
-                option=update_option,
-            )
-        else:
-            flash(
-                "Permission denied: please ask a panel maintainer or admin for help.",
-                "danger",
-            )
-
-        return redirect(url_for("panels.panel", panel_id=panel_obj["_id"]))
-
-        """
 
     institutes = list(user_institutes(store, current_user))
     panel_names = [

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -19,8 +19,10 @@ panels_bp = Blueprint("panels", __name__, template_folder="templates")
 @panels_bp.route("/panels", methods=["GET", "POST"])
 @templated("panels/panels.html")
 def panels():
-    """Show all panels for a case."""
+    """Show all panels for a user"""
     if request.method == "POST":
+        controllers.panel_create_or_update(store, request)
+        """
         # update an existing panel
         csv_file = request.files["csv_file"]
         content = csv_file.stream.read()
@@ -54,6 +56,7 @@ def panels():
             flash("new gene panel added, {}!".format(new_panel_name), "success")
             return redirect(url_for("panels.panel", panel_id=new_panel_id))
 
+
         # modify an existing panel
         update_option = request.form["modify_option"]
 
@@ -77,6 +80,8 @@ def panels():
             )
 
         return redirect(url_for("panels.panel", panel_id=panel_obj["_id"]))
+
+        """
 
     institutes = list(user_institutes(store, current_user))
     panel_names = [


### PR DESCRIPTION
Codefactor check is flagging the current  `panels` endpoint as too complex and this function can be easily simplified!

It's just a refactor PR, with no code added or removed.

**How to test**:
1. Start a local instance of Scout and try to add and modify genes for a gene panel

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
