### PR TITLE
Unify cases nav links - Fix #3211

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation
+- Unify caseS nav links
 - Removed unused `add_compounds` param from variant controllers function
 - Changed default hg19 genome for IGV.js to legacy hg19_1kg_decoy to fix a few problematic loci
 - Reduce code complexity (parse/ensembl.py)

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -33,7 +33,7 @@
   </li>
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
-      {{ institute.display_name }} cases
+      {{ institute.display_name }}
     </a>
   </li>
   <li class="nav-item active">

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -11,8 +11,11 @@
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
+  </li>
   <li class="nav-item active">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">Cases</a>
   </li>
 {% endblock %}
 

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -18,11 +18,46 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <span class="navbar-text">Causative variants</span>
   </li>
+{% endblock %}
+
+{% block content_main %}
+<div class="container-float">
+  <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
+    {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
+    <div class="col">
+        {{ causatives() }}
+    </div>
+  </div> <!-- end of div id body-row -->
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/1.6.0/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/1.6.0/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/1.5.1/js/buttons.bootstrap4.min.js"></script>
+<script>
+  $(document).ready(function () {
+    $('[data-toggle="tooltip"]').tooltip();
+  });
+  $(document).ready(function() {
+    $('#causatives_table').DataTable( {
+        paging: false,
+        dom: 'Bfrtip',
+        buttons: [
+            'copyHtml5',
+            'excelHtml5',
+        ]
+    } );
+} );
+</script>
 {% endblock %}
 
 {% macro causatives() %}
@@ -63,7 +98,7 @@
                     {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
                 {% else %}
                     {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) }}
-                {% endif%}                
+                {% endif%}
               </span>
             </td>
             <td><span class="badge badge-secondary">{{ variant.category|upper }}</span></td>
@@ -121,39 +156,3 @@
 </div>
 {% endmacro %}
 
-{% block content_main %}
-<div class="container-float">
-  <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
-    {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
-  <div class="col">
-    <div class="container-float">
-      {{ causatives() }}
-    </div>
-  </div>
-  </div> <!-- end of div id body-row -->
-</div>
-{% endblock %}
-
-{% block scripts %}
-{{ super() }}
-<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/buttons/1.6.0/js/dataTables.buttons.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-<script src="https://cdn.datatables.net/buttons/1.6.0/js/buttons.html5.min.js"></script>
-<script src="https://cdn.datatables.net/buttons/1.5.1/js/buttons.bootstrap4.min.js"></script>
-<script>
-  $(document).ready(function () {
-    $('[data-toggle="tooltip"]').tooltip();
-  });
-  $(document).ready(function() {
-    $('#causatives_table').DataTable( {
-        paging: false,
-        dom: 'Bfrtip',
-        buttons: [
-            'copyHtml5',
-            'excelHtml5',
-        ]
-    } );
-} );
-</script>
-{% endblock %}

--- a/scout/server/blueprints/institutes/templates/overview/clinvar_submissions.html
+++ b/scout/server/blueprints/institutes/templates/overview/clinvar_submissions.html
@@ -11,7 +11,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <span class="navbar-text">Clinvar submissions</span>

--- a/scout/server/blueprints/institutes/templates/overview/filters.html
+++ b/scout/server/blueprints/institutes/templates/overview/filters.html
@@ -22,7 +22,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('overview.filters', institute_id=institute._id) }}">Filters</a>

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -18,7 +18,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <a class="nav-link">Search variants</a>

--- a/scout/server/blueprints/institutes/templates/overview/institute_settings.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_settings.html
@@ -18,7 +18,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <a class="nav-link">Settings</a>

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -22,7 +22,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('overview.advanced_phenotypes', institute_id=institute._id) }}">Advanced phenotype models </a>

--- a/scout/server/blueprints/institutes/templates/overview/phenomodels.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodels.html
@@ -19,7 +19,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <a class="nav-link" href="#">Advanced phenotype models </a>

--- a/scout/server/blueprints/institutes/templates/overview/users.html
+++ b/scout/server/blueprints/institutes/templates/overview/users.html
@@ -12,7 +12,7 @@
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
   <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }} cases </a>
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
   </li>
   <li class="nav-item active">
     <a class="nav-link">Users</a>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Remove the extra subscript "cases" from the institute display name on the navbar from some of the pages to unify.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
