### PR TITLE
Display genes beneath each splice junction track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Changed
+- Display Gene track beneath each sample track when displaying splice junctions in igv browser
 ### Fixed
 
 ## [4.43.1]

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -48,6 +48,8 @@ samples:
     tissue_type: blood
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A1.test.cgh
+    rna_coverage_bigwig: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered.bigWig
+    splice_junctions_bed: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered_sorted.bed.gz
 
   - analysis_type: wes
     sample_id: ADM1059A3
@@ -61,6 +63,8 @@ samples:
     tissue_type: blood
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A3.test.cgh
+    rna_coverage_bigwig: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered.bigWig
+    splice_junctions_bed: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered_sorted.bed.gz
 
 custom_images:
   str:

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -80,7 +80,7 @@
                                 }
                             ]
                           }, // end of sashimi track with data
-                          {
+                          { // genes track
                             name: geneTrack.name,
                             type: geneTrack.type,
                             format: geneTrack.forma,
@@ -93,7 +93,7 @@
                             searchable: true,
                             order: {{counter.loop}},
                             infoURL: "https://www.ncbi.nlm.nih.gov/gene/?term=$$"
-                          },
+                          }, // end of genes track
                         {% endfor %}
                     ] // end of tracks
             };

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -83,7 +83,7 @@
                           { // genes track
                             name: geneTrack.name,
                             type: geneTrack.type,
-                            format: geneTrack.forma,
+                            format: geneTrack.format,
                             sourceType: geneTrack.sourceType,
                             url: geneTrack.url,
                             indexURL: geneTrack.indexURL,

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -88,7 +88,7 @@
                             url: geneTrack.url,
                             indexURL: geneTrack.indexURL,
                             displayMode: geneTrack.displayMode,
-                            visibilityWindow: -1,
+                            visibilityWindow: 300000000,
                             height: 100,
                             searchable: true,
                             order: {{counter.loop}},

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -30,8 +30,17 @@
 
 <script type="text/javascript">
 
-    document.addEventListener("DOMContentLoaded", function () {
+    function getGeneTrack(allTracks){
+        for(var i=0;i<allTracks.length;i++){
+          if (allTracks[i]["name"] === "Genes"){
+            return allTracks[i];
+          }
+        }
+    }
+    var geneTrack = getGeneTrack({{custom_tracks|safe}});
 
+    document.addEventListener("DOMContentLoaded", function () {
+      {% set counter = namespace(loop=0) %}
         var options =
             {
                 // Example of fully specifying a reference GRCh38. Scout is supporting only this for now
@@ -45,28 +54,15 @@
                 locus: '{{ locus }}',
                 tracks:
                     [
-                      {% for custTrack in custom_tracks %}
-                        {% if custTrack.name == "Genes" %}
-                          {
-                            name: "{{ custTrack.name }}",
-                            type: "{{ custTrack.type }}",
-                            format: "{{ custTrack.format }}",
-                            sourceType: "{{ custTrack.sourceType }}",
-                            url: "{{ custTrack.url|replace('%2F','/') }}",
-                            indexURL: "{{ custTrack.indexURL|replace('%2F','/') }}",
-                            displayMode: "{{ custTrack.displayMode }}",
-                            visibilityWindow: 300000000,
-                            order: Number.MAX_VALUE,
-                            searchable: true
-                          },
-                        {% endif %}
-                      {% endfor %}
                         {% for track in tracks %} // sample tracks
+                        {% set counter.loop = counter.loop + 1 %}
                           {
                               type: 'merged',
                               name: '{{ track.name }}',
+                              order: {{counter.loop}},
                               height: 500,
-                              tracks: [
+                              tracks:
+                              [
                                 {
                                   type: 'wig',
                                   format: "bigwig",
@@ -84,6 +80,20 @@
                                 }
                             ]
                           }, // end of sashimi track with data
+                          {
+                            name: geneTrack.name,
+                            type: geneTrack.type,
+                            format: geneTrack.forma,
+                            sourceType: geneTrack.sourceType,
+                            url: geneTrack.url,
+                            indexURL: geneTrack.indexURL,
+                            displayMode: geneTrack.displayMode,
+                            visibilityWindow: -1,
+                            height: 100,
+                            searchable: true,
+                            order: {{counter.loop}},
+                            infoURL: "https://www.ncbi.nlm.nih.gov/gene/?term=$$"
+                          },
                         {% endfor %}
                     ] // end of tracks
             };


### PR DESCRIPTION
Fix #2990 
Display genes track beneath each splice junctions track in igv.js browser instead of just one at the bottom of the page.

**How to test**:
1. Setup a demo database with the modified case config file
2. Go the whichever snv and check the RNA tracks
3. Each one should have a gene track beneath

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
