### PR TITLE
Avoid many code warnings by removing no_cursor_timeout param from  one query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Demo cancer case gets loaded together with demo RD case in demo instance
+### Fixed
+- Removed cursor timeout param in cases find adapter function to avoid many code warnings
 
 
 ## [4.51]

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -389,7 +389,7 @@ class CaseHandler(object):
         if order:
             return self.case_collection.find(query)
 
-        return self.case_collection.find(query, no_cursor_timeout=True).sort("updated_at", -1)
+        return self.case_collection.find(query).sort("updated_at", -1)
 
     def prioritized_cases(self, institute_id=None):
         """Fetches any prioritized cases from the backend.


### PR DESCRIPTION
From **MongoDB 3.6 (so not present in previous versions)**, if the query doesn't specify that there should be no timeout to results returned (cursor), cursor expired after 30 minutes. This param is used in pymongo only once in the code, in adapter.cases find. I don't think it's necessary and removing it would eliminate many warnings when running pytest.

Fixes partially #3294, specifically:
- tests/adapter/mongo/test_case_handling.py: 11 warnings
- tests/commands/delete/test_delete_cmd.py: 6 warnings
- tests/commands/export/test_export_cases_cmd.py: 1 warning
- tests/commands/load/test_load_research_cmd.py: 1 warning
- tests/commands/view/test_view_cases.py: 1 warning
- tests/commands/view/test_view_cases_cmd.py: 1 warning
- tests/commands/view/test_view_individuals_cmd.py: 1 warning
- tests/server/blueprints/cases/test_cases_views.py: 2 warnings
- tests/server/blueprints/dashboard/test_dashboard_controllers.py: 6 warnings
- tests/server/blueprints/institutes/test_institute_api.py: 2 warnings
- tests/server/blueprints/institutes/test_institute_views.py: 7 warning


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
