### PR TITLE
Fix variant page crashing when OMIM terms are list of integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed filter bug with high negative SPIDEX scores
 - Renamed button and modified link to IACR TP53, that has been moved to the US NCI: `https://tp53.isb-cgc.org/`
 - Parsing new format of OMIM case info when exporting patients to Matchmaker
+- Variant page crashing for cases with old OMIM terms structure (a list of integers instead of dictionary)
 
 ## [4.50.1]
 ### Fixed

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -37,13 +37,13 @@
                   <h6>Diagnosis phenotype (OMIM):</h6>
                   <select multiple="multiple" name="omim_select" id="omim_select" class="selectpicker">
                     {% for omim_term in case.diagnosis_phenotypes %}
-                      {% if 'disease_nr' in omim_term %}
+                      {% if omim_term is number %} <!-- Old way of saving OMIM terms in cases: list of diagnosis numbers -->
+                        <option value="{{omim_term}}">
+                          {{ omim_term }}
+                        </option>
+                      {% elif 'disease_nr' in omim_term %}
                         <option value="{{omim_term.disease_id}}"> <!-- New way of saving OMIM terms in cases: list of dicts -->
                           {{ omim_term.description }} ({{omim_term.disease_id}})
-                        </option>
-                      {% else %}
-                        <option value="{{omim_term}}"> <!-- Old way of saving OMIM terms in cases: list of diagnosis numbers -->
-                          {{ omim_term }}
                         </option>
                       {% endif %}
                     {% endfor %}


### PR DESCRIPTION
Old cases contain a field `diagnosis_phenotypes` as a list of integers. That field has been recently modified and it is dictionary now.
This PR fixes a variant page crashing when case had old `diagnosis_phenotypes` format. Fix #3260

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. I couldn't really replicate the error occurring in [the variant when the error occurred originally](https://scout.scilifelab.se/cust003/18073/73747e36c973f9b3036ed2d92f147461) (that now works!) but this should prevent it in any other variant
2. Test locally by modifying case["diagnosis_phenotypes"] assigning it a value like this = [616538]
3. Go to any variant page and make sure the page doesn't crash

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
