### PR TITLE
Remove flask-debugtoolbar that uses deprecated Jinja2 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed filter bug with high negative SPIDEX scores
 - Renamed button and modified link to IACR TP53, that has been moved to the US NCI: `https://tp53.isb-cgc.org/`
 - Parsing new format of OMIM case info when exporting patients to Matchmaker
+- Remove flask-debugtoolbar lib dependency that is using deprecated code and causes app to crash after new release of Jinja2 (3.1)
 
 ## [4.50.1]
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 
 werkzeug
 Flask>=0.10
-Flask-DebugToolbar
 Flask-Bootstrap
 Flask-CORS
 path.py

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -95,7 +95,6 @@ def create_app(config_file=None, config=None):
 def configure_extensions(app):
     """Configure Flask extensions."""
 
-    extensions.toolbar.init_app(app)
     extensions.bootstrap.init_app(app)
     extensions.mongo.init_app(app)
     extensions.store.init_app(app)
@@ -177,7 +176,7 @@ def register_filters(app):
         Return:
             str: humanized string of the decimal number
         """
-        min_number = 10**-ndigits
+        min_number = 10 ** -ndigits
         if isinstance(number, str):
             number = None
         if number is None:

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -176,7 +176,7 @@ def register_filters(app):
         Return:
             str: humanized string of the decimal number
         """
-        min_number = 10 ** -ndigits
+        min_number = 10**-ndigits
         if isinstance(number, str):
             number = None
         if number is None:

--- a/scout/server/extensions/__init__.py
+++ b/scout/server/extensions/__init__.py
@@ -2,7 +2,6 @@
 
 from authlib.integrations.flask_client import OAuth
 from flask_bootstrap import Bootstrap
-from flask_debugtoolbar import DebugToolbarExtension
 from flask_login import LoginManager
 from flask_mail import Mail
 
@@ -16,7 +15,6 @@ from .matchmaker_extension import MatchMaker
 from .mongo_extension import MongoDB
 from .rerunner_extension import RerunnerError, RerunnerService
 
-toolbar = DebugToolbarExtension()
 bootstrap = Bootstrap()
 store = MongoAdapter()
 login_manager = LoginManager()


### PR DESCRIPTION
Fix #3271 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Deployment on cg-vm1 should work

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
