### PR TITLE
Fix #3360 - allow marking case solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Dark mode, using browser/OS media preference
+- Case status change modal
 ### Changed
 - Improved HTML syntax in case report template
 - Modified message displayed when variant rank stats could not be calculated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Added
 - Dark mode, using browser/OS media preference
-- Case status change modal
+- Allow marking case as solved without defining causative variants
 ### Changed
 - Improved HTML syntax in case report template
 - Modified message displayed when variant rank stats could not be calculated

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from "cases/collapsible_actionbar.html" import action_bar, research_modal, rerun_modal, reanalysis_modal %}
+{% from "cases/collapsible_actionbar.html" import action_bar, research_modal, rerun_modal, reanalysis_modal, solve_modal %}
 {% from "utils.html" import comments_panel, activity_panel, pedigree_panel %}
 {% from "cases/utils.html" import clinvar_panel, causatives_list, suspects_list, remove_form, matching_causatives, matching_managed_variants, beacon_modal, matchmaker_modal %}
 {% from "cases/individuals_table.html" import cancer_individuals_table, individuals_table %}
@@ -166,6 +166,7 @@
       </div>
 
       {{ modal_synopsis() }}
+      {{ solve_modal(institute, case) }}
       {{ rerun_modal(institute, case) }}
       {{ research_modal(institute, case) }}
       {{ reanalysis_modal(institute, case) }}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -44,7 +44,7 @@
 {% block content_main %}
 <div class="container-float">
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
-    {{ action_bar(institute, case, collaborators, current_user) }} <!-- This is the sidebar -->
+    {{ action_bar(institute, case, causatives, collaborators, current_user) }} <!-- This is the sidebar -->
     {{ case_page() }}
   </div> <!-- end of div id body-row -->
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -1,4 +1,4 @@
-{% macro action_bar(institute, case, collaborators, current_user) %}
+{% macro action_bar(institute, case, causatives, collaborators, current_user) %}
 <!-- Collapsible Sidebar, Based on https://www.codeply.com/go/LFd2SEMECH -->
   <div id="sidebar-container" class="sidebar-expanded d-none d-md-block"><!-- d-* hiddens the Sidebar in smaller devices. Its itens can be kept on the Navbar 'Menu' -->
       <!-- Bootstrap List Group -->
@@ -33,7 +33,7 @@
             {{ check_decipher(case, institute) }}
           {% endif %}
           {{ confirm_inactivate(institute,case) }}
-          {{ archive_case(institute,case) }}
+          {{ archive_case(institute,case, causatives) }}
       </ul><!-- List Group END-->
   </div><!-- sidebar-container END -->
 {% endmacro %}
@@ -572,7 +572,7 @@
 </div>
 {% endmacro %}
 
-{% macro archive_case(institute,case)%}
+{% macro archive_case(institute,case, causatives)%}
 <div class="modal fade" id="archive_modal" tabindex="-1" role="dialog" aria-labelledby="archiveCaseLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
@@ -582,17 +582,29 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <div class="modal-body">
-        Are you sure? This will disable the alignment view and delete analysis files.
-        You will have to request a FULL rerun to continue evaluating e.g. research variants.
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <form method="POST"
-          action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
-          <button type="submit" class="btn btn-primary" value="archived" name="status">Archive</button>
-        </form>
-      </div>
+      {% if causatives|length == 0 %}
+        <div class="modal-body">
+          Are you sure? This will disable the alignment view and delete analysis files.
+          You will have to request a FULL rerun to continue evaluating e.g. research variants.
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <form method="POST"
+            action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
+            <button type="submit" class="btn btn-primary" value="archived" name="status">Archive</button>
+          </form>
+        </div>
+      {% else %}
+        <div class="modal-body">
+          You have marked causatives for this case. Please clear them before archiving the case.
+          Note that a solved case is subject to the same archive policy as archived cases.
+          Archived cases will not count as solved.
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -212,6 +212,16 @@
                 </button>
               {% endif %}
             </div>
+            {% if case.status != 'solved' %}
+              <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
+                Solve
+              </button>
+            {% else %}
+              <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
+                Unsolve
+              </button>
+            {% endif %}
+
             <div class="btn-group">
               <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-light btn-sm">
                 {{ 'De-prioritize' if case.status == 'prioritized' else 'Prioritize' }}
@@ -528,6 +538,35 @@
         </form>
       </div>
       {% endif %}
+    </div>
+  </div>
+</div>
+{% endmacro %}
+
+{% macro solve_modal(institute, case) %}
+<div class="modal fade" id="solve_modal" tabindex="-1" role="dialog" aria-labelledby="solveCaseLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="archiveCaseLabel">Confirm solve case</h5>
+        <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Are you sure? Marking a case as Solved will queue it to delete analysis files
+        ahead of schedule, and disable the alignment view.
+        You will then have to request a FULL rerun to continue evaluating e.g. research variants.
+        <br><br>Marking Solved directly does not store the Causative variant.
+        Only use it for cases where the causation is not readily markable, such as UPD or SMN.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <form method="POST"
+          action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
+          <button type="submit" class="btn btn-primary" value="solved" name="status">Solve</button>
+        </form>
+      </div>
     </div>
   </div>
 </div>

--- a/tests/commands/export/test_export_cases_cmd.py
+++ b/tests/commands/export/test_export_cases_cmd.py
@@ -64,7 +64,7 @@ def test_export_cases(mock_app, case_obj):
     assert result.exit_code == 0
     assert "scout/demo/643594" in result.output
 
-    # Test cli querying for cases with a specifi status (solved)
+    # Test cli querying for cases with a specific status (solved)
     result = runner.invoke(cli, ["export", "cases", "-s", "solved"])
     # Test case should be found
     assert result.exit_code == 0


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

This is the action part. I had a brief look around, and do not see anything that should break from this. Compare #2644. We already have relaxed the condition on having a causative with partial causatives. This fills a niche for causation that we may yet not have a variant category for (UPD, SMN, RNA-expression, ...). Sometimes these go with a known other variant as well, sometimes not.

When we are at it, solve part of #2644; block the Archive button when there are Causatives.



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>

**How to test**:
1. Click Solve for a case. Affirm the modal. Note that the case status changes to Solved. 
1. Unsolve and see it go back to Active.
1. Mark a variant Causative. 
1. Attempt to Archive the case. Note that this is now not possible from the archive modal.
1. Reset the causative, and test that archiving works.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
