### PR TITLE
Do not break text elements across pages when exporting reports to PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 ### Changed
+- Improved HTML syntax in case report template
 ### Fixed
 - Remove load demo case command from docker-compose.yml
 - Text elements being split across pages in PDF reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Text elements being split across pages in PDF reports
 
 ## [4.53]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1177,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-          <tablE class="table table-bordered " style="background-color: transparent">
+        <table role="presentation" class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1303,7 +1303,7 @@
 {% endmacro %}
 
 {% macro genotype_table(variant) %}
-<table class="table table-bordered table-sm" style="background-color: transparent">
+<table role="presentation" class="table table-bordered table-sm" style="background-color: transparent">
   <thead>
     <tr>
       <th rowspan="2">Sample</th>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -71,7 +71,7 @@
 {% endblock %} <!-- end of block body -->
 
 {% macro phenotype_panel() %}
-	<div class="card mb-3" style="border-width: 5px;">
+	<div class="card mb-3" style="border-width: 5px; display: block;">
 	  <div class="card-header">
 	    <a name="phenotype" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}" target="_blank"><strong>Case {{ case.display_name }}</a> - Phenotype Overview</strong>
 	  </div>
@@ -276,7 +276,7 @@
 {% endmacro %}
 
 {% macro gene_panels_panel() %}
-<div class="card mb-3" style="border-width: 5px;">
+<div class="card mb-3" style="border-width: 5px; display: block;">
   <div class="card-header">
     <a name="gene_panels"><strong>Default gene panels</strong></a>
   </div>
@@ -314,7 +314,7 @@
 {% endmacro %}
 
 {% macro causatives_panel() %}
-<div class="card border-success mb-3" style="border-width: 5px;">
+<div class="card border-success mb-3" style="border-width: 5px; display: block;">
   <div class="card-header bg-success text-white">
     <a name="causative_variants"><strong>Causative Variants</strong></a>
   </div>
@@ -333,7 +333,7 @@
 {% endmacro%}
 
 {% macro pinned_panel() %}
-<div class="card border-info mb-3" style="border-width: 5px;">
+<div class="card border-info mb-3" style="border-width: 5px; display: block;">
   <div class="card-header bg-info text-white">
     <a name="pinned_variants"><strong>Pinned Variants</strong></a>
   </div>
@@ -360,7 +360,7 @@
 {% endmacro %}
 
 {% macro classified_panel() %}
-<div class="card border-warning mb-3" style="border-width: 5px;">
+<div class="card border-warning mb-3" style="border-width: 5px; display: block;">
   <div class="card-header bg-warning text-black">
     <a name="acmg_variants"><strong>Other ACMG-classified Variants</strong></a>
   </div>
@@ -387,7 +387,7 @@
 {% endmacro %}
 
 {% macro tagged_panel() %}
-<div class="card border-warning mb-3" style="border-width: 5px;">
+<div class="card border-warning mb-3" style="border-width: 5px; display: block;">
   <div class="card-header bg-warning text-black">
     <a name="manual_ranked_variants"><strong>Other Manual Ranked (Tagged) Variants</strong></a>
   </div>
@@ -438,7 +438,7 @@
 {% endmacro %}
 
 {% macro commented_panel() %}
-<div class="card border-warning mb-3" style="border-width: 5px;">
+<div class="card border-warning mb-3" style="border-width: 5px; display: block;">
   <div class="card-header bg-warning text-black">
     <a name="commented_variants"><strong>Other Commented Variants</strong></a>
   </div>
@@ -474,7 +474,7 @@
 
 <!-- SNV -->
 {% macro sn_variant_content(variant, index) %} <!--The entire description of a single nucleotide variant, dynamic content -->
-  <div class="card" style="border-width: 5px;">
+  <div class="card" style="border-width: 5px; display: block;">
     <div class="card-header">
       <div class="row d-flex align-items-center">
         # <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name[:30]}}</strong></a>&nbsp;
@@ -974,7 +974,7 @@
 
 <!-- SV -->
 {% macro sv_variant_content(variant,index) %} <!--The entire description of a structural variant, dynamic contentc -->
-<div class="card" style="border-width: 5px;">
+<div class="card" style="border-width: 5px; display: block;">
   <div class="card-header">
     <div class="row d-flex align-items-center">
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
@@ -1232,7 +1232,7 @@
 
 <!-- STR -->
 {% macro str_variant_content(variant,index) %}
-<div class="card" style="border-width: 5px;">
+<div class="card" style="border-width: 5px; display: block;">
   <div class="card-header">
     <div class="row d-flex align-items-center">
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.str_repid}}:{{ variant.alternative|replace("<", "")|replace(">", "") }} - {{variant.str_display_ru or variant.str_ru}} - {{ variant.str_status| upper |replace("_", " ") }}</strong></a>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -542,50 +542,7 @@
       <table class="table table-sm">
         <tr>
           <td style="width=45%">
