### PR TITLE
Load demo cancer case ogether with demo RD case in demo instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Added
-- Demo cancer case gets loaded together demo RD case in demo instance
+- Demo cancer case gets loaded together with demo RD case in demo instance
 
 
 ## [4.51]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Added
+- Demo cancer case gets loaded together demo RD case in demo instance
+
+
 ## [4.51]
 ### Added
 - Config file containing codecov settings for pull requests

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -217,7 +217,7 @@ def load_demo_cases(adapter):
         adapter(scout.adapter.MongoAdapter)
     """
     for path in [load_path, cancer_load_path]:
-        case_handle = get_file_handle(load_path)
+        case_handle = get_file_handle(path)
         case_data = yaml.load(case_handle, Loader=yaml.SafeLoader)
         config_data = parse_case_data(config=case_data)
         adapter.load_case(config_data)

--- a/scout/load/setup.py
+++ b/scout/load/setup.py
@@ -15,7 +15,7 @@ from scout.build import build_institute
 
 # Case files
 # Gene panel
-from scout.demo import load_path, panel_path
+from scout.demo import cancer_load_path, load_path, panel_path
 
 ### Import demo files ###
 from scout.demo.resources import demo_files
@@ -188,20 +188,36 @@ def setup_scout(
 
     # If demo we load a gene panel and some case information
     if demo:
-        parsed_panel = parse_gene_panel(
-            path=panel_path,
-            institute="cust000",
-            panel_id="panel1",
-            version=1.0,
-            display_name="Test panel",
-        )
-        adapter.load_panel(parsed_panel)
-
-        case_handle = get_file_handle(load_path)
-        case_data = yaml.load(case_handle, Loader=yaml.SafeLoader)
-        config_data = parse_case_data(config=case_data)
-        adapter.load_case(config_data)
+        load_demo_panel(adapter)
+        load_demo_cases(adapter)
 
     LOG.info("Creating indexes")
     adapter.load_indexes()
     LOG.info("Scout instance setup successful")
+
+
+def load_demo_panel(adapter):
+    """Load demo gene panel
+    Args:
+        adapter(scout.adapter.MongoAdapter)
+    """
+    parsed_panel = parse_gene_panel(
+        path=panel_path,
+        institute="cust000",
+        panel_id="panel1",
+        version=1.0,
+        display_name="Test panel",
+    )
+    adapter.load_panel(parsed_panel)
+
+
+def load_demo_cases(adapter):
+    """Load one RD case and one cancer case for ad demo data for demo cust000
+    Args:
+        adapter(scout.adapter.MongoAdapter)
+    """
+    for path in [load_path, cancer_load_path]:
+        case_handle = get_file_handle(load_path)
+        case_data = yaml.load(case_handle, Loader=yaml.SafeLoader)
+        config_data = parse_case_data(config=case_data)
+        adapter.load_case(config_data)


### PR DESCRIPTION
Fix #3262 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Run `scout setup demo ` and make sure that both RD demo case and demo cancer cases are loaded for cust000

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
