### PR TITLE
Simplistic CDN alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Created a GitHub action that pushes the Dockerfile-server image to Docker Hub (scout-server) every time a new release is created
 - Reassign MatchMaker Exchange submission to another user when a Scout user is deleted
 - Expose public API JSON gene panels endpoint, primarily to enable automated rerun checking for updates
+- Script to pull, archive and switch all web pages to local versions of remote css and js
 ### Changed
 - Updated the python config file documentation in admin guide
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed test matrices to speed up automatic testing of PRs
 - Switch from Coveralls to Codecov to handle CI test coverage
 - Speed-up CI tests by caching installation of libs and splitting tests into randomized groups using pytest-test-groups
+- Improved LDAP login documentation
+- Use lib flask-ldapconn instead of flask_ldap3_login> to handle ldap authentication
 ### Fixed
 
 ## [4.45]

--- a/containers/development/docker-compose-matchmaker.yml
+++ b/containers/development/docker-compose-matchmaker.yml
@@ -9,9 +9,10 @@
 # THEN run this container with the command:
 # docker-compose -f docker-compose-matchmaker.yml up
 
+# docker-compose down
+
 version: '3'
-# usage:
-# sudo docker-compose up
+
 services:
   mongodb:
     # Lightweight Docker image for MongoDB which makes it easy to create:

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,8 @@ cryptography<3.4
 
 # webapp login
 authlib
-flask_ldap3_login>=0.9.17
 flask_login
+flask-ldapconn
 
 # Parsing
 cyvcf2<0.10.0

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -1,20 +1,35 @@
-"""Code for login controllers"""
+import logging
 
-DETECTIVES = [
-    "Dick Tracy",
-    "Miss Marple",
-    "Sherlock Holmes",
-    "Dr. Watson",
-    "Hercule Poirot",
-    "Jules Maigret",
-    "Inspector Morse",
-    "Dexter Morgan",
-    "Stella Gibson",
-    "Dale Cooper",
-    "Jessica Fletcher",
-    "Inspector Closseau",
-    "Columbo",
-]
+from flask import current_app, flash
+
+from scout.server.extensions import ldap_manager
+
+LOG = logging.getLogger(__name__)
+
+
+def ldap_authorized(userid, password):
+    """Log in a LDAP user
+
+    Args:
+        userid(str): user id provided in ldap login form (usually and email)
+        password(str): user passord provided in ldap loding form
+
+    Returns:
+        authorized(bool): True or False
+    """
+    authorized = False
+    try:
+        authorized = ldap_manager.authenticate(
+            username=userid,
+            password=password,
+            base_dn=current_app.config.get("LDAP_BASE_DN") or current_app.config.get("LDAP_BINDDN"),
+            attribute=current_app.config.get("LDAP_USER_LOGIN_ATTR")
+            or current_app.config.get("LDAP_SEARCH_ATTR"),
+        )
+    except Exception as ex:
+        flash(ex, "danger")
+
+    return authorized
 
 
 def event_rank(count):

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -13,8 +13,6 @@ from flask import (
     session,
     url_for,
 )
-from flask_ldap3_login import AuthenticationResponseStatus
-from flask_ldap3_login.forms import LDAPLoginForm
 from flask_login import login_user, logout_user
 
 from scout.server.extensions import ldap_manager, login_manager, oauth_client, store
@@ -37,8 +35,6 @@ login_manager.login_view = "login.login"
 login_manager.login_message = "Please log in to access this page."
 login_manager.login_message_category = "info"
 
-ldap_users = {}  # used by ldap save_user
-
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -57,13 +53,19 @@ def login():
 
     user_id = None
     user_mail = None
-    if current_app.config.get("LDAP_HOST") and request.method == "POST":
-        form = LDAPLoginForm()
-        LOG.info("Validating LDAP user")
-        if not form.validate_on_submit():
-            flash("username-password combination is not valid, plase try again", "warning")
+
+    if (
+        current_app.config.get("LDAP_HOST", current_app.config.get("LDAP_SERVER"))
+        and request.method == "POST"
+    ):
+        ldap_authorized = controllers.ldap_authorized(
+            request.form.get("ldap_user"), request.form.get("ldap_password")
+        )
+        if ldap_authorized is True:
+            user_id = request.form.get("ldap_user")
+        else:
+            flash("User not authorized by LDAP server", "warning")
             return redirect(url_for("public.index"))
