### PR TITLE
Remove hgnc_genes_find_one function, fix code that used it and bug in variants search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved LDAP login documentation
 - Use lib flask-ldapconn instead of flask_ldap3_login> to handle ldap authentication
 - Updated Managed variant documentation in user guide
+- Simplified gene variants search code
 ### Fixed
 - Validate uploaded managed variant file lines, warning the user.
+- Variants filtering by gene symbols file
 
 ## [4.45]
 ### Added

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -172,21 +172,6 @@ class GeneHandler(object):
             )
         return self.hgnc_collection.find({"aliases": hgnc_symbol, **build_query})
 
-    def hgnc_genes_find_one(self, hgnc_symbol, build="37"):
-        """Find one hgnc genes that match a hgnc symbol.
-
-        Check both hgnc_symbol and aliases
-
-        Args:
-            hgnc_symbol(str)
-            build(str): The build in which to search
-        Returns:
-           One single hgnc document
-        """
-
-        LOG.debug("Find one genes with symbol %s" % hgnc_symbol)
-        return self.hgnc_collection.find_one(filter={"build": build, "aliases": hgnc_symbol})
-
     def get_query_alias_or_id(self, hgnc_symbol, build):
         """Return query to search for hgnc-symbol or aliases"""
         query = {

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -330,7 +330,7 @@ class GeneHandler(object):
         if res:
             return [res]
 
-        return self.gene_aliases(symbol, build="37")
+        return self.gene_aliases(symbol, build=build)
 
     def gene_aliases(self, symbol, build="37"):
         """Return an iterable with hgnc_genes which have the provided symbol in the gene aliases

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -109,7 +109,7 @@ class GeneVariantFiltersForm(FlaskForm):
     """Base FiltersForm for SNVs"""
 
     variant_type = SelectMultipleField(choices=[("clinical", "clinical"), ("research", "research")])
-    hgnc_symbols = TagListField("HGNC Symbols/Ids (case sensitive)")
+    hgnc_symbols = TagListField("HGNC Symbols (comma-separated, case sensitive)")
     filter_variants = SubmitField(label="Filter variants")
     rank_score = IntegerField(default=15)
     phenotype_terms = TagListField("HPO terms")

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -112,7 +112,7 @@ class GeneVariantFiltersForm(FlaskForm):
     hgnc_symbols = TagListField("HGNC Symbols (comma-separated, case sensitive)")
     filter_variants = SubmitField(label="Filter variants")
     rank_score = IntegerField(default=15)
-    phenotype_terms = TagListField("HPO terms")
+    phenotype_terms = TagListField("HPO terms (comma-separated)")
     phenotype_groups = TagListField("Phenotype groups")
     similar_case = TagListField("Phenotypically similar case")
     cohorts = TagListField("Cohorts")

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -9,6 +9,7 @@ from flask_login import current_user
 from werkzeug.datastructures import Headers
 
 from scout.constants import ACMG_COMPLETE_MAP, ACMG_MAP, CASEDATA_HEADER, CLINVAR_HEADER
+from scout.server.blueprints.variants.controllers import update_form_hgnc_symbols
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, jsonconverter, templated, user_institutes
 
@@ -144,6 +145,10 @@ def gene_variants(institute_id):
         form.variant_type.data = ["clinical"]
 
     variant_type = form.data.get("variant_type")
+
+    # check if supplied gene symbols exist
+    if form.hgnc_symbols.data:
+        update_form_hgnc_symbols(store=store, case_obj=None, form=form)
 
     variants_query = store.gene_variants(
         query=form.data,

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -145,58 +145,21 @@ def gene_variants(institute_id):
 
     variant_type = form.data.get("variant_type")
 
-    # check if supplied gene symbols exist
-    hgnc_symbols = []
-    not_found_symbols = []
-    not_found_ids = []
-    data = {}
-    if (form.hgnc_symbols.data) and len(form.hgnc_symbols.data) > 0:
-        for hgnc_symbol in form.hgnc_symbols.data:
-            if hgnc_symbol.isdigit():
-                hgnc_gene_caption = store.hgnc_gene_caption(int(hgnc_symbol), build="37")
+    variants_query = store.gene_variants(
+        query=form.data,
+        institute_id=institute_id,
+        category="snv",
+        variant_type=variant_type,
+    )
 
-                if hgnc_gene_caption is None:
-                    hgnc_gene_caption = store.hgnc_gene_caption(int(hgnc_symbol), build="38")
+    result_size = store.count_gene_variants(
+        query=form.data,
+        institute_id=institute_id,
+        category="snv",
+        variant_type=variant_type,
+    )
+    data = controllers.gene_variants(store, variants_query, result_size, institute_id, page)
 
-                if hgnc_gene_caption is None:
-                    not_found_ids.append(hgnc_symbol)
-                else:
-                    hgnc_symbols.append(hgnc_gene_caption["hgnc_symbol"])
-
-            elif store.hgnc_genes_find_one(hgnc_symbol) is None:
-                not_found_symbols.append(hgnc_symbol)
-            else:
-                hgnc_symbols.append(hgnc_symbol)
-
-        if not_found_ids:
-            flash("HGNC id not found: {}".format(", ".join(not_found_ids)), "warning")
-        if not_found_symbols:
-            flash(
-                "HGNC symbol not found: {}".format(", ".join(not_found_symbols)),
-                "warning",
-            )
-
-        if hgnc_symbols == []:
-            # If there are not genes to search, return to previous page with a warning
-            flash("No valid gene provided for variant search.", "warning")
-            return redirect(request.referrer)
-
-        form.hgnc_symbols.data = hgnc_symbols
-
-        variants_query = store.gene_variants(
-            query=form.data,
-            institute_id=institute_id,
-            category="snv",
-            variant_type=variant_type,
-        )
-
-        result_size = store.count_gene_variants(
-            query=form.data,
-            institute_id=institute_id,
-            category="snv",
-            variant_type=variant_type,
-        )
-        data = controllers.gene_variants(store, variants_query, result_size, institute_id, page)
     return dict(institute=institute_obj, form=form, page=page, **data)
 
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1049,6 +1049,54 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
     return form
 
 
+def _flash_gene_symbol_errors(
+    non_clinical_symbols, not_found_symbols, not_found_ids, outdated_symbols, aliased_symbols
+):
+    """Flash error messages to make user aware that submitted gene symbols could not be directly used in variants search
+    Args:
+        non_clinical_symbols(set)
+        not_found_symbols(set)
+        not_found_ids(set)
+        not_found_ids(set)
+        outdated_symbols(set)
+        aliased_symbols(set)
+    """
+
+    errors = {
+        "non_clinical_symbols": {
+            "message": "Genes not included in gene panel versions in use when loading this case (clinical list)",
+            "gene_list": non_clinical_symbols,
+            "label": "info",
+        },
+        "not_found_symbols": {
+            "message": "HGNC symbols not present in database's genes collection",
+            "gene_list": not_found_symbols,
+            "label": "warning",
+        },
+        "not_found_ids": {
+            "message": "HGNC ids not present in database's genes collection",
+            "gene_list": not_found_ids,
+            "label": "warning",
+        },
+        "outdated_symbols": {
+            "message": "Outdated gene symbols found in the clinical panels loaded for the analysis.",
+            "gene_list": outdated_symbols,
+            "label": "info",
+        },
+        "aliased_symbols": {
+            "message": "Outdated gene symbols found in the search - alias used.",
+            "gene_list": aliased_symbols,
+            "label": "info",
+        },
+    }
+
+    # warn user if gene symbols are corresponding to any current gene,
+    for error in errors.values():
+        if not error["gene_list"]:
+            continue
+        flash(f'{error["message"]}:{error["gene_list"]}', error["label"])
+
+
 def check_form_gene_symbols(
     store, case_obj, is_clinical, genome_build, hgnc_symbols, not_found_ids
 ):
@@ -1113,39 +1161,9 @@ def check_form_gene_symbols(
             else:
                 non_clinical_symbols.add(gene_symbol)
 
-    errors = {
-        "non_clinical_symbols": {
-            "message": "Genes not included in gene panel versions in use when loading this case (clinical list)",
-            "gene_list": non_clinical_symbols,
-            "label": "info",
-        },
-        "not_found_symbols": {
-            "message": "HGNC symbols not present in database's genes collection",
-            "gene_list": not_found_symbols,
-            "label": "warning",
-        },
-        "not_found_ids": {
-            "message": "HGNC ids not present in database's genes collection",
-            "gene_list": not_found_ids,
-            "label": "warning",
-        },
-        "outdated_symbols": {
-            "message": "Outdated gene symbols found in the clinical panels loaded for the analysis.",
-            "gene_list": outdated_symbols,
-            "label": "info",
-        },
-        "aliased_symbols": {
-            "message": "Outdated gene symbols found in the search - alias used.",
-            "gene_list": aliased_symbols,
-            "label": "info",
-        },
-    }
-
-    # warn user if gene symbols are corresponding to any current gene,
-    for error in errors.values():
-        if not error["gene_list"]:
-            continue
-        flash(f'{error["message"]}:{error["gene_list"]}', error["label"])
+    _flash_gene_symbol_errors(
+        non_clinical_symbols, not_found_symbols, not_found_ids, outdated_symbols, aliased_symbols
+    )
 
     return updated_hgnc_symbols
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1073,10 +1073,10 @@ def check_form_gene_symbols(
     aliased_symbols = set()
     updated_hgnc_symbols = set()
 
-    clinical_hgnc_ids = store.clinical_hgnc_ids(case_obj)
-    clinical_symbols = store.clinical_symbols(case_obj)
+    clinical_hgnc_ids = store.clinical_hgnc_ids(case_obj) if case_obj else []
+    clinical_symbols = store.clinical_symbols(case_obj) if case_obj else []
 
-    # if no clinical symobols / panels were found loaded, warnings are treated as with research
+    # if no clinical symbols / panels were found loaded, warnings are treated as with research
     if len(clinical_hgnc_ids) == 0 and len(clinical_symbols) == 0:
         is_clinical = False
 
@@ -1165,7 +1165,7 @@ def update_form_hgnc_symbols(store, case_obj, form):
 
     hgnc_symbols = []
     not_found_ids = []
-    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
+    genome_build = "38" if case_obj and "38" in str(case_obj.get("genome_build", "37")) else "37"
 
     # retrieve current symbols from form
     if form.hgnc_symbols.data:
@@ -1181,7 +1181,7 @@ def update_form_hgnc_symbols(store, case_obj, form):
                 hgnc_symbols.append(hgnc_symbol)
 
     # add HPO genes to list, if they were missing
-    if "hpo" in form.data["gene_panels"]:
+    if "hpo" in form.data.get("gene_panels", []):
         hpo_symbols = list(
             set(term_obj["hgnc_symbol"] for term_obj in case_obj["dynamic_gene_list"])
         )
@@ -1193,6 +1193,7 @@ def update_form_hgnc_symbols(store, case_obj, form):
 
     # check if supplied gene symbols exist and are clinical
     is_clinical = form.data.get("variant_type", "clinical") == "clinical"
+
     updated_hgnc_symbols = check_form_gene_symbols(
         store, case_obj, is_clinical, genome_build, hgnc_symbols, not_found_ids
     )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -805,13 +805,17 @@ def upload_panel(store, institute_id, case_name, stream):
     raw_symbols = [
         line.strip().split("\t")[0] for line in stream if line and not line.startswith("#")
     ]
-    # check if supplied gene symbols exist
-    hgnc_symbols = []
+    # check if supplied gene symbols exist, search genes by official symbol or alias
+    hgnc_symbols = set()
     for raw_symbol in raw_symbols:
-        if store.hgnc_genes_find_one(raw_symbol) is None:
-            hgnc_symbols.append(raw_symbol)
-        else:
+        matching_genes = list(
+            store.gene_by_symbol_or_aliases(symbol=raw_symbol, build=case_obj.get("genome_build"))
+        )
+        if not matching_genes:
             flash("HGNC symbol not found: {}".format(raw_symbol), "warning")
+            continue
+        for gene_dict in matching_genes:
+            hgnc_symbols.add(gene_dict.get("hgnc_symbol"))
 
     return hgnc_symbols
 

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -733,33 +733,6 @@ def test_gene_variants_filter(app, institute_obj, case_obj):
         assert "POT1" in str(resp.data)
 
 
-def test_gene_variants_no_valid_gene(app, institute_obj, case_obj, mocker, mock_redirect):
-    """Test the gene_variant endpoint with a gene symbol not in database"""
-
-    mocker.patch("scout.server.blueprints.institutes.views.redirect", return_value=mock_redirect)
-
-    # GIVEN an initialized app
-    # GIVEN a valid user and institute
-    with app.test_client() as client:
-        # GIVEN that the user could be logged in
-        resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
-
-        # When user submits a query for a variants in a gene that is not in database
-        filter_query = {
-            "hgnc_symbols": "UNKNOWN-GENE",
-            "variant_type": ["clinical"],
-            "rank_score": 11,
-        }
-
-        resp = client.post(
-            url_for("overview.gene_variants", institute_id=institute_obj["internal_id"]),
-            data=filter_query,
-        )
-        # THEN the page should redirect
-        assert resp.status_code == 302
-
-
 def test_institute_users(app, institute_obj, user_obj):
     """Test the link to all institute users"""
     # GIVEN an initialized app


### PR DESCRIPTION
 Fix #3030

This function was still used in 2 places:
- Variants filter, searching for variants matching a gene symbol list provided in an uploaded file. This functionality is broken at the moment
![image](https://user-images.githubusercontent.com/28093618/146898186-077a8df7-6003-4664-8033-a933e14bac34.png)

- Institute pages, gene variants search (Search SNVs and INDELs). In this case I'm proposing a change to the code that will **simplify** and speed-up the variants search

**How to test**:
1. From master branch, create a simple txt file containing a list of gene symbols, some of which don't exist in the database: example:
POT1
ELN
HELLO

Provide this file for filtering variants in a demo instance and make sure that the functionality is not working as intended.

2. Switch to this branch and make sure that the filtering works

3. Go to institute page, gene variants functionality and search for the same gene using the form:
![image](https://user-images.githubusercontent.com/28093618/146899099-bd506f45-9d06-425f-a4ef-87435b30c46e.png)

4. Make sure results are returned

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
