### PR TITLE
Speed up OMIM panel creation by collecting only gene info light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Changed
-- Changed `--downloads_folder` param into `--downloads-folder` in update genes command to make it consistent with other cli commands.
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
 - Speed up gene panels creation and update by collecting only light gene info from database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changed `--downloads_folder` param into `--downloads-folder` in update genes command to make it consistent with other cli commands.
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
+- Speed up gene panels creation and update by collecting only light gene info from database
 
 
 ## [4.42]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Changed
+- Changed `--downloads_folder` param into `--downloads-folder` in update genes command to make it consistent with other cli commands.
 ### Fixed
 
 

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -73,7 +73,7 @@ class GeneHandler(object):
         projection["start"] = 1
         projection["end"] = 1
 
-        LOG.debug("Fetching gene %s" % hgnc_identifier)
+        LOG.debug("Fetching gene (light) %s" % hgnc_identifier)
         gene_symbol_obj = self.hgnc_collection.find_one(query, projection)
         if not gene_symbol_obj:
             return None

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -58,13 +58,12 @@ class PanelHandler:
         """
         institute = institute or "cust002"
         existing_panel = self.gene_panel(panel_id="OMIM-AUTO")
-        if not existing_panel:
-            LOG.warning("OMIM-AUTO does not exists in database")
-            LOG.info("Creating a first version")
 
         version = 1.0
         if existing_panel:
             version = float(math.floor(existing_panel["version"]) + 1)
+        else:
+            LOG.warning("OMIM-AUTO does not exists in database. It will be created now.")
 
         LOG.info("Setting version to %s", version)
 

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -48,9 +48,9 @@ def build_gene(gene_info, adapter):
             "Gene {0} is missing hgnc id. Panel genes has to have hgnc_id".format(symbol)
         )
 
-    hgnc_gene = adapter.hgnc_gene(hgnc_identifier=hgnc_id, build="37") or adapter.hgnc_gene(
-        hgnc_identifier=hgnc_id, build="38"
-    )
+    hgnc_gene = adapter.hgnc_gene_caption(
+        hgnc_identifier=hgnc_id, build="37"
+    ) or adapter.hgnc_gene_caption(hgnc_identifier=hgnc_id, build="38")
     if hgnc_gene is None:
         raise IntegrityError("hgnc_id {0} is not in the gene database!".format(hgnc_id))
 

--- a/scout/commands/update/genes.py
+++ b/scout/commands/update/genes.py
@@ -113,7 +113,7 @@ def fetch_downloaded_resources(resources, downloads_folder, builds):
 )
 @click.option(
     "-f",
-    "--downloads-folder",
+    "--downloads_folder",
     type=click.Path(exists=True, dir_okay=True, readable=True),
     help="specify path to folder where files necessary to update genes are pre-downloaded",
 )

--- a/scout/commands/update/genes.py
+++ b/scout/commands/update/genes.py
@@ -113,7 +113,7 @@ def fetch_downloaded_resources(resources, downloads_folder, builds):
 )
 @click.option(
     "-f",
-    "--downloads_folder",
+    "--downloads-folder",
     type=click.Path(exists=True, dir_okay=True, readable=True),
     help="specify path to folder where files necessary to update genes are pre-downloaded",
 )


### PR DESCRIPTION
Fix #2823

**How to test**:
1. Locally, download the necessary files to update the OMIM panel:
`scout download everything --api-key #########`
1. Update the local database by loading all genes (both 37 and 38):
`scout update genes -f .`
1. From master branch, time the creation of the OMIM panel using the following command:
`time scout --demo update omim --genemap2 genemap2.txt --mim2genes mim2genes.txt --institute cust000`
**Write down how much time it took**
1. From MongoDb compass, remove the newly created panel.
2. Switch to this branch and repeat step 3

**Expected outcome**:
The creating of the panel from this branch should be consistently faster.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
