### PR TITLE
Shallow link two STR loci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add a toggle for melter rerun monitoring of cases
 - Add a config option to show the rerun monitoring toggle
 - Add a cli option to export cases with rerun monitoring enabled
-- Add a link to STRipy for STR variants
+- Add a link to STRipy for STR variants; shallow for ARX and HOXA13
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -3,6 +3,8 @@ from flask import current_app
 from scout.constants import SPIDEX_HUMAN
 from scout.utils.convert import amino_acid_residue_change_3_to_1
 
+SHALLOW_REFERENCE_STR_LOCI = ["ARX", "HOXA13"]
+
 
 def add_gene_links(gene_obj, build=37):
     """Update a gene object with links
@@ -70,6 +72,9 @@ def stripy_gene(hgnc_symbol):
 
     if not hgnc_symbol:
         return None
+
+    if hgnc_symbol in SHALLOW_REFERENCE_STR_LOCI:
+        return "https://stripy.org/database"
     return link.format(hgnc_symbol)
 
 
@@ -78,6 +83,10 @@ def gnomad_str_gene(hgnc_symbol):
 
     if not hgnc_symbol:
         return None
+
+    if hgnc_symbol in SHALLOW_REFERENCE_STR_LOCI:
+        return "https://gnomad.broadinstitute.org/short-tandem-repeats?dataset=gnomad_r3"
+
     return link.format(hgnc_symbol)
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fix #3209.

ARX and HOXA13 get shallow links to the respective db loci lists, since the GnomAD and STRipy pages have their own nomenclature for those atm. I would not be surprised to see them make landing/joint pages for those in the future, esp if we find more such genes, but this will solve the issue for now.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
