### PR TITLE
Fix editing gene panels and replace "csv" with "text" on gene panels page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Gene panel crashing on edit action
 
 ## [4.44]
 ### Added

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -35,8 +35,8 @@ def panel_create_or_update(store, request):
 
     """
     # Try to read the csv or txt file containing genes info
-    csv_file = request.files["csv_file"]
-    content = csv_file.stream.read()
+    panel_file = request.files["panel_file"]
+    content = panel_file.stream.read()
     lines = None
     try:
         if b"\n" in content:

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -71,7 +71,7 @@ def panel_create_or_update(store, request):
     # modify an existing panel
     update_option = request.form["modify_option"]
 
-    panel_obj = store.gene_panel(request.form["panel_name"], include_hidden=current_user.is_admin)
+    panel_obj = store.gene_panel(request.form["panel_name"])
     if panel_obj is None:
         return redirect(request.referrer)
 

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -54,11 +54,11 @@
         </div>
         <div class="form-row ">
           <div class="form-group col-sm-2">
-            <label class="col-form-label">CSV file</label>
+            <label class="col-form-label">Gene panel file</label>
           </div>
           <div class="col-sm-5 text-center">
-            <input type="file" name="csv_file" class="custom-file-input" required onchange="this.nextElementSibling.innerText = this.files[0].name">
-            <label class="custom-file-label" for="csv_file">Choose file</label><br>
+            <input type="file" name="panel_file" class="custom-file-input" required onchange="this.nextElementSibling.innerText = this.files[0].name">
+            <label class="custom-file-label" for="panel_file">Choose file</label><br>
             <p class="help-block">How do I format my <a href="https://clinical-genomics.github.io/scout/user-guide/panels/#uploading-a-new-gene-panel-version" target="_blank">gene panel file</a>?</p>
           </div>
           <div class="col-sm-5">
@@ -175,18 +175,18 @@
         <div class="form-group">
           <div class="custom-control custom-radio">
             <input type="radio" id="add_{{panel_obj.display_name}}" name="modify_option" class="custom-control-input" value="add" checked>
-            <label class="custom-control-label" for="add_{{panel_obj.display_name}}">Add genes from CSV file</label>
+            <label class="custom-control-label" for="add_{{panel_obj.display_name}}">Add genes from text file</label>
           </div>
           <div class="custom-control custom-radio">
             <input type="radio" id="replace_{{panel_obj.display_name}}" name="modify_option" class="custom-control-input" value="replace">
-            <label class="custom-control-label" for="replace_{{panel_obj.display_name}}">Replace genes using CSV file</label>
+            <label class="custom-control-label" for="replace_{{panel_obj.display_name}}">Replace genes using text file</label>
           </div>
         </div>
       </div><!--end of col-->
       <div class="col-sm-7">
         <div class="form-group">
-            <input type="file" name="csv_file" class="custom-file-input" required>
-            <label class="custom-file-label" for="csv_file">Choose file</label><br>
+            <input type="file" name="panel_file" class="custom-file-input" required>
+            <label class="custom-file-label" for="panel_file">Choose file</label><br>
             <p class="help-block">How do I format my <a href="https://clinical-genomics.github.io/scout/user-guide/panels/#uploading-a-new-gene-panel-version">gene panel file</a>?</p>
         </div>
       </div><!--end of col-->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -561,7 +561,7 @@ def institute_obj(request, parsed_institute):
 @pytest.fixture(scope="function")
 def managed_variants_lines(request):
     managed_variants_lines = [
-        "##my_csv_file",
+        "##my_panel_file",
         "#chromosome;position;end;reference;alternative;category;sub_category;description\n",
         "14;76548781;76548781;CTGGACC;G;snv;indel;IFT43 indel test\n",
         "17;48696925;48696925;G;T;snv;snv;CACNA1G intronic test\n",


### PR DESCRIPTION
Fix #3043

**How to test**:
1. Locally, launch a demo instance
2. From main branch, try to edit demo panel by uploading a file with genes, as shown in #3043. The page should crash
3. Switch to this branch and repeat. It should work now

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
