### PR TITLE
Filter cases by OMIM terms in cases and dashboard pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide by default variants only present in unaffected individuals in variants filters
 - OMIM terms in general case report
 - Individual-level info on OMIM and HPO terms in general case report
+- Dashboard case filters fields help
+- Filter cases by OMIM terms in cases and dashboard pages
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -184,10 +184,10 @@ class CaseHandler(object):
                 query["$or"] = [
                     {
                         "diagnosis_phenotypes.disease_id": {"$in": omim_terms}
-                    },  # OMIM phenotypes are assigned as key/values of a dictionary
+                    },  # OMIM phenotypes are assigned as a list of dictionaries
                     {
                         "diagnosis_phenotypes": {"$in": omim_terms}
-                    },  # old way of saving OMIM terms for a case --> list
+                    },  # old way of saving OMIM terms --> list of ids [616538,611277]
                 ]
 
             else:  # query for cases with no HPO terms

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -177,6 +177,25 @@ class CaseHandler(object):
                     {"phenotype_terms": {"$exists": False}},
                 ]
 
+        if query_field == "exact_dia":
+            if query_term != "":
+                # User might have provided multiple query terms
+                omim_terms = [term for term in query_term.replace(" ", "").split(",")]
+                query["$or"] = [
+                    {
+                        "diagnosis_phenotypes.disease_id": {"$in": omim_terms}
+                    },  # OMIM phenotypes are assigned as key/values of a dictionary
+                    {
+                        "diagnosis_phenotypes": {"$in": omim_terms}
+                    },  # old way of saving OMIM terms for a case --> list
+                ]
+
+            else:  # query for cases with no HPO terms
+                query["$or"] = [
+                    {"diagnosis_phenotypes": {"$size": 0}},
+                    {"diagnosis_phenotypes": {"$exists": False}},
+                ]
+
         if query_field == "synopsis":
             if query_term != "":
                 query["$text"] = {"$search": query_term}

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -161,7 +161,7 @@ CASE_SEARCH_TERMS = {
         "placeholder": "example:HP:0001166",
     },
     "cohort": {"label": "Patient Cohort", "prefix": "cohort:", "placeholder": "example:pedhep"},
