### PR TITLE
Fix error in case PDF report when no pedigree can be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bootstrap upgraded to version 5
 - Fix some Sourcery and SonarCloud suggestions
 - Escape special characters in case search on institute and dashboard pages
+- Broken case PDF reports when no Madeline pedigree image can be created
 
 ## [4.53]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -80,11 +80,13 @@
 	      <tr>
           {% if case.madeline_info and case.individuals|length > 1 %}
 	        <td style='width: 33%;'>
-	            {% if format == 'html' %}
-	              {{ case.madeline_info|safe }}
-	            {% elif case.madeline_path %} <!--PDF version-->
+            {% if case.madeline_info %}
+              {% if format == 'html' %}
+                {{ case.madeline_info|safe }}
+              {% elif case.madeline_path %} <!-- PDF report -->
                 <img alt="pedigree_img" src="{{case.madeline_path}}">
-	            {% endif %}
+              {% endif %}
+            {% endif %}
           </td>
           {% endif %}
           <td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -80,13 +80,11 @@
 	      <tr>
           {% if case.madeline_info and case.individuals|length > 1 %}
 	        <td style='width: 33%;'>
-            {% if case.madeline_info %}
-              {% if format == 'html' %}
-                {{ case.madeline_info|safe }}
-              {% elif case.madeline_path %} <!-- PDF report -->
+	            {% if format == 'html' %}
+	              {{ case.madeline_info|safe }}
+	            {% elif case.madeline_path %} <!--PDF version-->
                 <img alt="pedigree_img" src="{{case.madeline_path}}">
-              {% endif %}
-            {% endif %}
+	            {% endif %}
           </td>
           {% endif %}
           <td>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -235,7 +235,9 @@ def pdf_case_report(institute_id, case_name):
             )  # Transform to png, since PDFkit can't render svg images
             data["case"]["madeline_path"] = write_to
         except Exception as ex:
-            LOG.error(f"Could not convert SVG pedigree figure {case_obj['madeline_info']} to PNG")
+            LOG.error(
+                f"Could not convert SVG pedigree figure {case_obj['madeline_info']} to PNG: {ex}"
+            )
 
     html_report = render_template("cases/case_report.html", format="pdf", **data)
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -227,12 +227,15 @@ def pdf_case_report(institute_id, case_name):
 
     # Workaround to be able to print the case pedigree to pdf
     if case_obj.get("madeline_info") and case_obj.get("madeline_info") != "":
-        write_to = os.path.join(cases_bp.static_folder, "madeline.png")
-        svg2png(
-            bytestring=case_obj["madeline_info"],
-            write_to=write_to,
-        )  # Transform to png, since PDFkit can't render svg images
-        data["case"]["madeline_path"] = write_to
+        try:
+            write_to = os.path.join(cases_bp.static_folder, "madeline.png")
+            svg2png(
+                bytestring=case_obj["madeline_info"],
+                write_to=write_to,
+            )  # Transform to png, since PDFkit can't render svg images
+            data["case"]["madeline_path"] = write_to
+        except Exception as ex:
+            LOG.error(f"Could not convert SVG pedigree figure {case_obj['madeline_info']} to PNG")
 
     html_report = render_template("cases/case_report.html", format="pdf", **data)
 


### PR DESCRIPTION
Fix #3362 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1.  Install on stage (cg-vm1) and try to create a PDF report for [this case](https://scout-stage.scilifelab.se/cust000/SWEDAC-2019-HG-05-Trio-NovaSeq)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
