### PR TITLE
Test for report existence - Fix #3130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Introduced page margins on exported PDF reports
 - Smaller gene fonts in downloaded HPO genes PDF reports
 - Reintroduced gene coverage data in the PDF-exported general report
+- Check for existence of report files before linking
 
 
 ## [4.48.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Introduced page margins on exported PDF reports
 - Smaller gene fonts in downloaded HPO genes PDF reports
 - Reintroduced gene coverage data in the PDF-exported general report
-- Check for existence of report files before linking
+- Check for existence of case report files before creating sidebar links
 
 
 ## [4.48.1]

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -1,5 +1,6 @@
 """Code for flask app"""
 import logging
+import os
 import re
 
 import coloredlogs
@@ -66,6 +67,7 @@ def create_app(config_file=None, config=None):
     configure_extensions(app)
     register_blueprints(app)
     register_filters(app)
+    register_tests(app)
 
     if not (app.debug or app.testing) and app.config.get("MAIL_USERNAME"):
         # setup email logging of errors
@@ -207,10 +209,17 @@ def register_filters(app):
 
     @app.template_filter()
     def count_cursor(pymongo_cursor):
-        """Count numer of returned documents (deprecated pymongo.cursor.count())"""
+        """Count number of returned documents (deprecated pymongo.cursor.count())"""
         # Perform operations on a copy of the cursor so original does not move
         cursor_copy = pymongo_cursor.clone()
         return len(list(cursor_copy))
+
+
+def register_tests(app):
+    @app.template_test("existing")
+    def path_exists(path):
+        """Check if file exists. Helper for jinja template."""
+        return os.path.exists(path)
 
 
 def configure_oauth_login(app):

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -1,7 +1,6 @@
 """Code for flask app"""
 import logging
 import os
-import re
 
 import coloredlogs
 from flask import Flask, current_app, redirect, request, url_for

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -11,7 +11,7 @@
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }}
 {% endblock %}
 
-{% block css %}
+{% block css %}se_exi
 {{ super() }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
 <link rel="stylesheet" href="{{ url_for('cases.static', filename='case_styles.css') }}"></link>
@@ -44,7 +44,7 @@
 {% block content_main %}
 <div class="container-float">
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
-    {{ action_bar(institute, case, collaborators, current_user) }} <!-- This is the sidebar -->
+    {{ action_bar(institute, case, collaborators, current_user, path_exists) }} <!-- This is the sidebar -->
     {{ case_page() }}
   </div> <!-- end of div id body-row -->
 </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -11,7 +11,7 @@
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }}
 {% endblock %}
 
-{% block css %}se_exi
+{% block css %}
 {{ super() }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
 <link rel="stylesheet" href="{{ url_for('cases.static', filename='case_styles.css') }}"></link>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -44,7 +44,7 @@
 {% block content_main %}
 <div class="container-float">
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
-    {{ action_bar(institute, case, collaborators, current_user, path_exists) }} <!-- This is the sidebar -->
+    {{ action_bar(institute, case, collaborators, current_user) }} <!-- This is the sidebar -->
     {{ case_page() }}
   </div> <!-- end of div id body-row -->
 </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -65,8 +65,8 @@
             <div class="col-sm-8">
               {{ variants_buttons() }}
             </div>
-        </div>
-    </div> <!--end of div class="row" -->
+        </div> <!--end of div class="row" -->
+      </div>
 
       {% if other_causatives|length > 0%}
         <div class="row mt-0">
@@ -173,10 +173,8 @@
       {{ reanalysis_modal(institute, case) }}
       {{ beacon_modal(case) }}
       {{ matchmaker_modal(institute, case, suspects, mme_nodes) }}
-    </div> <!-- end of card body -->
-  </div> <!-- end of card div-->
-</div><!-- end of <div class="col"> -->
-</div>
+  </div><!-- end of <div containter> -->
+</div><!-- end of <div col> -->
 {% endmacro %}
 
 {% macro variants_buttons() %}
@@ -284,7 +282,7 @@
           <div class="col-12">
             {% for grouped_case in case_group %}
               <span class="badge badge-pill badge-light">
-                <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}"">{{ grouped_case.display_name }}</a>
+                <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}">{{ grouped_case.display_name }}</a>
                   <span>
                     <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
                         <span class="fa fa-remove"></span></a>
