### PR TITLE
Fixed managed variants search by description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Save diagnosis labels along with OMIM terms in Matchmaker Exchange submission objects
 - `libegl-mesa0_21.0.3-0ubuntu0.3~20.04.5_amd64.deb` lib not found by GitHub actions Docker build
 - Remove unused `chromograph_image_files` and `chromograph_prefixes` keys saved when creating or updating an RD case
+- Search managed variants by description and with ignore case
 ### Changed
 - Introduced page margins on exported PDF reports
 - Smaller gene fonts in downloaded HPO genes PDF reports

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -143,7 +143,6 @@ class ManagedVariantHandler(object):
 
         query = {"category": {"$in": category}}
         query_with_options = self.add_options(query, query_options)
-        LOG.warning(query_with_options)
         return self.managed_variant_collection.find(query_with_options)
 
     def count_managed_variants(

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -143,6 +143,7 @@ class ManagedVariantHandler(object):
 
         query = {"category": {"$in": category}}
         query_with_options = self.add_options(query, query_options)
+        LOG.warning(query_with_options)
         return self.managed_variant_collection.find(query_with_options)
 
     def count_managed_variants(
@@ -172,7 +173,10 @@ class ManagedVariantHandler(object):
 
         if query_options:
             if "description" in query_options:
-                query["description"] = {"$regex": ".*" + query_options["description"] + ".*"}
+                query["description"] = {
+                    "$regex": ".*" + query_options["description"] + ".*",
+                    "$options": "i",
+                }
 
             if "position" in query_options:
                 query["end"] = {"$gte": int(query_options["position"])}

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import datetime
 
-import pymongo
 from bson import ObjectId
 from pymongo.errors import DuplicateKeyError
 
@@ -191,8 +190,12 @@ class ManagedVariantHandler(object):
 
         return query
 
-    def get_managed_variants(self, institute_id=None, category=["snv"], build="37"):
+    def get_managed_variants(self, category=["snv"], build="37"):
         """Return managed variant_ids. Limit by institute, category and build.
+
+        Accepts:
+            category(str): "snv", "sv"
+            build(str): "37" or "38"
 
         Returns:
             managed_variant_ids(iterable(variant_id: String))

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -500,7 +500,7 @@ class VariantHandler(VariantLoader):
 
         institute_id = case_obj["owner"] if case_obj else institute_obj["_id"]
 
-        positional_variant_ids = self.get_managed_variants(institute_id)
+        positional_variant_ids = self.get_managed_variants()
 
         if len(positional_variant_ids) == 0:
             return []

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -5,20 +5,15 @@ import pathlib
 import re
 import tempfile
 from datetime import datetime
-from pprint import pprint as pp
 
 # Third party modules
 import pymongo
 from cyvcf2 import VCF
-from intervaltree import IntervalTree
-from pymongo.errors import BulkWriteError, DuplicateKeyError
+from pymongo.errors import DuplicateKeyError
 
-from scout.build import build_variant
 from scout.exceptions import IntegrityError
-from scout.parse.variant import parse_variant
 
 # Local modules
-from scout.parse.variant.rank_score import parse_rank_score
 from scout.utils.coordinates import is_par
 
 from .variant_loader import VariantLoader

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -66,6 +66,10 @@ def managed_variants(request):
         subcat[0] for subcat in SUBCATEGORY_CHOICES
     ]:
         query_options["sub_category"].append(sub_cat)
+
+    if request.form.get("description") is not None and request.form.get("description") != "":
+        query_options["description"] = request.form["description"]
+
     # Set requested variant coordinates in query options
     set_query_coordinates(query_options, request.form)
 


### PR DESCRIPTION
Fix #3160 
- Introduced ignore case in the search by description

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Load 2 variants into managed variants, **one** with a description.
2. Filter by one word present in the variant description
3. The search should return only one variant

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
