### PR TITLE
Fix Typos and Ordering in adapter/mongo.base.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cast MNVs to SNV for test
 - Export verified variants from all institutes when user is admin
 - Cancer coverage and QC report not found for demo cancer case
+- Fix code typos
 
 ## [4.47]
 ### Added

--- a/scout/adapter/mongo/base.py
+++ b/scout/adapter/mongo/base.py
@@ -104,6 +104,7 @@ class MongoAdapter(
         self.event_collection = database.event
         self.exon_collection = database.exon
         self.filter_collection = database.filter
+        self.hgnc_collection = database.hgnc_gene
         self.hpo_term_collection = database.hpo_term
         self.institute_collection = database.institute
         self.managed_variant_collection = database.managed_variant
@@ -112,7 +113,6 @@ class MongoAdapter(
         self.transcript_collection = database.transcript
         self.user_collection = database.user
         self.variant_collection = database.variant
-        self.hgnc_collection = database.hgnc_gene
 
     def collections(self):
         """Return all collection names

--- a/scout/adapter/mongo/base.py
+++ b/scout/adapter/mongo/base.py
@@ -79,7 +79,7 @@ class MongoAdapter(
     PhenoModelHandler,
 ):
 
-    """Adapter for cummunication with a mongo database."""
+    """Adapter for communication with a Mongo database."""
 
     def __init__(self, database=None):
         if database:
@@ -94,25 +94,25 @@ class MongoAdapter(
     def setup(self, database):
         """Setup connection to database."""
         self.db = database
-        self.hgnc_collection = database.hgnc_gene
-        self.user_collection = database.user
-        self.institute_collection = database.institute
-        self.event_collection = database.event
+        self.acmg_collection = database.acmg
         self.case_collection = database.case
         self.case_group_collection = database.case_group
-        self.panel_collection = database.gene_panel
-        self.hpo_term_collection = database.hpo_term
-        self.disease_term_collection = database.disease_term
-        self.variant_collection = database.variant
-        self.acmg_collection = database.acmg
         self.clinvar_collection = database.clinvar
         self.clinvar_submission_collection = database.clinvar_submission
-        self.exon_collection = database.exon
-        self.transcript_collection = database.transcript
-        self.filter_collection = database.filter
         self.cytoband_collection = database.cytoband
+        self.disease_term_collection = database.disease_term
+        self.event_collection = database.event
+        self.exon_collection = database.exon
+        self.filter_collection = database.filter
+        self.hpo_term_collection = database.hpo_term
+        self.institute_collection = database.institute
         self.managed_variant_collection = database.managed_variant
+        self.panel_collection = database.gene_panel
         self.phenomodel_collection = database.phenomodel
+        self.transcript_collection = database.transcript
+        self.user_collection = database.user
+        self.variant_collection = database.variant
+        self.hgnc_collection = database.hgnc_gene
 
     def collections(self):
         """Return all collection names

--- a/scout/adapter/mongo/base.py
+++ b/scout/adapter/mongo/base.py
@@ -28,7 +28,6 @@ Copyright (c) 2017 __MoonsoInc__. All rights reserved.
 
 """
 import logging
-from datetime import datetime
 
 from flask import current_app
 


### PR DESCRIPTION
A minimal PR. This PR fixes a typo and ordering of instance variables of `adapter/mongo/base.py`

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data
Run pytests. Test server.


**Expected outcome**:
The functionality should be working. Pytest should succeed.

**Review:**
- [ ] code approved by
- [ ] tests executed by
