### PR TITLE
Freeze temporarily Werkzeug to v.2.0 to fix deprecated safe_str_cmp import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Variant page crashing for cases with old OMIM terms structure (a list of integers instead of dictionary)
 - Variant page crashing when creating MARRVEL link for cases with no genome build
 - SpliceAI documentation link
-- Fix deprecated `safe_str_cmp` import from `werkzeug.security` by freezing Werkzeug lib to v2.0 until bugfix v.0.6 of Flask_login is released
+- Fix deprecated `safe_str_cmp` import from `werkzeug.security` by freezing Werkzeug lib to v2.0 until Flask_login v.0.6 with bugfix is released
 
 ## [4.50.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Variant page crashing for cases with old OMIM terms structure (a list of integers instead of dictionary)
 - Variant page crashing when creating MARRVEL link for cases with no genome build
 - SpliceAI documentation link
+- Fix deprecated `safe_str_cmp` import from `werkzeug.security` by freezing Werkzeug lib to v2.0 until bugfix v.0.6 of Flask_login is released
 
 ## [4.50.1]
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Everything needed in production
 
-werkzeug
+werkzeug<=2.0
 Flask>=0.10
 Flask-Bootstrap
 Flask-CORS


### PR DESCRIPTION
Fix #3278. 
Freeze temporarily Werkzeug until [v.0.6 of flask_login](https://github.com/maxcountryman/flask-login/blob/264ae9707ef3597c9377016e1cd2bf3f1a3ccc39/CHANGES#L21) is out.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. All automatic tests should pass
2. Demo app should work locally (after being installed on a fresh conda env)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
