### PR TITLE
Removed unused  add_compounds param from variant controllers function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Changed
-- Removed unused `add_compounds` param from variant controller function
+- Removed unused `add_compounds` param from variant controllers function
 
 ## [4.49]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Changed
+- Removed unused `add_compounds` param from variant controller function
+
 ## [4.49]
 ### Fixed
 - Pydantic model types for genome_build, madeline_info, peddy_ped_check and peddy_sex_check, rank_model_version and sv_rank_model_version

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -388,7 +388,6 @@ def case_report_variants(store, case_obj, institute_obj, data):
                 add_case=False,
                 add_other=False,
                 get_overlapping=False,
-                add_compounds=False,
                 variant_type=var_obj["category"],
                 institute_obj=institute_obj,
                 case_obj=case_obj,

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -21,7 +21,7 @@ from scout.constants import (
 )
 from scout.server.blueprints.variant.utils import update_representative_gene
 from scout.server.extensions import cloud_tracks, gens
-from scout.server.links import ensembl, get_variant_links
+from scout.server.links import get_variant_links
 from scout.server.utils import (
     case_append_alignments,
     institute_and_case,

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -164,7 +164,6 @@ def variant(
     add_case=True,
     add_other=True,
     get_overlapping=True,
-    add_compounds=True,
     variant_category=None,
     variant_type=None,
     case_obj=None,

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -57,7 +57,6 @@ def variant_verification(
         add_case=True,
         add_other=False,
         get_overlapping=False,
-        add_compounds=False,
     )
     variant_obj = data["variant"]
     case_obj = data["case"]

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -285,7 +285,6 @@ def test_variant_controller_with_compounds(app, institute_obj, case_obj):
             add_case=True,
             add_other=True,
             get_overlapping=True,
-            add_compounds=True,
             variant_type=category,
         )
 
@@ -325,7 +324,6 @@ def test_variant_controller_with_clnsig(app, institute_obj, case_obj):
             add_case=True,
             add_other=True,
             get_overlapping=True,
-            add_compounds=True,
             variant_type=category,
         )
 
@@ -356,7 +354,6 @@ def test_variant_controller(app, institute_obj, case_obj, variant_obj):
             add_case=True,
             add_other=True,
             get_overlapping=True,
-            add_compounds=True,
             variant_type=category,
         )
 


### PR DESCRIPTION
- Removes a param that is never used in a function

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