-    "similar case": {
+    "similar_case": {
         "label": "Similar Case",
         "prefix": "similar_case:",
         "placeholder": "example:18201",

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -136,32 +136,46 @@ SOURCES = [
 SAMPLE_SOURCE = dict((i, el) for i, el in enumerate(SOURCES))
 
 CASE_SEARCH_TERMS = {
-    "case": {"label": "Case or Individual Name", "prefix": "case:"},
+    "case": {"label": "Case or Individual Name", "prefix": "case:", "placeholder": "example:18201"},
     "exact_pheno": {
         "label": "HPO Terms",
         "prefix": "exact_pheno:",
+        "placeholder": "example:HP:0001166,HP:0001250,...",
+    },
+    "exact_dia": {
+        "label": "OMIM Terms",
+        "prefix": "exact_dia:",
+        "placeholder": "example:OMIM:616538,OMIM:607681,...",
     },
     "synopsis": {
         "label": "Search Synopsis",
         "prefix": "synopsis:",
+        "placeholder": "example:epilepsy",
     },
-    "panel": {"label": "Gene Panel", "prefix": "panel:"},
-    "status": {"label": "Case Status", "prefix": "status:"},
-    "track": {"label": "Analysis Track", "prefix": "track:"},
+    "panel": {"label": "Gene Panel", "prefix": "panel:", "placeholder": "example:NMD"},
+    "status": {"label": "Case Status", "prefix": "status:", "placeholder": "example:active"},
+    "track": {"label": "Analysis Track", "prefix": "track:", "placeholder": "rare or cancer"},
     "pheno_group": {
         "label": "Phenotype Group",
         "prefix": "pheno_group:",
+        "placeholder": "example:HP:0001166",
     },
-    "cohort": {"label": "Patient Cohort", "prefix": "cohort:"},
-    "Similar case": {
+    "cohort": {"label": "Patient Cohort", "prefix": "cohort:", "placeholder": "example:pedhep"},
+    "similar case": {
         "label": "Similar Case",
         "prefix": "similar_case:",
+        "placeholder": "example:18201",
     },
     "similar_pheno": {
         "label": "Similar Phenotype",
         "prefix": "similar_pheno:",
+        "placeholder": "example:HP:0001166,HP:0001250,..",
     },
-    "pinned": {"label": "Pinned Gene", "prefix": "pinned:"},
-    "causative": {"label": "Causative Gene", "prefix": "causative:"},
-    "user": {"label": "Assigned User", "prefix": "user:"},
+    "pinned": {"label": "Pinned Gene", "prefix": "pinned:", "placeholder": "example:POT1"},
+    "causative": {"label": "Causative Gene", "prefix": "causative:", "placeholder": "example:POT1"},
+    "user": {
+        "label": "Assigned User",
+        "prefix": "user:",
+        "placeholder": "example:John Doe",
+    },
 }

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -3,6 +3,7 @@ import logging
 from flask import flash, redirect, request, url_for
 from flask_login import current_user
 
+from scout.constants import CASE_SEARCH_TERMS
 from scout.server.extensions import store
 from scout.server.utils import user_institutes
 
@@ -58,7 +59,7 @@ def populate_dashboard_data(request):
     Returns:
         data(dict): data to be diplayed in the template
     """
-    data = {"dashboard_form": dashboard_form(request.form)}
+    data = {"dashboard_form": dashboard_form(request.form), "search_terms": CASE_SEARCH_TERMS}
     if request.method == "GET":
         return data
 

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -159,28 +159,40 @@
   <script src="{{ url_for('dashboard.static', filename='charts.js') }}"></script>
   <script type="text/javascript">
 
-    document.querySelector("#download_verified").addEventListener("submit", function(e){
-      // Avoid page spinner being stuck on download verified variants
-      $(window).unbind('beforeunload');
-    });
+    if(document.getElementById('download_verified')){
+      document.querySelector("#download_verified").addEventListener("submit", function(e){
+        // Avoid page spinner being stuck on download verified variants
+        $(window).unbind('beforeunload');
+      });
+    }
 
-    var sel = document.getElementById("search_type");
-    var text = document.getElementById("search_term");
+    // Code taking care of case filtering
+    var caseSearchTerms = {{ search_terms|safe }};
+    var searchTerm = document.getElementById('search_term'); // Case search term label
+    var sel = document.getElementById('search_type'); // Case search term select
+    document.getElementById("search_type").onchange = function() {
+      // Change case search term placeholder
+      selectedKey = sel.options[sel.selectedIndex].value.slice(0, -1);
+      if(selectedKey){
+        searchTerm.placeholder=caseSearchTerms[selectedKey]["placeholder"];
+        searchTerm.disabled = false;
+      }
+      else{
+        searchTerm.disabled = (sel.value == "");
+        searchTerm.placeholder="Search term";
+      }
+      // Reset search
+      searchTerm.value="";
+    };
 
     $(document).ready(function(){
-      text.disabled = (sel.value == "");
+      searchTerm.disabled = (sel.value == "");
       {% if not total_cases %}
         hide_div("all");
       {% else %}
         hide_div('{{panel}}');
       {% endif %}
     });
-
-    if(sel){
-      sel.onchange = function(e) {
-        text.disabled = (sel.value == "");
-      };
-    }
 
     function hide_div(show_div){
       panels = ["general", "cases", "variants"];

--- a/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
+++ b/scout/server/blueprints/dashboard/templates/dashboard/dashboard_general.html
@@ -206,11 +206,11 @@
           // Hide search type select and search term in the filters if panel=="variants"
           if (show_div=="variants"){
             sel.style.display = "none";
-            text.style.display = "none";
+            searchTerm.style.display = "none";
           }
           else{
             sel.style.display = "block";
-            text.style.display = "block";
+            searchTerm.style.display = "block";
           }
         }
         else{ // hide the other 2 divs

--- a/scout/server/blueprints/institutes/static/form_scripts.js
+++ b/scout/server/blueprints/institutes/static/form_scripts.js
@@ -1,26 +1,3 @@
-var searchTerm = document.getElementById('search_term');
-var sel = document.getElementById('search_type');
-
-var selectHelper = {
-  "case:": "example:18201",
-  "exact_pheno:": "example:HP:0001166,HP:0001250,...",
-  "synopsis:" : "example:epilepsy",
-  "panel:" : "example:NMD",
-  "status:": "example:active",
-  "pheno_group:" : "example:HP:0001166",
-  "cohort:" : "example:pedhep",
-  "similar_case:" : "example:18201",
-  "similar_pheno:" : "example:HP:0001166,HP:0001250,..",
-  "pinned:": "example:POT1",
-  "causative:": "example:POT1",
-  "user:": "example:Kent",
-};
-
-document.getElementById("search_type").onchange = function() {
-  searchTerm.placeholder=selectHelper[sel.value];
-  searchTerm.value="";
-};
-
 $(function () {
   $('[data-toggle="tooltip"]').tooltip();
   $('table').stickyTableHeaders({

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -283,4 +283,16 @@
   {{ super() }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-table-headers/0.1.19/js/jquery.stickytableheaders.min.js"></script>
   <script src="{{ url_for('overview.static', filename='form_scripts.js') }}"></script>
+  <script>
+  var caseSearchTerms = {{ search_terms|safe }};
+  var searchTerm = document.getElementById('search_term'); // Case search term label
+  var sel = document.getElementById('search_type'); // Case search term select
+  document.getElementById("search_type").onchange = function() {
+    // Change case search term placeholder
+    selectedItem = sel.options[sel.selectedIndex].value.slice(0, -1);
+    searchTerm.placeholder=caseSearchTerms[selectedItem]["placeholder"];
+    // Reset search
+    searchTerm.value="";
+  };
+  </script>
 {% endblock %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -289,8 +289,8 @@
   var sel = document.getElementById('search_type'); // Case search term select
   document.getElementById("search_type").onchange = function() {
     // Change case search term placeholder
-    selectedItem = sel.options[sel.selectedIndex].value.slice(0, -1);
-    searchTerm.placeholder=caseSearchTerms[selectedItem]["placeholder"];
+    selectedKey = sel.options[sel.selectedIndex].value.slice(0, -1);
+    searchTerm.placeholder=caseSearchTerms[selectedKey]["placeholder"];
     // Reset search
     searchTerm.value="";
   };

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -278,6 +278,20 @@ def test_get_cases_no_HPO(adapter, case_obj):
     assert sum(1 for i in cases) == 0
 
 
+def test_cases_no_diagnosis(adapter, case_obj, omim_term):
+    """Test filtering cases by empty diagnosis field"""
+
+    # GIVEN a case without any diagnosis:
+    assert "diagnosis_phenotypes" not in case_obj
+    adapter.case_collection.insert_one(case_obj)
+
+    # WHEN cases are filtered using OMIM terms with empty value
+    name_query = "exact_dia:"
+    cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
+    # THEN a case should be returned
+    assert sum(1 for i in cases) == 1
+
+
 def test_get_cases_no_assignees(real_adapter, case_obj):
     adapter = real_adapter
     # GIVEN an empty database (no cases)
@@ -606,9 +620,9 @@ def test_cases_by_diagnosis(adapter, case_obj, omim_term):
     }
     adapter.case_collection.insert_one(case_obj)
     # WHEN cases are filtered using OMIM terms containing that term
-    name_query = f"exact_dia:{omim_term['disease_id']},OMIM:000001"
+    name_query = f"exact_dia:{omim_term['disease_id']},OMIM:999999"
 
-    # WHEN querying for active cases
+    # WHEN querying for cases with the given OMIM term
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
     # THEN a case should be returned
     assert sum(1 for i in cases) == 1

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 import copy
 import logging
-from pprint import pprint as pp
 
 import pymongo
 import pytest
 
-from scout.constants import INDEXES, REV_ACMG_MAP
+from scout.constants import REV_ACMG_MAP
 from scout.exceptions import IntegrityError
 
 logger = logging.getLogger(__name__)

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -595,6 +595,25 @@ def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj):
     assert res["status"] == "inactive"
 
 
+def test_cases_by_diagnosis(adapter, case_obj, omim_term):
+    """Test filtering cases by assigned OMIM terms"""
+
+    # GIVEN a case with a diagnosis:
+    case_obj["diagnosis_phenotypes"] = {
+        "disease_nr": omim_term["disease_nr"],
+        "disease_id": omim_term["disease_id"],
+        "description": omim_term["description"],
+    }
+    adapter.case_collection.insert_one(case_obj)
+    # WHEN cases are filtered using OMIM terms containing that term
+    name_query = f"exact_dia:{omim_term['disease_id']},OMIM:000001"
+
+    # WHEN querying for active cases
+    cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
+    # THEN a case should be returned
+    assert sum(1 for i in cases) == 1
+
+
 def test_cases_by_phenotype(hpo_database, test_hpo_terms, case_obj):
     adapter = hpo_database
 


### PR DESCRIPTION
Fix #3221

- Add filtering of cases by OMIM terms in both cases and dashboard pages
- Introduce placeholder, to give case query example in dashboard page 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Install on cg-vm1 and filter using one of more OMIM terms
2. Filter also by OMIM terms with blank field. It should return cases without diagnoses

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
