### PR TITLE
Gene collection update time corresponds to last gene creation date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Handle `no intervals found` warning in load_region test
 - Beacon remove variants
 - Protect remote_cors function in alignviewers view from Server-Side Request Forgery (SSRF)
+- Check creation date of last document in gene collection to display when genes collection was updated last
 
 ## [4.51]
 ### Added

--- a/scout/server/blueprints/genes/controllers.py
+++ b/scout/server/blueprints/genes/controllers.py
@@ -26,7 +26,7 @@ def genes(store, query):
     nr_genes_37 = store.nr_genes(build="37")
     nr_genes_38 = store.nr_genes(build="38")
     genes_subset = list(store.all_genes(add_transcripts=False, limit=20))
-    last_inserted_gene = store.hgnc_collection.find({}).sort([("timestamp", -1)]).limit(1)
+    last_inserted_gene = store.hgnc_collection.find({}).sort("_id", -1).limit(1)
     last_updated = document_generated(last_inserted_gene[0]["_id"] if last_inserted_gene else None)
     return dict(genes=genes_subset, last_updated=last_updated, nr_genes=(nr_genes_37, nr_genes_38))
 

--- a/scout/server/blueprints/genes/controllers.py
+++ b/scout/server/blueprints/genes/controllers.py
@@ -26,7 +26,8 @@ def genes(store, query):
     nr_genes_37 = store.nr_genes(build="37")
     nr_genes_38 = store.nr_genes(build="38")
     genes_subset = list(store.all_genes(add_transcripts=False, limit=20))
-    last_updated = document_generated(genes_subset[0]["_id"] if genes_subset else None)
+    last_inserted_gene = store.hgnc_collection.find({}).sort([("timestamp", -1)]).limit(1)
+    last_updated = document_generated(last_inserted_gene[0]["_id"] if last_inserted_gene else None)
     return dict(genes=genes_subset, last_updated=last_updated, nr_genes=(nr_genes_37, nr_genes_38))
 
 


### PR DESCRIPTION
Genes in build 37 and 38 can be updated separately, so instead of collecting a random gene to see when gene collection was updated, use date of last inserted gene.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
