### PR TITLE
Reintroduce coverage report in PDF general report of RD cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Introduced page margins on exported PDF reports
 - Smaller gene fonts in downloaded HPO genes PDF reports
+- Reintroduced gene coverage data in the PDF-exported general report
 
 
 ## [4.48.1]

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -52,10 +52,11 @@ JSON_HEADERS = {
 }
 
 
-def coverage_report_contents(institute_obj, case_obj):
+def coverage_report_contents(base_url, institute_obj, case_obj):
     """Capture the contents of a case coverage report (chanjo-report), to be displayed in the general case report
 
     Args:
+        base_url(str): base url of this application
         institute_obj(models.Institute)
         case_obj(models.Case)
 
@@ -86,9 +87,10 @@ def coverage_report_contents(institute_obj, case_obj):
     request_data["level"] = institute_obj.get("coverage_cutoff", 15)
 
     # Collect the coverage report HTML string
-    coverage_report_html = render_template("report/report.html", format="pdf", **request_data)
+    resp = requests.post(base_url + "reports/report", data=request_data)
+
     # Extract the contents between <body> and </body>
-    html_body_content = coverage_report_html.split("<body>")[1].split("</body>")[0]
+    html_body_content = resp.text.split("<body>")[1].split("</body>")[0]
     return html_body_content
 
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -78,8 +78,7 @@ def coverage_report_contents(base_url, institute_obj, case_obj):
         full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])
         panel_names.append(full_name)
     panel_names = " ,".join(panel_names)
-    request_data["extras"] = {"gene_ids": list(distinct_genes)}
-
+    request_data["gene_ids"] = ",".join([str(gene_id) for gene_id in list(distinct_genes)])
     request_data["panel_name"] = panel_names
     request_data["request_sent"] = datetime.datetime.now()
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -9,7 +9,7 @@ from base64 import b64encode
 import query_phenomizer
 import requests
 from bson.objectid import ObjectId
-from flask import current_app, flash, redirect, request, url_for
+from flask import current_app, flash, redirect, render_template, request, url_for
 from flask_login import current_user
 from flask_mail import Message
 from requests.auth import HTTPBasicAuth
@@ -50,6 +50,46 @@ JSON_HEADERS = {
     "Content-type": "application/json; charset=utf-8",
     "Accept": "text/json",
 }
+
+
+def coverage_report_contents(institute_obj, case_obj):
+    """Capture the contents of a case coverage report (chanjo-report), to be displayed in the general case report
+
+    Args:
+        institute_obj(models.Institute)
+        case_obj(models.Case)
+
+    Returns:
+        coverage_html(str): A string corresponding to the HTML content of a chanjo-report
+    """
+    request_data = {}
+    # extract sample ids from case_obj and add them to the post request object:
+    request_data["sample_id"] = [ind["individual_id"] for ind in case_obj["individuals"]]
+
+    # extract default panel names and default genes from case_obj and add them to the post request object
+    distinct_genes = set()
+    panel_names = []
+    for panel_info in case_obj.get("panels", []):
+        if panel_info.get("is_default") is False:
+            continue
+        panel_obj = store.gene_panel(panel_info["panel_name"], version=panel_info.get("version"))
+        distinct_genes.update([gene["hgnc_id"] for gene in panel_obj.get("genes", [])])
+        full_name = "{} ({})".format(panel_obj["display_name"], panel_obj["version"])
+        panel_names.append(full_name)
+    panel_names = " ,".join(panel_names)
+    request_data["extras"] = {"gene_ids": list(distinct_genes)}
+
+    request_data["panel_name"] = panel_names
+    request_data["request_sent"] = datetime.datetime.now()
+
+    # add institute-specific cutoff level to the post request object
+    request_data["level"] = institute_obj.get("coverage_cutoff", 15)
+
+    # Collect the coverage report HTML string
+    coverage_report_html = render_template("report/report.html", format="pdf", **request_data)
+    # Extract the contents between <body> and </body>
+    html_body_content = coverage_report_html.split("<body>")[1].split("</body>")[0]
+    return html_body_content
 
 
 def case(store, institute_obj, case_obj):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -9,7 +9,7 @@ from base64 import b64encode
 import query_phenomizer
 import requests
 from bson.objectid import ObjectId
-from flask import current_app, flash, redirect, render_template, request, url_for
+from flask import current_app, flash, redirect, request, url_for
 from flask_login import current_user
 from flask_mail import Message
 from requests.auth import HTTPBasicAuth

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -61,7 +61,7 @@ def coverage_report_contents(base_url, institute_obj, case_obj):
         case_obj(models.Case)
 
     Returns:
-        coverage_html(str): A string corresponding to the HTML content of a chanjo-report
+        html_body_content(str): A string corresponding to the text within the <body> of an HTML chanjo-report page
     """
     request_data = {}
     # extract sample ids from case_obj and add them to the post request object:

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -64,7 +64,7 @@
    {{ dismissed_panel() }}
    [END OF VARIANT REPORT]<br><br>
    {% if coverage_report %}
