### PR TITLE
Fix #3223 - add PanelApp gene link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide by default variants only present in unaffected individuals in variants filters
 - OMIM terms in general case report
 - Individual-level info on OMIM and HPO terms in general case report
+- PanelApp gene link
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide by default variants only present in unaffected individuals in variants filters
 - OMIM terms in general case report
 - Individual-level info on OMIM and HPO terms in general case report
-- PanelApp gene link
+- PanelApp gene link among the external links on variant page
 ### Fixed
 - A malformed panel id request would crash with exception: now gives user warning flash with redirect
 - Link to HPO resource file hosted on `http://purl.obolibrary.org`

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -261,6 +261,7 @@
             <a href="{{ gene.stripy_link }}" class="btn btn-outline-secondary" target="_blank">STRipy</a>
             <a href="{{ gene.gnomad_str_link}}" class="btn btn-outline-secondary" target="_blank">GnomAD STR</a>
           {% endif %}
+          <a href="{{ gene.panelapp_link }}" class="btn btn-outline-secondary" target="_blank">PanelApp</a>
           <a href="http://marrvel.org/human/variant/{{ variant.chromosome }}:{{ variant.position }} {{ variant.reference }}>{{variant.alternative}}" class="btn btn-outline-secondary" target="_blank">MARRVEL</a>
       </div>
     {% endfor %}

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -65,6 +65,15 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["iarctp53_link"] = iarctp53(hgnc_symbol)
     gene_obj["stripy_link"] = stripy_gene(hgnc_symbol)
     gene_obj["gnomad_str_link"] = gnomad_str_gene(hgnc_symbol)
+    gene_obj["panelapp_link"] = panelapp_gene(hgnc_symbol)
+
+
+def panelapp_gene(hgnc_symbol):
+    link = "https://panelapp.genomicsengland.co.uk/panels/entities/{}"
+
+    if not hgnc_symbol:
+        return None
+    return link.format(hgnc_symbol)
 
 
 def stripy_gene(hgnc_symbol):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Variant page gene deep link to PanelApp via gene symbol.

![Screenshot 2022-03-07 at 12 21 22](https://user-images.githubusercontent.com/758570/157022158-6087293f-784f-46de-87a3-b7b639036ea0.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
