### PR TITLE
cDNA and protein changes displayed in institute causatives table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Demo cancer case gets loaded together with demo RD case in demo instance
 - Parse REVEL_score alongside REVEL_rankscore from csq field and display it on SNV variant page
 - Rank score results now show the ranking range
+- cDNA and protein changes displayed on institute causatives pages
 ### Changed
 - Verify user before redirecting to IGV alignments and sashimi plots
 - Build case IGV tracks starting from case and variant objects instead of passing all params in a form

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -61,7 +61,9 @@ def causatives(institute_obj, request):
     all_cases = {}
     for variant_obj in variants:
         if variant_obj["category"] in ["snv", "cancer"]:
-            update_representative_gene(variant_obj, variant_obj.get("genes", []))
+            update_representative_gene(
+                variant_obj, variant_obj.get("genes", [])
+            )  # required to display cDNA and protein change
         if variant_obj["case_id"] not in all_cases:
             case_obj = store.case(variant_obj["case_id"])
             all_cases[variant_obj["case_id"]] = case_obj

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -60,7 +60,8 @@ def causatives(institute_obj, request):
     all_variants = {}
     all_cases = {}
     for variant_obj in variants:
-        update_representative_gene(variant_obj, variant_obj.get("genes", []))
+        if variant_obj["category"] in ["snv", "cancer"]:
+            update_representative_gene(variant_obj, variant_obj.get("genes", []))
         if variant_obj["case_id"] not in all_cases:
             case_obj = store.case(variant_obj["case_id"])
             all_cases[variant_obj["case_id"]] = case_obj

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -16,7 +16,7 @@ from scout.constants import (
     PHENOTYPE_GROUPS,
 )
 from scout.parse.clinvar import clinvar_submission_header, clinvar_submission_lines
-from scout.server.blueprints.variant.utils import predictions
+from scout.server.blueprints.variant.utils import predictions, update_representative_gene
 from scout.server.extensions import store
 from scout.server.utils import institute_and_case, user_institutes
 from scout.utils.md5 import generate_md5_key
@@ -60,8 +60,19 @@ def causatives(institute_obj, request):
     all_variants = {}
     all_cases = {}
     for variant_obj in variants:
+        update_representative_gene(variant_obj, variant_obj.get("genes", []))
         if variant_obj["case_id"] not in all_cases:
             case_obj = store.case(variant_obj["case_id"])
+            """
+            parse_variant(
+                store,
+                institute_obj,
+                case_obj,
+                variant_obj,
+                True,
+                str(case_obj.get("genome_build", "37")),
+            )
+            """
             all_cases[variant_obj["case_id"]] = case_obj
         else:
             case_obj = all_cases[variant_obj["case_id"]]

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -63,16 +63,6 @@ def causatives(institute_obj, request):
         update_representative_gene(variant_obj, variant_obj.get("genes", []))
         if variant_obj["case_id"] not in all_cases:
             case_obj = store.case(variant_obj["case_id"])
-            """
-            parse_variant(
-                store,
-                institute_obj,
-                case_obj,
-                variant_obj,
-                True,
-                str(case_obj.get("genome_build", "37")),
-            )
-            """
             all_cases[variant_obj["case_id"]] = case_obj
         else:
             case_obj = all_cases[variant_obj["case_id"]]

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -60,12 +60,6 @@
 </script>
 {% endblock %}
 
-{% macro variant_cdna() %}
-{% endmacro %}
-
-{% macro variant_protein_change() %}
-{% endmacro %}
-
 {% macro causatives() %}
 <div class="card mt-3">
   <div class="card-body">

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -60,6 +60,12 @@
 </script>
 {% endblock %}
 
+{% macro variant_cdna() %}
+{% endmacro %}
+
+{% macro variant_protein_change() %}
+{% endmacro %}
+
 {% macro causatives() %}
 <div class="card mt-3">
   <div class="card-body">
@@ -67,15 +73,16 @@
         <thead>
           <tr>
             <th>Gene</th>
-            <th>Variant Name</th>
+            <th>Variant</th>
             <th>Change</th>
+            <th>HGVS[c]</th>
+            <th>HGVS[p]</th>
             <th>Category</th>
             <th data-toggle='tooltip' data-container='body' title="score(model version)">Rank score</th>
             <th data-toggle='tooltip' data-container='body' title="ref/alt-GQ">Zygosity</th>
             <th>Inheritance</th>
             <th>ACMG</th>
-            <th>Case Name</th>
-            <th>Case Status</th>
+            <th>Case</th>
           </tr>
         </thead>
         <tbody>
@@ -93,13 +100,32 @@
                 variant_id=variant._id) }}" data-toggle='tooltip' data-container='body' title="{{ variant.display_name }}">{{ variant.display_name|truncate(10, True) }}
               </a>
             </td>
-            <td><span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
+            <td>
+              <span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ group_variant.reference|truncate(30, True) }} → {{ group_variant.alternative|truncate(30, True) }}">
                 {% if group_variant.category in 'str' %}
                     {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
                 {% else %}
                     {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) }}
                 {% endif%}
               </span>
