### PR TITLE
Fix variants searching by symbol and alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Fix filter variants by genes
 
 ## [4.43.1]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -467,7 +467,7 @@ class CaseHandler(object):
         elif hgnc_symbols:
             LOG.info("Fetching genes by hgnc symbols")
             for symbol in hgnc_symbols:
-                those_genes = self.gene_by_alias(symbol=symbol, build=build)
+                those_genes = self.gene_aliases(symbol=symbol, build=build)
                 for gene_obj in those_genes:
                     res.append(gene_obj)
 

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -316,13 +316,21 @@ class GeneHandler(object):
         LOG.info("All genes fetched")
         return hgnc_dict
 
+    def gene_by_symbol_or_aliases(self, symbol, build="37"):
+        """Return an iterable with only one gene is found with a given symbol or a list of genes
+           with the provided symbol contained in the aliases list.
+        Args:
+            symbol(str)
+            build(str)
+
+        Returns:
+            res(dict or pymongo.Cursor(dict)): return a gene dictionary or a cursor with gene dictionaries
+        """
+        res = self.hgnc_collection.find_one({"hgnc_symbol": symbol, "build": str(build)})
+        return res or self.gene_by_alias(symbol, build="37")
+
     def gene_by_alias(self, symbol, build="37"):
-        """Return an iterable with hgnc_genes.
-
-        If the gene symbol is listed as primary the iterable will only have
-        one result. If not the iterable will include all hgnc genes that have
-        the symbol as an alias.
-
+        """Return an iterable with hgnc_genes which have the provided symbol in the gene aliases
         Args:
             symbol(str)
             build(str)
@@ -332,12 +340,7 @@ class GeneHandler(object):
         """
         LOG.debug("Fetch gene by symbol if possible: {}".format(symbol))
 
-        res = self.hgnc_collection.find({"hgnc_symbol": symbol, "build": str(build)})
-
-        if self.hgnc_collection.find_one({"aliases": symbol, "build": str(build)}) is None:
-            LOG.debug("No gene with symbol {} was found. Attempting an alias.".format(symbol))
-            res = self.hgnc_collection.find({"aliases": symbol, "build": str(build)})
-
+        res = self.hgnc_collection.find({"aliases": symbol, "build": str(build)})
         return res
 
     def genes_by_alias(self, build="37", genes=None):

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -324,10 +324,13 @@ class GeneHandler(object):
             build(str)
 
         Returns:
-            res(dict or pymongo.Cursor(dict)): return a gene dictionary or a cursor with gene dictionaries
+            res(list or pymongo.Cursor(dict)): return a list with one gene or a cursor with several gene dictionaries
         """
         res = self.hgnc_collection.find_one({"hgnc_symbol": symbol, "build": str(build)})
-        return res or self.gene_by_alias(symbol, build="37")
+        if res:
+            return [res]
+        else:
+            return self.gene_by_alias(symbol, build="37")
 
     def gene_by_alias(self, symbol, build="37"):
         """Return an iterable with hgnc_genes which have the provided symbol in the gene aliases

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -317,8 +317,8 @@ class GeneHandler(object):
         return hgnc_dict
 
     def gene_by_symbol_or_aliases(self, symbol, build="37"):
-        """Return an iterable with only one gene is found with a given symbol or a list of genes
-           with the provided symbol contained in the aliases list.
+        """Return an iterable with only one gene when gene with a given symbol if found
+           or a cursor with genes where the provided symbol is among the aliases.
         Args:
             symbol(str)
             build(str)

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -173,8 +173,7 @@ class GeneHandler(object):
         return self.hgnc_collection.find({"aliases": hgnc_symbol, **build_query})
 
     def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
-        """Find one hgnc genes that match a hgnc symbol. Replaces deprecated
-        pymongo.cursor.count()
+        """Find one hgnc genes that match a hgnc symbol.
 
         Check both hgnc_symbol and aliases
 
@@ -186,9 +185,7 @@ class GeneHandler(object):
         """
 
         LOG.debug("Find one genes with symbol %s" % hgnc_symbol)
