### PR TITLE
Fix validated variants export when gene has no transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## []
+### Fixed
+- Export of verified variants when variant gene has no transcripts
+
 ## [4.57.1]
 ### Fixed
 - Updating/replacing a gene panel from file with a corrupted or malformed file

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -104,7 +104,7 @@ def export_verified_variants(aggregate_variants, unique_callers):
             ):  # this will be a unique long field in the document
                 genes.append(gene.get("hgnc_symbol", ""))
                 funct_anno.append(gene.get("functional_annotation"))
-                for transcript in gene.get("transcripts"):
+                for transcript in gene.get("transcripts", []):
                     if transcript.get("is_canonical") and transcript.get("protein_sequence_name"):
                         prot_effect.append(
                             urllib.parse.unquote(transcript.get("protein_sequence_name"))

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -2,7 +2,7 @@
 import logging
 import urllib.parse
 
-from scout.constants import CALLERS, CHROMOSOME_INTEGERS, CHROMOSOMES
+from scout.constants import CHROMOSOME_INTEGERS
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix #3481 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Locally, start a demo server (scout --demo serve)

1. Go to the first variant (POT 1 gene) of the demo rare disease case. Pin it.
 
1. Go to the case page mark this variant validated as a true positive:

<img width="616" alt="image" src="https://user-images.githubusercontent.com/28093618/176695850-378f7c6b-4e1b-4ea3-b3c5-3df42750f5a0.png">

1. In mongodb compass, pick the relative variant document (query: `{_id:"4c7d5c70d955875504db72ef8e1abe77"}`) and remove the `transcripts` key present in `genes`: 
 
<img width="539" alt="image" src="https://user-images.githubusercontent.com/28093618/176696814-9f9d357c-334e-46cd-a6db-cf850b1e7904.png">

1. Go to the dashboard and select all variants (empty search):

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/28093618/176697044-49f7e28c-8ab8-41d2-9f46-5566a1c440b1.png">

1. Move to the third tab (Variants statistics) and click on the "Download all verified variants in your cases" button

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/28093618/176697140-f69a92fc-9d67-4e64-8420-4dd10eb42863.png">

1. It should crash

1. Switch to this branch and repeat: it should NOT crash


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
