### PR TITLE
Remove stream argument deprecation warning in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Demo cancer case gets loaded together with demo RD case in demo instance
-
+### Changed
+- Verify user before redirecting to IGV alignments and sashimi plots
+- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
+## Fixed
+- Removed stream argument deprecation warning in tests
 
 ## [4.51]
 ### Added
@@ -21,8 +25,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Simplified code of scout/adapter/mongo/variant
 - Update IGV.js to v2.11.2
 - Show summary number of variant gene panels on general report if more than 3
-- Verify user before redirecting to IGV alignments and sashimi plots
-- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
 ### Fixed
 - Marrvel link for variants in genome build 38 (using liftover to build 37)
 - Remove flags from codecov config file

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -191,7 +191,7 @@ def test_query_biomart_38_xml(ensembl_biomart_xml_query):
         b"ACTR3\tENST00000478928\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200, stream=True)
+    responses.add(responses.GET, url, body=response, status=200)
     # WHEN querying ensembl
     client = ensembl_rest_clients.EnsemblBiomartClient(
         build=build, xml=ensembl_biomart_xml_query, header=False
@@ -237,7 +237,7 @@ datasetConfigVersion = "0.6" completionStamp = "1">\
         b"ACTR3\tENST00000478928\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200, stream=True)
+    responses.add(responses.GET, url, body=response, status=200)
     # WHEN querying ensembl
     client = ensembl_rest_clients.EnsemblBiomartClient(
         build="38", filters=filters, attributes=attributes, header=False

--- a/tests/utils/test_ensembl_rest_clients.py
+++ b/tests/utils/test_ensembl_rest_clients.py
@@ -1,6 +1,6 @@
 """Tests for ensembl rest api"""
 
-from urllib.parse import quote, urlencode
+from urllib.parse import quote
 
 import responses
 from requests.exceptions import HTTPError, MissingSchema
@@ -191,7 +191,7 @@ def test_query_biomart_38_xml(ensembl_biomart_xml_query):
         b"ACTR3\tENST00000478928\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200)
+    responses.add(responses.GET, url, body=response, status=200, stream=True)
     # WHEN querying ensembl
     client = ensembl_rest_clients.EnsemblBiomartClient(
         build=build, xml=ensembl_biomart_xml_query, header=False
@@ -237,7 +237,7 @@ datasetConfigVersion = "0.6" completionStamp = "1">\
         b"ACTR3\tENST00000478928\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200)
+    responses.add(responses.GET, url, body=response, status=200, stream=True)
     # WHEN querying ensembl
     client = ensembl_rest_clients.EnsemblBiomartClient(
         build="38", filters=filters, attributes=attributes, header=False


### PR DESCRIPTION
Fixed last deprecation warning in the list in #3294 

**How to test**:
Main branch:

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/28093618/164181848-e65457a7-972e-486f-aa1c-d116cbb818fe.png">


This branch:

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/28093618/164181737-678b77a7-caab-40f7-b1ec-599cdcc41dca.png">


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by mikaell
- [x] tests executed by CR & mikaell
 