-            <table id="panel-table" class="table table-bordered table-sm" style="background-color: transparent">
-              <thead>
-                <tr>
-                  <th rowspan="2">Sample</th>
-                    <th rowspan="2">Genotype (GT)</th>
-                    <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                    {% if cancer %}
-                      <th rowspan="2" title="Variant Allele Frequency">VAF</th>
-                    {% else %}
-                      <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th>
-                    {% endif %}
-                  </tr>
-                  <tr>
-                    <th>Reference</th>
-                    <th>Alternative</th>
-                  </tr>
-                </tr>
-              </thead>
-              <tbody>
-                {% for sample in variant.samples %}
-                  <tr {% if sample.display_name in affected %} class="table-danger" {% endif%}>
-                    <td>{{ sample.display_name }}</td>
-                    <td class="text-center">{{ sample.genotype_call }}</td>
-                    {% if sample.allele_depths %}
-                        {% for number in sample.allele_depths %}
-                          <td class="text-right">{{ number }}</td>
-                        {% endfor %}
-                    {% else %}
-                        <td class="text-right"><small>N/A</small></td>
-                        <td class="text-right"><small>N/A</small></td>
-                    {% endif %}
-                    {% if cancer %}
-                      {% if sample.read_depth and sample.allele_depths[1] != -1 %}
-                        <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
-                      {% else %}
-                        <td class="text-right">N/A</td>
-                      {% endif %}
-                    {% else %}
-                      <td class="text-right">{{ sample.genotype_quality }}</td>
-                    {% endif %}
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+            {{ genotype_table(variant) }}
           </td>
           <td style="width:3%"></td>
           <td>
@@ -1026,50 +983,7 @@
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
         <td>
-          <table id="panel-table" class="table table-bordered table-sm" style="background-color: transparent">
-            <thead>
-              <tr>
-                <th rowspan="2">Sample</th>
-                  <th rowspan="2">Genotype (GT)</th>
-                  <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
-                  {% if cancer %}
-                    <th rowspan="2" title="Variant Allele Frequency">VAF</th>
-                  {% else %}
-                    <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th>
-                  {% endif %}
-                </tr>
-                <tr>
-                  <th>Reference</th>
-                  <th>Alternative</th>
-                </tr>
-              </tr>
-            </thead>
-            <tbody>
-              {% for sample in variant.samples %}
-                <tr {% if sample.display_name in affected %} class="table-danger" {% endif %}>
-                  <td>{{ sample.display_name }}</td>
-                  <td class="text-center">{{ sample.genotype_call }}</td>
-                  {% if sample.allele_depths %}
-                      {% for number in sample.allele_depths %}
-                        <td class="text-right">{{ number }}</td>
-                      {% endfor %}
-                  {% else %}
-                      <td class="text-right"><small>N/A</small></td>
-                      <td class="text-right"><small>N/A</small></td>
-                  {% endif %}
-                  {% if cancer %}
-                    {% if sample.read_depth and sample.allele_depths[1] != -1 %}
-                      <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
-                    {% else %}
-                      <td class="text-right">N/A</td>
-                    {% endif %}
-                  {% else %}
-                    <td class="text-right">{{ sample.genotype_quality }}</td>
-                  {% endif %}
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
+          {{genotype_table(variant)}}
         </td>
         <td style="width:3%"></td>
         <td>
@@ -1263,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-          <table id="panel-table" class="table table-bordered " style="background-color: transparent">
+          <tablE class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1386,4 +1300,51 @@
     </h6>
   </div>
 {% endif %}
