### PR TITLE
Do not drop disease terms collection when updating diseases via cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Fixed
 - Do not drop HPO terms collection when updating HPO terms via the command line
+- Do not drop disease (OMIM) terms collection when updating diseases via the command line
 
 ## [4.43]
 ### Added

--- a/scout/commands/update/disease.py
+++ b/scout/commands/update/disease.py
@@ -102,7 +102,7 @@ def diseases(downloads_folder, api_key):
     _check_resources(resources)
 
     LOG.info("Dropping DiseaseTerms")
-    adapter.disease_term_collection.drop()
+    adapter.disease_term_collection.delete_many({})
     LOG.debug("DiseaseTerms dropped")
 
     load_disease_terms(


### PR DESCRIPTION
There are no indexes for the the OMIM terms collection, so this is more to avoid a bug when we introduce indexes for it.

**How to test**:
1. From this branch, run the command `scout --demo update diseases --api-key ############`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