@@ -318,6 +316,7 @@
           {% for grouped_case in case_group %}
             <li class="list-group-item">{{ grouped_case.display_name }}</li>
           {% endfor %}
+          </ul>
           Add case:
           <input type="text" name="other_case_name" class="typeahead_cases form-control" data-provide="typeahead" autocomplete="off" placeholder="Search for case name..." cols="30" rows="10"></input>
         </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -1,4 +1,4 @@
-{% macro action_bar(institute, case, collaborators, current_user) %}
+{% macro action_bar(institute, case, collaborators, current_user, path_exists) %}
 <!-- Collapsible Sidebar, Based on https://www.codeply.com/go/LFd2SEMECH -->
   <div id="sidebar-container" class="sidebar-expanded d-none d-md-block"><!-- d-* hiddens the Sidebar in smaller devices. Its itens can be kept on the Navbar 'Menu' -->
       <!-- Bootstrap List Group -->
@@ -10,7 +10,7 @@
               </div>
           </a>
           <!-- Menu with submenu -->
-          {{ reports(institute,case) }}
+          {{ reports(institute,case, path_exists) }}
           {{ default_gene_panel(institute, case) }}
           {{ analysis_date(case) }}
           {{ genome_build(case) }}
@@ -55,7 +55,7 @@
   {% endfor %}
 {% endmacro %}
 
-{% macro reports(institute,case) %}
+{% macro reports(institute,case, path_exists) %}
 <a href="#submenu1" data-toggle="collapse" aria-expanded="false" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
     <div class="d-flex w-100 justify-content-start align-items-center">
         <span class="fa fa-book fa-fw mr-3"></span>
@@ -84,7 +84,7 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">MultiQC</span>
-          {% if os.path.exists(data["case"]["multiqc"]) %}
+          {% if path_exists(case.multiqc) %}
             <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
           {% else %}
             <i class="fa fa-exclamation-triangle"></i>
@@ -117,16 +117,16 @@
     </div>
     {% endif %}
     {% if case.cnv_report %}
-      {{ cnv_report(institute._id, case) }}
+      {{ cnv_report(institute._id, case, path_exists) }}
     {% endif %}
     {% if case.gene_fusion_report or case.gene_fusion_report_research %}
-      {{ gene_fusion_reports(institute._id, case) }}
+      {{ gene_fusion_reports(institute._id, case, path_exists) }}
     {% endif %}
     {% if case.coverage_qc_report %}
-      {{ coverage_qc_report(institute._id, case) }}
+      {{ coverage_qc_report(institute._id, case, path_exists) }}
     {% endif %}
     {% if case.delivery_report %}
-      {{ delivery_report(institute._id, case) }}
+      {{ delivery_report(institute._id, case, path_exists=path_exists) }}
     {% endif %}
     {% if case.analyses %}
       {% for analysis in case.analyses %}
@@ -531,13 +531,13 @@
 </div>
 {% endmacro %}
 
-{% macro delivery_report(institute, case, date=None) %}
+{% macro delivery_report(institute, case, date=None, path_exists=None) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
       <span class="menu-collapsed ml-2">Delivery ({{date or case.analysis_date.date() }})</span>
     </div>
-    {% if os.path.exists(data["case"]["delivery_report"]) or date != None %}
+    {% if date != None or path_exists(case.delivery_report) %}
       <div>
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
                           case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>
@@ -553,14 +553,14 @@
 </div>
 {% endmacro %}
 
-{% macro cnv_report(institute, case) %}
+{% macro cnv_report(institute, case, path_exists) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
       <span class="menu-collapsed ml-2">CNV report</span>
     </div>
     <div>
-      {% if os.path.exists(data["case"]["cnv_report"]) %}
+      {% if path_exists(case.cnv_report) %}
         <a href="{{ url_for('cases.cnv_report', institute_id=institute,
                         case_name=case.display_name, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
       {% else %}
@@ -571,7 +571,7 @@
 </div>
 {% endmacro %}
 
-{% macro gene_fusion_reports(institute, case) %}
+{% macro gene_fusion_reports(institute, case, path_exists) %}
 {% set fusion_reports = ["gene_fusion_report", "gene_fusion_report_research"] %}
 {% for report_type in fusion_reports %}
   {% if case[report_type] %}
@@ -581,7 +581,7 @@
           <span class="menu-collapsed ml-2">{{ report_type|replace("_report","")|replace("_"," ")|capitalize }}</span>
         </div>
         <div>
-          {% if os.path.exists(data["case"][report_type]) %}
+          {% if path_exists(case[report_type]) %}
             <a href="{{ url_for('cases.gene_fusion_report', institute_id=institute,
                             case_name=case.display_name, report_type=report_type) }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
           {% else %}
