### PR TITLE
Fix password visibility in LDAP login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Remove load demo case command from docker-compose.yml
 - Text elements being split across pages in PDF reports
+- Made login password field of type `password` in LDAP login form
 
 ## [4.53]
 ### Added

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -30,7 +30,7 @@
           <input type="text" name="ldap_user" class="form-control" placeholder="user email/id" required>
           </div>
           <div class="col-5">
-            <input type="text" name="ldap_password" class="form-control" placeholder="user password" required>
+            <input type="password" name="ldap_password" class="form-control" placeholder="user password" required>
           </div>
           <div class="col-2">
             <button type="submit" class="btn btn-primary form-control text-white" onclick="sendBrowserInfo()">Login</button>


### PR DESCRIPTION
Fix #3349 

**How to test**:
1. Try login with an LDAP user

**Expected outcome**:
Password shouldn't be visible during typing

**Review:**
- [x] code approved by DN
- [X] tests executed by CR
