### PR TITLE
Fix startswith typo in tx_overview function (variant controllers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cli command loading demo data in docker-compose when case custom images exist and is None
 - Increased MongoDB connection serverSelectionTimeoutMS parameter to 30K (default value according to MongoDB documentation)
 - Better differentiate old obs counts 0 vs N/A
-- Broken cancer variants page when default gene panel was deleted 
+- Broken cancer variants page when default gene panel was deleted
+- Typo in tx_overview function in variant controllers file
 
 ## [4.41.1]
 ### Fixed

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -83,7 +83,7 @@ def tx_overview(variant_obj):
                 decorated_tx = None
                 if ovw_tx["mane"] and ovw_tx["mane"].startswith(refseq_id):
                     decorated_tx = ovw_tx["mane"]
-                elif ovw_tx["mane_plus"] and ovw_tx["mane_plus"].starstwith(refseq_id):
+                elif ovw_tx["mane_plus"] and ovw_tx["mane_plus"].startswith(refseq_id):
                     decorated_tx = ovw_tx["mane_plus"]
                 elif refseq_id.startswith("XM"):
                     ovw_tx["muted_refseq_ids"].append(refseq_id)


### PR DESCRIPTION
This PR fixes a typo tx_overview function (variant controllers) that is causing a bug in current master. Thanks @mhkc for notifying the problem!!! 

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
