### PR TITLE
Reintroduce links to dbSNP, Beacon and SweGen in RD variant summary panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Update igv.js to v2.10.5
 ### Fixed
-- Reintroduced missing links to Swegen and Beacon in RD variant page, summary section
+- Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section
 
 ## [4.47]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [ ]
 ### Changed
 - Update igv.js to v2.10.5
+### Fixed
+- Reintroduced missing links to Swegen and Beacon in RD variant page, summary section
 
 ## [4.47]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -1,5 +1,5 @@
 {% macro database_buttons(variant) %}
-<div>
+<div class="mt-3">
   <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
   <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
   {% if variant.cosmic_links %} <!-- This is a list of tuples : [(id1, link1), (id2, link2), ..] -->

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -1,5 +1,4 @@
 {% macro database_buttons(variant) %}
-<div class="h6 mt-1">Databases</div>
 <div>
   <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
   <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -1,3 +1,39 @@
+{% macro database_buttons(variant) %}
+<div class="h6 mt-1">Databases</div>
+<div>
+  <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
+  <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
+  {% if variant.cosmic_links %} <!-- This is a list of tuples : [(id1, link1), (id2, link2), ..] -->
+    {% for cosmic_link in variant.cosmic_links %}
+      <a data-toggle="tooltip" title="COSMIC" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{cosmic_link[1]}}" target="_blank">{{cosmic_link[0]}}</a>
+    {% endfor %}
+  {% endif %}
+  {% if variant.dbsnp_id %}
+    {% for snp in variant.dbsnp_id.split(';') %}
+      <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
+    {% endfor %}
+  {% endif %}
+</div>
+<div class="btn-group">
+  {% if primary_transcript and primary_transcript.varsome_link %}
+  <a href="{{ primary_transcript.varsome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
+    data-toggle="tooltip" title="Varsome">V</a>
+  {% endif %}
+  {% if primary_transcript and primary_transcript.tp53_link %}
+    <a href="{{ primary_transcript.tp53_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
+      data-toggle="tooltip" title="MutanTP53">TP53</a>
+  {% endif %}
+  {% if primary_transcript and primary_transcript.cbioportal_link %}
+    <a href="{{ primary_transcript.cbioportal_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
+      data-toggle="tooltip" title="cBioPortal">CBP</a>
+  {% endif %}
+  {% if primary_transcript and primary_transcript.mycancergenome_link %}
+    <a href="{{ primary_transcript.mycancergenome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
+      data-toggle="tooltip" title="MyCancerGenome">MCG</a>
+  {% endif %}
+</div>
+{% endmacro %}
+
 {% macro splice_junctions_button(institute_id, case_name, variant_id) %}
   <a class="btn btn-sm btn-secondary text-white" href="{{url_for('alignviewers.sashimi_igv', institute_id=institute_id, case_name=case_name, variant_id=variant_id)}}" target="_blank"
     data-toggle="tooltip" data-placement="top" title="Only available in build GRCh38">RNA splicing</a>

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -3,7 +3,7 @@
 {% from "variant/utils.html" import rankscore_panel, overlapping_panel, genes_panel, transcripts_panel, proteins_panel,  pin_button, causative_button, modal_causative %}
 {% from "variant/tx_overview.html" import disease_associated, transcripts_overview %}
 {% from "variant/variant_details.html" import frequencies, gtcall_panel, observations_panel, old_observations, mappability_list, severity_list %}
-{% from "variant/buttons.html" import variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button, splice_junctions_button %}
+{% from "variant/buttons.html" import database_buttons, variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button, splice_junctions_button %}
 {% from "variant/components.html" import alignments, panel_classify, compounds_panel, matching_variants, external_links, clinsig_table  %}
 {% from "variant/sanger.html" import sanger_button, modal_sanger, modal_cancel_sanger %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes %}
@@ -268,42 +268,9 @@
       <div class="h6 mt-1">
         {{ clinsig_table(variant) }}
       </div>
