### PR TITLE
Deprecation warnings for soon to be gone features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow marking case as solved without defining causative variants
 - Admin users can create missing beacon datasets from the institute's settings page
 - GenCC links on gene and variant pages
+- Deprecation warnings when launching the app using a .yaml config file or loading cases using .ped files
 ### Changed
 - Improved HTML syntax in case report template
 - Modified message displayed when variant rank stats could not be calculated

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -49,7 +49,9 @@ def get_app(ctx=None):
     cli_config = {}
     # if a .yaml config file was provided use its params to intiate the app
     if options.params.get("config"):
-
+        logging.warning(
+            "Support for launching Scout using a .yaml config file is deprecated and will be removed in the next major release (5.0). Use a PYTHON (.py) config file instead.",
+        )
         with open(options.params["config"], "r") as in_handle:
             cli_config = yaml.load(in_handle, Loader=yaml.SafeLoader)
 

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -49,7 +49,7 @@ def get_app(ctx=None):
     cli_config = {}
     # if a .yaml config file was provided use its params to intiate the app
     if options.params.get("config"):
-        logging.warning(
+        LOG.warning(
             "Support for launching Scout using a .yaml config file is deprecated and will be removed in the next major release (5.0). Use a PYTHON (.py) config file instead.",
         )
         with open(options.params["config"], "r") as in_handle:

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 from ped_parser import FamilyParser

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -47,7 +47,7 @@ def parse_case_data(**kwargs):
 
     # If ped file  provided we need to parse that first
     if kwargs.get("ped"):
-        logging.warning(
+        LOG.warning(
             "Loading cases using .ped files is deprecated and will be no longer supported in the future. Load cases using .yaml config files instead.",
         )
         family_id, samples = parse_ped(kwargs["ped"])

--- a/scout/parse/case.py
+++ b/scout/parse/case.py
@@ -47,6 +47,9 @@ def parse_case_data(**kwargs):
 
     # If ped file  provided we need to parse that first
     if kwargs.get("ped"):
+        logging.warning(
+            "Loading cases using .ped files is deprecated and will be no longer supported in the future. Load cases using .yaml config files instead.",
+        )
         family_id, samples = parse_ped(kwargs["ped"])
         config_dict["family"] = family_id
         config_dict["samples"] = samples


### PR DESCRIPTION
Fix #3384 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.

**How to test**:
1. Locally, try to load the demo using a .ped file
2. Locally, try to launch a cli command by passing a config param corresponding to a .yaml config file

**Expected outcome**:
In both cases you should see a warning.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
