### PR TITLE
Configure an optional session timeout - now you get logged out after a month of inactivity!

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -19,5 +19,5 @@ jobs:
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: --min-confidence 80 --ignore-names cls,args,kwargs ${{steps.files.outputs.all}}
+          vulture-args: --min-confidence 80 --ignore-names cls,args,kwargs,real_variant_database ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Demo cancer case gets loaded together with demo RD case in demo instance
 - Parse REVEL_score alongside REVEL_rankscore from csq field and display it on SNV variant page
 - Rank score results now show the ranking range
+- Optional SESSION_TIMEOUT_MINUTES configuration in app config files 
 ### Changed
 - Verify user before redirecting to IGV alignments and sashimi plots
 - Build case IGV tracks starting from case and variant objects instead of passing all params in a form

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -95,7 +95,6 @@ def create_app(config_file=None, config=None):
                 # combine visited URL (convert byte string query string to unicode!)
                 next_url = "{}?{}".format(request.path, request.query_string.decode())
                 login_url = url_for("public.index", next=next_url)
-                LOG.error("HERE BITCHES")
                 return redirect(login_url)
 
     return app

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -4,7 +4,7 @@ import os
 from datetime import timedelta
 
 import coloredlogs
-from flask import Flask, current_app, redirect, request, session, url_for
+from flask import Flask, current_app, redirect, request, url_for
 from flask_babel import Babel
 from flask_cors import CORS
 from flask_login import current_user

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -1,9 +1,10 @@
 """Code for flask app"""
 import logging
 import os
+from datetime import timedelta
 
 import coloredlogs
-from flask import Flask, current_app, redirect, request, url_for
+from flask import Flask, current_app, redirect, request, session, url_for
 from flask_babel import Babel
 from flask_cors import CORS
 from flask_login import current_user
@@ -48,6 +49,7 @@ except ImportError:
 
 def create_app(config_file=None, config=None):
     """Flask app factory function."""
+
     app = Flask(__name__)
     CORS(app)
     app.jinja_env.add_extension("jinja2.ext.do")
@@ -59,6 +61,12 @@ def create_app(config_file=None, config=None):
         app.config.update((k, v) for k, v in config.items() if v is not None)
     if config_file:  # Params from an optional .py config file provided by the user
         app.config.from_pyfile(config_file)
+
+    session_timeout_minutes = app.config.get("SESSION_TIMEOUT_MINUTES")
+    if session_timeout_minutes:
+        session_duration = timedelta(minutes=session_timeout_minutes)
+        app.config["PERMANENT_SESSION_LIFETIME"] = session_duration
+        app.config["REMEMBER_COOKIE_DURATION"] = session_duration
 
     app.config["JSON_SORT_KEYS"] = False
     current_log_level = LOG.getEffectiveLevel()
@@ -87,6 +95,7 @@ def create_app(config_file=None, config=None):
                 # combine visited URL (convert byte string query string to unicode!)
                 next_url = "{}?{}".format(request.path, request.query_string.decode())
                 login_url = url_for("public.index", next=next_url)
+                LOG.error("HERE BITCHES")
                 return redirect(login_url)
 
     return app

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 SECRET_KEY = "this is not secret..."
-REMEMBER_COOKIE_NAME = "scout_remember_me"
+REMEMBER_COOKIE_NAME = "scout_remember_me"  # Prevent session timeout when user closes browser
+# SESSION_TIMEOUT_MINUTES = 60  # Minutes of inactivity before session times out
 
 # MONGO_URI = "mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/?replicaSet=rs0&readPreference=primary"
 MONGO_DBNAME = "scout"

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -28,7 +28,8 @@ class LoqusdbMock:
     def case_count(self):
         return self.nr_cases
 
-    def get_variant(self, var_dict):
+    def get_variant(self, var_dict, loqusdb_id="None"):
+        loqus_instance = self.loqusdb_settings.get(loqusdb_id)
         var = self.variants.get(var_dict["_id"], {})
         var["total"] = self.nr_cases
         return var

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -112,6 +112,8 @@ def rerunner_app(user_obj):
             SERVER_NAME="test",
             RERUNNER_API_ENTRYPOINT="http://rerunner:5001/v1.0/rerun",
             RERUNNER_API_KEY="test_key",
+            REMEMBER_COOKIE_NAME="remember_me",
+            SESSION_TIMEOUT_MINUTES=10,
         )
     )
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -2,14 +2,10 @@
 import logging
 import uuid
 
-import pymongo
 import pytest
 from flask import request
-from flask_login import login_user, logout_user
+from flask_login import login_user
 
-from scout.adapter import MongoAdapter
-from scout.load.hgnc_gene import load_hgnc_genes
-from scout.load.hpo import load_hpo
 from scout.server.app import create_app
 from scout.server.blueprints.login.models import LoginUser
 
@@ -32,7 +28,7 @@ class LoqusdbMock:
     def case_count(self):
         return self.nr_cases
 
-    def get_variant(self, var_dict, loqusdb_id=None):
+    def get_variant(self, var_dict):
         var = self.variants.get(var_dict["_id"], {})
         var["total"] = self.nr_cases
         return var
@@ -80,6 +76,7 @@ def loqusdb():
 @pytest.fixture
 def app(real_database_name, real_variant_database, user_obj):
     """A test app containing the endpoints of the real app"""
+
     app = create_app(
         config=dict(
             TESTING=True,

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -28,7 +28,7 @@ class LoqusdbMock:
     def case_count(self):
         return self.nr_cases
 
-    def get_variant(self, var_dict, loqusdb_id="None"):
+    def get_variant(self, var_dict, loqusdb_id="test"):
         loqus_instance = self.loqusdb_settings.get(loqusdb_id)
         var = self.variants.get(var_dict["_id"], {})
         var["total"] = self.nr_cases


### PR DESCRIPTION
Might be safer to log out a user after an amount of minutes of inactivity. **Users get logged out after a month (!) of inactivity at the moment**. That's because a month is the default value when you don't set any session value.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Locally, uncomment and modify the `SESSION_TIMEOUT_MINUTES` config file to 1
2. Run demo scout and log in.
3. Make sure that you are logged out after a minute

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
