### PR TITLE
Unified somatic cancer variant navigaion labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
+- Relabel more cancer variant pages somatic for navigation
 
 ## [4.49]
 ### Fixed

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -128,15 +128,15 @@
         {% if case.vcf_files.vcf_snv %}
           <a href="{{ url_for('variants.variants', institute_id=case.owner, case_name=case.display_name, variant_type='research') }}">Research SNV and INDELs</a>
         {% elif case.vcf_files.vcf_cancer %}
-          <a href="{{ url_for('variants.cancer_variants', institute_id=case.owner, case_name=case.display_name, variant_type='research') }}">Clinical cancer variants</a>
+          <a href="{{ url_for('variants.cancer_variants', institute_id=case.owner, case_name=case.display_name, variant_type='research') }}">Clinical Somatic Variants</a>
         {% endif %}
       {% else %}
         {% if case.vcf_files.vcf_snv %}
           <a href="{{ url_for('variants.variants', institute_id=case.owner, case_name=case.display_name, variant_type='clinical', gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">Clinical SNV and INDELs</a>
         {% elif case.vcf_files.vcf_cancer %}
-          <a href="{{ url_for('variants.cancer_variants', institute_id=case.owner, case_name=case.display_name, variant_type='clinical') }}">Clinical cancer variants</a>
+          <a href="{{ url_for('variants.cancer_variants', institute_id=case.owner, case_name=case.display_name, variant_type='clinical') }}">Clinical Somatic Variants</a>
         {% elif case.vcf_files.vcf_cancer_sv %}
-          <a href="{{ url_for('variants.cancer_sv_variants', institute_id=case.owner, case_name=case.display_name, variant_type='clinical') }}">Clinical cancer structural variants</a>
+          <a href="{{ url_for('variants.cancer_sv_variants', institute_id=case.owner, case_name=case.display_name, variant_type='clinical') }}">Clinical Somatic Structural Variants</a>
         {% endif %}
       {% endif %}
     </td>

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -32,7 +32,7 @@
   <li class="nav-item">
     {% if cancer %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
-          <span class="navbar-text">{{ form.variant_type.data|capitalize }} Somatic Variants</span>
+          {{ variant.variant_type|capitalize }} somatic variants
       </a>
     {% elif str %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -32,7 +32,7 @@
   <li class="nav-item">
     {% if cancer %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
-        {{ variant.variant_type|capitalize }} cancer variants
+          <span class="navbar-text">{{ form.variant_type.data|capitalize }} Somatic Variants</span>
       </a>
     {% elif str %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -19,6 +19,9 @@
 
 {% block top_nav %}
   {{ super() }}
+   <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
+  </li>
   <li class="nav-item">
     <a class="nav-link text-nowrap" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}

--- a/scout/server/blueprints/variant/templates/variant/clinvar.html
+++ b/scout/server/blueprints/variant/templates/variant/clinvar.html
@@ -34,7 +34,7 @@
   <li class="nav-item">
     {% if cancer %}
       <a class="nav-link" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">
-        {{ variant.variant_type|capitalize }} cancer variants
+        {{ variant.variant_type|capitalize }} somatic variants
       </a>
     {% else %}
       <a class="nav-link" href="{{ url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -30,7 +30,7 @@
   <li class="nav-item">
     {% if variant.category == "cancer_sv" %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical', gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
-        {{ variant.variant_type|capitalize }} cancer structural variants
+        {{ variant.variant_type|capitalize }} somatic structural variants
       </a>
     {% else %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -18,6 +18,9 @@
 {% block top_nav %}
   {{ super() }}
   <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
+  </li>
+  <li class="nav-item">
     <a class="nav-link text-nowrap" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}
     </a>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -34,7 +34,7 @@
   <li class="nav-item">
     {% if cancer %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.cancer_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type, gene_panels=case.panels|selectattr('is_default')|map(attribute='panel_name')|list) }}">
-        {{ variant.variant_type|capitalize }} cancer variants
+        {{ variant.variant_type|capitalize }} somatic variants
       </a>
     {% elif str %}
       <a class="nav-link text-nowrap" href="{{ url_for('variants.str_variants', institute_id=institute._id, case_name=case.display_name, variant_type=variant.variant_type) }}">

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -21,6 +21,9 @@
 
 {% block top_nav %}
   {{ super() }}
+   <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
+  </li>
   <li class="nav-item">
     <a class="nav-link text-nowrap" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
       {{ institute.display_name }}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -41,7 +41,7 @@
       {{ pagination_hidden_div(page) }}
       <div class="card panel-default" id="accordion">
         <div class="card-header">
-          <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">Cancer Structural Variant Filters</a></strong>
+          <strong><a data-toggle="collapse" data-parent="#accordion" href="#collapseFilters">Somatic Structural Variant Filters</a></strong>
         </div>
         <!--Expand filters form if filters were used in a previous POST request-->
         <div id="collapseFilters" class="card-body panel-collapse collapse {{ 'show' if expand_search is sameas true }}">

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -29,7 +29,7 @@
     </a>
   </li>
   <li class="nav-item active">
-    <span class="navbar-text">{{ form.variant_type.data|capitalize }} Somatic Variants</span>
+    <span class="navbar-text">{{ variant_type|capitalize }} somatic variants</span>
   </li>
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -5,7 +5,7 @@
 {% from "variants/indicators.html" import pin_indicator, causative_badge, comments_badge, evaluations_badge, research_assessments_badge, clinical_assessments_badge, group_assessments_badge, other_tiered_variants %}
 
 {% block title %}
-  {{ variant_type|capitalize }} cancer variants
+  {{ variant_type|capitalize }} somatic variants
 {% endblock %}
 
 {% block css %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug - see issue #3171. Some time ago we relabelled cancer variantS pages somatic variantS, but we never did that for the variant pages. This looks a little silly when navigating back and forth. Also institute was missing from the navigation bar on variant pages, perhaps to save space, perhaps due to omission. 

![Screenshot 2022-02-17 at 10 01 14](https://user-images.githubusercontent.com/758570/154446594-a37364d5-cf79-490a-bcce-c7b6abf5bd39.png)

![Screenshot 2022-02-17 at 10 00 58](https://user-images.githubusercontent.com/758570/154446603-f17ab83f-8dca-427c-aac8-a5060a6488c0.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. check variant and variantS pages to make sure "cancer" is replaced with "somatic" and that the nav bar looks consistent when navigating up and down the hierarchy.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
