### PR TITLE
Gene panels api endpoint - fix #3001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Created a GitHub action that pushes the Dockerfile-server image to Docker Hub (scout-server-stage) every time a PR is opened
 - Created a GitHub action that pushes the Dockerfile-server image to Docker Hub (scout-server) every time a new release is created
 - Reassign MatchMaker Exchange submission to another user when a Scout user is deleted
+- Expose public API JSON gene panels endpoint, primarily to enable automated rerun checking for updates
 ### Changed
 - Updated the python config file documentation in admin guide
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -267,8 +267,8 @@ def panel_export(store, panel_obj):
     return dict(panel=panel_obj)
 
 
-def panels_to_json(store, panel_name):
-    """Fetch matching gene panels and convert to JSON."""
+def get_panels(store, panel_name):
+    """Fetch matching gene panels and return a list."""
     gene_panels = list(store.gene_panels(panel_id=panel_name, include_hidden=True))
 
     return gene_panels

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -269,6 +269,8 @@ def panel_export(store, panel_obj):
 
 def panels_to_json(store, panel_name):
     """Fetch matching gene panels and convert to JSON."""
-    gene_panels = store.gene_panels(panel_id=panel_name, include_hidden=True)
+    gene_panels = list(store.gene_panels(panel_id=panel_name, include_hidden=True))
 
-    return list(gene_panels)
+    log.debug("gene panels %s", gene_panels)
+
+    return gene_panels

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -265,3 +265,10 @@ def panel_export(store, panel_obj):
     panel_obj["name_and_version"] = full_name
 
     return dict(panel=panel_obj)
+
+
+def panels_to_json(store, panel_name):
+    """Fetch matching gene panels and convert to JSON."""
+    gene_panels = store.gene_panels(panel_id=panel_name, include_hidden=True)
+
+    return list(gene_panels)

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -271,6 +271,4 @@ def panels_to_json(store, panel_name):
     """Fetch matching gene panels and convert to JSON."""
     gene_panels = list(store.gene_panels(panel_id=panel_name, include_hidden=True))
 
-    log.debug("gene panels %s", gene_panels)
-
     return gene_panels

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -7,7 +7,7 @@ from flask_login import current_user
 from flask_weasyprint import HTML, render_pdf
 
 from scout.server.extensions import store
-from scout.server.utils import templated, user_institutes
+from scout.server.utils import public_endpoint, templated, user_institutes
 
 from . import controllers
 from .forms import PanelGeneForm
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 panels_bp = Blueprint("panels", __name__, template_folder="templates")
 
 
-@genes_bp.route("/api/v1/panels/<panel_name>")
+@panels_bp.route("/api/v1/panels/<panel_name>")
 @public_endpoint
 def api_panels(panel_name):
     """Return JSON data about panels with a given panel name.

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import datetime
+import json
 import logging
 
-from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
+from flask import Blueprint, Response, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 from flask_weasyprint import HTML, render_pdf
 
 from scout.server.extensions import store
-from scout.server.utils import public_endpoint, templated, user_institutes
+from scout.server.utils import jsonconverter, public_endpoint, templated, user_institutes
 
 from . import controllers
 from .forms import PanelGeneForm
@@ -16,14 +17,15 @@ LOG = logging.getLogger(__name__)
 panels_bp = Blueprint("panels", __name__, template_folder="templates")
 
 
-@panels_bp.route("/api/v1/panels/<panel_name>")
+@panels_bp.route("/api/v1/panels/<panel_name>", methods=["GET", "POST"])
 @public_endpoint
 def api_panels(panel_name):
     """Return JSON data about panels with a given panel name.
     Returns all versions.
     """
     json_out = controllers.panels_to_json(store, panel_name)
-    return jsonify(json_out)
+
+    return Response(json.dumps(json_out, default=jsonconverter), mimetype="application/json")
 
 
 @panels_bp.route("/panels", methods=["GET", "POST"])

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -23,7 +23,7 @@ def api_panels(panel_name):
     """Return JSON data about panels with a given panel name.
     Returns all versions.
     """
-    json_out = controllers.panels_to_json(store, panel_name)
+    json_out = controllers.get_panels(store, panel_name)
 
     return Response(json.dumps(json_out, default=jsonconverter), mimetype="application/json")
 

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -2,7 +2,7 @@
 import datetime
 import logging
 
-from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user
 from flask_weasyprint import HTML, render_pdf
 
@@ -14,6 +14,16 @@ from .forms import PanelGeneForm
 
 LOG = logging.getLogger(__name__)
 panels_bp = Blueprint("panels", __name__, template_folder="templates")
+
+
+@genes_bp.route("/api/v1/panels/<panel_name>")
+@public_endpoint
+def api_panels(panel_name):
+    """Return JSON data about panels with a given panel name.
+    Returns all versions.
+    """
+    json_out = controllers.panels_to_json(store, panel_name)
+    return jsonify(json_out)
 
 
 @panels_bp.route("/panels", methods=["GET", "POST"])

--- a/tests/server/blueprints/panels/test_panels_views.py
+++ b/tests/server/blueprints/panels/test_panels_views.py
@@ -4,6 +4,19 @@ from flask import url_for
 from scout.server.extensions import store
 
 
+def test_panel_api_json(client, real_panel_database):
+
+    # GIVEN a panel in the database
+    panel_obj = real_panel_database.gene_panels()[0]
+    panel_name = panel_obj["panel_name"]
+
+    # WHEN querying the gene panels api endpoint
+    resp = client.get(url_for("panels.api_panels", panel_name=panel_name))
+    # THEN it should JSON response with the target gene panel included
+    assert len(resp.json) > 0
+    assert panel_name in str(resp.json)
+
+
 def test_panel_get(client, real_panel_database):
     adapter = real_panel_database
 


### PR DESCRIPTION
This PR adds a functionality: gene panels JSON REST API. Will return all versions of a named panel, including update dates as key `dates`. This date can be compared to the date (and if desired version and later actual gene changes) on the monitored case `case.panels[i].updated_at` for matching `panel_name` in `case.panels[i].panel_name`. 

**How to test**:
1. Attempt to retrieve a demo panel via the public API 
```
$ curl http://localhost:5000/api/v1/panels/panel1 
[{"_id": "5ef44f61d020103d9c9ad74e", "panel_name": "panel1", "institute": "cust000", "version": 1.0, "date": "2016-12-09T00:00:00", "maintainer": [], "display_name": "Test panel", "description": null, "genes": [{"hgnc_id": 7481, "symbol": "MT-TF"},
```

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
