### PR TITLE
Fix #3467 - STR variantS locus info open in new tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Some of the DataTables tables got a bit dark in dark mode
 - Update list of variant specific events
 - Missing link in saved MatchMaker-related events
+- Locus info links from STR variantS page open in new browser tabs
 
 ## [4.56]
 ### Added

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -201,6 +201,8 @@
   href="{{ variant.str_source_link }}"
   class="link"
   target="_blank"
+  referrerpolicy="no-referrer"
+  rel="noopener"
   data-bs-toggle="popover"
   data-bs-html="true"
   data-bs-trigger="hover"
@@ -230,7 +232,7 @@
   title="">{{ variant.str_repid }}
   </a>
   {% for gene in variant.genes %}
-    <span class="badge bg-secondary"><a href="{{ gene.stripy_link }}" class="text-white">S</a></span>
-    <span class="badge bg-secondary"><a href="{{ gene.gnomad_str_link }}" class="text-white">G</a></span>
+    <span class="badge bg-secondary"><a href="{{ gene.stripy_link }}" class="text-white" referrerpolicy="no-referrer" rel="noopener" target="_blank">S</a></span>
+    <span class="badge bg-secondary"><a href="{{ gene.gnomad_str_link }}" class="text-white" referrerpolicy="no-referrer" rel="noopener" target="_blank">G</a></span>
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

🆗 Clicking links open new tabs:
![Screenshot 2022-06-22 at 12 07 01](https://user-images.githubusercontent.com/758570/175004372-f7bee3cb-6428-441a-8c3d-485665d69e4d.png)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