-        user_id = form.username.data
 
     if current_app.config.get("GOOGLE"):
         if session.get("email"):
@@ -83,7 +85,7 @@ def login():
 
     user_obj = store.user(email=user_mail, user_id=user_id)
     if user_obj is None:
-        flash("User not found", "warning")
+        flash("User not found in Scout database", "warning")
         return redirect(url_for("public.index"))
 
     user_obj["accessed_at"] = datetime.now()
@@ -133,10 +135,3 @@ def perform_login(user_dict):
         return redirect(request.args.get("next") or next_url or url_for("cases.index"))
     flash("sorry, you could not log in", "warning")
     return redirect(url_for("public.index"))
-
-
-@ldap_manager.save_user
-def save_user(dn, username, data, memberships):
-    user = LdapUser(dn, username, data)
-    ldap_users[dn] = user
-    return user

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -24,18 +24,17 @@
         <a class="btn btn-primary" onclick="sendBrowserInfo()" href="{{ url_for('login.login') }}" role="button">
           Login with Google
         </a>
-      {% elif config.LDAP_HOST %}
-        <form class="form-row" method="POST" action="{{ url_for('login.login') }}">
-          <div class="col-4">
-            <label>Username{{ form.username(class="form-control") }}</label>
+      {% elif config.LDAP_HOST or config.LDAP_SERVER %}
+        <form class="form-row" method="POST" action="{{ url_for('login.login') }}" class="form-inline">
+          <div class="col-5">
+          <input type="text" name="ldap_user" class="form-control" placeholder="user email/id" required>
           </div>
-          <div class="col-4">
-            <label>Password{{ form.password(class="form-control") }}</label>
+          <div class="col-5">
+            <input type="text" name="ldap_password" class="form-control" placeholder="user password" required>
           </div>
-          <div class="col-4">
+          <div class="col-2">
             <button type="submit" class="btn btn-primary form-control text-white" onclick="sendBrowserInfo()">Login</button>
           </div>
-          {{ form.hidden_tag() }}
         </form>
         {% else %}
         <form action="{{ url_for('login.login') }}">

--- a/scout/server/blueprints/public/views.py
+++ b/scout/server/blueprints/public/views.py
@@ -3,7 +3,6 @@ import logging
 from pathlib import Path
 
 from flask import Blueprint, current_app, render_template, send_from_directory
-from flask_ldap3_login.forms import LDAPLoginForm
 
 from scout import __version__
 from scout.server.utils import public_endpoint