@@ -601,7 +601,7 @@
       <span class="menu-collapsed ml-2">Coverage and QC report</span>
     </div>
 
-    {% if os.path.exists(data["case"][coverage_qc_report]) %}
+    {% if path_exists(case.coverage_qc_report) %}
       <div>
         <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
                           case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -553,7 +553,7 @@
                           case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
     {% else %}
-      <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></i></div>
+      <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>
     {% endif %}
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -533,27 +533,30 @@
 {% endmacro %}
 
 {% macro analysis_report(institute, case, analysis) %}
-<div href="#" class="bg-dark list-group-item text-white">
-  <div class="d-flex flex-row flex-fill bd-highlight">
-    <div>
-      <span class="menu-collapsed ml-2">Delivery ({{ analysis.date.date() }})</span>
+{% if analysis.delivery_report == case.delivery_report and analysis.date.date() == case.analysis_date.date() %}
+{% else %}
+  <div href="#" class="bg-dark list-group-item text-white">
+    <div class="d-flex flex-row flex-fill bd-highlight">
+      <div>
+        <span class="menu-collapsed ml-2">Delivery ({{ analysis.date.date() }})</span>
+      </div>
+      {% if analysis.delivery_report != case.delivery_report and analysis.delivery_report is existing %}
+        <div>
+          <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                            case_name=case.display_name, date=analysis.date.date()) }}" target="_blank"><i class="fa fa-link"></i></a>
+        </div>
+        <div>
+          <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                            case_name=case.display_name, date=analysis.date.date(), format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
+        </div>
+      {% elif analysis.delivery_report == case.delivery_report %}
+        <div><i class="fa fa-exclamation-circle ml-1" data-toggle="tooltip" title="A delivery report had been registered for the analysis but has been replaced."></i></div>
+      {% else %}
+        <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>
+      {% endif %}
     </div>
-    {% if analysis.delivery_report != case.delivery_report and analysis.delivery_report is existing %}
-      <div>
-        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                          case_name=case.display_name, date=analysis.date.date()) }}" target="_blank"><i class="fa fa-link"></i></a>
-      </div>
-      <div>
-        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                          case_name=case.display_name, date=analysis.date.date(), format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
-      </div>
-    {% elif analysis.delivery_report == case.delivery_report and analysis.date.date() != case.analysis_date.date() %}
-      <div><i class="fa fa-exclamation-circle ml-1" data-toggle="tooltip" title="A delivery report had been registered for the analysis but it is the same as the latest."></i></div>
-    {% else %}
-      <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>
-    {% endif %}
   </div>
-</div>
+{% endif %}
 {% endmacro %}
 
 {% macro delivery_report(institute, case) %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -88,7 +88,7 @@
           {% if case.multiqc is existing %}
             <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
           {% else %}
-            <i class="fa fa-exclamation-triangle ml-1"></i>
+            <i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A MultiQC report has been registered for the case but not found on the file system.">
           {% endif %}
         </div>
       </div>
@@ -553,7 +553,7 @@
                           case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
     {% else %}
-      <div><i class="fa fa-exclamation-triangle"></i></div>
+      <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></i></div>
     {% endif %}
   </div>
 </div>
@@ -570,7 +570,7 @@
         <a href="{{ url_for('cases.cnv_report', institute_id=institute,
                         case_name=case.display_name, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
       {% else %}
-        <i class="fa fa-exclamation-triangle ml-1"></i>
+        <i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A CNV report has been registered for the case but not found on the file system."></i>
       {% endif %}
     </div>
   </div>
@@ -591,7 +591,7 @@
             <a href="{{ url_for('cases.gene_fusion_report', institute_id=institute,
                             case_name=case.display_name, report_type=report_type) }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
           {% else %}
-            <i class="fa fa-exclamation-triangle ml-1"></i>
+            <i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A fusion report has been registered for the case but not found on the file system."></i>
           {% endif %}
         </div>
       </div>
@@ -617,7 +617,7 @@
                           case_name=case.display_name, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
     {% else %}
-         <div><i class="fa fa-exclamation-triangle ml-1"></i></div>
+         <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A QC report has been registered for the case but not found on the file system."></i></div>
     {% endif %}
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -617,7 +617,7 @@
                           case_name=case.display_name, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
     {% else %}
-         <div><i class="fa fa-exclamation-triangle"></i></div>
+         <div><i class="fa fa-exclamation-triangle ml-1"></i></div>
     {% endif %}
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -88,7 +88,7 @@
           {% if case.multiqc is existing %}
             <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
           {% else %}
-            <i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A MultiQC report has been registered for the case but not found on the file system.">
+            <i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A MultiQC report has been registered for the case but not found on the file system."></i>
           {% endif %}
         </div>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -368,7 +368,7 @@
 {% endmacro %}
 
 {% macro check_decipher(case, institute) %}
-<a href="#submenu5" data-toggle="collapse" aria-expanded="false" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">  <div class="d-flex w-100 justify-content-start align-items-center"
+<a href="#submenu5" data-toggle="collapse" aria-expanded="false" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
   <div class="d-flex w-100 justify-content-start align-items-center">
     <span class="fa fa-check fa-fw mr-3"></span>
     <span class="menu-collapsed">Decipher check</span>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -126,12 +126,17 @@
       {{ coverage_qc_report(institute._id, case, path_exists) }}
     {% endif %}
     {% if case.delivery_report %}
-      {{ delivery_report(institute._id, case, path_exists=path_exists) }}
+      {{ delivery_report(institute._id, case, date=None, path_exists=path_exists) }}
     {% endif %}
     {% if case.analyses %}
       {% for analysis in case.analyses %}
         {% if analysis.delivery_report and analysis.delivery_report != case.delivery_report %}
-          {{ delivery_report( institute._id, case, analysis.date.date() ) }}
+          {% if path_exists(analysis.delivery_report) %}
+            {{ delivery_report( institute._id, case, date=analysis.date.date()) }}
+          {% else %}
+            {{ delivery_report( institute._id, case, date=analysis.date.date(), path_exists=false) }}
+          {% endif %}
+
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -537,7 +542,7 @@
     <div>
       <span class="menu-collapsed ml-2">Delivery ({{date or case.analysis_date.date() }})</span>
     </div>
-    {% if date != None or path_exists(case.delivery_report) %}
+    {% if (date == None and path_exists(case.delivery_report)) or (date != None and path_exists == None) %}
       <div>
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
                           case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -547,7 +547,7 @@
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
                           case_name=case.display_name, date=analysis.date.date(), format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
-    {% elif analysis.delivery_report == case.delivery_report and analysis.date.date() != case.anlysis_date.date() %}
+    {% elif analysis.delivery_report == case.delivery_report and analysis.date.date() != case.analysis_date.date() %}
       <div><i class="fa fa-exclamation-circle ml-1" data-toggle="tooltip" title="A delivery report had been registered for the analysis but it is the same as the latest."></i></div>
     {% else %}
       <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -131,13 +131,8 @@
     {% endif %}
     {% if case.analyses %}
       {% for analysis in case.analyses %}
-        {% if analysis.delivery_report and analysis.delivery_report != case.delivery_report %}
-          {% if analysis.delivery_report is existing %}
-            {{ delivery_report( institute._id, case, date=analysis.date.date()) }}
-          {% else %}
-            {{ delivery_report( institute._id, case, date=analysis.date.date(), analysis_path_exists=false) }}
-          {% endif %}
-
+        {% if analysis.delivery_report %}
+          {{ analysis_report( institute._id, case, analysis) }}
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -537,20 +532,44 @@
 </div>
 {% endmacro %}
 
