### PR TITLE
Fix gene search form when gene exists only in build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`
+- Gene search form when gene exists only in build 38
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/server/blueprints/genes/views.py
+++ b/scout/server/blueprints/genes/views.py
@@ -52,7 +52,7 @@ def api_genes():
     query = request.args.get("query")
     if query is None or query.replace("-", "").isalnum() is False:
         return jsonify({"code": 400, "message": "missing or invalid 'query' param in request"})
-    build = request.args.get("build", "37")
+    build = request.args.get("build")
 
     json_out = controllers.genes_to_json(store, query, build)
     return jsonify(json_out)


### PR DESCRIPTION
Fix #3181 --> Genes (all present only in build 38) are uploaded but can't be searched in genes page

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Make sure example genes (PIGBOS1, HTD2, PLSCR3 and SELENOO) are present in scout database. If they are not it might likely be that genes in build 38 were not loaded last time we updated the database
2. Once genes are in the database, from main branch, look for them using the genes search form, they shouldn't be found
3. Switch to this branch and repeat, they should be found in build 38

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
