### PR TITLE
PDF page margins and smaller HPO genes reports fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.48.1]
+### Changed
+- Introduced page margins on exported PDF reports
+- Smaller gene fonts in downloaded HPO genes PDF reports
+
+## [4.48.1]
 ### Fixed
 - General case PDF report for recent cases with no pedigree
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -935,7 +935,7 @@ def download_hpo_genes(institute_id, case_name, category):
     phenotype_terms_with_genes = controllers.phenotypes_genes(store, case_obj, is_clinical)
     html_content = ""
     for term_id, term in phenotype_terms_with_genes.items():
-        html_content += f"<hr><strong>{term_id} - {term.get('description')}</strong><br><br><i>{term.get('genes')}</i><br>"
+        html_content += f"<hr><strong>{term_id} - {term.get('description')}</strong><br><br><font style='font-size:16px;'><i>{term.get('genes')}</i></font><br><br>"
 
     bytes_file = html_to_pdf_file(html_content, "portrait", 300)
     file_name = "_".join(

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -15,7 +15,7 @@ from flask_login import current_user
 LOG = logging.getLogger(__name__)
 
 
-def html_to_pdf_file(html_string, orientation, dpi=96, margins=["2cm", "1cm", "1cm", "1cm"]):
+def html_to_pdf_file(html_string, orientation, dpi=96, margins=["1.5cm", "1cm", "1cm", "1cm"]):
     """Creates a pdf file from the content of an HTML file
     Args:
         html_string(string): an HTML string to be rendered as PDF

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -15,12 +15,13 @@ from flask_login import current_user
 LOG = logging.getLogger(__name__)
 
 
-def html_to_pdf_file(html_string, orientation, dpi=96):
+def html_to_pdf_file(html_string, orientation, dpi=96, margins=["2cm", "1cm", "1cm", "1cm"]):
     """Creates a pdf file from the content of an HTML file
     Args:
         html_string(string): an HTML string to be rendered as PDF
         orientation(string): landscape, portrait
         dpi(int): dot density of the page to be printed
+        margins(list): [ margin-top, margin-right, margin-bottom, margin-left], in cm
 
     Returns:
         bytes_file(BytesIO): a BytesIO file
@@ -30,6 +31,10 @@ def html_to_pdf_file(html_string, orientation, dpi=96):
         "orientation": orientation,
         "encoding": "UTF-8",
         "dpi": dpi,
+        "margin-top": margins[0],
+        "margin-right": margins[1],
+        "margin-bottom": margins[2],
+        "margin-left": margins[3],
         "enable-local-file-access": None,
     }
     pdf = pdfkit.from_string(html_string, False, options=options, verbose=True)


### PR DESCRIPTION
Fix #3144 :
- Introduce default page margins on exported PDF reports
- Decrease fonts of gene names text in HPO genes reports
 
<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Install on cg-vm1 and compare with current main branch

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
