### PR TITLE
Fix gene api queries input check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Check outdated gene symbols and update with aliases also for cancer
 ### Fixed
 - Genes API endpoint to return a json formatted error when request is malformed
+- Gene api queries input check
 
 ## [4.43.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Genes API endpoint to return a json formatted error when request is malformed
 
 ## [4.43.1]
 ### Added

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -50,6 +50,11 @@ def gene(hgnc_id=None, hgnc_symbol=None):
 def api_genes():
     """Return JSON data about genes."""
     query = request.args.get("query")
-    build = request.args.get("build", "all")
-    json_out = controllers.genes_to_json(store, query, build)
-    return jsonify(json_out)
+    if query is None:
+        return jsonify({"code": 400, "message": "missing 'query' param in request"})
+    build = request.args.get("build", "37")
+    try:
+        json_out = controllers.genes_to_json(store, query, build)
+        return jsonify(json_out)
+    except Exception as ex:
+        return jsonify({"code": 400, "message": ex})

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -50,11 +50,9 @@ def gene(hgnc_id=None, hgnc_symbol=None):
 def api_genes():
     """Return JSON data about genes."""
     query = request.args.get("query")
-    if query is None:
-        return jsonify({"code": 400, "message": "missing 'query' param in request"})
+    if query is None or query.isalnum() is False:
+        return jsonify({"code": 400, "message": "missing or invalid 'query' param in request"})
     build = request.args.get("build", "37")
-    try:
-        json_out = controllers.genes_to_json(store, query, build)
-        return jsonify(json_out)
-    except Exception as ex:
-        return jsonify({"code": 500, "message": ex})
+
+    json_out = controllers.genes_to_json(store, query, build)
+    return jsonify(json_out)

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -57,4 +57,4 @@ def api_genes():
         json_out = controllers.genes_to_json(store, query, build)
         return jsonify(json_out)
     except Exception as ex:
-        return jsonify({"code": 400, "message": ex})
+        return jsonify({"code": 500, "message": ex})


### PR DESCRIPTION
Fix an error when running a gene query using the API with illegal chars query param. Example:

`curl 'localhost:5000/api/v1/genes?query=lalala\&build=sas'`

## How to test locally ##
- Launch a demo app connected to a MongoDB version 4.4
- On main, the query should make the app crash
- Switch to this branch and it should return an empty list instead

**Expected outcome**:
The query should return an empty list

**Review:**
- [ ] code approved by
- [ ] tests executed by
