### PR TITLE
Handle `no intervals found` warning in load_region test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Demo cancer case gets loaded together with demo RD case in demo instance
-
+### Changed
+- Verify user before redirecting to IGV alignments and sashimi plots
+- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
+## Fixed
+- Handle `no intervals found` warning in load_region test
 
 ## [4.51]
 ### Added
@@ -21,8 +25,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Simplified code of scout/adapter/mongo/variant
 - Update IGV.js to v2.11.2
 - Show summary number of variant gene panels on general report if more than 3
-- Verify user before redirecting to IGV alignments and sashimi plots
-- Build case IGV tracks starting from case and variant objects instead of passing all params in a form
 ### Fixed
 - Marrvel link for variants in genome build 38 (using liftover to build 37)
 - Remove flags from codecov config file

--- a/tests/commands/load/test_load_region_cmd.py
+++ b/tests/commands/load/test_load_region_cmd.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from scout.commands import cli
 
 
@@ -13,24 +15,30 @@ def test_load_region(mock_app, case_obj):
     result = runner.invoke(cli, ["load", "region", "--case-id", case_obj["_id"]])
     assert result.exit_code == 0
 
-    # test load region using case_id + hgnc_id:
-    result = runner.invoke(cli, ["load", "region", "--case-id", case_obj["_id"], "--hgnc-id", 170])
-    assert result.exit_code == 0
+    with pytest.warns(
+        UserWarning
+    ):  # This function will raise a UserWarning: no intervals found for b'scout/demo/643594.clinical.SV.vcf.gz' at 2:114647537-114720173
 
-    # test load region using case_id + coordinates
-    result = runner.invoke(
-        cli,
-        [
-            "load",
-            "region",
-            "--case-id",
-            case_obj["_id"],
-            "-c",
-            "2",
-            "-s",
-            114647537,
-            "-e",
-            114720173,
-        ],
-    )
-    assert result.exit_code == 0
+        # test load region using case_id + hgnc_id:
+        result = runner.invoke(
+            cli, ["load", "region", "--case-id", case_obj["_id"], "--hgnc-id", 170]
+        )
+        assert result.exit_code == 0
+
+        # test load region using case_id + coordinates
+        result = runner.invoke(
+            cli,
+            [
+                "load",
+                "region",
+                "--case-id",
+                case_obj["_id"],
+                "--chromosome",
+                "2",
+                "--start",
+                114647537,
+                "--end",
+                114720173,
+            ],
+        )
+        assert result.exit_code == 0

--- a/tests/commands/load/test_load_region_cmd.py
+++ b/tests/commands/load/test_load_region_cmd.py
@@ -17,7 +17,7 @@ def test_load_region(mock_app, case_obj):
 
     with pytest.warns(
         UserWarning
-    ):  # This function will raise a UserWarning: no intervals found for b'scout/demo/643594.clinical.SV.vcf.gz' at 2:114647537-114720173
+    ):  # The command will raise a UserWarning: no intervals found for b'scout/demo/643594.clinical.SV.vcf.gz' at 2:114647537-114720173
 
         # test load region using case_id + hgnc_id:
         result = runner.invoke(


### PR DESCRIPTION
Partially fixes #3294 ---> tests/commands/load/test_load_region_cmd.py::test_load_region
/Users/chiararasi/Documents/work/GITs/scout/scout/adapter/mongo/variant_loader.py:408: UserWarning: no intervals found for b'scout/demo/643594.clinical.SV.vcf.gz' at 2:114647537-114720173
for nr_variants, variant in enumerate(variants):

**How to test**:
Run: `pytest tests/commands/load/test_load_region_cmd.py`
On main branch:

<img width="1201" alt="image" src="https://user-images.githubusercontent.com/28093618/164195607-a03ca347-5e6f-4370-96f4-f0f0d432812a.png">

On this branch:

<img width="1199" alt="image" src="https://user-images.githubusercontent.com/28093618/164195371-ce7956a6-a170-4abb-951e-c110b833601b.png">

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
