### PR TITLE
Fix align of elems on the beacon submission modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Some of the DataTables tables got a bit dark in dark mode
 - Update list of variant specific events
 - Missing link in saved MatchMaker-related events
+- Alignment of elements on the Beacon submission modal window
 
 ## [4.56]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -155,7 +155,7 @@
             <input type="hidden" name="case" value="{{case._id}}">
 
             <!--Sample selection-->
-            <div class="row d-flex justify-content-center">
+            <div class="d-flex justify-content-center">
               <div class="form-check form-check-inline">
                 <input class="form-check-input" type="radio" id="sampleradio1" name="samples" value="affected" checked>
                 <label class="form-check-label" for="sampleradio1">


### PR DESCRIPTION
Fix #3459

From this:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/28093618/174786913-24712e5a-8e20-4488-8503-3f7f39b6adaf.png">


To this: (tested locally with a connected beacon instance)

<img width="704" alt="image" src="https://user-images.githubusercontent.com/28093618/174786822-2f3f13b9-f2d5-4e9f-9546-da83cd1c447c.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
