### PR TITLE
Fix GATK default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.52]
 ### Added
+### Changed
+### Fixed
+- Successful parse of FOUND_IN should avoid GATK caller default
+
+## [4.52]
+### Added
 - Demo cancer case gets loaded together with demo RD case in demo instance
 - Parse REVEL_score alongside REVEL_rankscore from csq field and display it on SNV variant page
 - Rank score results now show the ranking range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [4.52]
+## []
 ### Added
 ### Changed
 ### Fixed

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -41,7 +41,9 @@ def parse_callers(variant, category="snv"):
             called_by = info.split("|")[0]
             callers[called_by] = "Pass"
 
-    if category == "snv" and not raw_info or other_info:
+    if raw_info or other_info:
+        return callers
+    if category == "snv":
         # cyvcf2 FILTER is None if VCF file column FILTER is "PASS"
         filter_status = "Pass"
         if variant.FILTER is not None:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

When encountering an SNV with `INFO.FOUND_IN=deepvariant;` it seems we still set GATK to Pass by default as well, as if the caller info was missing completely. 

A bit complex logic on that if statement; splitting it to make it super obvious.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
