### PR TITLE
Show and download .cgh files in cancer case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Optional SESSION_TIMEOUT_MINUTES configuration in app config files
 - Script to convert old OMIM case format (list of integers) to new format (list of dictionaries)
 - Additional check for user logged in status before serving alignment files
+- Download .cgh files from cancer samples table on cancer case page
 ### Changed
 - Verify user before redirecting to IGV alignments and sashimi plots
 - Build case IGV tracks starting from case and variant objects instead of passing all params in a form

--- a/scout/demo/999-99.test.cgh
+++ b/scout/demo/999-99.test.cgh
@@ -1,0 +1,2 @@
+## vcf2cytosure
+## TEST FILE

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -14,6 +14,7 @@ samples:
     sex: male
     expected_coverage: 90
     mt_bam: scout/demo/reduced_mt.bam
+    vcf2cytosure: scout/demo/999-99.test.cgh
     tmb: 7
     msi: 15
     tumor_purity: 1

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -19,6 +19,8 @@
             <th data-toggle='tooltip' data-container='body' class="col-xs-1"
              title="Measure of tumor purity">Tumor Purity</th>
             <th data-toggle='tooltip' data-container='body' class="col-xs-1"
+             title="Downloadable CytoSure file">CGH</th>
+            <th data-toggle='tooltip' data-container='body' class="col-xs-1"
              title="Tissue origin for the sample">Tissue</th>
             <th style="width: 5%"></th>
           </tr>
@@ -46,6 +48,16 @@
               {% else %}
                 <td>N/A</td>
               {% endif %}
+              <td>
+                {% if ind.vcf2cytosure %}
+                <a href="{{ url_for('cases.vcf2cytosure', institute_id=institute._id,
+                      case_name=case.display_name, individual_id=ind.individual_id) }}" download class="btn">
+                  <i class="fa fa-download"></i>
+                </a>
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
               <td>
                 <select class="form-control col-6" name="tissue_type.{{ind.individual_id}}">
                   {% for key,tissue in tissues.items() %}
@@ -163,17 +175,18 @@
                 {% else %}
                   N/A
                 {% endif %}
-                <td>
-                  <select id="tissue-selection" class="form-control-sm col-10" name="tissue_{{ind.individual_id}}">
-                    {% for key,tissue in tissues.items() %}
-                      <option value="{{tissue}}" {{ 'selected' if ind.tissue_type == tissue }}>{{tissue}}</option>
-                    {% endfor %}
-                  </select>
-                </td>
-                <td>
-                  <button class="btn btn-secondary btn-sm form-control" name="update_ind"
-                    type="submit" value="{{ ind.individual_id }}">Save</button>
-                </td>
+              </td>
+              <td>
+                <select id="tissue-selection" class="form-control-sm col-10" name="tissue_{{ind.individual_id}}">
+                  {% for key,tissue in tissues.items() %}
+                    <option value="{{tissue}}" {{ 'selected' if ind.tissue_type == tissue }}>{{tissue}}</option>
+                  {% endfor %}
+                </select>
+              </td>
+              <td>
+                <button class="btn btn-secondary btn-sm form-control" name="update_ind"
+                  type="submit" value="{{ ind.individual_id }}">Save</button>
+              </td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
Fix #3121 --> Download VCF files from cancer case page

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Locally, run `scout setup demo`

**Expected outcome**:
- [x] Cancer sample on cancer case page should have a downloadable .cgh file (samples tables)

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
