### PR TITLE
Fix send_file deprecation warnings that will turn into bugs with Flask 2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Demo cancer case gets loaded together with demo RD case in demo instance
-
+### Changed
+- Verify user before redirecting to IGV alignments and sashimi plots
+- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
+### Fixed
+- Handle `attachment_filename` parameter renamed to `download_name` when Flask 2.2 will be released
 
 ## [4.51]
 ### Added
@@ -21,8 +25,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Simplified code of scout/adapter/mongo/variant
 - Update IGV.js to v2.11.2
 - Show summary number of variant gene panels on general report if more than 3
-- Verify user before redirecting to IGV alignments and sashimi plots
-- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
 ### Fixed
 - Marrvel link for variants in genome build 38 (using liftover to build 37)
 - Remove flags from codecov config file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Everything needed in production
 
 werkzeug<=2.0
-Flask>=0.10
+Flask>=2.0
 Flask-Bootstrap
 Flask-CORS
 path.py

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -75,7 +75,7 @@ def remote_static():
 def unindexed_remote_static():
     file_path = request.args.get("file")
     base_name = os.path.basename(file_path)
-    resp = send_file(file_path, attachment_filename=base_name)
+    resp = send_file(file_path, download_name=base_name)
     return resp
 
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -980,9 +980,7 @@ def vcf2cytosure(institute_id, case_name, individual_id):
         [display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh"]
     )
     LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
-    return send_from_directory(
-        outdir, filename, download_name=attachment_filename, as_attachment=True
-    )
+    return send_from_directory(outdir, filename, download_name=download_name, as_attachment=True)
 
 
 @cases_bp.route("/<institute_id>/<case_name>/multiqc")

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -244,7 +244,7 @@ def pdf_case_report(institute_id, case_name):
     )
     return send_file(
         bytes_file,
-        attachment_filename=file_name,
+        download_name=file_name,
         mimetype="application/pdf",
         as_attachment=True,
     )
@@ -268,7 +268,7 @@ def mt_report(institute_id, case_name):
             data,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename="_".join(["scout", case_name, "MT_report", today]) + ".zip",
+            download_name="_".join(["scout", case_name, "MT_report", today]) + ".zip",
             cache_timeout=0,
         )
 
@@ -698,7 +698,7 @@ def delivery_report(institute_id, case_name):
             )
             return send_file(
                 bytes_file,
-                attachment_filename=file_name,
+                download_name=file_name,
                 mimetype="application/pdf",
                 as_attachment=True,
             )
@@ -767,7 +767,7 @@ def coverage_qc_report(institute_id, case_name):
                 )
                 return send_file(
                     bytes_file,
-                    attachment_filename=file_name,
+                    download_name=file_name,
                     mimetype="application/pdf",
                     as_attachment=True,
                 )
@@ -960,7 +960,7 @@ def download_hpo_genes(institute_id, case_name, category):
     )
     return send_file(
         bytes_file,
-        attachment_filename=file_name,
+        download_name=file_name,
         mimetype="application/pdf",
         as_attachment=True,
     )
@@ -976,12 +976,12 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     outdir = os.path.abspath(os.path.dirname(vcf2cytosure))
     filename = os.path.basename(vcf2cytosure)
-    attachment_filename = ".".join(
+    download_name = ".".join(
         [display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh"]
     )
     LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
     return send_from_directory(
-        outdir, filename, attachment_filename=attachment_filename, as_attachment=True
+        outdir, filename, download_name=attachment_filename, as_attachment=True
     )
 
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -979,7 +979,7 @@ def vcf2cytosure(institute_id, case_name, individual_id):
     download_name = ".".join(
         [display_name, case_obj["display_name"], case_obj["_id"], "vcf2cytosure.cgh"]
     )
-    LOG.debug("Attempt to deliver file {0} from dir {1}".format(attachment_filename, outdir))
+    LOG.debug("Attempt to deliver file {0} from dir {1}".format(download_name, outdir))
     return send_from_directory(outdir, filename, download_name=download_name, as_attachment=True)
 
 

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -220,7 +220,7 @@ def panel_export(panel_id):
     )
     return send_file(
         bytes_file,
-        attachment_filename=file_name,
+        download_name=file_name,
         mimetype="application/pdf",
         as_attachment=True,
     )

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -558,7 +558,7 @@ def download_verified():
             data,
             mimetype="application/zip",
             as_attachment=True,
-            attachment_filename="_".join(["scout", "verified_variants", today]) + ".zip",
+            download_name="_".join(["scout", "verified_variants", today]) + ".zip",
             cache_timeout=0,
         )
 


### PR DESCRIPTION
Partially fixing all send_file deprecation warnings in #3294. 
In the end of March Flask 2.1 was released. When Flask 2.2 will be released all the warnings we have will become bugs!

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, GitHub actions
