### PR TITLE
Introduce Vuture GitHub action to identify unused code - Action Only -

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -1,0 +1,23 @@
+name: "Vulture - Find unused code"
+on:
+  - pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: vulture
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Find changed Python files
+        id: files
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          filter: "*.py"
+
+      - name: Scavenge
+        uses: anaynayak/python-vulture-action@v1.0
+        id: vulture
+        with:
+          vulture-args: --min-confidence 80 ${{steps.files.outputs.all}}
+        continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Expose public API JSON gene panels endpoint, primarily to enable automated rerun checking for updates
 - Add utils for dictionary type
 - Filter institute cases using multiple HPO terms
+- Vulture GitHub action to identify and remove unused variables and imports
 ### Changed
 - Updated the python config file documentation in admin guide
 - Case configuration parsing now uses Pydantic for improved typechecking and config handling
@@ -29,7 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Validate uploaded managed variant file lines, warning the user.
 - Exporting validated variants with missing "genes" database key
-- No results returned when searching for gene variants using a phenotype term 
+- No results returned when searching for gene variants using a phenotype term
 - Variants filtering by gene symbols file
 
 ## [4.45]

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """
-
 "main concept of MongoDB is embed whenever possible"
 Ref: http://stackoverflow.com/questions/4655610#comment5129510_4656431
 """


### PR DESCRIPTION
I had it in mind since a while, and I finally tested running [Vulture](https://github.com/jendrikseipp/vulture) over our repo.
By setting the confidence value param to 80% (--min-confidence ) I've found a bunch of imports and variables that are not used.

This PR:
- Adds search for variables and imports that are not used, within the modified code of any PR.
- The new GitHub action checks if some code is unused with 80% confidence. The tests doesn't fail but the output might be useful to improve the code.

**How to test**:
- [x] The modified file scout/models/variant/variant.py has been. modified and should trigger warnings in the code if it contains unused code

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions