### PR TITLE
List partial causatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Better error handling for partly broken/timed out chanjo reports
 - Broken javascript code when case Chromograph data is malformed
 - Broader space for case synopsis in general report
+- Show partial causatives on causatives and matching causatives panels
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -660,6 +660,18 @@ class VariantHandler(VariantLoader):
                 yielded_other_causative_ids.append(other_causative_id)
                 yield other_causative
 
+            other_case_partial_causatives = other_case.get("partial_causatives", {}).keys()
+            if other_causative_id in other_case_partial_causatives:
+                other_causative = {
+                    "_id": other_causative_id,
+                    "institute_id": other_case["owner"],
+                    "case_id": other_case["_id"],
+                    "case_display_name": other_case["display_name"],
+                    "partial": True,
+                }
+                yielded_other_causative_ids.append(other_causative_id)
+                yield other_causative
+
     def delete_variants(self, case_id, variant_type, category=None):
         """Delete variants of one type for a case
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -4,14 +4,10 @@ import logging
 import pathlib
 import re
 import tempfile
-from datetime import datetime
 
 # Third party modules
 import pymongo
 from cyvcf2 import VCF
-from pymongo.errors import DuplicateKeyError
-
-from scout.exceptions import IntegrityError
 
 # Local modules
 from scout.utils.coordinates import is_par

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -558,7 +558,6 @@ class VariantHandler(VariantLoader):
         if limit_genes:
             filters["genes.hgnc_id"] = {"$in": limit_genes}
 
-        LOG.debug("Attempting filtered matching causatives query: %s", filters)
         return self.variant_collection.find(filters)
 
     def check_causatives(self, case_obj=None, institute_obj=None, limit_genes=None):
@@ -600,13 +599,7 @@ class VariantHandler(VariantLoader):
             if other_causative_id in other_case.get("causatives", []):
                 positional_variant_ids.add(var_event["variant_id"])
 
-            LOG.debug(
-                "Other causative id %s, keys %s",
-                other_causative_id,
-                other_case.get("partial_causatives", {}).keys(),
-            )
             if other_causative_id in other_case.get("partial_causatives", {}).keys():
-                LOG.debug("match partial causative!")
                 positional_variant_ids.add(var_event["variant_id"])
 
         return self.match_affected_gt(case_obj, institute_obj, positional_variant_ids, limit_genes)
@@ -755,12 +748,6 @@ class VariantHandler(VariantLoader):
             evaluation_event["variant_id"] for evaluation_event in evaluation_events
         ]
 
-        LOG.debug(
-            "Found evaluated variant ids for case %s institute %s: %s ",
-            case_id,
-            institute_id,
-            evaluated_variant_ids,
-        )
         return evaluated_variant_ids
 
     def evaluated_variants(self, case_id, institute_id):

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -578,7 +578,11 @@ class VariantHandler(VariantLoader):
         """
         institute_id = case_obj["owner"] if case_obj else institute_obj["_id"]
         var_causative_events = self.event_collection.find(
-            {"institute": institute_id, "verb": "mark_causative", "category": "variant"}
+            {
+                "institute": institute_id,
+                "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
+                "category": "variant",
+            }
         )
         positional_variant_ids = set()
         for var_event in var_causative_events:
@@ -594,6 +598,15 @@ class VariantHandler(VariantLoader):
             other_causative_id = other_link.split("/")[-1]
 
             if other_causative_id in other_case.get("causatives", []):
+                positional_variant_ids.add(var_event["variant_id"])
+
+            LOG.debug(
+                "Other causative id %s, keys %s",
+                other_causative_id,
+                other_case.get("partial_causatives", {}).keys(),
+            )
+            if other_causative_id in other_case.get("partial_causatives", {}).keys():
+                LOG.debug("match partial causative!")
                 positional_variant_ids.add(var_event["variant_id"])
 
         return self.match_affected_gt(case_obj, institute_obj, positional_variant_ids, limit_genes)

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -487,7 +487,7 @@
       </div>
       {% if variant.get('phenotypes') %}
         <div class="row mt-3">
-          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
             OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
             HPO terms:&nbsp;
             {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
@@ -978,7 +978,7 @@
     </div>
     {% if variant.get('phenotypes') %}
       <div class="row mt-3">
-        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
           OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
           HPO terms:&nbsp;
           {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
@@ -1225,7 +1225,7 @@
     </div>
     {% if variant.get('phenotypes') %}
       <div class="row mt-3">
-        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-secondary">Partial causative</span>
+        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
           OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
           HPO terms:&nbsp;
           {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -143,7 +143,7 @@
             </td>
             <td>
               {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
-                <span class="badge badge-warning">partial</span>
+                <span class="badge badge-warning" data-toggle="tooltip" title="Partial causative variants explain part of the case phenotype">partial</span>
               {% endif %}
               <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} pull-right">
                 {{ case.status }}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -143,7 +143,7 @@
             </td>
             <td>
               {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
-                <span class="badge badge-secondary">partial</span>
+                <span class="badge badge-warning">partial</span>
               {% endif %}
               <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} pull-right">
                 {{ case.status }}

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -82,7 +82,7 @@
           {% for _, group in variant_groups.items() %}
           {% set group_variant = group[0][1] %}
           {% for case, variant in group %}
-          {% if case.causatives and variant._id in case.causatives %}
+          {% if (case.causatives and variant._id in case.causatives) or (case.partial_causatives and variant._id in case.partial_causatives) %}
           <tr>
             <td>
               {{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}
@@ -142,6 +142,9 @@
               </a>
             </td>
             <td>
+              {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
+                <span class="badge badge-secondary">partial</span>
+              {% endif %}
               <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} pull-right">
                 {{ case.status }}
               </span>

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -74,7 +74,7 @@ def causatives(institute_id):
             variants,
             key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
         )
-    LOG.debug("all raw causative variants: %s", variants)
+
     all_variants = {}
     all_cases = {}
     for variant_obj in variants:
@@ -89,7 +89,6 @@ def causatives(institute_id):
 
         all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
 
-    LOG.debug("all causative variants: %s", all_variants)
     acmg_map = {key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()}
 
     return dict(institute=institute_obj, variant_groups=all_variants, acmg_map=acmg_map)

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -74,6 +74,7 @@ def causatives(institute_id):
             variants,
             key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
         )
+    LOG.debug("all raw causative variants: %s", variants)
     all_variants = {}
     all_cases = {}
     for variant_obj in variants:
@@ -88,6 +89,7 @@ def causatives(institute_id):
 
         all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
 
+    LOG.debug("all causative variants: %s", all_variants)
     acmg_map = {key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()}
 
     return dict(institute=institute_obj, variant_groups=all_variants, acmg_map=acmg_map)

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -158,7 +158,7 @@
             {{ other_variant.case_display_name }}
           </a>&nbsp;
           {% if other_variant.partial %}
-            <span class="badge badge-secondary">partial</span>
+            <span class="badge badge-warning">partial</span>
           {% endif %}
         {% endfor %}
       </div> <!--end of card body-->

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -157,6 +157,9 @@
                               variant_id=other_variant._id) }}">
             {{ other_variant.case_display_name }}
           </a>&nbsp;
+          {% if other_variant.partial %}
+            <span class="badge badge-secondary">partial</span>
+          {% endif %}
         {% endfor %}
       </div> <!--end of card body-->
     </div><!--end of card-->

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -158,7 +158,7 @@
             {{ other_variant.case_display_name }}
           </a>&nbsp;
           {% if other_variant.partial %}
-            <span class="badge badge-warning">partial</span>
+            <span class="badge badge-warning" data-toggle="tooltip" title="Partial causative variants explain part of the case phenotype">partial</span>
           {% endif %}
         {% endfor %}
       </div> <!--end of card body-->


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

When marking partial causative, variant can be seen on causatives view
![Screenshot 2022-03-08 at 10 29 35](https://user-images.githubusercontent.com/758570/157209057-5d72828a-16de-4f92-8eae-6b74c0d67c69.png)
and as a matching causative
![Screenshot 2022-03-08 at 10 38 44](https://user-images.githubusercontent.com/758570/157209935-cdc83675-c5e9-4200-ab27-31d7d99d556b.png)
also, on the variant level:
![Screenshot 2022-03-08 at 11 23 27](https://user-images.githubusercontent.com/758570/157217648-64c28b26-84dd-4c78-aa09-9ec13f5d420a.png)
 
compared to main:
![Screenshot 2022-03-08 at 10 41 25](https://user-images.githubusercontent.com/758570/157210282-048c80ea-a9e6-472c-ac56-825158e93c34.png)
![Screenshot 2022-03-08 at 10 41 19](https://user-images.githubusercontent.com/758570/157210286-e7290fb4-e176-47e4-ae36-7985de601c3e.png)
Especially the latter is a little worrying, but afaik at least cust002 rarely use partial.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
