### PR TITLE
Do not apply visited link style to any button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Fixed
+- Style of user login button
+
 ## [4.55]
 ### Changed
 - Represent different tumor samples as vials in cases page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## []
 ### Fixed
-- Style of user login button
+- Remove a:visited css style from all buttons
 
 ## [4.55]
 ### Changed

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -21,7 +21,7 @@
       </p>
     {% else %}
       {% if config.GOOGLE %}
-        <a class="btn btn-primary" onclick="sendBrowserInfo()" href="{{ url_for('login.login') }}" role="button">
+        <a class="btn btn-primary btn-lg text-white" onclick="sendBrowserInfo()" href="{{ url_for('login.login') }}" role="button">
           Login with Google
         </a>
       {% elif config.LDAP_HOST or config.LDAP_SERVER %}

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -32,20 +32,8 @@ table.dataTable {margin-bottom: 0}
 	 top: 50px;
 }
 
-a:visited {
+a:visited :not(btn) {
 	color: var(--bs-purple);
-}
-
-a.btn-secondary:visited {
-  color: white;
-}
-
-a.btn-primary:visited {
-  color: white;
-}
-
-a.dropdown-item:visited {
-  all: unset;
 }
 
 /* affected, archived and similar accents */

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -40,6 +40,10 @@ a.btn-secondary:visited {
   color: white;
 }
 
+a.btn-primary:visited {
+  color: white;
+}
+
 a.dropdown-item:visited {
   all: unset;
 }

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -32,8 +32,16 @@ table.dataTable {margin-bottom: 0}
 	 top: 50px;
 }
 
-a:visited :not(btn) {
+a:visited {
 	color: var(--bs-purple);
+}
+
+a.btn:visited {
+  color: inherit;
+}
+
+a.dropdown-item:visited {
+  all: unset;
 }
 
 /* affected, archived and similar accents */


### PR DESCRIPTION
Fix #3424 

From this:

<img width="295" alt="image" src="https://user-images.githubusercontent.com/28093618/173747916-bba81f2d-295c-4bb9-9f50-610000916995.png">


To this:

<img width="361" alt="image" src="https://user-images.githubusercontent.com/28093618/173747654-168fa7d7-7434-43ed-b215-2bf630ad27d5.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
