### PR TITLE
Filter institute cases using multiple HPO terms - Fixed gene variants search with HPO terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Created a GitHub action that pushes the Dockerfile-server image to Docker Hub (scout-server) every time a new release is created
 - Reassign MatchMaker Exchange submission to another user when a Scout user is deleted
 - Expose public API JSON gene panels endpoint, primarily to enable automated rerun checking for updates
+- Filter institute cases using multiple HPO terms
 ### Changed
 - Updated the python config file documentation in admin guide
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling
@@ -24,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated Managed variant documentation in user guide
 ### Fixed
 - Validate uploaded managed variant file lines, warning the user.
+- No results returned when searching for gene variants using a phenotype term 
 
 ## [4.45]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -168,12 +168,16 @@ class CaseHandler(object):
 
         if query_field == "exact_pheno":
             if query_term != "":
-                query["phenotype_terms.phenotype_id"] = query_term
+                # User might have provided multiple query terms
+                query["phenotype_terms.phenotype_id"] = {
+                    "$in": [term for term in query_term.replace(" ", "").split(",")]
+                }
             else:  # query for cases with no HPO terms
                 query["$or"] = [
                     {"phenotype_terms": {"$size": 0}},
                     {"phenotype_terms": {"$exists": False}},
                 ]
+
         if query_field == "synopsis":
             if query_term != "":
                 query["$text"] = {"$search": query_term}

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -129,9 +129,9 @@ class QueryHandler(object):
 
         if mongo_case_query != {}:
             mongo_case_query["owner"] = institute_id
-            LOG.debug("Search cases for selection set, using query {0}".format(select_case_obj))
-            select_case_obj = self.case_collection.find(mongo_case_query)
-            select_cases = [case_id.get("display_name") for case_id in select_case_obj]
+            LOG.debug("Search cases for selection set, using query {0}".format(mongo_case_query))
+            select_case_objs = self.case_collection.find(mongo_case_query)
+            select_cases = [case_id.get("_id") for case_id in select_case_objs]
 
         if query.get("similar_case"):
             similar_case_display_name = query["similar_case"][0]

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -134,7 +134,7 @@ SAMPLE_SOURCE = dict((i, el) for i, el in enumerate(SOURCES))
 CASE_SEARCH_TERMS = {
     "case": {"label": "Case or Individual Name", "prefix": "case:"},
     "exact_pheno": {
-        "label": "HPO Term",
+        "label": "HPO Terms",
         "prefix": "exact_pheno:",
     },
     "synopsis": {

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -307,9 +307,6 @@ def populate_case_filter_form(params):
     """
     form = CaseFilterForm(params)
     form.search_type.default = params.get("search_type")
-    search_term = form.search_term.data or ""
-    if ":" in search_term:
-        form.search_term.data = search_term[search_term.index(":") + 1 :]  # remove prefix
     return form
 
 

--- a/scout/server/blueprints/institutes/static/form_scripts.js
+++ b/scout/server/blueprints/institutes/static/form_scripts.js
@@ -3,7 +3,7 @@ var sel = document.getElementById('search_type');
 
 var selectHelper = {
   "case:": "example:18201",
-  "exact_pheno:": "example:HP:0001166,HP:0001250,..",
+  "exact_pheno:": "example:HP:0001166,HP:0001250,...",
   "synopsis:" : "example:epilepsy",
   "panel:" : "example:NMD",
   "status:": "example:active",

--- a/scout/server/blueprints/institutes/static/form_scripts.js
+++ b/scout/server/blueprints/institutes/static/form_scripts.js
@@ -3,7 +3,7 @@ var sel = document.getElementById('search_type');
 
 var selectHelper = {
   "case:": "example:18201",
-  "exact_pheno:": "example:HP:0001166",
+  "exact_pheno:": "example:HP:0001166,HP:0001250,..",
   "synopsis:" : "example:epilepsy",
   "panel:" : "example:NMD",
   "status:": "example:active",


### PR DESCRIPTION
- Allow filtering institute cases using multiple HPO terms: fix #2690
- Fix searching gene variants specifying one or more HPO terms: fix #3073

**Preparing for test**:
1. Locally, load a second case in scout demo: `scout --demo load case scout/demo/643595.config.yaml`
2. Assign one or more HPO terms to this case, for instance: HP:0012444
3. Note that demo case 643594 has already assigned a couple of phenotypes

**Testing**:
1. On main branch, make sure that filtering cases by multiple HPO terms doesn't work in:
- Cases page (http://localhost:5000/cust000/cases)
- Dashboard (http://localhost:5000/dashboard)
- Gene variants (http://localhost:5000/cust000/gene_variants). In this page even searching with one term is broken

2. Switch to this branch and try the pages above by filtering with one phenotype from case 643594 and one phenotype from case 643595. All the pages should return meaningful results (from 2 cases)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
