### PR TITLE
Fixed parsing of old frequency obs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`
 - Gene search form when gene exists only in build 38
 - Fixed odd redirect error and poor error message on missing column for gene panel csv upload
+- Modified keys name used to parse local observations (archived) frequencies to reflect change in MIP keys naming
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -96,7 +96,7 @@ def build_variant(
         max_exac_frequency = float,
         local_frequency = float,
         local_obs_old = int,
-        local_obs_hom_old = int
+        local_obs_hom_old = int,
         local_obs_old_freq = float,
 
         # Predicted deleteriousness:

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -96,8 +96,7 @@ def build_variant(
         max_exac_frequency = float,
         local_frequency = float,
         local_obs_old = int,
-        local_obs_hom_old = int,
-        local_obs_total_old = int,
+        local_obs_old_freq = float,
 
         # Predicted deleteriousness:
         cadd_score = float,
@@ -392,8 +391,8 @@ def build_variant(
     if variant.get("local_obs_old"):
         variant_obj["local_obs_old"] = variant["local_obs_old"]
 
-    if variant.get("local_obs_hom_old"):
-        variant_obj["local_obs_hom_old"] = variant["local_obs_hom_old"]
+    if variant.get("local_obs_old_freq"):
+        variant_obj["local_obs_old_freq"] = variant["local_obs_old_freq"]
 
     # Add the sv counts:
     if frequencies.get("clingen_benign"):

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -96,6 +96,7 @@ def build_variant(
         max_exac_frequency = float,
         local_frequency = float,
         local_obs_old = int,
+        local_obs_hom_old = int
         local_obs_old_freq = float,
 
         # Predicted deleteriousness:
@@ -388,10 +389,13 @@ def build_variant(
         variant_obj["thousand_genomes_frequency_right"] = float(frequencies["thousand_g_right"])
 
     # add the local observation counts from the old archive
-    if variant.get("local_obs_old"):
+    if variant.get("local_obs_old"):  # SNVs and SVs
         variant_obj["local_obs_old"] = variant["local_obs_old"]
 
-    if variant.get("local_obs_old_freq"):
+    if variant.get("local_obs_hom_old"):  # SNVs
+        variant_obj["local_obs_hom_old"] = variant["local_obs_hom_old"]
+
+    if variant.get("local_obs_old_freq"):  # SVs
         variant_obj["local_obs_old_freq"] = variant["local_obs_old_freq"]
 
     # Add the sv counts:

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -64,6 +64,7 @@ variant = dict(
     max_thousand_genomes_frequency=float,
     max_exac_frequency=float,
     local_frequency=float,
+    local_obs_hom_old=int,
     local_obs_old=int,
     local_obs_old_freq=float,
     # Predicted deleteriousness:

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -1,10 +1,4 @@
 # -*- coding: utf-8 -*-
-"""
-"main concept of MongoDB is embed whenever possible"
-Ref: http://stackoverflow.com/questions/4655610#comment5129510_4656431
-"""
-
-from scout.constants import CLINSIG_MAP, CONSERVATION, GENETIC_MODELS, VARIANT_CALL
 
 variant = dict(
     # document_id is a md5 string created by institute_genelist_caseid_variantid:

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -71,8 +71,7 @@ variant = dict(
     max_exac_frequency=float,
     local_frequency=float,
     local_obs_old=int,
-    local_obs_hom_old=int,
-    local_obs_total_old=int,
+    local_obs_old_freq=float,
     # Predicted deleteriousness:
     cadd_score=float,
     clnsig=list,  # list of <clinsig>

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -64,8 +64,8 @@ variant = dict(
     max_thousand_genomes_frequency=float,
     max_exac_frequency=float,
     local_frequency=float,
-    local_obs_hom_old=int,
     local_obs_old=int,
+    local_obs_hom_old=int,
     local_obs_old_freq=float,
     # Predicted deleteriousness:
     cadd_score=float,

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -332,13 +332,13 @@ def parse_variant(
     parsed_variant["frequencies"] = frequencies
 
     # parse out old local observation count
-    local_obs_old = variant.INFO.get("Obs")
+    local_obs_old = variant.INFO.get("clinical_genomics_loqusObs")
     if local_obs_old:
         parsed_variant["local_obs_old"] = int(local_obs_old)
 
-    local_obs_hom_old = variant.INFO.get("Hom")
-    if local_obs_hom_old:
-        parsed_variant["local_obs_hom_old"] = int(local_obs_hom_old)
+    local_obs_old_freq = variant.INFO.get("clinical_genomics_loqusFrq")
+    if local_obs_old_freq:
+        parsed_variant["local_obs_old_freq"] = float(local_obs_old_freq)
 
     ###################### Add severity predictions ######################
     cadd = parse_cadd(variant, parsed_transcripts)

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -331,11 +331,17 @@ def parse_variant(
 
     parsed_variant["frequencies"] = frequencies
 
-    # parse out old local observation count
-    local_obs_old = variant.INFO.get("clinical_genomics_loqusObs")
+    # SNVs contain INFO field Obs, SVs contain clinical_genomics_loqusObs
+    local_obs_old = variant.INFO.get("Obs") or variant.INFO.get("clinical_genomics_loqusObs")
     if local_obs_old:
         parsed_variant["local_obs_old"] = int(local_obs_old)
 
+    # SNVs only
+    local_obs_hom_old = variant.INFO.get("Hom")
+    if local_obs_hom_old:
+        parsed_variant["local_obs_hom_old"] = int(local_obs_hom_old)
+
+    # SVs only
     local_obs_old_freq = variant.INFO.get("clinical_genomics_loqusFrq")
     if local_obs_old_freq:
         parsed_variant["local_obs_old_freq"] = float(local_obs_old_freq)

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -202,7 +202,7 @@
         <tbody>
           <tr>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
-            <td>{{ variant.local_obs_old_freq|default('N/A') }}</td>
+            <td>{% if variant.local_obs_old_freq %} variant.local_obs_old_freq|round(6) {% else %}'N/A'{% endif %}</td>
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -203,7 +203,7 @@
         <tbody>
           <tr>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
-            <td>{{ variant.local_obs_total_old|default('N/A') }}</td>
+            <td>{{ variant.local_obs_hom_old|default('N/A') }}</td>
             <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% else %} N/A {% endif %}</td>
           </tr>
         </tbody>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -202,7 +202,7 @@
         <tbody>
           <tr>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
-            <td>{% if variant.local_obs_old_freq %} variant.local_obs_old_freq|round(6) {% else %}'N/A'{% endif %}</td>
+            <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% else %} 'N/A' {% endif %}</td>
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -196,15 +196,13 @@
         <thead class="thead-light">
           <tr>
             <th scope="col">Nr obs.</th>
-            <th scope="col">Nr homo.</th>
-            <th scope="col">Total nr.</th>
+            <th scope="col">Frequency</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
-            <td>{{ variant.local_obs_hom_old|default('N/A') }}</td>
-            <td>{{ variant.local_obs_total_old|default('N/A') }}</td>
+            <td>{{ variant.local_obs_old_freq|default('N/A') }}</td>
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -196,13 +196,15 @@
         <thead class="thead-light">
           <tr>
             <th scope="col">Nr obs.</th>
+            <th scope="col">Nr homo.</th>
             <th scope="col">Frequency</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
-            <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% else %} 'N/A' {% endif %}</td>
+            <td>{{ variant.local_obs_total_old|default('N/A') }}</td>
+            <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% else %} N/A {% endif %}</td>
           </tr>
         </tbody>
       </table>

--- a/tests/parse/test_parse_variant.py
+++ b/tests/parse/test_parse_variant.py
@@ -3,6 +3,24 @@ from scout.exceptions import VcfError
 from scout.parse.variant import parse_variant
 
 
+def test_parse_old_obs_archive(case_obj, cyvcf2_variant):
+    """Test parsing local_obs_old and local_obs_old_freq off a variant VCF file"""
+
+    nr_old_obs = 22
+    freq_old_obs = 0.3
+
+    # GIVEN a VCF variant containing old local observations stats
+    cyvcf2_variant.INFO["clinical_genomics_loqusObs"] = nr_old_obs
+    cyvcf2_variant.INFO["clinical_genomics_loqusFrq"] = freq_old_obs
+
+    # WHEN parsing the variant
+    parsed_var = parse_variant(cyvcf2_variant, case_obj)
+
+    # THEN the parsed variant should contain these values
+    assert parsed_var["local_obs_old"] == nr_old_obs
+    assert parsed_var["local_obs_old_freq"] == freq_old_obs
+
+
 def test_parse_minimal(one_variant, case_obj):
     """Test to parse a minimal variant"""
     parsed_variant = parse_variant(one_variant, case_obj, variant_type="clinical")

--- a/tests/parse/test_parse_variant.py
+++ b/tests/parse/test_parse_variant.py
@@ -3,7 +3,7 @@ from scout.exceptions import VcfError
 from scout.parse.variant import parse_variant
 
 
-def test_parse_old_obs_archive(case_obj, cyvcf2_variant):
+def test_parse_old_obs_archive_SV(case_obj, cyvcf2_variant):
     """Test parsing local_obs_old and local_obs_old_freq off a variant VCF file"""
 
     nr_old_obs = 22


### PR DESCRIPTION
Fix #3197 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Load a newish case on stage

**Expected outcome**:
nr. of old obs and frequency of old obs should be visible in variant page
**Review:**
- [x] code approved by DN
- [x] tests executed by CR
