### PR TITLE
Avoid case page crash on Phenomizer queries timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Avoid case page crash on Phenomizer queries timeout
 
 
 ## [4.42]

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -782,8 +782,8 @@ def hpo_diseases(username, password, hpo_ids, p_value_treshold=1):
         results = query_phenomizer.query(username, password, *hpo_ids)
         diseases = [result for result in results if result["p_value"] <= p_value_treshold]
         return diseases
-    except SystemExit:
-        return None
+    except RuntimeError:
+        flash("Could not establish a conection to Phenomizer", "danger")
 
 
 def rerun(store, mail, current_user, institute_id, case_name, sender, recipient):

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -420,12 +420,13 @@ def phenotypes_actions(institute_id, case_name):
         username = current_app.config["PHENOMIZER_USERNAME"]
         password = current_app.config["PHENOMIZER_PASSWORD"]
         diseases = controllers.hpo_diseases(username, password, hpo_ids)
-        return render_template(
-            "cases/diseases.html",
-            diseases=diseases,
-            institute=institute_obj,
-            case=case_obj,
-        )
+        if diseases:
+            return render_template(
+                "cases/diseases.html",
+                diseases=diseases,
+                institute=institute_obj,
+                case=case_obj,
+            )
 
     if action == "DELETE":
         for hpo_id in hpo_ids:


### PR DESCRIPTION
Fix #2997

The fate of Phenomizer is uncertain, and for the time being the server is down:

![image](https://user-images.githubusercontent.com/28093618/143817595-f20ef9db-a628-4f3f-9415-2a73a9bed349.png)


**How to test**:
1. Locally, reproduce the bug by adding `PHENOMIZER_USERNAME` and `PHENOMIZER_PASSWORD` to the demo config file. You could assign these params any values since, but could also use [the Scout prod ones](https://github.com/Clinical-Genomics/servers/blob/650245a1b7d1b30da0d5da0de1c150216887960f/config/clinical-db.scilifelab.se/scout.conf.py#L24)
2. Start the app and go the demo case page
3. Click on the phenomizer button in the phenotypes panel:
![image](https://user-images.githubusercontent.com/28093618/143817363-6ecdff64-cf3d-4fdf-b54c-b6055ad32cf9.png)

4. The page should crash
5. Switch to this branch and it should display a red flash message with an error instead.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
