### PR TITLE
Decrease complexity of code in scout/adapter/mongo/variant to silence codefactor complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.50.1]
+### Changed
+- Simplified code of scout/adapter/mongo/variant
 ### Fixed
 - Show matching causative STR_repid for legacy str variants (pre Stranger hgnc_id)
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -848,10 +848,10 @@ class VariantHandler(VariantLoader):
             if category != var_type:
                 continue
             if variant_type == "clinical":
-                variant_file = case_obj["vcf_files"].get("_".join(["vcf", "var_type"]))
+                variant_file = case_obj["vcf_files"].get("_".join(["vcf", var_type]))
+                LOG.error(variant_file)
             elif variant_type == "research":
-                variant_file = case_obj["vcf_files"].get("_".join(["vcf", "var_type", "research"]))
-
+                variant_file = case_obj["vcf_files"].get("_".join(["vcf", var_type, "research"]))
         return variant_file
 
     def get_region_vcf(

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -849,7 +849,6 @@ class VariantHandler(VariantLoader):
                 continue
             if variant_type == "clinical":
                 variant_file = case_obj["vcf_files"].get("_".join(["vcf", var_type]))
-                LOG.error(variant_file)
             elif variant_type == "research":
                 variant_file = case_obj["vcf_files"].get("_".join(["vcf", var_type, "research"]))
         return variant_file

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -844,7 +844,7 @@ class VariantHandler(VariantLoader):
             variant_file(str): string path to a VCF file on disk
         """
         variant_file = None
-        for var_type in ["snv", "sv", "str", "research"]:
+        for var_type in ["snv", "sv", "str", "cancer"]:
             if category != var_type:
                 continue
             if variant_type == "clinical":

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -833,7 +833,7 @@ class VariantHandler(VariantLoader):
         return variants.values()
 
     def get_variant_file(self, case_obj, category, variant_type):
-        """Retrieve that should be parsed to extract variants
+        """Retrieve file name for file that should be parsed to extract variants
 
         Accepts:
             case_obj(dict): a case dictionary


### PR DESCRIPTION
Fixes (partially) #2984 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
