### PR TITLE
Disable ESLint warnings for JS functions located on an external file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cast MNVs to SNV for test
 - Export verified variants from all institutes when user is admin
 - Cancer coverage and QC report not found for demo cancer case
-- Pull request template instructions on how to deploy to test server 
+- Pull request template instructions on how to deploy to test server
 - PDF Delivery report not showing Swedac logo
 - Fix code typos
+- Disable codefactor raised by ESLint for javascript functions located on another file
 
 ## [4.47]
 ### Added

--- a/scout/server/blueprints/variants/static/form_scripts.js
+++ b/scout/server/blueprints/variants/static/form_scripts.js
@@ -1,5 +1,5 @@
 /* exported updatedChromSelOptions */
-function updatedChromSelOptions() {
+function updatedChromSelOptions() { // eslint-disable-line no-unused-vars
 	console.log("updatedChromSelOptions")
 
   chrom = getSelectedChromosomes()
@@ -195,7 +195,7 @@ function eraseChromPosString() {
 /* exported updatedChromPosInput */
 // Link chromosome position input field with chromosome and cytoband dropdowns.
 // Changes in chrom_pos input are reflected in chrom, start and end fields
-function updatedChromPosInput() {
+function updatedChromPosInput() { // eslint-disable-line no-unused-vars
 	console.log('Update to chrom pos field detected!')
 	var chromSel = document.forms["filters_form"].elements["chrom"];
 	var chromPos = document.forms["filters_form"].elements["chrom_pos"];
@@ -247,4 +247,3 @@ function updatedChromPosInput() {
 		}
 	}
 }
-


### PR DESCRIPTION
Silence a couple of annoying Codefactor warnings introduced by last PR

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Make sure that variants filtering works fine

**Expected outcome**:
- No codefactor warnings
- All tests shpuld pass

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, codefactor
