### PR TITLE
Fixed visibility of Sanger ordered badge in light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ##[]
 ### Fixed
 - Some of the DataTables tables got a bit dark in dark mode
-- Visibility of Sanger odered badge on case page, light mode
+- Visibility of Sanger ordered badge on case page, light mode
 
 ## [4.56]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ##[]
 ### Fixed
 - Some of the DataTables tables got a bit dark in dark mode
--
+- Visibility of Sanger odered badge on case page, light mode
+
 ## [4.56]
 ### Added
 - Test for PanelApp panels loading

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -22,7 +22,7 @@
                   {% endif %}
                 </a>
                 {% if panel.is_default %}
-                  <span class="badge bg-default float-end">Default</span>
+                  <span class="badge bg-dark float-end">Default</span>
                 {% endif %}
               </td>
               <td>{{ panel.version }} <small class="text">({{ panel.updated_at.date() }})</small></td>

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -330,7 +330,7 @@
   {% if variant.validation in ['True positive','False positive'] %}
     <span class="badge bg-success">Validated</span>
   {% elif variant.sanger_ordered %}
-    <span class="badge bg-default">Verification ordered</span>
+    <span class="badge bg-secondary">Verification ordered</span>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
Fix #3447 

Main branch (white on white):

<img width="614" alt="image" src="https://user-images.githubusercontent.com/28093618/174240383-9d18382c-af5e-4c8d-8caf-24e53ac5459f.png">


This branch:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/28093618/174240285-6a0fad25-4d90-4721-a9b5-01be89028c76.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