+{% endmacro %}
+
+{% macro genotype_table(variant) %}
+<table class="table table-bordered table-sm" style="background-color: transparent">
+  <thead>
+    <tr>
+      <th rowspan="2">Sample</th>
+        <th rowspan="2">Genotype (GT)</th>
+        <th colspan="2" title="Unfiltered count of reads that support a given allele.">Allele depth (AD)</th>
+        {% if cancer %}
+          <th rowspan="2" title="Variant Allele Frequency">VAF</th>
+        {% else %}
+          <th rowspan="2" title="Phred-scaled confidence that the true genotype is the one provided in GT (max=99).">Genotype quality (GQ)</th>
+        {% endif %}
+      </tr>
+      <tr>
+        <th>Reference</th>
+        <th>Alternative</th>
+      </tr>
+    </tr>
+  </thead>
+  <tbody>
+    {% for sample in variant.samples %}
+      <tr {% if sample.display_name in affected %} class="table-danger" {% endif%}>
+        <td>{{ sample.display_name }}</td>
+        <td class="text-center">{{ sample.genotype_call }}</td>
+        {% if sample.allele_depths %}
+            {% for number in sample.allele_depths %}
+              <td class="text-right">{{ number }}</td>
+            {% endfor %}
+        {% else %}
+            <td class="text-right"><small>N/A</small></td>
+            <td class="text-right"><small>N/A</small></td>
+        {% endif %}
+        {% if cancer %}
+          {% if sample.read_depth and sample.allele_depths[1] != -1 %}
+            <td class="text-right">{{ (sample.allele_depths[1]/sample.read_depth)|round(4) }}</td>
+          {% else %}
+            <td class="text-right">N/A</td>
+          {% endif %}
+        {% else %}
+          <td class="text-right">{{ sample.genotype_quality }}</td>
+        {% endif %}
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -807,7 +807,7 @@
 {% endmacro %}
 
 {% macro dismissed_panel() %}
-  <div class="card border-danger mb-3" style="border-width: 5px;">
+  <div class="card border-danger mb-3" style="border-width: 5px; display: block;">
     <div class="card-header bg-danger text-black">
       <a name="dismissed_variants"><strong>Dismissed Variants</strong></a>
     </div>
@@ -1012,7 +1012,7 @@
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}
+              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom or variant.chromosome}}:{{variant.end}}
             {% endif %}
           </td>
           {% if variant.cytoband_start and variant.cytoband_end %}
@@ -1269,7 +1269,7 @@
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom}}:{{variant.end}}
+              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom or variant.chromosome}}:{{variant.end}}
             {% endif %}
           </td>
           {% if variant.cytoband_start and variant.cytoband_end %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1177,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <table summary="genotype table" class="table table-bordered " style="background-color: transparent">
+        <table aria-label="Genotype table" class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1303,7 +1303,7 @@
 {% endmacro %}
 
 {% macro genotype_table(variant) %}
-<table summary="genotype table" class="table table-bordered table-sm" style="background-color: transparent">
+<table aria-label="Genotype table" class="table table-bordered table-sm" style="background-color: transparent">
   <thead>
     <tr>
       <th rowspan="2">Sample</th>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -992,7 +992,7 @@
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom or variant.chromosome}}:{{variant.end}}
+              chr{{variant.chromosome}}:{{variant.position}}/chr{{variant.end_chrom or variant.chromosome}}:{{variant.end}}
             {% endif %}
           </td>
           {% if variant.cytoband_start and variant.cytoband_end %}
@@ -1239,7 +1239,7 @@
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
             {% else %}
