### PR TITLE
Fix mark partial causative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Better error handling for partly broken/timed out chanjo reports
 - Broken javascript code when case Chromograph data is malformed
 - Broader space for case synopsis in general report
+- Partial causative assignment in cases with no OMIM or HPO terms
+- Partial causative OMIM select options in variant page
 ### Changed
 - Slightly smaller and improved layout of content in case PDF report
 - Relabel more cancer variant pages somatic for navigation

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -441,7 +441,7 @@
                 <div class="col-8">
                   {% for omim in variant_phenotypes.omim_terms %}
                     <span class="badge badge-sm badge-secondary">
-                      <a class="text-white" target="_blank" href="http://omim.org/entry/{{omim}}">
+                      <a class="text-white" target="_blank" href="http://omim.org/entry/{{omim|replace('OMIM:','')}}">
                         {{omim}}
                       </a>
                     </span>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -36,9 +36,9 @@
                   <!-- Phenotype could be specified using OMIM -->
                   <h6>Diagnosis phenotype (OMIM):</h6>
                   <select multiple="multiple" name="omim_select" id="omim_select" class="selectpicker">
-                    {% for omim_term in case.diagnosis_phenotypes %} <!-- New way of saving OMIM terms in cases: list of dicts -->
+                    {% for omim_term in case.diagnosis_phenotypes %}
                       {% if 'disease_nr' in omim_term %}
-                        <option value="{{omim_term.disease_id}}"> <!-- Old way of saving OMIM terms in cases: list of diagnosis numbers -->
+                        <option value="{{omim_term.disease_id}}"> <!-- New way of saving OMIM terms in cases: list of dicts -->
                           {{ omim_term.description }} ({{omim_term.disease_id}})
                         </option>
                       {% else %}

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -32,7 +32,7 @@
               <h6><strong>Associated phenotype</strong></h6>
               <!-- A partial causative variant is resposible for a specific phenotype. Make sure phenotype is specified -->
               <div class="row ml-3">
-                <div class="col-4">
+                <div class="col-6">
                   <!-- Phenotype could be specified using OMIM -->
                   <h6>Diagnosis phenotype (OMIM):</h6>
                   <select multiple="multiple" name="omim_select" id="omim_select" class="selectpicker">
@@ -49,7 +49,7 @@
                     {% endfor %}
                   </select>
                 </div>
-                <div class="col-8">
+                <div class="col-6">
                   <!-- Phenotype could also be specified by HPO terms -->
                   <h6>Phenotype terms (HPO):</h6>
                   <select multiple="multiple" name="hpo_select" id="hpo_select" class="selectpicker">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -22,10 +22,7 @@
                     <br>
                     <div>
                       <input type="checkbox" class="ios8-switch" id="partial_causative" name="partial_causative"
-                        data-toggle='collapse' data-target='#partial_phenotypes'
-                          {% if case.phenotype_terms|length == 0 and case.diagnosis_phenotypes|length == 0 %}
-                            disabled
-                          {% endif %}>
+                        data-toggle='collapse' data-target='#partial_phenotypes'>
                       <label for="partial_causative"></label>
                     </div>
                   </div>
@@ -39,10 +36,16 @@
                   <!-- Phenotype could be specified using OMIM -->
                   <h6>Diagnosis phenotype (OMIM):</h6>
                   <select multiple="multiple" name="omim_select" id="omim_select" class="selectpicker">
-                    {% for omim_id in case.diagnosis_phenotypes %}
-                      <option value="{{omim_id}}">
-                        {{ omim_id }}
-                      </option>
+                    {% for omim_term in case.diagnosis_phenotypes %} <!-- New way of saving OMIM terms in cases: list of dicts -->
+                      {% if 'disease_nr' in omim_term %}
+                        <option value="{{omim_term.disease_id}}"> <!-- Old way of saving OMIM terms in cases: list of diagnosis numbers -->
+                          {{ omim_term.description }} ({{omim_term.disease_id}})
+                        </option>
+                      {% else %}
+                        <option value="{{omim_term}}"> <!-- Old way of saving OMIM terms in cases: list of diagnosis numbers -->
+                          {{ omim_term }}
+                        </option>
+                      {% endif %}
                     {% endfor %}
                   </select>
                 </div>


### PR DESCRIPTION
- Fix Partial causative assignment in cases with no OMIM or HPO terms (fix #3226)
- Partial causative OMIM select options in variant page (the ugly visualization of OMIM options is due to the change of how diagnoses are saved in case document)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test: locally**:
1. On main branch: try to assign a variant as partial causative. The OMIM select options will be super long if you have individual-level diagnoses in demo case
2. Switch to this branch and OMIM options should look fine
3. Switch back to main branch and remove all OMIM and HPO terms from the case: try to assign a variant as partial causative: confirm that you cant't
4. Switch to this branch and repeat: it should work instead

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
