### PR TITLE
Fix #3442 - lighten gene symbols on causatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update of HPO terms via command line
 - Background color of `MIXED` and `PANEL-UMI` sequencing types on cases page
 - Fixed regex error when searching for cases with query ending with `\ `
+- Genesymbols on Causatives page lighter in dark mode
 
 ## [4.55]
 ### Changed

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -82,7 +82,7 @@
           {% if (case.causatives and variant._id in case.causatives) or (case.partial_causatives and variant._id in case.partial_causatives) %}
           <tr>
             <td>
-              {{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}
+              <span class="text-body">{{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}</span>
             </td>
             <td><a href="{{ url_for('variant.variant',
                 institute_id=institute._id,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

![Screenshot 2022-06-16 at 11 02 04](https://user-images.githubusercontent.com/758570/174034431-4df66bf8-4999-4d8e-9523-5b1928a10d96.png)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
