### PR TITLE
Fix managed link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updating database genes in build 37
 - ACMG classification summary hidden by sticky navbar
 - Logo backgrounds fixed to white on welcome page
-- Update KUH logo
-
+- Update KUH and GMS logos
+- Link color for Managed variants
 
 ## [4.54]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -567,7 +567,7 @@
   <div class="card panel-default" >
     <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
       that have been marked as causative in another case for this insitute">
-      <strong><a data-bs-toggle="collapse" href="#matchingCausatives" class="text-white">Matching causatives from other cases ({{other_causatives|length}})</a></strong>
+      <strong><a data-bs-toggle="collapse" class="text-body" href="#matchingCausatives" class="text-white">Matching causatives from other cases ({{other_causatives|length}})</a></strong>
     </div>
     <ul class="list-group collapse" id="matchingCausatives">
       {% for variant in other_causatives %}
@@ -614,7 +614,7 @@
   <div class="card panel-default">
     <div data-bs-toggle='tooltip' class="panel-heading" title="Any variants in this case
       that have been marked as managed">
-      <strong><a data-bs-toggle="collapse" href="#matchingManaged">Managed variants ({{managed_variants|length}})</a></strong>
+      <strong><a data-bs-toggle="collapse" class="text-body" href="#matchingManaged">Managed variants ({{managed_variants|length}})</a></strong>
     </div>
     <ul class="list-group">
       {% for variant in managed_variants %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -614,7 +614,7 @@
   <div class="card panel-default">
     <div data-bs-toggle='tooltip' class="panel-heading" title="Any variants in this case
       that have been marked as managed">
-      <strong><a data-bs-toggle="collapse" href="#matchingManaged" class="text-white">Managed variants ({{managed_variants|length}})</a></strong>
+      <strong><a data-bs-toggle="collapse" href="#matchingManaged">Managed variants ({{managed_variants|length}})</a></strong>
     </div>
     <ul class="list-group">
       {% for variant in managed_variants %}

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -75,10 +75,10 @@
       </div>
     </div>
     <p class="pb-1 pt-2">Collaborations:</p>
-    <div class="row bg-dark rounded-3">
+    <div class="row rounded-3">
       <div class="col-xs-12 mb-2 mt-2 col-sm-3">
         <a href="https://genomicmedicine.se/" target="_blank">
-          <img class="img-fluid mx-auto" width="250" alt="Genomic Medicine Sweden logotype" src="{{ url_for('public.static', filename='logo-gms.png') }}">
+          <img class="img-fluid mx-auto" width="250" alt="Genomic Medicine Sweden logotype" src="{{ url_for('public.static', filename='GMS-logo-dark.png') }}">
         </a>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

![Screenshot 2022-06-14 at 14 38 14](https://user-images.githubusercontent.com/758570/173579356-e0d0d1dc-9d09-4204-b453-739e9fba56c3.png)
![Screenshot 2022-06-14 at 14 38 08](https://user-images.githubusercontent.com/758570/173579359-299521d0-40d6-4903-a9db-e4278d02c1a7.png)

Also got a new positive GMS logo from Mikaela! 🥳 

![Screenshot 2022-06-14 at 14 42 27](https://user-images.githubusercontent.com/758570/173579662-b74ff0cc-d775-4a2f-8e35-eac84a472457.png)
 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
