### PR TITLE
Fix tooltip of multigene variants with None SpliceAI values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Background color of `MIXED` and `PANEL-UMI` sequencing types on cases page
 - Fixed regex error when searching for cases with query ending with `\ `
 - Genesymbols on Causatives page lighter in dark mode
+- Tooltip of multigene variants with None SpliceAI values
 
 ## [4.55]
 ### Changed

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -272,11 +272,13 @@
                     SpliceAI highest delta score {{ entry }} </strong> at position {{ variant.spliceai_positions[loop.index0]}} relative to this variant.
                     <br>All scores and positions(relative to variant):<br>
                     {%  if variant.spliceai_predictions[loop.index0] is not none %}
-                       {{ variant.spliceai_predictions[loop.index0]|join("<br>")}}
+                       {{ variant.spliceai_predictions[loop.index0]|join('<br>')}}
                     {%  endif %}
                   {% endfor %}
               {% else %}
-              'No SpliceAI positions annotated for this variant.' {% endif %}">
+                'No SpliceAI positions annotated for this variant.'
+              {% endif %}
+              ">
             {{ variant.spliceai_scores|join(', ') or "-"}}
           </span>
         </li>


### PR DESCRIPTION
Attempt at fix #3441 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
