### PR TITLE
Collaborator hpo gene variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - No results returned when searching for gene variants using a phenotype term
 - Variants filtering by gene symbols file
 - Make gene HGNC symbols field mandatory in gene variants page and run search only on form submit
+- Make sure collaborator gene variants are still visible, even if HPO filter is used
 
 ## [4.45]
 ### Added

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -127,7 +127,7 @@ class QueryHandler(object):
             mongo_case_query["cohorts"] = {"$in": query["cohorts"]}
 
         if mongo_case_query != {}:
-            mongo_case_query["collaborators"] = {"$in": institute_id}
+            mongo_case_query["collaborators"] = institute_id
             LOG.debug("Search cases for selection set, using query {0}".format(mongo_case_query))
             select_case_objs = self.case_collection.find(mongo_case_query)
             select_cases = [case_id.get("_id") for case_id in select_case_objs]

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -127,7 +127,7 @@ class QueryHandler(object):
             mongo_case_query["cohorts"] = {"$in": query["cohorts"]}
 
         if mongo_case_query != {}:
-            mongo_case_query["owner"] = institute_id
+            mongo_case_query["collaborators"] = {"$in": institute_id}
             LOG.debug("Search cases for selection set, using query {0}".format(mongo_case_query))
             select_case_objs = self.case_collection.find(mongo_case_query)
             select_cases = [case_id.get("_id") for case_id in select_case_objs]

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -372,7 +372,7 @@ def get_sanger_unevaluated(store, institute_id, user_id):
     return unevaluated
 
 
-def gene_variants(store, pymongo_cursor, variant_count, institute_id, page=1, per_page=50):
+def gene_variants(store, pymongo_cursor, variant_count, page=1, per_page=50):
     """Pre-process list of variants."""
 
     skip_count = per_page * max(page - 1, 0)

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -165,7 +165,7 @@ def gene_variants(institute_id):
             category="snv",
             variant_type=variant_type,
         )
-        data = controllers.gene_variants(store, variants_query, result_size, institute_id, page)
+        data = controllers.gene_variants(store, variants_query, result_size, page)
 
     return dict(institute=institute_obj, form=form, page=page, **data)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

**How to test**:
1. search for some gene variants, and take note of or adapt HPO terms so that you have one owned by your home institute and one owned by another institute, but where your home institute is a collaborator.
2. limit to HPO terms, and note that you now only see variants where owner matches
3. apply patch, and note that also collaborators variants are again visible

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
