### PR TITLE
Fix removing old gene panels with no 'maintainer' key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Typo in tx_overview function in variant controllers file
 - Fixed loqusdbapi SV search URL
 - SV variants filtering using Decipher criterion
+- Removing old gene panels that don't contain the `maintainer` key.
 
 ## [4.41.1]
 ### Fixed

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -22,7 +22,7 @@ def shall_display_panel(panel_obj, user):
 
 def panel_write_granted(panel_obj, user):
     return any(
-        ["maintainer" not in panel_obj, user.is_admin, user._id in panel_obj.get("maintainer")]
+        ["maintainer" not in panel_obj, user.is_admin, user._id in panel_obj.get("maintainer",[])]
     )
 
 
@@ -73,7 +73,7 @@ def panel_create_or_update(store, request):
 
     panel_obj = store.gene_panel(request.form["panel_name"], include_hidden=current_user.is_admin)
     if panel_obj is None:
-        return abort(404, "gene panel not found: {}".format(request.form["panel_name"]))
+        return redirect(request.referrer)
 
     if panel_write_granted(panel_obj, current_user):
         panel_obj = update_panel(

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -141,7 +141,7 @@ def panel_delete(panel_id):
     panel_obj = store.gene_panel(panel_id) or store.panel(panel_id)
     if panel_obj is None:
         flash(
-            f"Panel object with id '{panel_obj}' was not found.",
+            f"Panel object with id '{panel_id}' was not found.",
             "danger",
         )
         return redirect(request.referrer)

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -139,9 +139,12 @@ def panel_update(panel_id):
 def panel_delete(panel_id):
     """Remove an existing panel."""
     panel_obj = store.gene_panel(panel_id) or store.panel(panel_id)
-    # abort when trying to hide an already hidden panel
-    if panel_obj.get("hidden", False):
-        abort(404)
+    if panel_obj is None:
+        flash(
+            f"Panel object with id '{panel_obj}' was not found.",
+            "danger",
+        )
+        return redirect(request.referrer)
 
     if controllers.panel_write_granted(panel_obj, current_user):
         LOG.info("Mark gene panel: %s as deleted (hidden)" % panel_obj["display_name"])


### PR DESCRIPTION
Fix #2995 

**How to test**:
1. Locally, from within the MongoDB compass, remove the 'maintainer' key from the demo panel. Try removing the panel
2. On clinical-db, try removing one of the old panels that has no 'maintainer' key

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