-{% macro delivery_report(institute, case, date=None, analysis_path_exists=None) %}
+{% macro analysis_report(institute, case, analysis) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
-      <span class="menu-collapsed ml-2">Delivery ({{date or case.analysis_date.date() }})</span>
+      <span class="menu-collapsed ml-2">Delivery ({{ analysis.date.date() }})</span>
     </div>
-    {% if (date == None and case.delivery_report is existing) or (date != None and analysis_path_exists == None) %}
+    {% if analysis.delivery_report != case.delivery_report and analysis.delivery_report is existing %}
       <div>
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                          case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>
+                          case_name=case.display_name, date=analysis.date.date()) }}" target="_blank"><i class="fa fa-link"></i></a>
       </div>
       <div>
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                          case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
+                          case_name=case.display_name, date=analysis.date.date(), format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
+      </div>
+    {% elif analysis.delivery_report == case.delivery_report %}
+      <div><i class="fa fa-exclamation-circle ml-1" data-toggle="tooltip" title="A delivery report had been registered for the analysis but it is the same as the latest."></i></div>
+    {% else %}
+      <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}
+
+{% macro delivery_report(institute, case) %}
+<div href="#" class="bg-dark list-group-item text-white">
+  <div class="d-flex flex-row flex-fill bd-highlight">
+    <div>
+      <span class="menu-collapsed ml-2">Delivery ({{ case.analysis_date.date() }})</span>
+    </div>
+    {% if case.delivery_report is existing %}
+      <div>
+        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                          case_name=case.display_name, date=None) }}" target="_blank"><i class="fa fa-link"></i></a>
+      </div>
+      <div>
+        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                          case_name=case.display_name, date=None, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
     {% else %}
       <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -88,7 +88,7 @@
           {% if case.multiqc is existing %}
             <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
           {% else %}
-            <i class="fa fa-exclamation-triangle"></i>
+            <i class="fa fa-exclamation-triangle ml-1"></i>
           {% endif %}
         </div>
       </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -1,4 +1,4 @@
-{% macro action_bar(institute, case, collaborators, current_user, path_exists) %}
+{% macro action_bar(institute, case, collaborators, current_user) %}
 <!-- Collapsible Sidebar, Based on https://www.codeply.com/go/LFd2SEMECH -->
   <div id="sidebar-container" class="sidebar-expanded d-none d-md-block"><!-- d-* hiddens the Sidebar in smaller devices. Its itens can be kept on the Navbar 'Menu' -->
       <!-- Bootstrap List Group -->
@@ -10,7 +10,7 @@
               </div>
           </a>
           <!-- Menu with submenu -->
-          {{ reports(institute,case, path_exists) }}
+          {{ reports(institute,case) }}
           {{ default_gene_panel(institute, case) }}
           {{ analysis_date(case) }}
           {{ genome_build(case) }}
@@ -50,12 +50,13 @@
             {% if case.outdated_panels and panel.panel_name in case.outdated_panels %}
               <a><span class="badge badge-pill badge-sm badge-warning" data-toggle="popover" data-placement="left" data-html="true" data-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
             {% endif %}
+          </span>
         </div>
       </div>
   {% endfor %}
 {% endmacro %}
 
-{% macro reports(institute,case, path_exists) %}
+{% macro reports(institute,case) %}
 <a href="#submenu1" data-toggle="collapse" aria-expanded="false" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
     <div class="d-flex w-100 justify-content-start align-items-center">
         <span class="fa fa-book fa-fw mr-3"></span>
@@ -84,7 +85,7 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">MultiQC</span>
-          {% if path_exists(case.multiqc) %}
+          {% if case.multiqc is existing %}
             <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
           {% else %}
             <i class="fa fa-exclamation-triangle"></i>
@@ -117,24 +118,24 @@
     </div>
     {% endif %}
     {% if case.cnv_report %}
-      {{ cnv_report(institute._id, case, path_exists) }}
+      {{ cnv_report(institute._id, case) }}
     {% endif %}
     {% if case.gene_fusion_report or case.gene_fusion_report_research %}
-      {{ gene_fusion_reports(institute._id, case, path_exists) }}
+      {{ gene_fusion_reports(institute._id, case) }}
     {% endif %}
     {% if case.coverage_qc_report %}
-      {{ coverage_qc_report(institute._id, case, path_exists) }}
+      {{ coverage_qc_report(institute._id, case) }}
     {% endif %}
     {% if case.delivery_report %}
-      {{ delivery_report(institute._id, case, date=None, path_exists=path_exists) }}
+      {{ delivery_report(institute._id, case) }}
     {% endif %}
     {% if case.analyses %}
       {% for analysis in case.analyses %}
         {% if analysis.delivery_report and analysis.delivery_report != case.delivery_report %}
-          {% if path_exists(analysis.delivery_report) %}
+          {% if analysis.delivery_report is existing %}
             {{ delivery_report( institute._id, case, date=analysis.date.date()) }}
           {% else %}
-            {{ delivery_report( institute._id, case, date=analysis.date.date(), path_exists=false) }}
+            {{ delivery_report( institute._id, case, date=analysis.date.date(), analysis_path_exists=false) }}
           {% endif %}
 
         {% endif %}
