### PR TITLE
Fix alignment of low tumor purity badge in cancer case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Fixed
+- Low tumor purity badge alignment in cancer samples table on cancer case view
+
 ## [4.54]
 ### Added
 - Dark mode, using browser/OS media preference

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -17,7 +17,7 @@ samples:
     vcf2cytosure: scout/demo/999-99.test.cgh
     tmb: 7
     msi: 15
-    tumor_purity: 1
+    tumor_purity: 0.1
 
   - analysis_type: panel
     sample_id: 998-99

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -40,17 +40,15 @@
               <td>{{ ind.msi or 'N/A' }}</td>
               {% if ind.phenotype_human == "tumor" %}
                 <td>
-                  <div class="row">
-                  {% if not ind.tumor_purity or ind.tumor_purity|float < 0.2 %}
-                  <div class="col-1">
-                    <div class="badge bg-danger rounded-pill">
-                      <span class="fa fa-exclamation " data-bs-toggle='tooltip' data-bs-container='body' title="Low or missing tumor purity"></span>
-                    </div>
-                  </div>
-                  {% endif %}
-                  <div class="col-11"><input name="tumor_purity.{{ind.individual_id}}" type="number" step="0.01" min="0.1" max=1
-                  class="form-control col-7" value="{{ind.tumor_purity}}"></div>
-                </div>
+                  <div class="d-flex align-items-center">
+                    {% if not ind.tumor_purity or ind.tumor_purity|float < 0.2 %}
+                      <div class="badge bg-danger rounded-pill">
+                        <span class="fa fa-exclamation " data-bs-toggle='tooltip' data-bs-container='body' title="Low or missing tumor purity"></span>
+                      </div>
+                    {% endif %}
+                    <input name="tumor_purity.{{ind.individual_id}}" type="number" step="0.01" min="0.1" max=1
+                    class="form-control" value="{{ind.tumor_purity}}">
+                  <div>
                 </td>
               {% else %}
                 <td>N/A</td>


### PR DESCRIPTION
Fix #3392 

From this:

<img width="827" alt="image" src="https://user-images.githubusercontent.com/28093618/172999669-a86f6ca0-e5e9-4620-b654-490e4b8539f5.png">


To this:

<img width="885" alt="image" src="https://user-images.githubusercontent.com/28093618/172999620-40b5b9fe-d983-424d-ac76-7598f9a5ad2d.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.

**How to test**:
1. Run `scout setup demo`, then check cancer case

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
