### PR TITLE
Fix error updating/replacing a gene panel from file with a corrupted/malformed gene panel file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Fixed
+- Updating/replacing a gene panel from file with a corrupted or malformed file
 
 ## [4.57]
-## Added
+### Added
 - Display last 50 or 500 events for a user in a timeline
 - Show dismiss count from other cases on matching variantS
 - Save Beacon-related events in events collection

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -105,7 +105,8 @@ def update_existing_panel(store, request, lines):
             "Permission denied: please ask a panel maintainer or admin for help.",
             "danger",
         )
-    return panel_obj.get("_id")
+    if panel_obj:
+        return panel_obj.get("_id")
 
 
 def panel_create_or_update(store, request):

--- a/scout/server/blueprints/panels/controllers.py
+++ b/scout/server/blueprints/panels/controllers.py
@@ -100,13 +100,13 @@ def update_existing_panel(store, request, lines):
             csv_lines=lines,
             option=update_option,
         )
+        if panel_obj:
+            return panel_obj.get("_id")
     else:
         flash(
             "Permission denied: please ask a panel maintainer or admin for help.",
             "danger",
         )
-    if panel_obj:
-        return panel_obj.get("_id")
 
 
 def panel_create_or_update(store, request):


### PR DESCRIPTION
Fix #3472

To reproduce the error:
- Go to gene panels
- Pick a panel
- Using a malformed gene panel file (**missing the first column**, hgnc id, for a gene for instance), click on 
<img width="135" alt="image" src="https://user-images.githubusercontent.com/28093618/175317327-4b084d5e-bc65-4713-8508-98c8663a9961.png">

- Then update it with corrupted panel:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/28093618/175317468-e15e270c-f0da-440a-bca4-0c8471b6bd58.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Switch to this branch and try to upload again the malformed panel. It should display error instead of crashing

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
