### PR TITLE
Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
 
 
 ## [4.42]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ query_phenomizer
 Flask-Babel
 livereload
 python-dateutil
-pymongo>=3.7
+pymongo>=3.7,<4.0
 pathlib
 WeasyPrint==0.42.3
 xlsxwriter


### PR DESCRIPTION
Fix #3003

**How to test**:
1. Create a new conda env and install both scout and the requirements-dev libs
2. Run `pytest -x`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
