### PR TITLE
Drop classification float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Low tumor purity badge alignment in cancer samples table on cancer case view
 - VariantS comment popovers reactivate on hover
+- ACMG classification summary hidden by sticky navbar
 
 ## [4.54]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Low tumor purity badge alignment in cancer samples table on cancer case view
 - VariantS comment popovers reactivate on hover
-- - Updating database genes in build 37
+- Updating database genes in build 37
 - ACMG classification summary hidden by sticky navbar
 
 

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -5,15 +5,15 @@
 {% endblock %}
 
 {% block content_main %}
-  <div class="container mt-3">
+  <div class="container mt-3 mb-5">
     <form action="{{ url_for('variant.variant_acmg', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
       <div class="card panel-default mt-3">
         <div class="card-body">
           {% if not evaluation %}
-              <div class="mb-3">
+              <div class="mt-3 fixed-bottom bg-light border">
                 <div class="text-center">
                   {% for option in ACMG_OPTIONS %}
-                    <a id="acmg-{{ option.code }}" class="btn btn-light acmg-preview">{{ option.label }}</a>
+                    <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
                   {% endfor %}
                 </div>
               </div>
@@ -28,7 +28,7 @@
         </div>
       </div>
 
-      <div class="d-flex justify-content-between mt-3">
+      <div class="d-flex justify-content-between mt-3 ">
         {% for category, criteria_group in CRITERIA.items() %}
           <div class="flex-1 {{ 'me-3' if not loop.last }}">
             <h4>Evidence of {{ category }}</h4>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -5,21 +5,18 @@
 {% endblock %}
 
 {% block content_main %}
-  {% if not evaluation %}
-    <div class="float-top-secondary">
-      <div class="text-center">
-        {% for option in ACMG_OPTIONS %}
-          <a id="acmg-{{ option.code }}" class="btn btn-light acmg-preview">{{ option.label }}</a>
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
-  <hr>
   <div class="container mt-3">
     <form action="{{ url_for('variant.variant_acmg', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
       <div class="card panel-default mt-3">
         <div class="card-body">
           {% if not evaluation %}
+              <div class="mb-3">
+                <div class="text-center">
+                  {% for option in ACMG_OPTIONS %}
+                    <a id="acmg-{{ option.code }}" class="btn btn-light acmg-preview">{{ option.label }}</a>
+                  {% endfor %}
+                </div>
+              </div>
             <button class="btn btn-primary form-control">Submit</button>
           {% else %}
             <h4>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -4,6 +4,26 @@
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ variant.display_name }} - Classify
 {% endblock %}
 
+{% block top_nav %}
+  {{ super() }}
+  <li class="nav-item">
+    <a class="nav-link text-nowrap" href="{{ url_for('cases.index') }}">Institutes</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link text-nowrap" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
+      {{ institute.display_name }}
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link text-nowrap" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
+      {{ case.display_name }}
+    </a>
+  </li>
+  <li class="nav-item active d-flex align-items-center">
+    <span class="navbar-text">{{ variant.display_name }}</span>
+  </li>
+{% endblock %}
+
 {% block content_main %}
   <div class="container mt-3 mb-5">
     <form action="{{ url_for('variant.variant_acmg', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -127,7 +127,6 @@ table.dataTable {margin-bottom: 0}
 	}
 }
 
-
 /* Custom navbar theme */
 .navbar{
   height: 50px;
@@ -144,16 +143,6 @@ table.dataTable {margin-bottom: 0}
 }
 .navbar-nav > .active > .navbar-text {
 	color:var(--bs-white);
-}
-
-.float-top-secondary {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	padding: 1rem;
-	z-index: 99;
-	border-bottom: 1px solid;
 }
 
 /*.navbar-nav > li > a:hover,*/


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The classification summary was hidden by the sticky navbar. One could play with offsets and have the secondary-flow below the navbar, but I'm not sure it helps anyone much? Here is a suggestion to just keep it scrolling with the page.

![Screenshot 2022-06-13 at 11 00 34](https://user-images.githubusercontent.com/758570/173318380-b73eeb7c-33a8-4c2a-9dee-ceadc89f44a8.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
</details>
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
