### PR TITLE
Speed-up CI tests further by randomizing test groups contents

### DIFF
--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -61,7 +61,7 @@ jobs:
           pip install --upgrade --upgrade-strategy eager -r requirements-dev.txt -e .
 
       - name: Run pytest
-        run: pytest --cov --test-group-count 6 --test-group=${{ matrix.group }} --rootdir=/home/runner/work/scout
+        run: pytest --cov --test-group-count 6 --test-group=${{ matrix.group }} --test-group-random-seed=12345 --rootdir=/home/runner/work/scout
 
       - name: Upload coverage
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling
 - Removed test matrices to speed up automatic testing of PRs
 - Switch from Coveralls to Codecov to handle CI test coverage
-- Speed-up CI tests by caching installation of libs and splitting tests into groups using pytest-split
+- Speed-up CI tests by caching installation of libs and splitting tests into randomized groups using pytest-test-groups
 ### Fixed
 
 ## [4.45]


### PR DESCRIPTION
CI testing now is a bit faster, but splitting tests by groups makes it so that there are some groups (for instance group 5) that contain slower tests than other groups. Randomizing group contents should re-distribute slower tests into all groups, making them a but more balanced. This way the entire process should be faster.

**How to test**:
1. Check the automatic tests in the GitHub actions

**Expected outcome**:
- [x] Tests executed in test groups should be in random order
- [x] CI tests execution time should be faster than in the last merged PR

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub action
