### PR TITLE
Fixed genes API endpoint to return a json formatted error when request is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Genes API endpoint to return a json formatted error when request is malformed
 
 ## [4.43.1]
 ### Added

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -50,6 +50,11 @@ def gene(hgnc_id=None, hgnc_symbol=None):
 def api_genes():
     """Return JSON data about genes."""
     query = request.args.get("query")
-    build = request.args.get("build", "all")
-    json_out = controllers.genes_to_json(store, query, build)
-    return jsonify(json_out)
+    if query is None:
+        return jsonify({"code": 400, "message": "missing 'query' param in request"})
+    build = request.args.get("build", "37")
+    try:
+        json_out = controllers.genes_to_json(store, query, build)
+        return jsonify(json_out)
+    except Exception as ex:
+        return jsonify({"code": 400, "message": ex})

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -57,4 +57,4 @@ def api_genes():
         json_out = controllers.genes_to_json(store, query, build)
         return jsonify(json_out)
     except Exception as ex:
-        return jsonify({"code": 400, "message": ex})
+        return jsonify({"code": 500, "message": ex})


### PR DESCRIPTION
Fix #3028 

**How to test**:
1. Locally, main branch, start the server with `scout --demo serve`
2. In another terminal window, run `curl localhost:5000//api/v1/gene`
3. You should get an error
4. Switch to this branch and repeat step 2
5. You get a formatted json error with a message

6. Check also that request with a gene param works as it should, run: `curl localhost:5000//api/v1/genes?query=pot1`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
