### PR TITLE
Represent different tumor samples as vials in cases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Fixed
 - Low tumor purity badge alignment in cancer samples table on cancer case view
+### Changed
+- Represent different tumor samples as vials in cases page
 
 ## [4.54]
 ### Added

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -98,7 +98,7 @@
       <a href="{{ url_for('cases.case', institute_id=case.owner, case_name=case.display_name) }}">
         {{ case.display_name }}
       </a>
-      {% if case.individuals|length > 1%}
+      {% if case.individuals|length > 1 %}
         <span class="badge bg-primary">
           {% for item in case.individuals %}
             {% if case.track == "cancer" %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -98,10 +98,14 @@
       <a href="{{ url_for('cases.case', institute_id=case.owner, case_name=case.display_name) }}">
         {{ case.display_name }}
       </a>
-      {% if case.individuals|length > 1 %}
+      {% if case.individuals|length > 1%}
         <span class="badge bg-primary">
           {% for item in case.individuals %}
-            <i class="fa fa-user"></i>
+            {% if case.track == "cancer" %}
+              <i class="fa fa-vial"></i>
+            {% else %} <!-- rare disease case -->
+              <i class="fa fa-user"></i>
+            {% endif %}
           {% endfor %}
         </span>
       {% endif %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -102,9 +102,9 @@
         <span class="badge bg-primary">
           {% for item in case.individuals %}
             {% if case.track == "cancer" %}
-              <i class="fa fa-vial"></i>
+              <em class="fa fa-vial"></em>
             {% else %} <!-- rare disease case -->
-              <i class="fa fa-user"></i>
+              <em class="fa fa-user"></em>
             {% endif %}
           {% endfor %}
         </span>

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -99,15 +99,15 @@
         {{ case.display_name }}
       </a>
       {% if case.individuals|length > 1 %}
-        <span class="badge bg-primary">
-          {% for item in case.individuals %}
-            {% if case.track == "cancer" %}
-              <em class="fa fa-vial"></em>
-            {% else %} <!-- rare disease case -->
-              <em class="fa fa-user"></em>
-            {% endif %}
-          {% endfor %}
-        </span>
+      <span class="badge bg-primary">
+        {% for item in case.individuals %}
+          {% if case.track == "cancer" %}
+            <span class="fa fa-vial"></span>
+          {% else %} <!-- rare disease case -->
+            <span class="fa fa-user"></span>
+          {% endif %}
+        {% endfor %}
+      </span>
       {% endif %}
       {% for user in case.assignees %}
         <span class="badge bg-secondary">{{ user.name }}</span>


### PR DESCRIPTION
Fix #3391 

Change from this:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/28093618/173015297-e20d9dd0-f52f-49ba-8ccc-27b1b80047b8.png">


To this:

<img width="424" alt="image" src="https://user-images.githubusercontent.com/28093618/173016214-ec35326c-eed4-4a90-a8ee-8a7ef3322ef2.png">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
