### PR TITLE
Export of PDF gene panel report using PDFKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Keep portrait orientation in PDF delivery report
 - Export delivery report to PDF using PDFKit instead of Weasyprint
 - PDF export of clinical and research HPO panels using PDFKit instead of Weasyprint
-- Export delivery report to PDF using PDFKit
 - Export gene panel report to PDF using PDFKit
 ### Fixed
 - Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated cancer "Coverage and QC report" example
 - Keep portrait orientation in PDF delivery report
 - Export delivery report to PDF using PDFKit
+- Export gene panel report to PDF using PDFKit
 ### Fixed
 - Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section
 - Demo delivery report orientation to fit new columns
@@ -24,9 +25,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cast MNVs to SNV for test
 - Export verified variants from all institutes when user is admin
 - Cancer coverage and QC report not found for demo cancer case
-- Pull request template instructions on how to deploy to test server 
+- Pull request template instructions on how to deploy to test server
 - PDF Delivery report not showing Swedac logo
 - Fix code typos
+- Loading spinner stuck after downloading a PDF gene panel report
 
 ## [4.47]
 ### Added

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -102,7 +102,7 @@
         </li>
       {% endif %}
       <li class="list-group-item">
-        <a href="{{ url_for('panels.panel_export', panel_id=panel._id) }}" class="btn btn-warning btn-sm">Export to PDF</a>
+        <a href="{{ url_for('panels.panel_export', panel_id=panel._id) }}" class="btn btn-warning btn-sm" download>Export to PDF</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This PR:
- Library switch (PDFKit instead of Weasyprint) for downloading gene panels reports (fix #3125 )
- Fixes the loading spinner that keeps spinning after loading a gene panel report
- Loading of gene panel reports is much faster now


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. On cg-vm1, **main branch**: go to a gene panel and click on **Export to PDF**:
![image](https://user-images.githubusercontent.com/28093618/152339527-93570e7b-8739-43e5-967f-44eb15ab7907.png)
1. Make sure that the loading spinner keeps going after the download is finished
2. Switch to this branch and repeat, you should see that:
- [ ] download of the report is faster
- [ ] The spinner stops after the download


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