-        return self.hgnc_collection.find_one(
-            filter={"build": build, "hgnc_symbol": hgnc_symbol, "aliases": hgnc_symbol}
-        )
+        return self.hgnc_collection.find_one(filter={"build": build, "aliases": hgnc_symbol})
 
     def get_query_alias_or_id(self, hgnc_symbol, build):
         """Return query to search for hgnc-symbol or aliases"""

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -330,9 +330,9 @@ class GeneHandler(object):
         if res:
             return [res]
 
-        return self.gene_by_alias(symbol, build="37")
+        return self.gene_aliases(symbol, build="37")
 
-    def gene_by_alias(self, symbol, build="37"):
+    def gene_aliases(self, symbol, build="37"):
         """Return an iterable with hgnc_genes which have the provided symbol in the gene aliases
         Args:
             symbol(str)

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -341,8 +341,6 @@ class GeneHandler(object):
         Returns:
             res(pymongo.Cursor(dict))
         """
-        LOG.debug("Fetch gene by symbol if possible: {}".format(symbol))
-
         res = self.hgnc_collection.find({"aliases": symbol, "build": str(build)})
         return res
 

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -329,8 +329,8 @@ class GeneHandler(object):
         res = self.hgnc_collection.find_one({"hgnc_symbol": symbol, "build": str(build)})
         if res:
             return [res]
-        else:
-            return self.gene_by_alias(symbol, build="37")
+
+        return self.gene_by_alias(symbol, build="37")
 
     def gene_by_alias(self, symbol, build="37"):
         """Return an iterable with hgnc_genes which have the provided symbol in the gene aliases

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -173,7 +173,7 @@ class GeneHandler(object):
         return self.hgnc_collection.find({"aliases": hgnc_symbol, **build_query})
 
     def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
-        """Find one hgnc genes that match a hgnc symbol. Replaces depricated
+        """Find one hgnc genes that match a hgnc symbol. Replaces deprecated
         pymongo.cursor.count()
 
         Check both hgnc_symbol and aliases
@@ -186,7 +186,9 @@ class GeneHandler(object):
         """
 
         LOG.debug("Find one genes with symbol %s" % hgnc_symbol)
