### PR TITLE
Switch refSeq transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - SpliceAI documentation link
 - Fix deprecated `safe_str_cmp` import from `werkzeug.security` by freezing Werkzeug lib to v2.0 until Flask_login v.0.6 with bugfix is released
 - List gene names densely in general report for SVs that contain more than 3 genes
-
+- Show transcript ids on refseq genes on hg19 in IGV.js, using refgene source
 
 ## [4.50.1]
 ### Fixed

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -13,13 +13,9 @@ HG38CYTOBAND_URL = (
 HG38GENES_FORMAT = "gtf"
 HG38GENES_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz"
 HG38GENES_INDEX_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/genes/Homo_sapiens.GRCh38.80.sorted.gtf.gz.tbi"
-HG19GENES_FORMAT = "bed"
-HG19GENES_URL = (
-    "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz"
-)
-HG19GENES_INDEX_URL = (
-    "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg19/genes/refGene.hg19.bed.gz.tbi"
-)
+HG19GENES_FORMAT = "refgene"
+HG19GENES_URL = "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.sorted.txt.gz"
+HG19GENES_INDEX_URL = "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.sorted.txt.gz.tbi"
 
 HG38CLINVAR_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
 HG19CLINVAR_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Show transcript numbers on IGV.js refSeq gene track entries.

![Screenshot 2022-03-29 at 15 44 58](https://user-images.githubusercontent.com/758570/160626156-95df38c4-af14-4842-82a3-59c8988b6d11.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
