### PR TITLE
Remove leading and trailing spaces from cases search in cases and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove a:visited css style from all buttons
 - Update of HPO terms via command line
 - Background color of `MIXED` sequencing type on cases page
+- Fixed regex error when searching for cases with query ending with `\ `
 
 ## [4.55]
 ### Changed

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -77,9 +77,10 @@ def populate_dashboard_data(request):
     if institute_id == "All":
         institute_id = None
 
-    slice_query = compose_slice_query(
-        request.form.get("search_type"), re.escape(request.form.get("search_term"))
+    search_term = (
+        re.escape(request.form["search_term"].strip()) if request.form.get("search_term") else ""
     )
+    slice_query = compose_slice_query(request.form.get("search_type"), search_term)
     get_dashboard_info(store, data, institute_id, slice_query)
     return data
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -21,7 +21,6 @@ from scout.server.blueprints.variant.utils import predictions, update_representa
 from scout.server.extensions import beacon, store
 from scout.server.utils import institute_and_case, user_institutes
 from scout.utils.md5 import generate_md5_key
-from scout.utils.scout_requests import get_request_json
 
 from .forms import BeaconDatasetForm, CaseFilterForm
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -315,7 +315,7 @@ def cases(store, request, institute_id):
     name_query = None
     if request.args.get("search_term"):
         name_query = "".join(
-            [request.args.get("search_type"), re.escape(request.args.get("search_term"))]
+            [request.args.get("search_type"), re.escape(request.args["search_term"].strip())]
         )
     data["name_query"] = name_query
     limit = int(request.args.get("search_limit")) if request.args.get("search_limit") else 100


### PR DESCRIPTION
Fix #3407 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on cg-vm1 (stage) and search for cases with `\ ` (note the space)
2. Do same search in dashboard page
3. It should not return error

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