-        return self.hgnc_collection.find_one(filter={"build": build, "aliases": hgnc_symbol})
+        return self.hgnc_collection.find_one(
+            filter={"build": build, "hgnc_symbol": hgnc_symbol, "aliases": hgnc_symbol}
+        )
 
     def get_query_alias_or_id(self, hgnc_symbol, build):
         """Return query to search for hgnc-symbol or aliases"""

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -108,7 +108,7 @@ def variants(
         if hgnc_id:
             gene_obj = adapter.hgnc_gene(hgnc_id, case_obj["genome_build"])
         if hgnc_symbol:
-            for res in adapter.gene_by_alias(hgnc_symbol, case_obj["genome_build"]):
+            for res in adapter.gene_aliases(hgnc_symbol, case_obj["genome_build"]):
                 gene_obj = res
         if not gene_obj:
             LOG.warning("The gene could not be found")

--- a/scout/commands/view/aliases.py
+++ b/scout/commands/view/aliases.py
@@ -19,7 +19,7 @@ def aliases(build, symbol):
 
     if symbol:
         alias_genes = {}
-        res = adapter.gene_by_alias(symbol, build=build)
+        res = adapter.gene_aliases(symbol, build=build)
         for gene_obj in res:
             hgnc_id = gene_obj["hgnc_id"]
             # Collect the true symbol given by hgnc

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1063,10 +1063,10 @@ def check_form_gene_symbols(
     Returns:
         updated_hgnc_symbols(list): List of gene symbols that are found in database and are up to date
     """
-    non_clinical_symbols = []
-    not_found_symbols = []
-    outdated_symbols = []
-    updated_hgnc_symbols = []
+    non_clinical_symbols = set()
+    not_found_symbols = set()
+    outdated_symbols = set()
+    updated_hgnc_symbols = set()
 
     clinical_hgnc_ids = store.clinical_hgnc_ids(case_obj)
     clinical_symbols = store.clinical_symbols(case_obj)
@@ -1076,7 +1076,7 @@ def check_form_gene_symbols(
         hgnc_genes = list(store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build))
 
         if not hgnc_genes:
-            not_found_symbols.append(hgnc_symbol)
+            not_found_symbols.add(hgnc_symbol)
             continue
 
         for hgnc_gene in hgnc_genes:
@@ -1084,7 +1084,7 @@ def check_form_gene_symbols(
 
             # collect queried symbols for both clinical variants and research variants
             if hgnc_gene["hgnc_id"] in clinical_hgnc_ids or is_clinical is False:
-                updated_hgnc_symbols.append(gene_symbol)
+                updated_hgnc_symbols.add(gene_symbol)
 
                 # research variants
                 if is_clinical is False:
@@ -1092,10 +1092,10 @@ def check_form_gene_symbols(
 
                 # warn if queried symbol or corresponding gene symbol in panel is outdated
                 if hgnc_symbol not in clinical_symbols:
-                    outdated_symbols.append(hgnc_symbol)
+                    outdated_symbols.add(hgnc_symbol)
 
             else:
-                non_clinical_symbols.append(hgnc_symbol)
+                non_clinical_symbols.add(hgnc_symbol)
 
     errors = {
         "non_clinical_symbols": {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1077,20 +1077,24 @@ def check_form_gene_symbols(
 
         if not hgnc_genes:
             not_found_symbols.append(hgnc_symbol)
+            continue
 
         for hgnc_gene in hgnc_genes:
-            if is_clinical is False:  # research variants
-                updated_hgnc_symbols.append(hgnc_symbol)
-            elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
+            gene_symbol = hgnc_gene.get("hgnc_symbol")
+
+            # collect queried symbols for both clinical variants and research variants
+            if hgnc_gene["hgnc_id"] in clinical_hgnc_ids or is_clinical is False:
+                updated_hgnc_symbols.append(gene_symbol)
+
+                # research variants
+                if is_clinical is False:
+                    continue
+
+                # warn if queried symbol or corresponding gene symbol in panel is outdated
                 if hgnc_symbol not in clinical_symbols:
-                    # clinical symbols from gene panels might not be up to date with latest gene names
-                    # but their HGNC id would still match
                     outdated_symbols.append(hgnc_symbol)
-                    if hgnc_gene.get("hgnc_symbol"):
-                        updated_hgnc_symbols.append(hgnc_gene.get("hgnc_symbol"))
-                else:
-                    updated_hgnc_symbols.append(hgnc_symbol)
-            else:  # clinical variants
+
+            else:
                 non_clinical_symbols.append(hgnc_symbol)
 
     errors = {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1095,7 +1095,7 @@ def check_form_gene_symbols(
                     outdated_symbols.add(hgnc_symbol)
 
             else:
-                non_clinical_symbols.add(hgnc_symbol)
+                non_clinical_symbols.add(gene_symbol)
 
     errors = {
         "non_clinical_symbols": {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1075,9 +1075,7 @@ def check_form_gene_symbols(
         hgnc_genes = store.hgnc_genes(hgnc_symbol=hgnc_symbol, build=genome_build)
 
         for hgnc_gene in hgnc_genes:
-            if hgnc_gene is None:
-                not_found_symbols.append(hgnc_symbol)
-            elif is_clinical is False:  # research variants
+            if is_clinical is False:  # research variants
                 updated_hgnc_symbols.append(hgnc_symbol)
             elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
                 updated_hgnc_symbols.append(hgnc_symbol)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1107,7 +1107,7 @@ def check_form_gene_symbols(
             "label": "warning",
         },
         "outdated_symbols": {
-            "message": "Gene panel versions used for loading variants of this case (clinical list) contain outdated gene symbols. The current HGNC id was found on the clinical list.",
+            "message": "Outdated gene symbols either provided in search or found in the panels used for the analysis.",
             "gene_list": outdated_symbols,
             "label": "info",
         },

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1073,17 +1073,20 @@ def check_form_gene_symbols(
 
     for hgnc_symbol in hgnc_symbols:
         # Retrieve a gene with "hgnc_symbol" as hgnc symbol or a list of genes where hgnc_symbol is among the aliases
-        hgnc_genes = list(store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build))
+        hgnc_genes = store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build)
 
-        if not hgnc_genes:
-            not_found_symbols.add(hgnc_symbol)
-            continue
-
-        if len(hgnc_genes) > 1:  # Gene was not found using provided symbol, aliases were returned
+        if (
+            isinstance(hgnc_genes, list) is False
+        ):  # Gene was not found using provided symbol, aliases were returned
+            hgnc_genes = list(hgnc_genes)
             flash(
                 f"Could not find a gene with symbol '{hgnc_symbol}'. Search was extended to genes using symbol as an alias.",
                 "warning",
             )
+
+        if not hgnc_genes:
+            not_found_symbols.add(hgnc_symbol)
+            continue
 
         for hgnc_gene in hgnc_genes:
             gene_symbol = hgnc_gene.get("hgnc_symbol")

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1072,7 +1072,10 @@ def check_form_gene_symbols(
     clinical_symbols = store.clinical_symbols(case_obj)
 
     for hgnc_symbol in hgnc_symbols:
-        hgnc_genes = store.hgnc_genes(hgnc_symbol=hgnc_symbol, build=genome_build)
+        # Retrieve a gene with "hgnc_symbol" as hgnc symbol or a list of genes where hgnc_symbol is among the aliases
+        hgnc_genes = store.gene_by_alias(symbol=hgnc_symbol, build=genome_build)
+        if not hgnc_genes:
+            not_found_symbols.append(hgnc_symbol)
 
         for hgnc_gene in hgnc_genes:
             if is_clinical is False:  # research variants

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1082,11 +1082,14 @@ def check_form_gene_symbols(
             if is_clinical is False:  # research variants
                 updated_hgnc_symbols.append(hgnc_symbol)
             elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
-                updated_hgnc_symbols.append(hgnc_symbol)
                 if hgnc_symbol not in clinical_symbols:
                     # clinical symbols from gene panels might not be up to date with latest gene names
                     # but their HGNC id would still match
                     outdated_symbols.append(hgnc_symbol)
+                    if hgnc_gene.get("hgnc_symbol"):
+                        updated_hgnc_symbols.append(hgnc_gene.get("hgnc_symbol"))
+                else:
+                    updated_hgnc_symbols.append(hgnc_symbol)
             else:  # clinical variants
                 non_clinical_symbols.append(hgnc_symbol)
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1072,20 +1072,21 @@ def check_form_gene_symbols(
     clinical_symbols = store.clinical_symbols(case_obj)
 
     for hgnc_symbol in hgnc_symbols:
-        hgnc_gene = store.hgnc_genes_find_one(hgnc_symbol, genome_build)
+        hgnc_genes = store.hgnc_genes(hgnc_symbol=hgnc_symbol, build=genome_build)
 
-        if hgnc_gene is None:
-            not_found_symbols.append(hgnc_symbol)
-        elif is_clinical is False:  # research variants
-            updated_hgnc_symbols.append(hgnc_symbol)
-        elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
-            updated_hgnc_symbols.append(hgnc_symbol)
-            if hgnc_symbol not in clinical_symbols:
-                # clinical symbols from gene panels might not be up to date with latest gene names
-                # but their HGNC id would still match
-                outdated_symbols.append(hgnc_symbol)
-        else:  # clinical variants
-            non_clinical_symbols.append(hgnc_symbol)
+        for hgnc_gene in hgnc_genes:
+            if hgnc_gene is None:
+                not_found_symbols.append(hgnc_symbol)
+            elif is_clinical is False:  # research variants
+                updated_hgnc_symbols.append(hgnc_symbol)
+            elif hgnc_gene["hgnc_id"] in clinical_hgnc_ids:  # clinical variants
+                updated_hgnc_symbols.append(hgnc_symbol)
+                if hgnc_symbol not in clinical_symbols:
+                    # clinical symbols from gene panels might not be up to date with latest gene names
+                    # but their HGNC id would still match
+                    outdated_symbols.append(hgnc_symbol)
+            else:  # clinical variants
+                non_clinical_symbols.append(hgnc_symbol)
 
     errors = {
         "non_clinical_symbols": {

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1079,6 +1079,12 @@ def check_form_gene_symbols(
             not_found_symbols.add(hgnc_symbol)
             continue
 
+        if len(hgnc_genes) > 1:  # Gene was not found using provided symbol, aliases were returned
+            flash(
+                f"Could not find a gene with symbol '{hgnc_symbol}'. Search was extended to genes using symbol as an alias.",
+                "warning",
+            )
+
         for hgnc_gene in hgnc_genes:
             gene_symbol = hgnc_gene.get("hgnc_symbol")
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1073,7 +1073,8 @@ def check_form_gene_symbols(
 
     for hgnc_symbol in hgnc_symbols:
         # Retrieve a gene with "hgnc_symbol" as hgnc symbol or a list of genes where hgnc_symbol is among the aliases
-        hgnc_genes = store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build)
+        hgnc_genes = list(store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build))
+
         if not hgnc_genes:
             not_found_symbols.append(hgnc_symbol)
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1073,7 +1073,7 @@ def check_form_gene_symbols(
 
     for hgnc_symbol in hgnc_symbols:
         # Retrieve a gene with "hgnc_symbol" as hgnc symbol or a list of genes where hgnc_symbol is among the aliases
-        hgnc_genes = store.gene_by_alias(symbol=hgnc_symbol, build=genome_build)
+        hgnc_genes = store.gene_by_symbol_or_aliases(symbol=hgnc_symbol, build=genome_build)
         if not hgnc_genes:
             not_found_symbols.append(hgnc_symbol)
 

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -420,6 +420,24 @@ def test_hgnc_symbol_to_gene(adapter):
     assert gene_obj2["hgnc_symbol"] in res
 
 
+def test_gene_by_symbol_or_aliases(adapter, parsed_gene):
+    """Test the function that given a gene symbol returns either the official gene with that symbol
+    or all genes that have the gene as alias"""
+
+    # GIVEN a database containing a gene
+    adapter.load_hgnc_gene(parsed_gene)
+
+    # THEN using the function to search the gene by symbol should return a list with the gene
+    result = adapter.gene_by_symbol_or_aliases(symbol=parsed_gene["hgnc_symbol"])
+    assert type(result) == list
+    assert len(result) == 1
+
+    # GIVEN a gene symbol not found in "hgnc_symbol" field of ant gene
+    # The function should return a pymongo iterable (results of searching genes by alias)
+    result = adapter.gene_by_symbol_or_aliases(symbol="FOO")
+    assert type(result) != list
+
+
 #################### HGNC transcript tests ####################
 
 

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -432,7 +432,7 @@ def test_gene_by_symbol_or_aliases(adapter, parsed_gene):
     assert type(result) == list
     assert len(result) == 1
 
-    # GIVEN a gene symbol not found in "hgnc_symbol" field of ant gene
+    # GIVEN a gene symbol not found in "hgnc_symbol" field of any gene
     # The function should return a pymongo iterable (results of searching genes by alias)
     result = adapter.gene_by_symbol_or_aliases(symbol="FOO")
     assert type(result) != list


### PR DESCRIPTION
Fix #3024. This should fix the bug, but perhaps the functionality might be improved to return all variants that have TAP1 as gene symbol or TAP1 as an alias.

**How to test**:
1. Load on scout stage and look for variants in TAP1 or TAP2 in case that contains these variants

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
