### PR TITLE
Increase the height of the genes track in the IGV viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved LDAP login documentation
 - Use lib flask-ldapconn instead of flask_ldap3_login> to handle ldap authentication
 - Updated Managed variant documentation in user guide
+- Increased the height of the genes track in the IGV viewer
 ### Fixed
 - Validate uploaded managed variant file lines, warning the user.
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -58,6 +58,7 @@
                             order: Number.MIN_VALUE,
                             {% if custTrack.name == "Genes" %}
                                 indexURL: "{{ custTrack.indexURL|replace('%2F','/') }}",
+                                height: 150,
                             {% endif %}
                         },
                       {% endfor %}


### PR DESCRIPTION
ATM gene view:

Main branch:
![image](https://user-images.githubusercontent.com/28093618/147056017-050de545-c1ed-4fa1-b3e9-a684aa76e1b5.png)


This branch:
![image](https://user-images.githubusercontent.com/28093618/147055852-9795ac55-fb23-49d2-aa14-f12ba776caad.png)


**How to test**:
1. Locally, first search for MT variant and open it in the IGV browser.
2. Then go to another gene 

3. On clinical-db, open any variant from a case with cram files

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
