### PR TITLE
Fix broken javascript code when case Chromograph data is malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Typo in parse variant transcripts function
 - Modified keys name used to parse local observations (archived) frequencies to reflect change in MIP keys naming
 - Better error handling for partly broken/timed out chanjo reports
+- Broken javascript code when case Chromograph data is malformed
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -329,12 +329,12 @@
 {% endmacro %}
 
 <!-- Iterate through Individuals, if chromograph_files is presenet add a panel for images -->
+{% set chromograph = namespace(available=false) %}
 {% macro insert_multi_image_panel() %}
 <div class="panel-group" id="accordion">
-  {% set chromograph_available = false %}
   {% for i in case.individuals %}
     {% if i.chromograph_images and (i.chromograph_images.coverage or i.chromograph_images.autozygous or i.chromograph_images.upd_sites) %}
-      {% set chromograph_available = true %}
+      {% set chromograph.available = true %}
       <div class="panel-heading">
         <h5 class="panel-title">
           <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapse_{{i.individual_id}}">
@@ -454,7 +454,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
 
 <script>
-  {% if chromograph_available %}
+  {% if chromograph.available %}
+    console.log("CHROMOGRAPH AVAILABLE");
     window.onload= add_image_panels();
     window.onresize= function(){
         console.log("Width '%s' ", $(window).width())

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -331,8 +331,10 @@
 <!-- Iterate through Individuals, if chromograph_files is presenet add a panel for images -->
 {% macro insert_multi_image_panel() %}
 <div class="panel-group" id="accordion">
+  {% set chromograph_available = false %}
   {% for i in case.individuals %}
     {% if i.chromograph_images and (i.chromograph_images.coverage or i.chromograph_images.autozygous or i.chromograph_images.upd_sites) %}
+      {% set chromograph_images = true %}
       <div class="panel-heading">
         <h5 class="panel-title">
           <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapse_{{i.individual_id}}">
@@ -452,19 +454,19 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.11/purify.min.js"></script>
 
 <script>
-  window.onload= add_image_panels();
-  window.onresize= function(){
-      console.log("Width '%s' ", $(window).width())
-      add_image_panels();
-  }
-
-
-  function add_image_panels(){
-      add_image_to_individual_panel( {{case.individuals|tojson}},
-                                     "{{institute._id}}",
-                                     "{{case.display_name}}"
-                                   );
-  }
+  {% if chromograph_available %}
+    window.onload= add_image_panels();
+    window.onresize= function(){
+        console.log("Width '%s' ", $(window).width())
+        add_image_panels();
+    }
+    function add_image_panels(){
+        add_image_to_individual_panel( {{case.individuals|tojson}},
+                                       "{{institute._id}}",
+                                       "{{case.display_name}}"
+                                     );
+    }
+  {% endif %}
 
   {% if case.panels %}
     $('#panel-table').DataTable({

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -334,7 +334,7 @@
   {% set chromograph_available = false %}
   {% for i in case.individuals %}
     {% if i.chromograph_images and (i.chromograph_images.coverage or i.chromograph_images.autozygous or i.chromograph_images.upd_sites) %}
-      {% set chromograph_images = true %}
+      {% set chromograph_available = true %}
       <div class="panel-heading">
         <h5 class="panel-title">
           <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapse_{{i.individual_id}}">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -455,7 +455,6 @@
 
 <script>
   {% if chromograph.available %}
-    console.log("CHROMOGRAPH AVAILABLE");
     window.onload= add_image_panels();
     window.onresize= function(){
         console.log("Width '%s' ", $(window).width())


### PR DESCRIPTION
Fix #3208

The problem is that the js code to create chromograph images is called on case page onload even regardless of the case individuals having chromograph images or not

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
