### PR TITLE
Add export fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+##
+### Added
+- Added CADD, GERP, GnomAD and genotype calls to variantS export
+
 ## [4.46.1]
 ### Fixed
 - Downloading of files generated within the app container (MT-report, verified variants, pedigrees, ..)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-##
+## []
 ### Added
-- Added CADD, GERP, GnomAD and genotype calls to variantS export
+- Added CADD, GnomAD and genotype calls to variantS export
 
 ## [4.46.1]
 ### Fixed

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -8,6 +8,9 @@ EXPORT_HEADER = [
     "Gene_name",
     "Canonical_transcript/HGVS/protein_change",
     "Primary_transcript/HGVS/protein_change",
+    "CADD",
+    "GERP",
+    "GnomAD Max AF",
 ]
 
 MT_EXPORT_HEADER = [

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -9,8 +9,7 @@ EXPORT_HEADER = [
     "Canonical_transcript/HGVS/protein_change",
     "Primary_transcript/HGVS/protein_change",
     "CADD",
-    "GERP",
-    "GnomAD Max AF",
+    "GnomAD AF",
 ]
 
 MT_EXPORT_HEADER = [

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -586,11 +586,18 @@ def variant_export_lines(store, case_obj, variants_query):
         for individual in case_obj["individuals"]:
             for variant_gt in variant_gts:
                 if individual["individual_id"] == variant_gt["sample_id"]:
+                    variant_line.append(variant_gt["genotype_call"])
                     # gather coverage info
                     variant_line.append(variant_gt["allele_depths"][0])  # AD reference
                     variant_line.append(variant_gt["allele_depths"][1])  # AD alternate
                     # gather genotype quality info
                     variant_line.append(variant_gt["genotype_quality"])
+
+        variant_line.append(variant.get("cadd_score", "N/A"))
+        variant_line.append(variant.get("gerp_conservation", "N/A"))
+        frequencies = variant.get("frequencies", {})
+        variant_line.append(frequencies.get("gnomad_max"), "N/A"))
+
 
         variant_line = [str(i) for i in variant_line]
         export_variants.append(",".join(variant_line))
@@ -686,6 +693,7 @@ def variants_export_header(case_obj):
     # Add fields specific for case samples
     for individual in case_obj["individuals"]:
         display_name = str(individual["display_name"])
+        header.append("GT_" + display_name)  # Add Genotype filed for a sample
         header.append("AD_reference_" + display_name)  # Add AD reference field for a sample
         header.append("AD_alternate_" + display_name)  # Add AD alternate field for a sample
         header.append("GT_quality_" + display_name)  # Add Genotype quality field for a sample

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -33,7 +33,7 @@ from scout.server.blueprints.variant.utils import (
 from scout.server.links import cosmic_links, str_source_link
 from scout.server.utils import case_append_alignments, institute_and_case, user_institutes
 
-from .forms import (
+from .forms import (  # noqa: F401
     FILTERSFORMCLASS,
     CancerFiltersForm,
     CancerSvFiltersForm,
@@ -41,7 +41,7 @@ from .forms import (
     StrFiltersForm,
     SvFiltersForm,
     VariantFiltersForm,
-)  # noqa: F401
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -582,6 +582,10 @@ def variant_export_lines(store, case_obj, variants_query):
                 )  # empty HGNC id, emoty gene name and empty transcripts columns
                 empty_col += 1
 
+        variant_line.append(variant.get("cadd_score", "N/A"))
+
+        variant_line.append(variant.get("gnomad_frequency", "N/A"))
+
         variant_gts = variant["samples"]  # list of coverage and gt calls for case samples
         for individual in case_obj["individuals"]:
             for variant_gt in variant_gts:
@@ -592,12 +596,6 @@ def variant_export_lines(store, case_obj, variants_query):
                     variant_line.append(variant_gt["allele_depths"][1])  # AD alternate
                     # gather genotype quality info
                     variant_line.append(variant_gt["genotype_quality"])
-
-        variant_line.append(variant.get("cadd_score", "N/A"))
-        variant_line.append(variant.get("gerp_conservation", "N/A"))
-        frequencies = variant.get("frequencies", {})
-        variant_line.append(frequencies.get("gnomad_max"), "N/A"))
-
 
         variant_line = [str(i) for i in variant_line]
         export_variants.append(",".join(variant_line))

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -33,7 +33,15 @@ from scout.server.blueprints.variant.utils import (
 from scout.server.links import cosmic_links, str_source_link
 from scout.server.utils import case_append_alignments, institute_and_case, user_institutes
 
-from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, SvFiltersForm
+from .forms import (
+    FILTERSFORMCLASS,
+    CancerFiltersForm,
+    CancerSvFiltersForm,
+    FiltersForm,
+    StrFiltersForm,
+    SvFiltersForm,
+    VariantFiltersForm,
+)
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -33,15 +33,7 @@ from scout.server.blueprints.variant.utils import (
 from scout.server.links import cosmic_links, str_source_link
 from scout.server.utils import case_append_alignments, institute_and_case, user_institutes
 
-from .forms import (
-    FILTERSFORMCLASS,
-    CancerFiltersForm,
-    CancerSvFiltersForm,
-    FiltersForm,
-    StrFiltersForm,
-    SvFiltersForm,
-    VariantFiltersForm,
-)
+from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, SvFiltersForm
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -41,7 +41,7 @@ from .forms import (
     StrFiltersForm,
     SvFiltersForm,
     VariantFiltersForm,
-)
+)  # noqa: F401
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -375,8 +375,8 @@ def test_variant_csv_export(real_variant_database, case_obj):
     export_header = variants_export_header(case_obj)
 
     # Assert that exported document has n fields:
-    # n = (EXPORT_HEADER items in variants_export.py) + (3 * number of individuals analysed for the case)
-    assert len(export_header) == len(EXPORT_HEADER) + 3 * len(case_obj["individuals"])
+    # n = (EXPORT_HEADER items in variants_export.py) + (4 * number of individuals analysed for the case)
+    assert len(export_header) == len(EXPORT_HEADER) + 4 * len(case_obj["individuals"])
 
     # Given the lines of the document to be exported
     export_lines = variant_export_lines(adapter, case_obj, variants_to_export)


### PR DESCRIPTION
This PR adds a functionality.

The GERP conservation boolean we store for variant page display is not so informative. The user will at some point benefit more from actually using the likes of `bcftools` to query an annotated original VCF, so adding all possible annotations is hardly mandatory. Versioning of databases and tools becomes an issue with exported sheets.

**How to test**:
1. pick a case, download variantS and note the indicated columns are present.
2. try both single and multiple sample cases as genotype is for each individual

![Screenshot 2022-01-20 at 12 39 12](https://user-images.githubusercontent.com/758570/150332114-1079ecfc-240d-4d8d-895c-7de99529b948.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, CR
