### PR TITLE
Do not drop HPO terms collection when updating HPO terms via the cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
-
+- Do not drop HPO terms collection when updating HPO terms via the command line
 
 ## [4.43]
 ### Added

--- a/scout/commands/update/hpo.py
+++ b/scout/commands/update/hpo.py
@@ -43,8 +43,9 @@ def hpo(hpoterms, hpo_to_genes):
     adapter = store
 
     LOG.info("Dropping HPO terms")
-    adapter.hpo_term_collection.drop()
+    adapter.hpo_term_collection.delete_many({})
     LOG.debug("HPO terms dropped")
+
     if hpoterms:
         hpoterms = get_file_handle(hpoterms)
     if hpo_to_genes:


### PR DESCRIPTION
Fix #3015 

**How to test**:
1. Locally, set up a demo instance
2. Check that the hpo terms collection has several indexes
3. On main branch, run `scout --demo update hpo`
4. Make sure indexes are gone (except for _id)
5. Repeat from one from this branch
6. After updating the hpo terms, indexes should be retained

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
