### PR TITLE
Created a codecov yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
+### Added
+- Config file containing codecov settings for pull requests
 ### Changed
 - Updated deprecated Codecov GitHub action to v.2
 - Simplified code of scout/adapter/mongo/variant

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    patch: false
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0.3%
+        base: auto
+        flags:
+          - unit
+        paths:
+          - "scout"
+       # advanced settings
+        branches:
+          - main
+        if_ci_failed: error #success, failure, error, ignore
+        informational: false
+        only_pulls: false


### PR DESCRIPTION
FIx #3244
- Make codecov test fail if coverage goes down by 0.3% (should we make it 0.5% instead?)
- Avoid those annoying comments saying coverage went down on many lines of code

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
