### PR TITLE
Protect remote_cors from Server-Side Request Forgery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed stream argument deprecation warning in tests
 - Handle `no intervals found` warning in load_region test
 - Beacon remove variants
+- Protect remote_cors function in alignviewers view from Server-Side Request Forgery (SSRF)
 
 ## [4.51]
 ### Added

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -14,6 +14,25 @@ LOG = logging.getLogger(__name__)
 CUSTOM_TRACK_NAMES = ["Genes", "ClinVar", "ClinVar CNVs"]
 
 
+def check_session_tracks(resource):
+    """Make sure that a user requesting a resource is authenticated and resource is in session IGV tracks
+
+    Args:
+        resource(str): a resource on the server or on a remote URL
+
+    Returns
+        True is user has access to resource else False
+    """
+    # Check that user is logged in or that file extension is valid
+    if current_user.is_authenticated is False:
+        LOG.warning("Unauthenticated user requesting resource via remote_static")
+        return False
+    if resource not in session.get("igv_tracks", []):
+        LOG.warning(f"{resource} not in {session.get('igv_tracks', [])}")
+        return False
+    return True
+
+
 def set_session_tracks(display_obj):
     """Save igv tracks as a session object. This way it's easy to verify that a user is requesting one of these files from remote_static view endpoint
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -22,7 +22,7 @@ def set_session_tracks(display_obj):
     """
     session_tracks = list(display_obj.get("reference_track", {}).values())
     for key, track_items in display_obj.items():
-        if key not in ["tracks", "custom_tracks", "sample_tracks"]:
+        if key not in ["tracks", "custom_tracks", "sample_tracks", "cloud_public_tracks"]:
             continue
         for track_item in track_items:
             session_tracks += list(track_item.values())

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -39,8 +39,8 @@ def remote_cors(remote_url):
     Based on code from answers to this thread:
         https://stackoverflow.com/questions/6656363/proxying-to-another-web-service-with-flask/
     """
-    if remote_url not in session.get("igv_tracks", []):
-        LOG.warning(f"{remote_url} requested in remote_cors not in {session.get('igv_tracks', [])}")
+    # Check that user is logged in or that file extension is valid
+    if controllers.check_session_tracks(remote_url) is False:
         return abort(403)
 
     resp = requests.request(
@@ -74,11 +74,7 @@ def remote_static():
     file_path = request.args.get("file") or "."
 
     # Check that user is logged in or that file extension is valid
-    if current_user.is_authenticated is False:
-        LOG.warning("Unauthenticated user requesting resource via remote_static")
-        return abort(403)
-    if file_path not in session.get("igv_tracks", []):
-        LOG.warning(f"{file_path} not in {session.get('igv_tracks', [])}")
+    if controllers.check_session_tracks(file_path) is False:
         return abort(403)
 
     range_header = request.headers.get("Range", None)

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -39,6 +39,10 @@ def remote_cors(remote_url):
     Based on code from answers to this thread:
         https://stackoverflow.com/questions/6656363/proxying-to-another-web-service-with-flask/
     """
+    if remote_url not in session.get("igv_tracks", []):
+        LOG.warning(f"{remote_url} requested in remote_cors not in {session.get('igv_tracks', [])}")
+        return abort(403)
+
     resp = requests.request(
         method=request.method,
         url=remote_url,
@@ -70,7 +74,10 @@ def remote_static():
     file_path = request.args.get("file") or "."
 
     # Check that user is logged in or that file extension is valid
-    if current_user.is_authenticated is False or file_path not in session.get("igv_tracks", []):
+    if current_user.is_authenticated is False:
+        LOG.warning("Unauthenticated user requesting resource via remote_static")
+        return abort(403)
+    if file_path not in session.get("igv_tracks", []):
         LOG.warning(f"{file_path} not in {session.get('igv_tracks', [])}")
         return abort(403)
 

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -89,14 +89,14 @@ def test_remote_cors(app):
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
 
-        # GIVEN that resource file exists in user session
+        # GIVEN that resource url exists in user session
         with client.session_transaction() as session:
             session["igv_tracks"] = [cloud_track_url]
 
-        # WHEN the remote cors endpoint is invoked with an url
+        # WHEN the remote cors endpoint is invoked with cloud_track_url
         resp = client.get(url_for("alignviewers.remote_cors", remote_url=cloud_track_url))
 
-        # THEN it should return forbidden (403)
+        # THEN response should be successful
         assert resp.status_code == 200
 
 

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -47,8 +47,9 @@ def test_remote_static(app):
     with app.test_client() as client:
         # GIVEN that user is logged in
         client.get(url_for("auto_login"))
+
+        # GIVEN that resource file exists in user session
         with client.session_transaction() as session:
-            # GIVEN that resource file exists in user session
             session["igv_tracks"] = [file]
 
         # THEN the resource should be available to the user
@@ -61,20 +62,41 @@ def test_remote_static(app):
         assert resp.status_code == 200
 
 
-def test_remote_cors(app):
+def test_remote_cors_wrong_resource(app):
     """Test endpoint that serves as a proxy to the actual remote track on the cloud"""
-    cloud_track_url = "http://google.com"
+    # GIVEN a resource not present in session["igv_tracks"]
+    an_url = "http://google.com"
 
-    # GIVEN an initialized app
-    # GIVEN a valid user and institute
+    # GIVEN a running demo app
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
+
+        # WHEN the remote cors endpoint is invoked with an url
+        resp = client.get(url_for("alignviewers.remote_cors", remote_url=an_url))
+
+        # THEN it should return forbidden (403)
+        assert resp.status_code == 403
+
+
+def test_remote_cors(app):
+    """Test endpoint that serves as a proxy to the actual remote track on the cloud"""
+    # GIVEN an igv track on the cloud
+    cloud_track_url = "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777460/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz.tbi"
+
+    # GIVEN a running demo app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+
+        # GIVEN that resource file exists in user session
+        with client.session_transaction() as session:
+            session["igv_tracks"] = [cloud_track_url]
 
         # WHEN the remote cors endpoint is invoked with an url
         resp = client.get(url_for("alignviewers.remote_cors", remote_url=cloud_track_url))
-        # THEN it should return success response
+
+        # THEN it should return forbidden (403)
         assert resp.status_code == 200
 
 


### PR DESCRIPTION
Fix #3325 

**remote_cors** endpoint is only supposed to serve resources specified in config.py file, `CLOUD_IGV_TRACKS`. It can anyway used to return resources that are either on the same server as scout, or on other servers.

For instance, a file on the very scout server: https://scout-stage.scilifelab.se/remote/cors/https://scout-stage.scilifelab.se/public/static/logo-scilifelab.png

This PR checks makes sure that the endpoint returns only a resource saved in session["igv-tracks"]

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Install on scout-stage, and try to retrieve the resource from the [example before](https://scout-stage.scilifelab.se/remote/cors/https://scout-stage.scilifelab.se/public/static/logo-scilifelab.png), you should get a 403(forbidden) response

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
