### PR TITLE
Remove load demo cancer case in Docker Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 ### Changed
 ### Fixed
+- Remove load demo case command from docker-compose.yml
 
 ## [4.53]
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     build: .
     container_name: scout-cli
     command: bash -c "
-      scout --host mongodb setup demo
-      && scout --host mongodb --demo load case scout/demo/cancer.load_config.yaml"
+      scout --host mongodb setup demo"
     volumes:
       - ./scout:/home/worker/app/scout
     networks:


### PR DESCRIPTION
Demo cancer case is already loaded when setting up the Scout demo instance [now](#3296) but `docker-compose up` still contains the command to load it, so it has an error at the moment:

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/28093618/168604106-90a1c8ee-0003-48f1-a0ea-4a718650a537.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. From this branch, run `docker-compose up` and make sure the containers run fine

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
