### PR TITLE
Panel id except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add a toggle for melter rerun monitoring of cases
 - Add a config option to show the rerun monitoring toggle
 - Add a cli option to export cases with rerun monitoring enabled
+### Fixed
+- A malformed panel id request would crash with exception: now gives user warning flash with redirect
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation
 - Removed unused `add_compounds` param from variant controllers function
 - Changed default hg19 genome for IGV.js to legacy hg19_1kg_decoy to fix a few problematic loci
 - Reduce code complexity (parse/ensembl.py)
-
 
 ## [4.49]
 ### Fixed

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 
 import pymongo
 from bson import ObjectId
+from bson.errors import InvalidId
 
 from scout.build import build_panel
 from scout.exceptions import IntegrityError
@@ -187,7 +188,10 @@ class PanelHandler:
             dict: panel object or `None` if panel not found
         """
         if not isinstance(panel_id, ObjectId):
-            panel_id = ObjectId(panel_id)
+            try:
+                panel_id = ObjectId(panel_id)
+            except InvalidId as err:
+                LOG.error("Invalid panel id received: %s", err)
         panel_obj = self.panel_collection.find_one({"_id": panel_id})
         return panel_obj
 

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -79,6 +79,9 @@ def panel(panel_id):
     """Display (and add pending updates to) a specific gene panel."""
 
     panel_obj = store.gene_panel(panel_id) or store.panel(panel_id)
+    if not panel_obj:
+        flash("Panel with id {} not found.".format(panel_id), "warning")
+        return redirect(url_for("panels.panels"))
 
     if request.method == "POST":
         if request.form.get("update_description"):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

I still don't understand how some user ended up with a malformed panel id as in #3185. My best intuition is could be related to a panel file upload during the server file storage downtime. The log entry points to a hospital NAT IP user POSTing a panel.

There seems to be little reason to crash if someone happens to malform the panel id, e.g. simplest case by editing the request URL in the browser. Here is a try-except version with a flash and redirect instead:
![Screenshot 2022-02-24 at 15 52 04](https://user-images.githubusercontent.com/758570/155549712-f2690bf5-e6be-4e1c-acc4-1f39ffdc2151.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. click a gene panel
2. edit the url
3. note an exception crash
4. apply patch
5. you should now see a warning flash instead of crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