@@ -536,13 +537,13 @@
 </div>
 {% endmacro %}
 
-{% macro delivery_report(institute, case, date=None, path_exists=None) %}
+{% macro delivery_report(institute, case, date=None, analysis_path_exists=None) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
       <span class="menu-collapsed ml-2">Delivery ({{date or case.analysis_date.date() }})</span>
     </div>
-    {% if (date == None and path_exists(case.delivery_report)) or (date != None and path_exists == None) %}
+    {% if (date == None and case.delivery_report is existing) or (date != None and analysis_path_exists == None) %}
       <div>
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
                           case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>
@@ -558,14 +559,14 @@
 </div>
 {% endmacro %}
 
-{% macro cnv_report(institute, case, path_exists) %}
+{% macro cnv_report(institute, case) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
       <span class="menu-collapsed ml-2">CNV report</span>
     </div>
     <div>
-      {% if path_exists(case.cnv_report) %}
+      {% if case.cnv_report is existing %}
         <a href="{{ url_for('cases.cnv_report', institute_id=institute,
                         case_name=case.display_name, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
       {% else %}
@@ -576,7 +577,7 @@
 </div>
 {% endmacro %}
 
-{% macro gene_fusion_reports(institute, case, path_exists) %}
+{% macro gene_fusion_reports(institute, case) %}
 {% set fusion_reports = ["gene_fusion_report", "gene_fusion_report_research"] %}
 {% for report_type in fusion_reports %}
   {% if case[report_type] %}
@@ -586,7 +587,7 @@
           <span class="menu-collapsed ml-2">{{ report_type|replace("_report","")|replace("_"," ")|capitalize }}</span>
         </div>
         <div>
-          {% if path_exists(case[report_type]) %}
+          {% if case[report_type] is existing %}
             <a href="{{ url_for('cases.gene_fusion_report', institute_id=institute,
                             case_name=case.display_name, report_type=report_type) }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
           {% else %}
@@ -599,14 +600,14 @@
 {% endfor %}
 {% endmacro %}
 
-{% macro coverage_qc_report(institute, case, path_exists) %}
+{% macro coverage_qc_report(institute, case) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>
       <span class="menu-collapsed ml-2">Coverage and QC report</span>
     </div>
 
-    {% if path_exists(case.coverage_qc_report) %}
+    {% if case.coverage_qc_report is existing %}
       <div>
         <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
                           case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -14,7 +14,7 @@
           {{ default_gene_panel(institute, case) }}
           {{ analysis_date(case) }}
           {{ genome_build(case) }}
-          {{ rank_model(case) }}
+          {{ rank_model(case) }}
           <li class="list-group-item sidebar-separator menu-collapsed"></li>
           {{ status(institute, case) }}
           {{ assign(institute, case) }}
@@ -30,7 +30,7 @@
             {{ matchmaker_share(institute, case, current_user) }}
           {% endif %}
           {% if case.needs_check %}
-            {{ check_decipher(case, institute) }}
+            {{ check_decipher(case, institute) }}
           {% endif %}
           {{ confirm_inactivate(institute,case) }}
           {{ archive_case(institute,case) }}
@@ -84,7 +84,11 @@
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed ml-2">MultiQC</span>
-          <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
+          {% if os.path.exists(data["case"]["multiqc"]) %}
+            <a href="{{ url_for('cases.multiqc', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
+          {% else %}
+            <i class="fa fa-exclamation-triangle"></i>
+          {% endif %}
         </div>
       </div>
     {% endif %}
@@ -533,14 +537,18 @@
     <div>
       <span class="menu-collapsed ml-2">Delivery ({{date or case.analysis_date.date() }})</span>
     </div>
-    <div>
-      <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                        case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>
-    </div>
-    <div>
-      <a href="{{ url_for('cases.delivery_report', institute_id=institute,
-                        case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
-    </div>
+    {% if os.path.exists(data["case"]["delivery_report"]) or date != None %}
+      <div>
+        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                          case_name=case.display_name, date=date) }}" target="_blank"><i class="fa fa-link"></i></a>
+      </div>
+      <div>
+        <a href="{{ url_for('cases.delivery_report', institute_id=institute,
+                          case_name=case.display_name, date=date, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
+      </div>
+    {% else %}
+      <div><i class="fa fa-exclamation-triangle"></i></div>
+    {% endif %}
   </div>
 </div>
 {% endmacro %}
