### PR TITLE
Do not drop genes and txs collections on genes update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Do not drop genes and transcripts collections when updating genes via the command line
 
 ## [4.42.1]
 ### Added

--- a/scout/commands/update/genes.py
+++ b/scout/commands/update/genes.py
@@ -143,10 +143,11 @@ def genes(build, downloads_folder, api_key):
     else:  # If resources have been previosly downloaded, read those file and return their lines
         fetch_downloaded_resources(resources, downloads_folder, builds)
 
-    LOG.warning("Dropping all gene information")
-    adapter.drop_genes(build)
-    LOG.warning("Dropping all transcript information")
-    adapter.drop_transcripts(build)
+    for build in [builds]:
+        LOG.warning("Dropping all gene information")
+        adapter.drop_genes(build)
+        LOG.warning("Dropping all transcript information")
+        adapter.drop_transcripts(build)
 
     # Load genes and transcripts info
     for genome_build in builds:

--- a/scout/commands/update/genes.py
+++ b/scout/commands/update/genes.py
@@ -143,14 +143,14 @@ def genes(build, downloads_folder, api_key):
     else:  # If resources have been previosly downloaded, read those file and return their lines
         fetch_downloaded_resources(resources, downloads_folder, builds)
 
-    for build in [builds]:
-        LOG.warning("Dropping all gene information")
-        adapter.drop_genes(build)
-        LOG.warning("Dropping all transcript information")
-        adapter.drop_transcripts(build)
-
     # Load genes and transcripts info
     for genome_build in builds:
+
+        LOG.warning("Dropping all gene information")
+        adapter.drop_genes(genome_build)
+        LOG.warning("Dropping all transcript information")
+        adapter.drop_transcripts(genome_build)
+
         ensembl_gene_res = (
             resources.get("ensembl_genes_37")
             if genome_build == "37"


### PR DESCRIPTION
Fix #3009 

**How to test**:
1. Locally, with the demo instance.
2. Setup a demo database
3. Genes and txs collections should be indexes:
![image](https://user-images.githubusercontent.com/28093618/144392858-b6048835-b9ff-4d2b-b4ee-2dd0ecc3fd7e.png)

![image](https://user-images.githubusercontent.com/28093618/144392938-2903fc63-88c4-4c1e-bcf2-1e2d58dafe60.png)

4. On main (😃) branch, update genes with the command` scout --demo update genes`
5. Bye indexes (except for _id).
6. Switch to this branch and setup a demo instance from scratch (`scout setup demo`)
7. repeat step 4. 
8. Indexes should not be deleted

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
