### PR TITLE
Export verified variants from all institutes when user is admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section
 - Demo delivery report orientation to fit new columns
 - Missing delivery report in demo case
+- Export verified variants from all institutes when user is admin
 
 ## [4.47]
 ### Added

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -534,6 +534,8 @@ def upload_panel(institute_id, case_name):
 def download_verified():
     """Download all verified variants for user's cases"""
 
+    user_obj = store.user(current_user.email)
+
     user_institutes = (
         [inst["_id"] for inst in store.institutes()]
         if current_user.is_admin

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -534,7 +534,6 @@ def upload_panel(institute_id, case_name):
 def download_verified():
     """Download all verified variants for user's cases"""
 
-    flash(current_user.__dict__)
     user_institutes = (
         [inst["_id"] for inst in store.institutes()]
         if current_user.is_admin

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -6,7 +6,7 @@ import os.path
 import shutil
 
 import pymongo
-from flask import Blueprint, abort, current_app, flash, redirect, request, send_file, url_for
+from flask import Blueprint, flash, redirect, request, send_file, url_for
 from flask_login import current_user
 
 from scout.constants import (

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -537,7 +537,7 @@ def download_verified():
     user_institutes = (
         [inst["_id"] for inst in store.institutes()]
         if current_user.is_admin
-        else current_user.get("institutes")
+        else user_obj.get("institutes")
     )
     temp_excel_dir = os.path.join(variants_bp.static_folder, "verified_folder")
     os.makedirs(temp_excel_dir, exist_ok=True)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -533,8 +533,13 @@ def upload_panel(institute_id, case_name):
 @variants_bp.route("/verified", methods=["GET"])
 def download_verified():
     """Download all verified variants for user's cases"""
-    user_obj = store.user(current_user.email)
-    user_institutes = user_obj.get("institutes")
+
+    flash(current_user.__dict__)
+    user_institutes = (
+        [inst["_id"] for inst in store.institutes()]
+        if current_user.is_admin
+        else current_user.get("institutes")
+    )
     temp_excel_dir = os.path.join(variants_bp.static_folder, "verified_folder")
     os.makedirs(temp_excel_dir, exist_ok=True)
 


### PR DESCRIPTION
Fix #3109

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh your.email@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Install master branch in cg-vm1 
1. As an admin, go to the dashboard and run an empty query (all institutes)
1. You should see that you downloaded some files, one for each of your institutes
1. Switch to this branch and repeat

**Expected outcome**:
- [ ] You should be able to download validates variants from more institutes now 

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