@@ -23,18 +22,13 @@ public_bp = Blueprint(
 @public_endpoint
 def index():
     """Show the static landing page."""
-    form = None
-    if current_app.config.get("LDAP_HOST"):
-        form = LDAPLoginForm()
 
     badge_name = current_app.config.get("ACCREDITATION_BADGE")
     if badge_name and not Path(public_bp.static_folder, badge_name).is_file():
         LOG.warning(f'No file with name "{badge_name}" in {public_bp.static_folder}')
         badge_name = None
 
-    return render_template(
-        "public/index.html", version=__version__, form=form, accred_badge=badge_name
-    )
+    return render_template("public/index.html", version=__version__, accred_badge=badge_name)
 
 
 @public_bp.route("/favicon")

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -21,6 +21,15 @@ MAIL_USE_SSL = False
 # If null no badge is displayed in scout
 ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 
+# LDAP login Settings
+# Complete list of accepted parameters available here: https://github.com/rroemhild/flask-ldapconn
+# LDAP_HOST = "localhost" # Can also be named LDAP_SERVER
+# LDAP_PORT = 389
+# LDAP_BASE_DN = 'cn=admin,dc=example,dc=com # Can also be named LDAP_BINDDN
+# LDAP_USER_LOGIN_ATTR = "mail" # Can also be named LDAP_SEARCH_ATTR
+# LDAP_USE_SSL = False
+# LDAP_USE_TLS = True
+
 # Parameters required for Google Oauth 2.0 login
 # GOOGLE = dict(
 #    client_id="client.apps.googleusercontent.com",

--- a/scout/server/extensions/__init__.py
+++ b/scout/server/extensions/__init__.py
@@ -3,7 +3,6 @@
 from authlib.integrations.flask_client import OAuth
 from flask_bootstrap import Bootstrap
 from flask_debugtoolbar import DebugToolbarExtension
-from flask_ldap3_login import LDAP3LoginManager
 from flask_login import LoginManager
 from flask_mail import Mail
 
@@ -11,6 +10,7 @@ from scout.adapter import MongoAdapter
 from scout.utils.cloud_resources import AlignTrackHandler
 
 from .gens_extension import GensViewer
+from .ldap_extension import LdapManager
 from .loqus_extension import LoqusDB
 from .matchmaker_extension import MatchMaker
 from .mongo_extension import MongoDB
@@ -20,7 +20,7 @@ toolbar = DebugToolbarExtension()
 bootstrap = Bootstrap()
 store = MongoAdapter()
 login_manager = LoginManager()
-ldap_manager = LDAP3LoginManager()
+ldap_manager = LdapManager()
 oauth_client = OAuth()
 mail = Mail()
 loqusdb = LoqusDB()

--- a/scout/server/extensions/ldap_extension.py
+++ b/scout/server/extensions/ldap_extension.py
@@ -1,0 +1,70 @@
+import logging
+import ssl
+
+from flask_ldapconn import LDAPConn
+from ldap3 import ALL, SYNC, Connection, Server, Tls
+
+LOG = logging.getLogger(__name__)
+
+
+class LdapManager(LDAPConn):
+    """Interface to LDAP login"""
+
+    def init_app(self, app):
+        ssl_defaults = ssl.get_default_verify_paths()
+
+        # Default config
+        app.config.setdefault("LDAP_SERVER", "localhost")
+        app.config.setdefault("LDAP_PORT", 389)
+        app.config.setdefault("LDAP_BINDDN", None)
+        app.config.setdefault("LDAP_SECRET", None)
+        app.config.setdefault("LDAP_CONNECT_TIMEOUT", 10)
+        app.config.setdefault("LDAP_READ_ONLY", False)
+        app.config.setdefault("LDAP_VALID_NAMES", None)
+        app.config.setdefault("LDAP_PRIVATE_KEY_PASSWORD", None)
+        app.config.setdefault("LDAP_RAISE_EXCEPTIONS", False)
+
+        app.config.setdefault("LDAP_CONNECTION_STRATEGY", SYNC)
+
+        app.config.setdefault("LDAP_USE_SSL", False)
+        app.config.setdefault("LDAP_USE_TLS", True)
+        app.config.setdefault("LDAP_TLS_VERSION", ssl.PROTOCOL_TLSv1)
+        app.config.setdefault("LDAP_REQUIRE_CERT", ssl.CERT_REQUIRED)
+
+        app.config.setdefault("LDAP_CLIENT_PRIVATE_KEY", None)
+        app.config.setdefault("LDAP_CLIENT_CERT", None)
+
+        app.config.setdefault("LDAP_CA_CERTS_FILE", ssl_defaults.cafile)
+        app.config.setdefault("LDAP_CA_CERTS_PATH", ssl_defaults.capath)
+        app.config.setdefault("LDAP_CA_CERTS_DATA", None)
+
+        app.config.setdefault("FORCE_ATTRIBUTE_VALUE_AS_LIST", False)
+
+        self.tls = Tls(
+            local_private_key_file=app.config["LDAP_CLIENT_PRIVATE_KEY"],
+            local_certificate_file=app.config["LDAP_CLIENT_CERT"],
+            validate=app.config["LDAP_REQUIRE_CERT"]
+            if app.config.get("LDAP_CLIENT_CERT")
+            else ssl.CERT_NONE,
+            version=app.config["LDAP_TLS_VERSION"],
+            ca_certs_file=app.config["LDAP_CA_CERTS_FILE"],
+            valid_names=app.config["LDAP_VALID_NAMES"],
+            ca_certs_path=app.config["LDAP_CA_CERTS_PATH"],
+            ca_certs_data=app.config["LDAP_CA_CERTS_DATA"],
+            local_private_key_password=app.config["LDAP_PRIVATE_KEY_PASSWORD"],
+        )
+
+        self.ldap_server = Server(
+            host=app.config.get("LDAP_HOST") or app.config.get("LDAP_SERVER"),
+            port=app.config["LDAP_PORT"],
+            use_ssl=app.config["LDAP_USE_SSL"],
+            connect_timeout=app.config["LDAP_CONNECT_TIMEOUT"],
+            tls=self.tls,
+            get_info=ALL,
+        )
+
+        # Store ldap_conn object to extensions
+        app.extensions["ldap_conn"] = self
+
+        # Teardown appcontext
+        app.teardown_appcontext(self.teardown)

--- a/scripts/fetch_external_css_and_js.sh
+++ b/scripts/fetch_external_css_and_js.sh
@@ -6,9 +6,9 @@
 # CSS
 mkdir scout/server/blueprints/public/static/external
 # create a url list for later reference
-for url in git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do echo $url >> tmp.css_urls; done
+for url in `git grep \\.css` |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do echo $url >> tmp.css_urls; done
 # retrieve external css files with http(s)
-for url in git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do wget -P scout/server/blueprints/public/static/ $url; done
+for url in `git grep \\.css` |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do wget -P scout/server/blueprints/public/static/ $url; done
 # list files that need url changes
 for file in scout/server/blueprints/public/static/external/*css ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq> tmp.css_files
 # construct a substitution perl script to change the urls to point to url_for('public.static', filename)
@@ -20,9 +20,9 @@ for file in `cat tmp.css_files`; do perl -n tmp.css_patterns < $file > ${file}.e
 # JS
 
 # create a url list for later reference
-for url in `git grep \\.js |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
+for url in `git grep \\.js` |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
 # retrieve external js files with http(s)
-for url in git grep \\.js |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq ; do wget -P scout/server/blueprints/public/static/ $url; done
+for url in `git grep \\.js` |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq ; do wget -P scout/server/blueprints/public/static/ $url; done
 # list files that need url changes
 for file in scout/server/blueprints/public/static/external/*js ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq > tmp.js_files
 # construct a substitution perl script to change the urls to point to url_for('public.static', filename)

--- a/scripts/fetch_external_css_and_js.sh
+++ b/scripts/fetch_external_css_and_js.sh
@@ -6,9 +6,9 @@
 # CSS
 mkdir scout/server/blueprints/public/static/external
 # create a url list for later reference
-for url in `git grep \\.css` |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do echo $url >> tmp.css_urls; done
+for url in `git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq`; do echo $url >> tmp.css_urls; done
 # retrieve external css files with http(s)
-for url in `git grep \\.css` |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do wget -P scout/server/blueprints/public/static/ $url; done
+for url in `git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq`; do wget -P scout/server/blueprints/public/static/ $url; done
 # list files that need url changes
 for file in scout/server/blueprints/public/static/external/*css ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq> tmp.css_files
 # construct a substitution perl script to change the urls to point to url_for('public.static', filename)
@@ -20,9 +20,9 @@ for file in `cat tmp.css_files`; do perl -n tmp.css_patterns < $file > ${file}.e
 # JS
 
 # create a url list for later reference
-for url in `git grep \\.js` |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
+for url in `git grep \\.js |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
 # retrieve external js files with http(s)
-for url in `git grep \\.js` |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq ; do wget -P scout/server/blueprints/public/static/ $url; done
+for url in `git grep \\.js` |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq` ; do wget -P scout/server/blueprints/public/static/ $url; done
 # list files that need url changes
 for file in scout/server/blueprints/public/static/external/*js ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq > tmp.js_files
 # construct a substitution perl script to change the urls to point to url_for('public.static', filename)

--- a/scripts/fetch_external_css_and_js.sh
+++ b/scripts/fetch_external_css_and_js.sh
@@ -22,7 +22,7 @@ for file in `cat tmp.css_files`; do perl -n tmp.css_patterns < $file > ${file}.e
 # create a url list for later reference
 for url in `git grep \\.js |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
 # retrieve external js files with http(s)
-for url in `git grep \\.js` |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq` ; do wget -P scout/server/blueprints/public/static/ $url; done
+for url in `git grep \\.js |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq` ; do wget -P scout/server/blueprints/public/static/ $url; done
 # list files that need url changes
 for file in scout/server/blueprints/public/static/external/*js ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq > tmp.js_files
 # construct a substitution perl script to change the urls to point to url_for('public.static', filename)

--- a/scripts/fetch_external_css_and_js.sh
+++ b/scripts/fetch_external_css_and_js.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# cd ..
+# URLs for e.g. blueprints are relative assuming you are in the scout folder (repo root)
+
+# CSS
+mkdir scout/server/blueprints/public/static/external
+# create a url list for later reference
+for url in git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do echo $url >> tmp.css_urls; done
+# retrieve external css files with http(s)
+for url in git grep \\.css |grep "src\|href" |grep -v "url_for" |perl -ne 'm/href=\"([^"]+)/; print $1,"\n";'|sort|uniq; do wget -P scout/server/blueprints/public/static/ $url; done
+# list files that need url changes
+for file in scout/server/blueprints/public/static/external/*css ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq> tmp.css_files
+# construct a substitution perl script to change the urls to point to url_for('public.static', filename)
+for file in scout/server/blueprints/public/static/external/*css ; do git grep `basename $file`; done |grep -v demo |perl -ne 'm/href=\"([^"]+)/; $url=$1;$old_url=$url; $url=~s/https\:\/\/.+?([^\/]+)$/\{\{ url_for\("public.static", filename="external\/$1"\) \}\}/; $old_url=~s/\@/\\\@/; print "s+",$old_url,"+",$url,"+;\n";' | sort |uniq| sed -e 's/"/'\''/g' > tmp.css_patterns
+echo "print; ">> tmp.css_patterns
+# and actually apply the script
+for file in `cat tmp.css_files`; do perl -n tmp.css_patterns < $file > ${file}.external; mv ${file}.external $file; done
+
+# JS
+
+# create a url list for later reference
+for url in `git grep \\.js |grep "src" |grep -v "url_for\|demo" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq`;do echo $url >> tmp.js_urls; done
+# retrieve external js files with http(s)
+for url in git grep \\.js |grep "src\|href" |grep -v "demo\|url_for" |perl -ne 'm/src=\"([^"]+)/; print $1,"\n";'|sort|uniq ; do wget -P scout/server/blueprints/public/static/ $url; done
+# list files that need url changes
+for file in scout/server/blueprints/public/static/external/*js ; do git grep `basename $file`; done |grep -v demo |cut -f 1 -d\: |sort|uniq > tmp.js_files
+# construct a substitution perl script to change the urls to point to url_for('public.static', filename)
+for file in scout/server/blueprints/public/static/external/*js ; do git grep `basename $file`; done |grep -v demo |perl -ne 'm/src=\"([^"]+)/; $url=$1;$old_url=$url; $url=~s/https\:\/\/.+?([^\/]+)$/\{\{ url_for\("public.static", filename="external\/$1"\) \}\}/; $old_url=~s/\@/\\\@/; print "s+",$old_url,"+",$url,"+;\n";' |sort|uniq| sed -e 's/"/'\''/g'> tmp.js_patterns
+echo "print; ">> tmp.js_patterns
+# and actually apply the script
+for file in `cat tmp.js_files`; do perl -n tmp.js_patterns < $file > ${file}.external; mv ${file}.external $file; done

--- a/tests/server/blueprints/login/test_views.py
+++ b/tests/server/blueprints/login/test_views.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from flask import url_for
-from flask_ldap3_login.forms import LDAPLoginForm
 from flask_login import current_user
 
-from scout.server.extensions import store
+from scout.server.extensions import ldap_manager, store
 
 
 def test_unathorized_login(app, institute_obj, case_obj):
@@ -44,7 +43,7 @@ def test_ldap_login(ldap_app, user_obj, monkeypatch):
     def return_user(*args, **kwargs):
         return user_obj
 
-    monkeypatch.setattr(LDAPLoginForm, "validate_on_submit", validate_ldap)
+    monkeypatch.setattr(ldap_manager, "authenticate", validate_ldap)
     monkeypatch.setattr(store, "user", return_user)
 
     # GIVEN an initialized app with LDAP config params


### PR DESCRIPTION
This PR adds a functionality.

A student had a need for a local scout for use inside a highly secure facility (no direct internet). This solves the issue. Just run it on a machine with web access. It will dl all css and js used in the code, and edit accordingly to make the pages use the local copy, like a very simplistic CDN service. 

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
