### PR TITLE
Default SV callers to Manta (WES). Fix #3206

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Use lighter version of gene objects in Omim MongoDB adapter, panels controllers, panels views and institute controllers
 - Gene-variants table size is now adaptive
 - Remove unused file upload on gene-variants page
+- Default to manta rather than all callers for sv if no caller info given
 
 ## [4.49]
 ### Fixed

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -52,6 +52,6 @@ def parse_callers(variant, category="snv"):
         filter_status = "Pass"
         if variant.FILTER is not None:
             filter_status = "Filtered - {}".format(filter_status.replace(";", " - "))
-        callers["wes"] = filter_status
+        callers["manta"] = filter_status
 
     return callers

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -48,4 +48,10 @@ def parse_callers(variant, category="snv"):
             filter_status = "Filtered - {}".format(filter_status.replace(";", " - "))
         callers["gatk"] = filter_status
 
+    if category == "sv" and not raw_info or other_info:
+        filter_status = "Pass"
+        if variant.FILTER is not None:
+            filter_status = "Filtered - {}".format(filter_status.replace(";", " - "))
+        callers["wes"] = filter_status
+
     return callers


### PR DESCRIPTION
This PR adds a functionality or fixes a bug. See Clinical-Genomics/MIP#1977.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. load a wes MIP 10 case
2. note SV call filter status: should now be manta:PASS rather than all callers PASS.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
