### PR TITLE
Add panel-umi tag option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Added
+- `panel-umi` tag option when loading cancer analyses
+
 ## [4.55]
 ### Changed
 - Represent different tumor samples as vials in cases page

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -1,4 +1,4 @@
-ANALYSIS_TYPES = ("wgs", "wes", "mixed", "unknown", "panel", "external")
+ANALYSIS_TYPES = ("wgs", "wes", "mixed", "unknown", "panel", "panel-umi", "external")
 
 CUSTOM_CASE_REPORTS = [
     "multiqc",

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -5,7 +5,7 @@ owner: cust000
 family: 'cancer_test'
 family_name: 'cancer_case'
 samples:
-  - analysis_type: panel
+  - analysis_type: panel-umi
     sample_id: 999-99
     tumor_type: Chordoma
     capture_kit: Twist.V1

--- a/scout/parse/models.py
+++ b/scout/parse/models.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel, Field, root_validator, validator
 from typing_extensions import Literal
 
+from scout.constants import ANALYSIS_TYPES
 from scout.exceptions import ConfigError, PedigreeError
 from scout.utils.date import get_date
 
@@ -81,7 +82,7 @@ class Image(BaseModel):
 
 class ScoutIndividual(BaseModel):
     alignment_path: Optional[str] = None
-    analysis_type: Literal["wgs", "wes", "mixed", "unknown", "panel", "external"] = None
+    analysis_type: Literal[ANALYSIS_TYPES] = None
     bam_file: Optional[str] = ""
     bam_path: Optional[str] = None
     capture_kits: Optional[str] = Field(alias="capture_kit")  #!


### PR DESCRIPTION
Fix #3369 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Locally, run `scout setup demo` and check the analysis tags loaded for the samples of the demo cancer case

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by mikaell (locally)