@@ -552,8 +560,12 @@
       <span class="menu-collapsed ml-2">CNV report</span>
     </div>
     <div>
-      <a href="{{ url_for('cases.cnv_report', institute_id=institute,
+      {% if os.path.exists(data["case"]["cnv_report"]) %}
+        <a href="{{ url_for('cases.cnv_report', institute_id=institute,
                         case_name=case.display_name, format='pdf') }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
+      {% else %}
+        <i class="fa fa-exclamation-triangle"></i>
+      {% endif %}
     </div>
   </div>
 </div>
@@ -569,8 +581,12 @@
           <span class="menu-collapsed ml-2">{{ report_type|replace("_report","")|replace("_"," ")|capitalize }}</span>
         </div>
         <div>
-          <a href="{{ url_for('cases.gene_fusion_report', institute_id=institute,
+          {% if os.path.exists(data["case"][report_type]) %}
+            <a href="{{ url_for('cases.gene_fusion_report', institute_id=institute,
                             case_name=case.display_name, report_type=report_type) }}" target="_blank"><i class="fa fa-file-pdf-o"></i></a>
+          {% else %}
+            <i class="fa fa-exclamation-triangle"></i>
+          {% endif %}
         </div>
       </div>
     </div>
@@ -584,14 +600,19 @@
     <div>
       <span class="menu-collapsed ml-2">Coverage and QC report</span>
     </div>
-    <div>
-      <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
-                        case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
-    </div>
-    <div>
-      <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
-                        case_name=case.display_name, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
-    </div>
+
+    {% if os.path.exists(data["case"][coverage_qc_report]) %}
+      <div>
+        <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
+                          case_name=case.display_name) }}" target="_blank"><i class="fa fa-link"></i></a>
+      </div>
+      <div>
+        <a href="{{ url_for('cases.coverage_qc_report', institute_id=institute,
+                          case_name=case.display_name, format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
+      </div>
+    {% else %}
+         <div><i class="fa fa-exclamation-triangle"></i></div>
+    {% endif %}
   </div>
 </div>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -547,7 +547,7 @@
         <a href="{{ url_for('cases.delivery_report', institute_id=institute,
                           case_name=case.display_name, date=analysis.date.date(), format='pdf') }}" download><i class="fa fa-file-pdf-o"></i></a>
       </div>
-    {% elif analysis.delivery_report == case.delivery_report %}
+    {% elif analysis.delivery_report == case.delivery_report and analysis.date.date() != case.anlysis_date.date() %}
       <div><i class="fa fa-exclamation-circle ml-1" data-toggle="tooltip" title="A delivery report had been registered for the analysis but it is the same as the latest."></i></div>
     {% else %}
       <div><i class="fa fa-exclamation-triangle ml-1" data-toggle="tooltip" title="A delivery report has been registered for the case but not found on the file system."></i></div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -599,7 +599,7 @@
 {% endfor %}
 {% endmacro %}
 
-{% macro coverage_qc_report(institute, case) %}
+{% macro coverage_qc_report(institute, case, path_exists) %}
 <div href="#" class="bg-dark list-group-item text-white">
   <div class="d-flex flex-row flex-fill bd-highlight">
     <div>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -59,6 +59,11 @@ def index():
     return dict(institutes=institutes_count)
 
 
+def path_exists(path):
+    """Check if file exists. Helper for jinja template."""
+    return os.path.exists(path)
+
+
 @cases_bp.route("/<institute_id>/<case_name>")
 @templated("cases/case.html")
 def case(institute_id, case_name):
@@ -69,10 +74,6 @@ def case(institute_id, case_name):
         return redirect(request.referrer)
 
     data = controllers.case(store, institute_obj, case_obj)
-
-    def path_exists(path):
-        """Check if file exists. Helper for jinja template."""
-        return os.path.exists(path)
 
     return dict(
         institute=institute_obj,

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -69,6 +69,11 @@ def case(institute_id, case_name):
         return redirect(request.referrer)
 
     data = controllers.case(store, institute_obj, case_obj)
+
+    def path_exists(path):
+        """Check if file exists. Helper for jinja template."""
+        return os.path.exists(path)
+
     return dict(
         institute=institute_obj,
         case=case_obj,
@@ -76,6 +81,7 @@ def case(institute_id, case_name):
         tissue_types=SAMPLE_SOURCE,
         gens_info=gens.connection_settings(case_obj.get("genome_build")),
         display_rerunner=rerunner.connection_settings.get("display", False),
+        path_exists=path_exists,
         **data,
     )
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -77,7 +77,6 @@ def case(institute_id, case_name):
         tissue_types=SAMPLE_SOURCE,
         gens_info=gens.connection_settings(case_obj.get("genome_build")),
         display_rerunner=rerunner.connection_settings.get("display", False),
-        path_exists=path_exists,
         **data,
     )
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -59,11 +59,6 @@ def index():
     return dict(institutes=institutes_count)
 
 