+            </td>
+            <td>
+              {% if variant.first_rep_gene and variant.first_rep_gene.hgvs_identifier %}
+                <span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ variant.first_rep_gene.hgvs_identifier }}">
+                  {{variant.first_rep_gene.hgvs_identifier|truncate(15, True)}}
+                </span>
+              {% else %}
+                -
+              {% endif %}
+            </td>
+            <td>
+              {% if variant.first_rep_gene and variant.first_rep_gene.hgvsp_identifier %}
+                <span class="text-muted" style="display: inline-block; margin-left: 10px;" data-toggle='tooltip' data-container='body' title="{{ variant.first_rep_gene.hgvsp_identifier }}">
+                  {{variant.first_rep_gene.hgvsp_identifier|truncate(15, True)}}
+                </span>
+              {% else %}
+                -
+              {% endif %}
             </td>
             <td><span class="badge badge-secondary">{{ variant.category|upper }}</span></td>
             <td><a href="#"><span class="badge badge-pill badge-secondary">
@@ -126,7 +152,7 @@
             </td>
             <td>
               <a href="#" data-toggle="tooltip" title="ACMG classification assigned by Scout users (not Clinvar)"
-                style="text-decoration: none; color: #000;">ACMG:
+                style="text-decoration: none; color: #000;">
                 {% if 'acmg_classification' in variant %}
                 <span class="badge badge-{{acmg_map[variant.acmg_classification].color}}">{{acmg_map[variant.acmg_classification].short}}</span>
                 {% else %}
@@ -134,18 +160,16 @@
                 {% endif %}
               </a>
             </td>
-            <td>
+            <td >
               <a href="{{ url_for('cases.case',
                                         institute_id=institute._id,
                                         case_name=case.display_name) }}">
                 {{ case.display_name }}
               </a>
-            </td>
-            <td>
               {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
                 <span class="badge badge-warning" data-toggle="tooltip" title="Partial causative variants explain part of the case phenotype">partial</span>
               {% endif %}
-              <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} pull-right">
+              <span class="badge badge-{{ 'success' if case.status == 'solved' else 'default' }} mr-1">
                 {{ case.status }}
               </span>
             </td>
@@ -158,4 +182,3 @@
   </div>
 </div>
 {% endmacro %}
-

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -7,7 +7,7 @@ from flask import Blueprint, Response, flash, jsonify, redirect, render_template
 from flask_login import current_user
 from werkzeug.datastructures import Headers
 
-from scout.constants import ACMG_COMPLETE_MAP, ACMG_MAP, CASEDATA_HEADER, CLINVAR_HEADER
+from scout.constants import CASEDATA_HEADER, CLINVAR_HEADER
 from scout.server.blueprints.variants.controllers import update_form_hgnc_symbols
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, jsonconverter, templated
@@ -59,39 +59,7 @@ def cases(institute_id):
 @templated("overview/causatives.html")
 def causatives(institute_id):
     institute_obj = institute_and_case(store, institute_id)
-    query = request.args.get("query", "")
-    hgnc_id = None
-    if "|" in query:
-        # filter accepts an array of IDs. Provide an array with one ID element
-        try:
-            hgnc_id = [int(query.split(" | ", 1)[0])]
-        except ValueError:
-            flash("Provided gene info could not be parsed!", "warning")
-
-    variants = list(store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id))
-    if variants:
-        variants = sorted(
-            variants,
-            key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
-        )
-
-    all_variants = {}
-    all_cases = {}
-    for variant_obj in variants:
-        if variant_obj["case_id"] not in all_cases:
-            case_obj = store.case(variant_obj["case_id"])
-            all_cases[variant_obj["case_id"]] = case_obj
-        else:
-            case_obj = all_cases[variant_obj["case_id"]]
-
-        if variant_obj["variant_id"] not in all_variants:
-            all_variants[variant_obj["variant_id"]] = []
-
-        all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
-
-    acmg_map = {key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()}
-
-    return dict(institute=institute_obj, variant_groups=all_variants, acmg_map=acmg_map)
+    return controllers.causatives(institute_obj, request)
 
 
 @blueprint.route("/<institute_id>/filters", methods=["GET"])

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -71,8 +71,12 @@ def update_representative_gene(variant_obj, variant_genes):
         # get HGVNp identifier from the canonical transcript
         hgvsp_identifier = None
         for tc in first_rep_gene.get("transcripts", []):
-            if tc["is_canonical"]:
-                hgvsp_identifier = tc.get("protein_sequence_name")
+            if tc["is_canonical"] is False:
+                continue
+            hgvsp_identifier = tc.get("protein_sequence_name")
+            if first_rep_gene.get("hgvs_identifier") is None:
+                first_rep_gene["hgvs_identifier"] = tc.get("coding_sequence_name")
+
         first_rep_gene["hgvsp_identifier"] = hgvsp_identifier
 
         variant_obj["first_rep_gene"] = first_rep_gene

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -1,7 +1,7 @@
 import logging
 
 from scout.constants import ACMG_COMPLETE_MAP, CALLERS, CLINSIG_MAP, SO_TERMS
-from scout.server.links import add_gene_links, add_tx_links, ensembl
+from scout.server.links import add_gene_links, add_tx_links
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Fix #3259  --> Display cDNA and prot changes in causatives table
- Moved causatives code from causatives views to a dedicated controller

Before:

<img width="1268" alt="image" src="https://user-images.githubusercontent.com/28093618/165703666-941e8cb0-dcd6-4d74-b299-64e2f61806a4.png">


After:

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/28093618/165703468-d5df7410-e5e4-46a4-90b3-767fa90ca7ea.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Pick and institute and go to "Causatives" page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
