### PR TITLE
Decouple scout from broken loqusdbapi instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Changed
+- Start Scout also when loqusdbapi is not reachable
 ### Fixed
 - Gene panel crashing on edit action
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -401,6 +401,15 @@ def observations(store, loqusdb, case_obj, variant_obj):
     Returns:
         obs_data(dict)
     """
+    institute_id = variant_obj["institute"]
+    institute_obj = store.institute(institute_id)
+    loqusdb_id = institute_obj.get("loqusdb_id") or "default"
+    if loqusdb.loqusdb_settings[loqusdb_id]["version"] == None:
+        flash("Could not connect to the preselected loqusdb instance", "danger")
+        return {
+            "total": "N/A",
+        }
+
     chrom = variant_obj["chromosome"]
     end_chrom = variant_obj.get("end_chrom", chrom)
     pos = variant_obj["position"]
@@ -426,13 +435,6 @@ def observations(store, loqusdb, case_obj, variant_obj):
         "variant_type": variant_obj.get("sub_category", "").upper(),
         "category": category,
     }
-
-    institute_id = variant_obj["institute"]
-    institute_obj = store.institute(institute_id)
-    loqusdb_id = institute_obj.get("loqusdb_id") or "default"
-    if loqusdb.loqusdb_settings[loqusdb_id]["version"] == None:
-        flash("Could not connect to the preselected loqusdb instance", "danger")
-
     obs_data = loqusdb.get_variant(variant_query, loqusdb_id=loqusdb_id)
 
     if not obs_data:
@@ -472,7 +474,6 @@ def observations(store, loqusdb, case_obj, variant_obj):
 
         obs_data["cases"].append(dict(case=other_case, variant=other_variant))
 
-    flash(obs_data)
     return obs_data
 
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -404,7 +404,7 @@ def observations(store, loqusdb, case_obj, variant_obj):
     institute_id = variant_obj["institute"]
     institute_obj = store.institute(institute_id)
     loqusdb_id = institute_obj.get("loqusdb_id") or "default"
-    if loqusdb.loqusdb_settings[loqusdb_id]["version"] == None:
+    if loqusdb.loqusdb_settings[loqusdb_id]["version"] is None:
         flash("Could not connect to the preselected loqusdb instance", "danger")
         return {
             "total": "N/A",

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -2,7 +2,7 @@ import logging
 from base64 import b64encode
 from datetime import date
 
-from flask import url_for
+from flask import flash, url_for
 from flask_login import current_user
 
 from scout.constants import (
@@ -430,6 +430,9 @@ def observations(store, loqusdb, case_obj, variant_obj):
     institute_id = variant_obj["institute"]
     institute_obj = store.institute(institute_id)
     loqusdb_id = institute_obj.get("loqusdb_id") or "default"
+    if loqusdb.loqusdb_settings[loqusdb_id]["version"] == None:
+        flash("Could not connect to the preselected loqusdb instance", "danger")
+
     obs_data = loqusdb.get_variant(variant_query, loqusdb_id=loqusdb_id)
 
     if not obs_data:
@@ -469,6 +472,7 @@ def observations(store, loqusdb, case_obj, variant_obj):
 
         obs_data["cases"].append(dict(case=other_case, variant=other_variant))
 
+    flash(obs_data)
     return obs_data
 
 

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -170,12 +170,13 @@
         <tbody>
           <tr>
             {% if config.LOQUSDB_SETTINGS == 'Fail' %}
-              <td style="background-color: #ff9999;" colspan=3>Failed to contact loqusdb server</td>
-            {% else %}
+              <td style="background-color: #ff9999;" colspan=3>Failed to contact one of the connected loqusdb servers</td>
+              {% endif %}
+          </tr>
+          <tr>
             <td>{{ observations.observations|default('N/A') }}</td>
             <td>{{ observations.homozygote|default('N/A') }}</td>
             <td>{{ observations.total }}</td>
-            {% endif %}
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -158,7 +158,7 @@
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations</a>
       <span data-toggle="tooltip" title="Nr of observations is the total number of occurrences in the loqusdb instance. Missing links on greyed out case names for shared local case variants might be caused by variants not loaded after a rerun or inexact SV matching. Only names of collaborator cases are shown.">?</span>
     </div>
-    <div class="card-body" {% if config.LOQUSDB_SETTINGS == 'Fail' %} style="background-color: #ff9999;" {% endif %}>
+    <div class="card-body">
       <table class="table">
         <thead class="thead-light">
           <tr>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -158,7 +158,7 @@
       <a class="text-white" href="https://github.com/moonso/loqusdb" target="_blank">Local observations</a>
       <span data-toggle="tooltip" title="Nr of observations is the total number of occurrences in the loqusdb instance. Missing links on greyed out case names for shared local case variants might be caused by variants not loaded after a rerun or inexact SV matching. Only names of collaborator cases are shown.">?</span>
     </div>
-    <div class="card-body">
+    <div class="card-body" {% if config.LOQUSDB_SETTINGS == 'Fail' %} style="background-color: #ff9999;" {% endif %}>
       <table class="table">
         <thead class="thead-light">
           <tr>
@@ -169,9 +169,13 @@
         </thead>
         <tbody>
           <tr>
+            {% if config.LOQUSDB_SETTINGS == 'Fail' %}
+              <td style="background-color: #ff9999;" colspan=3>Failed to contact loqusdb server</td>
+            {% else %}
             <td>{{ observations.observations|default('N/A') }}</td>
             <td>{{ observations.homozygote|default('N/A') }}</td>
             <td>{{ observations.total }}</td>
+            {% endif %}
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -169,11 +169,6 @@
         </thead>
         <tbody>
           <tr>
-            {% if config.LOQUSDB_SETTINGS == 'Fail' %}
-              <td style="background-color: #ff9999;" colspan=3>Failed to contact one of the connected loqusdb servers</td>
-              {% endif %}
-          </tr>
-          <tr>
             <td>{{ observations.observations|default('N/A') }}</td>
             <td>{{ observations.homozygote|default('N/A') }}</td>
             <td>{{ observations.total }}</td>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -44,7 +44,11 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # connection details for LoqusDB MongoDB database
 # Example with 2 instances of LoqusDB, one using a binary file and one instance connected via REST API
 # When multiple instances are available, admin users can modify which one is in use for a given institute from the admin settings page
-LOQUSDB_SETTINGS = {"default": {"api_url": "http://127.0.0.1:9000"}}
+# LOQUSDB_SETTINGS = {
+#    "default" : {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "config_path": "/home/user/settings/loqus_default.yaml"},
+#    "loqus_api" : {"api_url": "http://127.0.0.1:9000"},
+# }
+
 #
 # Cloud IGV tracks can be configured here to allow users to enable them on their IGV views.
 # CLOUD_IGV_TRACKS = [

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -44,10 +44,7 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # connection details for LoqusDB MongoDB database
 # Example with 2 instances of LoqusDB, one using a binary file and one instance connected via REST API
 # When multiple instances are available, admin users can modify which one is in use for a given institute from the admin settings page
-# LOQUSDB_SETTINGS = {
-#    "default" : {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "config_path": "/home/user/settings/loqus_default.yaml"},
-#    "loqus_api" : {"api_url": "http://127.0.0.1:9000"},
-# }
+LOQUSDB_SETTINGS = {"default": {"api_url": "http://127.0.0.1:9000"}}
 #
 # Cloud IGV tracks can be configured here to allow users to enable them on their IGV views.
 # CLOUD_IGV_TRACKS = [

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -93,13 +93,19 @@ class LoqusDB:
                 setting["version"] = "2.5"
             else:
                 setting["version"] = self.get_instance_version(setting)
-            self.version_check(setting)
-
-        self.loqus_ids = self.loqusdb_settings.keys()
-        LOG.debug(f"LoqusDB setup: {self.__repr__()}")
+            try:
+                self.version_check(setting)
+                self.loqus_ids = self.loqusdb_settings.keys()
+                LOG.debug(f"LoqusDB setup: {self.__repr__()}")
+            except EnvironmentError as env_ex:
+                LOG.warning(env_ex)
+                app.config["LOQUSDB_SETTINGS"] = "Fail"
 
     def version_check(self, loqusdb_settings):
         """Check if a compatible version is used otherwise raise an error"""
+        if loqusdb_settings["version"] is None:
+            raise EnvironmentError("LoqusDB instance not available")
+
         if not loqusdb_settings["version"] >= "2.5":
             LOG.info("Please update your loqusdb version to >=2.5")
             raise EnvironmentError("Only compatible with loqusdb version >= 2.5")
@@ -127,9 +133,6 @@ class LoqusDB:
             return None
         json_resp = api_get("".join([api_url, "/"]))
         version = json_resp.get("content", {}).get("loqusdb_version")
-        if version is None:
-            raise ConfigError(f"LoqusDB API url '{api_url}' did not return a valid response.")
-
         return version
 
     def get_exec_loqus_version(self, loqusdb_id=None):

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -95,11 +95,10 @@ class LoqusDB:
                 setting["version"] = self.get_instance_version(setting)
             try:
                 self.version_check(setting)
-                self.loqus_ids = self.loqusdb_settings.keys()
-                LOG.debug(f"LoqusDB setup: {self.__repr__()}")
             except EnvironmentError as env_ex:
                 LOG.warning(env_ex)
-                app.config["LOQUSDB_SETTINGS"] = "Fail"
+            self.loqus_ids = self.loqusdb_settings.keys()
+            LOG.debug(f"LoqusDB setup: {self.__repr__()}")
 
     def version_check(self, loqusdb_settings):
         """Check if a compatible version is used otherwise raise an error"""

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -20,6 +20,14 @@ class LoqusdbMock:
     def __init__(self):
         self.nr_cases = 130
         self.variants = {"1_169898014_T_C": {"families": ["vitalmouse"]}}
+        self.loqusdb_settings = {
+            "default": {
+                "api_url": "http://127.0.0.1:9000",
+                "instance_type": "api",
+                "id": "default",
+                "version": "2.5",
+            }
+        }
 
     def case_count(self):
         return self.nr_cases

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -17,10 +17,9 @@ def test_get_api_loqus_version_no_connection(loqus_api_app):
     """Test function that returns the version of the LoqusDB API when the API is not available"""
 
     # When the get_api_loqus_version function is invoked for a non-reachable API
-    # THEN it should raise ConfigError
+    # THEN it should set the loqus version to None
     with loqus_api_app.app_context():
-        with pytest.raises(ConfigError):
-            assert loqusdb.get_api_loqus_version(api_url="test_url")
+        assert loqusdb.get_api_loqus_version(api_url="test_url") == None
 
 
 def test_get_api_loqus_version(loqus_api_app, monkeypatch):

--- a/tests/server/extensions/test_loqusdb_exe_extension.py
+++ b/tests/server/extensions/test_loqusdb_exe_extension.py
@@ -183,28 +183,6 @@ def test_loqusdb_exe_case_count_CalledProcessError(loqus_exe_app, monkeypatch):
         assert 0 == loqusdb.case_count(variant_category="snv")
 
 
-def test_loqusdb_exe_wrong_version(monkeypatch, loqus_exe, loqus_config):
-    """Test creating a loqus extension when loqusDB version is too old."""
-
-    # Given a mocked loqus exe instance returning a loqus version older than 2.5
-    def mockcommand(*args):
-        return "2.4"
-
-    monkeypatch.setattr(loqus_extension, "execute_command", mockcommand)
-
-    # WHEN instantiating an adapter
-    with pytest.raises(EnvironmentError):
-        # Then the app should not be created because of EnvironmentError
-        app = create_app(
-            config=dict(
-                LOQUSDB_SETTINGS={
-                    "binary_path": loqus_exe,
-                    "loqusdb_config": loqus_config,
-                }
-            )
-        )
-
-
 def test_init_app_loqus_list(monkeypatch, loqus_exe, loqus_config):
     """Test creating a Loqus extension from a list of config params"""
 


### PR DESCRIPTION
fix #3048

Start Scout also if a loqusdb instance is not reachable. But show a warning on variants pages:

![image](https://user-images.githubusercontent.com/28093618/145578812-2fed3a7d-4026-41c8-8061-2271dfded02f.png)


**How to test**:
1. Install on clinical-db stage and make sure scout runs and shows the warning described above all all variants pages

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
