### PR TITLE
Change Dockerfile builder images to install latest cyvcf2 during Dockerfile build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update igv.js to v2.10.5
 - Updated example of a case delivery report
 - Unfreeze cyvcf2
+- Builder images used in Scout Dockerfiles
 ### Fixed
 - Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section
 - Demo delivery report orientation to fit new columns

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.8-cyvcf2-venv:1.0 AS python-builder
+FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.8-cyvcf2-venv:1.0 AS python-builder
+FROM clinicalgenomics/python3.8-venv:1.0:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.8-venv:1.0:1.0 AS python-builder
+FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 


### PR DESCRIPTION
After unfreezing the cyvcf2 dependency the process of installing the dependency became much faster.

This means that we could modify the base images used in both Scout Dockerfile to be generical python images (with virtual env) instead of python+venv+cyvcf2 images



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh your.email@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Locally, try to build the Dockefile image and make sure that it takes not much longer than a minute
2. Install the branch on cg-vm1 and make sure Scout web works

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
