### PR TITLE
Fix  mismatch between SV n.genes in case report and SV variants page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix deprecated `safe_str_cmp` import from `werkzeug.security` by freezing Werkzeug lib to v2.0 until Flask_login v.0.6 with bugfix is released
 - List gene names densely in general report for SVs that contain more than 3 genes
 - Show transcript ids on refseq genes on hg19 in IGV.js, using refgene source
+- Display correct number of genes in general report for SVs that contain more than 32 genes
 
 ## [4.50.1]
 ### Fixed

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -31,8 +31,8 @@ VARIANT_REPORT_VARIANT_FEATURES = [
     "cadd_score",
     "genetic_models",
     "acmg_classification",
-    "genes",
-    "hgnc_symbols",
+    "genes",  # This is a list of dictionaries with gene info
+    "hgnc_symbols",  # This is a list of gene symbols (strings)
     "comments",
     "category",
     "dismiss_variant",

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -32,6 +32,7 @@ VARIANT_REPORT_VARIANT_FEATURES = [
     "genetic_models",
     "acmg_classification",
     "genes",
+    "hgnc_symbols",
     "comments",
     "category",
     "dismiss_variant",

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1195,9 +1195,7 @@
         </thead>
         <tbody>
           <td>
-            {% for symbol in variant.hgnc_symbols|sort %}
-              <div>{{ symbol }}</div>&nbsp
-            {% endfor %}
+            {{variant.hgnc_symbols|sort|join(" ")}}
           </td>
         </tbody>
       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -791,7 +791,7 @@
 {% macro dismissed_gene_list(variant) %}
   {% if variant.genes %}
     {% if variant.genes|length > 3%}
-      {{ variant.genes|length }}&nbsp;genes
+      {{ variant.hgnc_symbols|length }}&nbsp;genes
     {% else %}
       {% for gene in variant.genes %}
        <a href="http://www.genenames.org/cgi-bin/gene_symbol_report?match={{ gene.hgnc_symbol }}" target="_blank">{{ gene.hgnc_symbol }}&nbsp;<span class="badge badge-secondary">{{gene.region_annotation}}</span></a><br>
@@ -1191,14 +1191,12 @@
         </tbody>
       {% elif variant.genes %} <!-- more than 5 genes in this SV -->
         <thead>
-          <th>{{ variant.genes|length }} affected gene(s)</th>
+          <th>{{ variant.hgnc_symbols|length }} affected gene(s)</th>
         </thead>
         <tbody>
           <td>
-            {% for gene in variant.genes|sort(attribute='common.hgnc_symbol') %} <!-- Display all genes sorted by symbol -->
-              <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
-              <i>{{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}</i>
-              </a>&nbsp;
+            {% for symbol in variant.hgnc_symbols|sort %}
+              <div>{{ symbol }}</div>&nbsp
             {% endfor %}
           </td>
         </tbody>


### PR DESCRIPTION
Tentative fix #3285 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
