### PR TITLE
Specify which collection(s) update/build indexes for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Added
+- Specify which collection(s) update/build indexes for
 ### Changed
 ### Fixed
 

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -31,7 +31,7 @@ class IndexHandler(object):
                     indexes.append(index_name)
         return indexes
 
-    def load_indexes(self):
+    def load_indexes(self, collections=[]):
         """Add the proper indexes to the scout instance.
 
         All indexes are specified in scout/constants/indexes.py
@@ -39,7 +39,7 @@ class IndexHandler(object):
         If this method is utilised when new indexes are defined those should be added
 
         """
-        for collection_name in INDEXES:
+        for collection_name in collections or INDEXES:
             existing_indexes = self.indexes(collection_name)
             indexes = INDEXES[collection_name]
             for index in indexes:
@@ -55,7 +55,7 @@ class IndexHandler(object):
             )
             self.db[collection_name].create_indexes(indexes)
 
-    def update_indexes(self):
+    def update_indexes(self, collections=[]):
         """Update the indexes
 
         If there are any indexes that are not added to the database, add those.
@@ -64,7 +64,7 @@ class IndexHandler(object):
         LOG.info("Updating indexes...")
         nr_updated = 0
 
-        for collection_name in INDEXES:
+        for collection_name in collections or INDEXES:
             existing_indexes = self.indexes(collection_name)
             indexes = INDEXES[collection_name]
             for index in indexes:

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -33,12 +33,11 @@ class IndexHandler(object):
 
     def load_indexes(self, collections=[]):
         """Add the proper indexes to the scout instance.
-
-        All indexes are specified in scout/constants/indexes.py
-
-        If this method is utilised when new indexes are defined those should be added
-
+        Args:
+            collections(list): list of collections to update indexes for.
+                               If empty, load indexes for all collections.
         """
+        LOG.info(f"Adding indexes for collections: {collections or INDEXES}")
         for collection_name in collections or INDEXES:
             existing_indexes = self.indexes(collection_name)
             indexes = INDEXES[collection_name]
@@ -58,10 +57,11 @@ class IndexHandler(object):
     def update_indexes(self, collections=[]):
         """Update the indexes
 
-        If there are any indexes that are not added to the database, add those.
-
+        Args:
+            collections(list): list of collections to update indexes for.
+                               If empty, update indexes for all collections.
         """
-        LOG.info("Updating indexes...")
+        LOG.info(f"Updating indexes for collections: {collections or INDEXES}")
         nr_updated = 0
 
         for collection_name in collections or INDEXES:

--- a/scout/adapter/mongo/index.py
+++ b/scout/adapter/mongo/index.py
@@ -37,7 +37,7 @@ class IndexHandler(object):
             collections(list): list of collections to update indexes for.
                                If empty, load indexes for all collections.
         """
-        LOG.info(f"Adding indexes for collections: {collections or INDEXES}")
+        LOG.info(f"Adding indexes for collections: {collections or list(INDEXES.keys())}")
         for collection_name in collections or INDEXES:
             existing_indexes = self.indexes(collection_name)
             indexes = INDEXES[collection_name]
@@ -61,7 +61,7 @@ class IndexHandler(object):
             collections(list): list of collections to update indexes for.
                                If empty, update indexes for all collections.
         """
-        LOG.info(f"Updating indexes for collections: {collections or INDEXES}")
+        LOG.info(f"Updating indexes for collections: {collections or list(INDEXES.keys())}")
         nr_updated = 0
 
         for collection_name in collections or INDEXES:

--- a/scout/commands/index_command.py
+++ b/scout/commands/index_command.py
@@ -1,8 +1,10 @@
 import logging
+import sys
 
 import click
 from flask.cli import with_appcontext
 
+from scout.constants import INDEXES
 from scout.server.extensions import store
 
 LOG = logging.getLogger(__name__)
@@ -22,13 +24,22 @@ def abort_if_false(ctx, param, value):
     prompt="This will delete and rebuild all indexes(if not --update). Are you sure?",
 )
 @click.option("--update", help="Update the indexes", is_flag=True)
+@click.option(
+    "-c", "--collection", multiple=True, help="Name of collection to update/rebuild the indexes for"
+)
 @with_appcontext
-def index(update):
+def index(update, collection):
     """Create indexes for the database"""
     LOG.info("Running scout index")
     adapter = store
 
+    for coll in collection:
+        if coll in INDEXES:
+            LOG.error(coll)
+            continue
+        sys.exit(f"Collection '{coll}' not found in database")
+
     if update:
-        adapter.update_indexes()
+        adapter.update_indexes(collection)
     else:
-        adapter.load_indexes()
+        adapter.load_indexes(collection)

--- a/scout/commands/index_command.py
+++ b/scout/commands/index_command.py
@@ -21,7 +21,7 @@ def abort_if_false(ctx, param, value):
     is_flag=True,
     callback=abort_if_false,
     expose_value=False,
-    prompt="This will delete and rebuild all indexes(if not --update). Are you sure?",
+    prompt="This will delete and rebuild indexes(if not --update) for the given collections (or the whole database). Are you sure?",
 )
 @click.option("--update", help="Update the indexes", is_flag=True)
 @click.option(
@@ -33,11 +33,10 @@ def index(update, collection):
     LOG.info("Running scout index")
     adapter = store
 
-    for coll in collection:
-        if coll in INDEXES:
-            LOG.error(coll)
+    for collx in collection:
+        if collx in INDEXES:
             continue
-        sys.exit(f"Collection '{coll}' not found in database")
+        sys.exit(f"Collection '{collx}' not found in database")
 
     if update:
         adapter.update_indexes(collection)

--- a/tests/commands/test_index_cmd.py
+++ b/tests/commands/test_index_cmd.py
@@ -14,16 +14,16 @@ def test_index(mock_app):
     result = runner.invoke(cli, ["index"])
     # It should print confirm message
     assert (
-        "This will delete and rebuild all indexes(if not --update). Are you sure? [y/N]"
+        "This will delete and rebuild indexes(if not --update) for the given collections (or the whole database). Are you sure?"
         in result.output
     )
 
     # Provide confirm command to CLI (say yes)
-    result = runner.invoke(cli, ["index"], input="y")
+    result = runner.invoke(cli, ["index", "-c", "hgnc_gene"], input="y")
     assert result.exit_code == 0
     assert "INFO creating indexes" in result.output
 
     # Provide confirm command and update option
-    result = runner.invoke(cli, ["index", "--update"], input="y")
+    result = runner.invoke(cli, ["index", "--update", "-c", "hgnc_gene"], input="y")
     assert result.exit_code == 0
     assert "INFO All indexes in place" in result.output


### PR DESCRIPTION
Update/build indexes for specific collections, without doing it for all collections.

Example: scout (--demo) index --update -c gene -c transcript --update

**How to test**:
 Locally, we have a goof bug to test the PR with --> #3009
- [ ] From this branch, run the update genes command (`scout --demo update genes`)
- [ ] Note that indexes from genes and transcripts collections are dropped and not recreated
- [ ] Run `scout --demo index  -c gene -c transcript`
- [ ] HAHA, why didn't it work?, repeat the command with the fix
- [ ] The indexes should be created only for those collections

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