-    {{ coverage_report|safe }}<br>
+    <div style="display: inline-block;">{{ coverage_report|safe }}</div><br>
    {% endif %}
    <a href="https://clinical-genomics.github.io/scout" target="_blank">clinical-genomics.github.io/scout</a>
 </div>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -238,7 +238,7 @@ def pdf_case_report(institute_id, case_name):
     html_report = render_template("cases/case_report.html", format="pdf", **data)
 
     bytes_file = html_to_pdf_file(
-        html_string=html_report, orientation="portrait", dpi=300, zoom=0.75
+        html_string=html_report, orientation="portrait", dpi=300, zoom=0.7
     )
     file_name = "_".join(
         [

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -222,7 +222,9 @@ def pdf_case_report(institute_id, case_name):
         current_app.config.get("SQLALCHEMY_DATABASE_URI")
         and case_obj.get("track", "rare") != "cancer"
     ):
-        data["coverage_report"] = controllers.coverage_report_contents(institute_obj, case_obj)
+        data["coverage_report"] = controllers.coverage_report_contents(
+            request.url_root, institute_obj, case_obj
+        )
 
     # Workaround to be able to print the case pedigree to pdf
     if case_obj.get("madeline_info") and case_obj.get("madeline_info") != "":

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -217,6 +217,13 @@ def pdf_case_report(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     data = controllers.case_report_content(store, institute_id, case_name)
 
+    # add coverage report on the bottom of this report
+    if (
+        current_app.config.get("SQLALCHEMY_DATABASE_URI")
+        and case_obj.get("track", "rare") != "cancer"
+    ):
+        data["coverage_report"] = controllers.coverage_report_contents(institute_obj, case_obj)
+
     # Workaround to be able to print the case pedigree to pdf
     if case_obj.get("madeline_info") and case_obj.get("madeline_info") != "":
         write_to = os.path.join(cases_bp.static_folder, "madeline.png")
@@ -228,7 +235,7 @@ def pdf_case_report(institute_id, case_name):
 
     html_report = render_template("cases/case_report.html", format="pdf", **data)
 
-    bytes_file = html_to_pdf_file(html_report, "portrait", 300)
+    bytes_file = html_to_pdf_file(html_string=html_report, orientation="portrait", zoom=0.75)
     file_name = "_".join(
         [
             case_obj["display_name"],

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -235,7 +235,9 @@ def pdf_case_report(institute_id, case_name):
 
     html_report = render_template("cases/case_report.html", format="pdf", **data)
 
-    bytes_file = html_to_pdf_file(html_string=html_report, orientation="portrait", zoom=0.75)
+    bytes_file = html_to_pdf_file(
+        html_string=html_report, orientation="portrait", dpi=300, zoom=0.75
+    )
     file_name = "_".join(
         [
             case_obj["display_name"],

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -24,7 +24,7 @@ def html_to_pdf_file(
         orientation(string): landscape, portrait
         dpi(int): dot density of the page to be printed
         margins(list): [ margin-top, margin-right, margin-bottom, margin-left], in cm
-        zoom(float): increase of decrease the size of the content on the pages
+        zoom(float): change the size of the content on the pages
 
     Returns:
         bytes_file(BytesIO): a BytesIO file

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -15,19 +15,23 @@ from flask_login import current_user
 LOG = logging.getLogger(__name__)
 
 
-def html_to_pdf_file(html_string, orientation, dpi=96, margins=["1.5cm", "1cm", "1cm", "1cm"]):
+def html_to_pdf_file(
+    html_string, orientation, dpi=96, margins=["1.5cm", "1cm", "1cm", "1cm"], zoom=1
+):
     """Creates a pdf file from the content of an HTML file
     Args:
         html_string(string): an HTML string to be rendered as PDF
         orientation(string): landscape, portrait
         dpi(int): dot density of the page to be printed
         margins(list): [ margin-top, margin-right, margin-bottom, margin-left], in cm
+        zoom(float): increase of decrease the size of the content on the pages
 
     Returns:
         bytes_file(BytesIO): a BytesIO file
     """
     options = {
         "page-size": "A4",
+        "zoom": zoom,
         "orientation": orientation,
         "encoding": "UTF-8",
         "dpi": dpi,

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -27,7 +27,7 @@ def test_coverage_report_contents(app, institute_obj, case_obj):
         status=200,
     )
 
-    # THEN the returned result should be content included in <body> of the HTML response
+    # THEN the returned result should be the HTML content included in the <body> of the HTML response
     assert coverage_report_contents(base_url, institute_obj, case_obj) == "This is a test"
 
 

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,14 +1,34 @@
 """Tests for the cases controllers"""
-import requests  # import requests for the purposes of monkeypatching
+import requests
+import responses
 from flask import Blueprint, Flask, url_for
 
 from scout.server.blueprints.cases.controllers import (
     case,
     case_report_content,
+    coverage_report_contents,
     mt_coverage_stats,
     phenotypes_genes,
 )
 from scout.server.extensions import store
+
+
+@responses.activate
+def test_coverage_report_contents(app, institute_obj, case_obj):
+    """Test the method that extracts the <body> out of HTML response from a call to chanjo-report"""
+
+    base_url = "http://test.com/"
+
+    # GIVEN a mocked response from chanjo-report
+    responses.add(
+        responses.POST,
+        f"{base_url}reports/report",
+        body="<html><body>This is a test</body></html>",
+        status=200,
+    )
+
+    # THEN the returned result should be content included in <body> of the HTML response
+    assert coverage_report_contents(base_url, institute_obj, case_obj) == "This is a test"
 
 
 def test_phenotypes_genes_research(gene_database, case_obj, hpo_term, gene_list):


### PR DESCRIPTION
- Reintroduce coverage report in the PDF-exported case general report (fix #3142)
- Smaller content in PDF-exported general report

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
- [x] Install on cg-vm1 and check that both reports fit the page for recent cases
- [x] Check that coverage report is not included in PDF general report if case is a cancer case

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
