### PR TITLE
Fix #3395 - reactivate hover on variantS comments popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Fixed
 - Low tumor purity badge alignment in cancer samples table on cancer case view
+- variantS comment popovers reactivate on hover
 
 ## [4.54]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## []
 ### Fixed
 - Low tumor purity badge alignment in cancer samples table on cancer case view
-- variantS comment popovers reactivate on hover
+- VariantS comment popovers reactivate on hover
 
 ## [4.54]
 ### Added

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -24,7 +24,7 @@
        data-bs-toggle="popover"
        data-bs-placement="right"
        data-bs-html="true"
-       data-trigger="hover click"
+       data-bs-trigger="hover click"
        data-bs-content="{{ comments_content }}"
        title=""
        style="color:white;"

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -175,7 +175,7 @@
 <a class="badge bg-secondary text-white"
   data-bs-toggle="popover"
   data-bs-html="true"
-  data-trigger="hover click"
+  data-bs-trigger="hover click"
   data-bs-content="{% if variant.str_normal_max %}
     <table>
       <tr><td>Normal max</td><td>{{ variant.str_normal_max }}</td></tr>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

A couple of hovers trigger statements had been missed on bootstrap5 upgrade or subsequent merges. Thanks @genecracker! 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
