### PR TITLE
Remove WeasyPrint and Flask-WeasyPrint lib requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated cancer "Coverage and QC report" example
 - Keep portrait orientation in PDF delivery report
 - Export delivery report to PDF using PDFKit
+- Removed WeasyPrint lib dependency 
 ### Fixed
 - Reintroduced missing links to Swegen and Beacon and dbSNP in RD variant page, summary section
 - Demo delivery report orientation to fit new columns

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install --editable .
 
 Scout PDF reports are created using [Flask-WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
 
-<b>NB</b>: in order to convert HTML reports into PDF reports, we have recently switching from WeasyPrint lib to  [python-pdfkit](https://github.com/JazzCore/python-pdfkit). For this reason, when upgrading to a Scout version >4.47, you need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
+<b>NB</b>: in order to convert HTML reports into PDF reports, we have recently switched from WeasyPrint lib to  [python-pdfkit](https://github.com/JazzCore/python-pdfkit). For this reason, when upgrading to a Scout version >4.47, you need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
 
 You also need to have an instance of MongoDB running. I've found that it's easiest to do using the official Docker image:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install --editable .
 
 Scout PDF reports are created using [Flask-WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
 
-<b>NB</b>: in order to convert HTML reports into PDF reports, we have recently switched from WeasyPrint lib to  [python-pdfkit](https://github.com/JazzCore/python-pdfkit). For this reason, when upgrading to a Scout version >4.47, you need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
+<b>NB</b>: in order to convert HTML reports into PDF reports, we have recently switched from the WeasyPrint lib to [python-pdfkit](https://github.com/JazzCore/python-pdfkit). For this reason, when upgrading to a Scout version >4.47, you need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
 
 You also need to have an instance of MongoDB running. I've found that it's easiest to do using the official Docker image:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pip install --editable .
 
 Scout PDF reports are created using [Flask-WeasyPrint](https://pythonhosted.org/Flask-WeasyPrint/). This library requires external dependencies which need be installed separately (namely Cairo and Pango). See platform-specific instructions for Linux, macOS and Windows available on the WeasyPrint installation [pages](https://weasyprint.readthedocs.io/en/stable/install.html#).
 
-<b>NB</b>: in order to convert HTML reports into PDF reports, we are currently switching to the [python-pdfkit](https://github.com/JazzCore/python-pdfkit) library. For this reason, when upgrading to a Scout version >4.47, you may need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
+<b>NB</b>: in order to convert HTML reports into PDF reports, we have recently switching from WeasyPrint lib to  [python-pdfkit](https://github.com/JazzCore/python-pdfkit). For this reason, when upgrading to a Scout version >4.47, you need to install an additional [wkhtmltopdf system library](https://wkhtmltopdf.org/).
 
 You also need to have an instance of MongoDB running. I've found that it's easiest to do using the official Docker image:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ path.py
 Flask-Markdown
 Flask-WTF
 Flask-Mail
-Flask-WeasyPrint
 coloredlogs<=14.0
 query_phenomizer
 Flask-Babel
@@ -17,11 +16,13 @@ livereload
 python-dateutil
 pymongo>=3.7,<4.0
 pathlib
-WeasyPrint==0.42.3
 pdfkit
 xlsxwriter
 click
 cryptography<3.4
+defusedxml
+svglib
+cairosvg
 
 # webapp login
 authlib


### PR DESCRIPTION
Since we have switched to PDFKit, remove the WeasyPrint dependency

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
