### PR TITLE
Fixed some Pydantic case parsing model types and default values

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -19,5 +19,5 @@ jobs:
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: --min-confidence 80 --ignore-names cls ${{steps.files.outputs.all}}
+          vulture-args: --min-confidence 80 --ignore-names cls,args ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -19,5 +19,5 @@ jobs:
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: --min-confidence 80 ${{steps.files.outputs.all}}
+          vulture-args: --min-confidence 80 --ignore-names cls ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Fixed
-- Pydantic model types for genome_build, madeline_info, peddy_ped_check and peddy_sex_check
+- Pydantic model types for genome_build, madeline_info, peddy_ped_check and peddy_sex_check, rank_model_version and sv_rank_model_version
 
 ## [4.48.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Fixed
 - Pydantic model types for genome_build, madeline_info, peddy_ped_check and peddy_sex_check, rank_model_version and sv_rank_model_version
-
-## [4.48.1]
 ### Changed
 - Introduced page margins on exported PDF reports
 - Smaller gene fonts in downloaded HPO genes PDF reports
+
 
 ## [4.48.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Fixed
+- Pydantic model types for genome_build, madeline_info, peddy_ped_check and peddy_sex_check
+
 ## [4.48.1]
 ### Fixed
 - General case PDF report for recent cases with no pedigree

--- a/scout/parse/models.py
+++ b/scout/parse/models.py
@@ -291,10 +291,10 @@ class ScoutLoadConfig(BaseModel):
     peddy_ped_check: Optional[str] = Field(None, alias="peddy_check")
     peddy_sex_check: Optional[str] = Field(None, alias="peddy_sex")
     phenotype_terms: Optional[List[str]] = None
-    rank_model_version: Optional[str] = ""
+    rank_model_version: Optional[str] = None
     rank_score_threshold: Optional[int] = 0
     smn_tsv: Optional[str] = None
-    sv_rank_model_version: Optional[str] = ""
+    sv_rank_model_version: Optional[str] = None
     synopsis: Union[List[str], str] = None
     track: Literal["rare", "cancer"] = "rare"
     vcf_files: Optional[VcfFiles]

--- a/scout/parse/models.py
+++ b/scout/parse/models.py
@@ -281,15 +281,15 @@ class ScoutLoadConfig(BaseModel):
     gene_fusion_report: Optional[str] = None
     gene_fusion_report_research: Optional[str] = None
     gene_panels: Optional[List[str]] = []
-    genome_build: int = Field([], alias="human_genome_build")
+    genome_build: int = Field(38, alias="human_genome_build")
     individuals: List[ScoutIndividual] = Field([], alias="samples")
     lims_id: Optional[str] = None
-    madeline_info: Optional[str] = Field("", alias="madeline")  #!
+    madeline_info: Optional[str] = Field(None, alias="madeline")  #!
     multiqc: Optional[str] = None
     owner: str = None
     peddy_ped: Optional[str] = None
-    peddy_ped_check: Optional[str] = Field("", alias="peddy_check")
-    peddy_sex_check: Optional[str] = Field("", alias="peddy_sex")
+    peddy_ped_check: Optional[str] = Field(None, alias="peddy_check")
+    peddy_sex_check: Optional[str] = Field(None, alias="peddy_sex")
     phenotype_terms: Optional[List[str]] = None
     rank_model_version: Optional[str] = ""
     rank_score_threshold: Optional[int] = 0

--- a/scout/parse/models.py
+++ b/scout/parse/models.py
@@ -6,7 +6,7 @@ import re
 from fractions import Fraction
 from glob import glob
 from pathlib import Path
-from typing import Any, ByteString, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, root_validator, validator
 from typing_extensions import Literal


### PR DESCRIPTION
Some model types in pydantic parsing are incorrect or could have better (or none) values

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Load a demo case with and without the modified params in the config file and check that the created case document is correct

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
