### PR TITLE
Add Utils for Dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Created a GitHub action that pushes the Dockerfile-server image to Docker Hub (scout-server) every time a new release is created
 - Reassign MatchMaker Exchange submission to another user when a Scout user is deleted
 - Expose public API JSON gene panels endpoint, primarily to enable automated rerun checking for updates
+- Add utils for dictionary type
 ### Changed
 - Updated the python config file documentation in admin guide
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling

--- a/scout/utils/dict_utils.py
+++ b/scout/utils/dict_utils.py
@@ -1,0 +1,24 @@
+def remove_nonetype(dictionary):
+    """If value = None in key/value pair, the pair is removed.
+        Python >3
+    Args:
+        dictionary: dict
+
+    Returns:
+        dict
+    """
+
+    return {k: v for k, v in dictionary.items() if v is not None}
+
+
+def remove_empty_list(dictionary):
+    """If value = [] in key/value pair, the pair is removed.
+        Python >3
+    Args:
+        dictionary: dict
+
+    Returns:
+        dict
+    """
+
+    return {k: v for k, v in dictionary.items() if v != []}

--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -20,7 +20,7 @@ def test_remove_nonetype():
 
 def test_remove_empty_list_no_change():
     # WHEN a dict *not* containing an empty list, []
-    d = {"a": "1", "b": 2, "c": 3}
+    d = {"a": "1", "b": 2, "c": [3]}
 
     # THEN calling removeNoneValues(dict) will not change dict
     assert d == remove_empty_list(d)

--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -1,4 +1,4 @@
-from scout.utils.dict_utils import remove_nonetype, remove_empty_list
+from scout.utils.dict_utils import remove_empty_list, remove_nonetype
 
 
 def test_remove_nonetype_no_change():

--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -1,0 +1,36 @@
+from scout.utils.dict_utils import remove_nonetype, remove_empty_list
+
+
+def test_remove_nonetype_no_change():
+    # WHEN a dict *not* containing a None value
+    d = {"a": "1", "b": 2, "c": 3}
+
+    # THEN calling removeNoneValues(dict) will not change dict
+    assert d == remove_nonetype(d)
+
+
+def test_remove_nonetype():
+    # WHEN a dict containing a value which is None
+    d = {"a": "1", "b": 2, "c": None}
+
+    # THEN calling removeNoneValues(dict) will remove key-value pair
+    # where value=None
+    assert {"a": "1", "b": 2} == remove_nonetype(d)
+
+
+def test_remove_empty_list_no_change():
+    # WHEN a dict *not* containing an empty list, []
+    d = {"a": "1", "b": 2, "c": 3}
+
+    # THEN calling removeNoneValues(dict) will not change dict
+    assert d == remove_empty_list(d)
+
+
+def test_remove_empty_list():
+    # WHEN a dict containing a value which is []
+    d = {"a": "1", "b": 2, "c": []}
+
+    # THEN calling removeNoneValues(dict) will remove key-value pair
+    # where value=None
+    assert {"a": "1", "b": 2} == remove_empty_list(d)
+    


### PR DESCRIPTION
This PR adds a functionality: add a file for dictionary utils. This functionality already exists in the code base. This is an effort to gather it in one place for reusability. Future pr:s can refactor and start using this utility file.

**How to test**:
1. how to test it, possibly with real cases/data
Pytests should pass

Usage example:
```
>>> import dict_utils
>>> a = {'asd': 12, 'a': 123, 'k': 33, '1': None, '2': []}
>>> dict_utils.remove_nonetype(a)
{'asd': 12, 'a': 123, 'k': 33, '2': []}
```
**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