-              chr{{variant.chromosome}}:{{variant.position}}/{{'chr'+variant.end_chrom or variant.chromosome}}:{{variant.end}}
+              chr{{variant.chromosome}}:{{variant.position}}/chr{{variant.end_chrom or variant.chromosome}}:{{variant.end}}
             {% endif %}
           </td>
           {% if variant.cytoband_start and variant.cytoband_end %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1177,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <table role="presentation" class="table table-bordered " style="background-color: transparent">
+        <table class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1303,7 +1303,7 @@
 {% endmacro %}
 
 {% macro genotype_table(variant) %}
-<table role="presentation" class="table table-bordered table-sm" style="background-color: transparent">
+<table class="table table-bordered table-sm" style="background-color: transparent">
   <thead>
     <tr>
       <th rowspan="2">Sample</th>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -485,17 +485,7 @@
             <span class="badge badge-info" title="sanger-status">Verification ordered</span>
           {% endif %}
       </div>
-      {% if variant.get('phenotypes') %}
-        <div class="row mt-3">
-          <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
-            OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
-            HPO terms:&nbsp;
-            {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
-              {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
-            {%- endfor -%}
-          </h6>
-        </div>
-      {% endif %}
+      {{ variant_phenotypes(variant) }}
     </div>
     <div class="card-body">
       <table id="panel-table" class="table table-sm">
@@ -980,17 +970,7 @@
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
     &nbsp;<span class="badge badge-pill badge-warning">{{variant.sub_category|upper}}</span>
     </div>
-    {% if variant.get('phenotypes') %}
-      <div class="row mt-3">
-        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
-          OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
-          HPO terms:&nbsp;
-          {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
-            {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
-          {%- endfor -%}
-        </h6>
-      </div>
-    {% endif %}
+    {{ variant_phenotypes(variant) }}
   </div>
   <div class="card-body">
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
@@ -1238,17 +1218,7 @@
     # <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.str_repid}}:{{ variant.alternative|replace("<", "")|replace(">", "") }} - {{variant.str_display_ru or variant.str_ru}} - {{ variant.str_status| upper |replace("_", " ") }}</strong></a>
     &nbsp;<span class="badge badge-pill badge-info">{{variant.category | upper}}</span>
     </div>
-    {% if variant.get('phenotypes') %}
-      <div class="row mt-3">
-        <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
-          OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
-          HPO terms:&nbsp;
-          {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
-            {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
-          {%- endfor -%}
-        </h6>
-      </div>
-    {% endif %}
+    {{ variant_phenotypes(variant) }}
   </div>
   <div class="card-body">
     <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent">
@@ -1402,4 +1372,18 @@
     {% endif %}
   </div>
 </div>
+{% endmacro %}
+
+{% macro variant_phenotypes(variant) %}
+{% if variant.get('phenotypes') %}
+  <div class="row mt-3">
+    <h6 class="card-subtitle mb-2 text-muted"><span class="badge badge-warning">Partial causative</span>
+      OMIM terms: {{ variant['phenotypes'].get('diagnosis_phenotypes')|join(' ')}} -
+      HPO terms:&nbsp;
+      {%- for hpo_term in variant['phenotypes'].get('phenotype_terms') -%}
+        {{ hpo_term.phenotype_id}}({{hpo_term.feature}})&nbsp;
+      {%- endfor -%}
+    </h6>
+  </div>
+{% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1177,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <table class="table table-bordered " style="background-color: transparent">
+        <table role="none" class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1303,7 +1303,7 @@
 {% endmacro %}
 
 {% macro genotype_table(variant) %}
-<table class="table table-bordered table-sm" style="background-color: transparent">
+<table role="none" class="table table-bordered table-sm" style="background-color: transparent">
   <thead>
     <tr>
       <th rowspan="2">Sample</th>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1177,7 +1177,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <table role="none" class="table table-bordered " style="background-color: transparent">
+        <table summary="genotype table" class="table table-bordered " style="background-color: transparent">
             <thead>
               <tr class="table-secondary">
                 <th rowspan="2">Sample</th>
@@ -1303,7 +1303,7 @@
 {% endmacro %}
 
 {% macro genotype_table(variant) %}
-<table role="none" class="table table-bordered table-sm" style="background-color: transparent">
+<table summary="genotype table" class="table table-bordered table-sm" style="background-color: transparent">
   <thead>
     <tr>
       <th rowspan="2">Sample</th>

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -273,8 +273,9 @@ body {
 /* end of sidebar-related stuff */
 
 /* Do not break text element across pages when exporting reports to PDF using wkhtmltopdf */
-table, tr, td, th, tbody, thead, tfoot, div {
-    page-break-inside: avoid !important;
+table, tr, td, th, div, a {
+  page-break-inside: avoid;
+  break-inside: avoid;
 }
 
 /* CHECKBOX ios8-switch*/

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -270,8 +270,12 @@ body {
   text-align: right;
   padding-left: 10px;
 }
-/* end of sidebar-related stuff
+/* end of sidebar-related stuff */
 
+/* Do not break text element across pages when exporting reports to PDF using wkhtmltopdf */
+table, tr, td, th, tbody, thead, tfoot {
+    page-break-inside: avoid !important;
+}
 
 /* CHECKBOX ios8-switch*/
 input[type="checkbox"].ios8-switch {

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -273,7 +273,7 @@ body {
 /* end of sidebar-related stuff */
 
 /* Do not break text element across pages when exporting reports to PDF using wkhtmltopdf */
-table, tr, td, th, tbody, thead, tfoot {
+table, tr, td, th, tbody, thead, tfoot, div {
     page-break-inside: avoid !important;
 }
 

--- a/scout/server/static/bs4_styles.css
+++ b/scout/server/static/bs4_styles.css
@@ -2,6 +2,12 @@
   --bg-color: #eee;
 }
 
+@media print {
+  div {
+    break-inside: avoid;
+  }
+}
+
 .bg-primary {
   background-color: #A8D0E6 !important;
 }
@@ -271,12 +277,6 @@ body {
   padding-left: 10px;
 }
 /* end of sidebar-related stuff */
-
-/* Do not break text element across pages when exporting reports to PDF using wkhtmltopdf */
-table, tr, td, th, div, a {
-  page-break-inside: avoid;
-  break-inside: avoid;
-}
 
 /* CHECKBOX ios8-switch*/
 input[type="checkbox"].ios8-switch {


### PR DESCRIPTION
Fix #3166

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. On cg-vm1 (scout-stage) note that the PDF report of [this case](https://scout-stage.scilifelab.se/cust003/15001) has the problem
2. Clear browsing data
3. Switch to this branch and the exported should look better (no lines of text broken across lines)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