-    <!--LINK out resources-->
-      <div class="h6 mt-1">Databases</div>
-      <div>
-        <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
-        <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
-        {% if variant.cosmic_links %} <!-- This is a list of tuples : [(id1, link1), (id2, link2), ..] -->
-          {% for cosmic_link in variant.cosmic_links %}
-            <a data-toggle="tooltip" title="COSMIC" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" href="{{cosmic_link[1]}}" target="_blank">{{cosmic_link[0]}}</a>
-          {% endfor %}
-        {% endif %}
-        {% if variant.dbsnp_id %}
-          {% for snp in variant.dbsnp_id.split(';') %}
-            <a class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank" href="{{variant.snp_links[snp]}}">dbSNP ({{ snp }})</a>
-          {% endfor %}
-        {% endif %}
-      </div>
-      <div class="btn-group">
-        {% if primary_transcript and primary_transcript.varsome_link %}
-        <a href="{{ primary_transcript.varsome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
-          data-toggle="tooltip" title="Varsome">V</a>
-        {% endif %}
-        {% if primary_transcript and primary_transcript.tp53_link %}
-          <a href="{{ primary_transcript.tp53_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
-            data-toggle="tooltip" title="MutanTP53">TP53</a>
-        {% endif %}
-        {% if primary_transcript and primary_transcript.cbioportal_link %}
-          <a href="{{ primary_transcript.cbioportal_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
-            data-toggle="tooltip" title="cBioPortal">CBP</a>
-        {% endif %}
-        {% if primary_transcript and primary_transcript.mycancergenome_link %}
-          <a href="{{ primary_transcript.mycancergenome_link }}" class="btn btn-sm btn-info text-white mr-1 mb-1" role="button" target="_blank"
-            data-toggle="tooltip" title="MyCancerGenome">MCG</a>
-        {% endif %}
-      </div>
+      <!--LINK out resources-->
+      {{database_buttons(variant)}}
     </div>
-
     <!--IGV URLS-->
     <div class="h6 ml-4">Alignment</div>
     {{ alignments(institute, case, variant, current_user, case_groups, config, igv_tracks, splice_junctions_tracks) }}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -264,15 +264,16 @@
         </li>
         <li class="list-group-item">Rank score: <span class="font-weight-bold">{{ variant.rank_score }}</span>
         </li>
+        <li class="list-group-item">
+          {{ clinsig_table(variant) }}
+        </li>
+        <li class="list-group-item">
+          {{ database_buttons(variant) }}
+        </li>
       </ul>
-      <div class="h6 mt-1">
-        {{ clinsig_table(variant) }}
-      </div>
-      <!--LINK out resources-->
-      {{database_buttons(variant)}}
     </div>
     <!--IGV URLS-->
-    <div class="h6 ml-4">Alignment</div>
+    <div class="ml-4">Alignment</div>
     {{ alignments(institute, case, variant, current_user, case_groups, config, igv_tracks, splice_junctions_tracks) }}
 
     </div>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -1,4 +1,5 @@
 {% extends "layout_bs4.html" %}
+{% from "variant/buttons.html" import database_buttons %}
 {% from "utils.html" import comments_panel, activity_panel, pedigree_panel %}
 {% from "variants/utils.html" import compounds_table %}
 {% from "variant/utils.html" import modal_causative, rankscore_panel, overlapping_panel, genes_panel, transcripts_panel, proteins_panel,  pin_button, causative_button %}
@@ -348,6 +349,9 @@
           {% endfor %}
         </div>
       </ul>
+      {% if variant.category != "str" %}
+        {{ database_buttons(variant) }}
+      {% endif %}
       {{ alignments(institute, case, variant, current_user, case_groups, config, igv_tracks, splice_junctions_tracks) }}
       {% if variant.custom %}
       <table class="table table-bordered table-sm">

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -138,17 +138,6 @@
         </tbody>
       </table>
     </div>
-    {% if variant.track == "rd" %}
-      <div class="card-footer">
-        <a href="{{ variant.swegen_link }}" target="_blank">SweGen</a>
-        <a href="{{ variant.beacon_link }}" target="_blank">Beacon</a>
-        {% if variant.cosmic_link %}
-          <a href="{{ variant.cosmic_link }}" target="_blank">COSMIC</a>
-        {% else %}
-          COSMIC
-        {% endif %}
-      </div>
-    {% endif %}
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
Fix #3105 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh your.email@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Install on cg-vm1 or locally and make sure these links are visible while using this branch

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
