### PR TITLE
Fix to cancer variants page crashing when default gene panel was deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cli command loading demo data in docker-compose when case custom images exist and is None
 - Increased MongoDB connection serverSelectionTimeoutMS parameter to 30K (default value according to MongoDB documentation)
 - Better differentiate old obs counts 0 vs N/A
+- Broken cancer variants page when default gene panel was deleted 
 
 ## [4.41.1]
 ### Fixed

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -297,6 +297,7 @@ class PanelHandler:
                         panel_name, panel_version
                     )
                 )
+                continue
 
             for gene in panel_obj["genes"]:
                 hgnc_id = gene["hgnc_id"]
@@ -306,8 +307,6 @@ class PanelHandler:
                     continue
 
                 gene_dict[hgnc_id].add(panel_name)
-
-        LOG.info("Gene to panels done")
 
         return gene_dict
 

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -291,7 +291,6 @@ class PanelHandler:
             panel_version = panel_info["version"]
             panel_obj = self.gene_panel(panel_name, version=panel_version)
             if not panel_obj:
-                ## Raise exception here???
                 LOG.warning(
                     "Panel: {0}, version {1} does not exist in database".format(
                         panel_name, panel_version


### PR DESCRIPTION
Fix #2982 

**How to test-->Locally**:
1. On master branch, create a new gene panel which contains only gene TP53. Name it for instance `TP53_panel`.
2. Edit the load config file for the demo cancer case by adding these 2 lines:
```
default_gene_panels: [TP53_panel]
gene_panels: [TP53_panel]
```
3. Load demo cancer case into scout demo with the command: `scout --demo load case scout/demo/cancer.load_config.yaml`
4. Go the the demo cancer case's variants page and check it works. 
5. From MongoDB compass, remove the new gene panel.
6. Reload the cancer variants page and the page will crash
7. Switch to this branch and the page should load instead.


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
