### PR TITLE
Fix missing HPO resource link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add a cli option to export cases with rerun monitoring enabled
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
+- Link to HPO resource file hosted on `http://purl.obolibrary.org`
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -39,7 +39,13 @@ from .gene_tags import (
 )
 from .igv_tracks import CASE_SPECIFIC_TRACKS, HUMAN_REFERENCE, IGV_TRACKS, USER_DEFAULT_TRACKS
 from .indexes import INDEXES
-from .phenotype import COHORT_TAGS, PHENOTYPE_GROUPS, UPDATE_DISEASES_RESOURCES
+from .phenotype import (
+    COHORT_TAGS,
+    HPO_URL,
+    HPOTERMS_URL,
+    PHENOTYPE_GROUPS,
+    UPDATE_DISEASES_RESOURCES,
+)
 from .query_terms import FUNDAMENTAL_CRITERIA, PRIMARY_CRITERIA, SECONDARY_CRITERIA
 from .so_terms import SEVERE_SO_TERMS, SO_TERM_KEYS, SO_TERMS
 from .variant_tags import (

--- a/scout/constants/phenotype.py
+++ b/scout/constants/phenotype.py
@@ -1,3 +1,8 @@
+HPO_URL = "http://purl.obolibrary.org/obo/hp/hpoa/{}"
+HPOTERMS_URL = (
+    "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo"
+)
+
 PHENOTYPE_GROUPS = {
     "HP:0001298": {"name": "Encephalopathy", "abbr": "ENC"},
     "HP:0012759": {"name": "Neurodevelopmental abnormality", "abbr": "NDEV"},

--- a/scout/parse/hpo_mappings.py
+++ b/scout/parse/hpo_mappings.py
@@ -1,8 +1,3 @@
-"""
-Methods for parsing HPO terms extracted from the following files:
-https://ci.monarchinitiative.org/view/hpo/job/hpo.annotations/lastSuccessfulBuild/artifact/rare-diseases/util/annotation/genes_to_phenotype.txt
-https://ci.monarchinitiative.org/view/hpo/job/hpo.annotations/lastSuccessfulBuild/artifact/rare-diseases/util/annotation/phenotype_to_genes.txt
-"""
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -8,15 +8,10 @@ from urllib.error import HTTPError
 import requests
 from defusedxml import ElementTree
 
-from scout.constants import CHROMOSOMES
+from scout.constants import CHROMOSOMES, HPO_URL, HPOTERMS_URL
 from scout.utils.ensembl_rest_clients import EnsemblBiomartClient
 
 LOG = logging.getLogger(__name__)
-
-HPO_URL = "https://ci.monarchinitiative.org/view/hpo/job/hpo.annotations/lastSuccessfulBuild/artifact/rare-diseases/util/annotation/{}"
-HPOTERMS_URL = (
-    "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo"
-)
 TIMEOUT = 20
 
 


### PR DESCRIPTION
Fix #3191 by replacing the link to the resource

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Locally, run: scout --demo download everything --api-key a_valid_key

**Expected outcome**:
- A bunch of resource files should be downloaded without errors

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
