### PR TITLE
List gene names densely in general report for SVs that contain more than 3 genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed filter bug with high negative SPIDEX scores
 - Renamed button and modified link to IACR TP53, that has been moved to the US NCI: `https://tp53.isb-cgc.org/`
 - Parsing new format of OMIM case info when exporting patients to Matchmaker
+- List gene names densely in general report for SVs that contain more than 3 genes
 
 ## [4.50.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove flags from codecov config file
 - Fixed filter bug with high negative SPIDEX scores
 - Renamed button and modified link to IACR TP53, that has been moved to the US NCI: `https://tp53.isb-cgc.org/`
+- Parsing new format of OMIM case info when exporting patients to Matchmaker
 
 ## [4.50.1]
 ### Fixed

--- a/scout/parse/matchmaker.py
+++ b/scout/parse/matchmaker.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-import json
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -52,6 +51,8 @@ def omim_terms(store, case_obj):
     case_disorders = case_obj.get("diagnosis_phenotypes")  # array of OMIM terms
     if case_disorders:
         for disorder in case_disorders:
+            if isinstance(disorder, dict):
+                disorder = disorder.get("disease_nr")
             omim_term = store.disease_term(disorder)
             if omim_term is None:
                 LOG.warning(f"Disease term {disorder} could not be found in database.")

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1156,17 +1156,17 @@
       </tbody>
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
-      <thead>
-        <tr>
-          <th>Affected gene(s)</th>
-          <th>Description</th>
-          <th>Region annotation</th>
-          <th>Transcript - HGVS - Protein</th>
-          <th>OMIM phenotypes [inheritance]</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% if variant.genes %}
+      {% if variant.genes and variant.genes|length <= 3 %}
+        <thead>
+          <tr>
+            <th>Affected gene(s)</th>
+            <th>Description</th>
+            <th>Region annotation</th>
+            <th>Transcript - HGVS - Protein</th>
+            <th>OMIM phenotypes [inheritance]</th>
+          </tr>
+        </thead>
+        <tbody>
           {% for gene in variant.genes %}
             <tr>
               <td>
@@ -1188,11 +1188,22 @@
               </td>
             </tr>
           {% endfor %}
-        {% endif %}
-      </tbody>
+        </tbody>
+      {% elif variant.genes %} <!-- more than 3 genes in this SV -->
+        <thead>
+          <th>Affected gene(s)</th>
+        </thead>
+        <tbody>
+          <td>
+            {% for gene in variant.genes|sort(attribute='common.hgnc_symbol') %} <!-- Display all genes sorted by symbol -->
+              <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
+              {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+              </a>&nbsp;
+            {% endfor %}
+          </td>
+        </tbody>
+      {% endif %}
     </table>
-
-
     {% if variant.comments | count_cursor > 0  %}
       <br>
       <table id="panel-table" class="table table-sm" style="background-color: transparent">

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1191,7 +1191,7 @@
         </tbody>
       {% elif variant.genes %} <!-- more than 5 genes in this SV -->
         <thead>
-          <th>{% variant.genes|length %} Affected gene(s)</th>
+          <th>{% variant.genes|length %} affected gene(s)</th>
         </thead>
         <tbody>
           <td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1191,7 +1191,7 @@
         </tbody>
       {% elif variant.genes %} <!-- more than 5 genes in this SV -->
         <thead>
-          <th>{% variant.genes|length %} affected gene(s)</th>
+          <th>{{ variant.genes|length }} affected gene(s)</th>
         </thead>
         <tbody>
           <td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1189,7 +1189,7 @@
             </tr>
           {% endfor %}
         </tbody>
-      {% elif variant.genes %} <!-- more than 3 genes in this SV -->
+      {% elif variant.genes %} <!-- more than 5 genes in this SV -->
         <thead>
           <th>{% variant.genes|length %} Affected gene(s)</th>
         </thead>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1156,7 +1156,7 @@
       </tbody>
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
-      {% if variant.genes and variant.genes|length <= 5 %}
+      {% if variant.genes and variant.genes|length <= 3 %}
         <thead>
           <tr>
             <th>Affected gene(s)</th>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1156,7 +1156,7 @@
       </tbody>
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
-      {% if variant.genes and variant.genes|length <= 3 %}
+      {% if variant.genes and variant.genes|length <= 5 %}
         <thead>
           <tr>
             <th>Affected gene(s)</th>
@@ -1191,7 +1191,7 @@
         </tbody>
       {% elif variant.genes %} <!-- more than 3 genes in this SV -->
         <thead>
-          <th>Affected gene(s)</th>
+          <th>{% variant.genes|length %} Affected gene(s)</th>
         </thead>
         <tbody>
           <td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1197,7 +1197,7 @@
           <td>
             {% for gene in variant.genes|sort(attribute='common.hgnc_symbol') %} <!-- Display all genes sorted by symbol -->
               <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
-              {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+              <i>{{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}</i>
               </a>&nbsp;
             {% endfor %}
           </td>


### PR DESCRIPTION
Fix #3258 

Main branch, a pinned SV variant with many genes looks like this:

<img width="344" alt="image" src="https://user-images.githubusercontent.com/28093618/160122336-ad2dae40-cacf-47c3-89d0-313226e7b4a1.png">


Same variant using this branch:

<img width="876" alt="image" src="https://user-images.githubusercontent.com/28093618/160122137-76a39f60-576a-4303-9182-1fe23ff3c427.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