-def path_exists(path):
-    """Check if file exists. Helper for jinja template."""
-    return os.path.exists(path)
-
-
 @cases_bp.route("/<institute_id>/<case_name>")
 @templated("cases/case.html")
 def case(institute_id, case_name):

--- a/tests/server/blueprints/cases/test_cases_templates.py
+++ b/tests/server/blueprints/cases/test_cases_templates.py
@@ -3,8 +3,6 @@ import datetime
 
 from flask import get_template_attribute, url_for
 
-from scout.server.blueprints.cases.views import path_exists
-
 
 def test_report_transcripts_macro(app, institute_obj, case_obj, variant_gene_updated_info):
     """Test the variant_transcripts macro present in the general report page"""
@@ -87,7 +85,6 @@ def test_sidebar_macro(app, institute_obj, case_obj, user_obj):
             institute=institute_obj,
             case=case_obj,
             current_user=user_obj,
-            path_exists=path_exists,
         )
 
         # It should show the expected items:
@@ -124,7 +121,6 @@ def test_sidebar_cnv_report(app, institute_obj, cancer_case_obj, user_obj):
             institute=institute_obj,
             case=cancer_case_obj,
             current_user=user_obj,
-            path_exists=path_exists,
         )
 
         # It should show the expected items:

--- a/tests/server/blueprints/cases/test_cases_templates.py
+++ b/tests/server/blueprints/cases/test_cases_templates.py
@@ -2,10 +2,8 @@
 import datetime
 
 from flask import get_template_attribute, url_for
-from pymongo import ReturnDocument
 
 from scout.server.blueprints.cases.views import path_exists
-from scout.server.extensions import store
 
 
 def test_report_transcripts_macro(app, institute_obj, case_obj, variant_gene_updated_info):

--- a/tests/server/blueprints/cases/test_cases_templates.py
+++ b/tests/server/blueprints/cases/test_cases_templates.py
@@ -4,6 +4,7 @@ import datetime
 from flask import get_template_attribute, url_for
 from pymongo import ReturnDocument
 
+from scout.server.blueprints.cases.views import path_exists
 from scout.server.extensions import store
 
 
@@ -84,7 +85,12 @@ def test_sidebar_macro(app, institute_obj, case_obj, user_obj):
     with app.test_client() as client:
         # WHEN the case sidebar macro is called
         macro = get_template_attribute("cases/collapsible_actionbar.html", "action_bar")
-        html = macro(institute=institute_obj, case=case_obj, current_user=user_obj)
+        html = macro(
+            institute=institute_obj,
+            case=case_obj,
+            current_user=user_obj,
+            path_exists=path_exists,
+        )
 
         # It should show the expected items:
         assert "Reports" in html
@@ -116,7 +122,12 @@ def test_sidebar_cnv_report(app, institute_obj, cancer_case_obj, user_obj):
     with app.test_client() as client:
         # WHEN the case sidebar macro is called
         macro = get_template_attribute("cases/collapsible_actionbar.html", "action_bar")
-        html = macro(institute=institute_obj, case=cancer_case_obj, current_user=user_obj)
+        html = macro(
+            institute=institute_obj,
+            case=cancer_case_obj,
+            current_user=user_obj,
+            path_exists=path_exists,
+        )
 
         # It should show the expected items:
         assert "CNV report" in html


### PR DESCRIPTION
This PR adds a functionality or fixes a bug (fix #3130).
 
Test for existence of reports before adding link to action bar.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. temporarily move reports to a different file name, possibly one by one

![Screenshot 2022-02-09 at 12 43 53](https://user-images.githubusercontent.com/758570/153194139-7a099298-3e53-4cf4-b3ce-0f9f07e7a7a7.png)

**Expected outcome**:
The functionality should be working, and exclamation mark triangles be shown instead of link icons for missing reports.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
