### PR TITLE
Fix exporting from dashboard validated variants with missing "genes" key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated Managed variant documentation in user guide
 ### Fixed
 - Validate uploaded managed variant file lines, warning the user.
+- Exporting validated variants with missing "genes" database key
 
 ## [4.45]
 ### Added

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -99,7 +99,9 @@ def export_verified_variants(aggregate_variants, unique_callers):
             genes = []
             prot_effect = []
             funct_anno = []
-            for gene in variant.get("genes"):  # this will be a unique long field in the document
+            for gene in variant.get(
+                "genes", []
+            ):  # this will be a unique long field in the document
                 genes.append(gene.get("hgnc_symbol", ""))
                 funct_anno.append(gene.get("functional_annotation"))
                 for transcript in gene.get("transcripts"):

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -142,7 +142,7 @@
       </table>
         <br>
         <div class="card mt-3" >
-          <form id="dowload_var_stats" action="{{ url_for('variants.download_verified')}}" method="GET">
+          <form id="download_verified" action="{{ url_for('variants.download_verified')}}" method="GET">
             <button type="submit" name="verified_vars" value="verified" class="form-control">Download all verified variants for your cases</button>
           </form>
         </div>
@@ -158,6 +158,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js"></script>
   <script src="{{ url_for('dashboard.static', filename='charts.js') }}"></script>
   <script type="text/javascript">
+
+    document.querySelector("#download_verified").addEventListener("submit", function(e){
+      // Avoid page spinner being stuck on download verified variants
+      $(window).unbind('beforeunload');
+    });
 
     var sel = document.getElementById("search_type");
     var text = document.getElementById("search_term");

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -143,7 +143,7 @@
         <br>
         <div class="card mt-3" >
           <form id="dowload_var_stats" action="{{ url_for('variants.download_verified')}}" method="GET">
-            <button type="submit" name="verified_vars" value="verified" class="btn btn-primary btn-md">Download all verified variants for your cases</button>
+            <button type="submit" name="verified_vars" value="verified" class="form-control">Download all verified variants for your cases</button>
           </form>
         </div>
     </div>


### PR DESCRIPTION
- Fixes the export of validated variants with no "genes" document key (fix #3077) from the dashboard
- Better button style for the function
- Stops the loading page spinner after the validated variants are downloaded using the button above (fix #3079 )


**How to test, locally**:
Reproduce in master branch by:
- Editing a SNV of your choice from demo case by adding a coupe of new key/values (note that the second value is a boolean):

![image](https://user-images.githubusercontent.com/28093618/148743548-3779a70f-b04f-4d7c-9bf1-6c623c25b242.png)

- Remove completely the key/value "genes" from the same variant.
- Go to the dashboard, "variant statistics" and click on  "download all verified variants for your cases"
![image](https://user-images.githubusercontent.com/28093618/148743786-c162070e-1da3-4e4d-ab84-256eec6fecd8.png)
- The page should crash

- [ ] Switch to this branch and repeat the last step, the download should be successful
- [ ] The button should not keep spinning when the excel file with eventual variants is downloaded

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by mikaell
- [x] tests executed by mikaell
