### PR TITLE
Fix HTTP 500 for ranked cancer variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- HTTP 500 when visiting a the details page for a cancer variant that had been ranked with genmod
+
 ## [4.57.1]
 ### Fixed
 - Updating/replacing a gene panel from file with a corrupted or malformed file

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -209,6 +209,7 @@ def variant(
             'igv_tracks': IGV_TRACKS,
             'gens_info': <dict>,
             'evaluations': <list(evaluations)>,
+            'rank_score_results': <list(rank_score_results)>,
         }
 
     """

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -346,6 +346,14 @@
       return new bootstrap.Tooltip(tooltipTriggerEl, {container: 'body'})
     })
 
+    var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
+    var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
+      return new bootstrap.Popover(popoverTriggerEl, { sanitizeFn: function (content) {
+          return DOMPurify.sanitize(content)
+        },
+        container: 'body'})
+    })
+
     $('select[multiple]').selectpicker({
         width: '100%'
       });

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -1,12 +1,13 @@
 {% extends "layout.html" %}
 {% from "utils.html" import comments_panel, activity_panel %}
-{% from "variant/utils.html" import rankscore_panel, overlapping_panel, genes_panel, transcripts_panel, proteins_panel, pin_button, causative_button, modal_causative %}
+{% from "variant/utils.html" import overlapping_panel, genes_panel, transcripts_panel, proteins_panel, pin_button, causative_button, modal_causative %}
 {% from "variant/tx_overview.html" import disease_associated, transcripts_overview %}
 {% from "variant/variant_details.html" import frequencies, gtcall_panel, observations_panel, old_observations, mappability_list, severity_list %}
 {% from "variant/buttons.html" import database_buttons, variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button, splice_junctions_button %}
 {% from "variant/components.html" import alignments, compounds_panel, clinsig_table, external_links, external_scripts, external_stylesheets, matching_variants, panel_classify  %}
 {% from "variant/sanger.html" import sanger_button, modal_sanger, modal_cancel_sanger %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes %}
+{% from "variant/rank_score_results.html" import rankscore_panel %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ variant.display_name }}
@@ -104,8 +105,8 @@
 
     <div class="row">
       <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, case, institute) }}</div>
-      {% if variant.rank_score_results %}
-        <div class="col-12">{{ rankscore_panel(variant) }}</div>
+      {% if rank_score_results %}
+        <div class="col-12">{{ rankscore_panel(rank_score_results) }}</div>
       {% endif %}
     </div>
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

When trying to access the variant details page for a ranked cancer variant, a HTTP 500 was returned. From the stack trace it looked like it was isolated to the rendering of the rank score panel.

I was looking into making a test case for this, but gave up when it looked like I would have to set up a parallel test track with fixtures and all in order to get that working. I'd be happy to contribute to this, but before diving into that I'd like to see that my suggested changes make sense to start with.

<details>
<summary>Stack trace</summary>

```
2022-06-30 09:12:34 vs842 scout.server.blueprints.variant.views[14764] DEBUG Variants view requesting data for variant cfc2d0bd61fad4e05fc2d5e2590aecf3
2022-06-30 09:12:34 vs842 scout.adapter.mongo.case[14764] INFO Fetching case somatic_ranking_test institute clingen
2022-06-30 09:12:34 vs842 scout.adapter.mongo.case[14764] INFO Fetching case somatic_ranking_test
2022-06-30 09:12:34 vs842 scout.adapter.mongo.hgnc[14764] DEBUG Fetching gene 6342
2022-06-30 09:12:34 vs842 scout.adapter.mongo.omim[14764] DEBUG Fetching all diseases for gene 6342
2022-06-30 09:12:34 vs842 scout.server.blueprints.variant.controllers[14764] DEBUG Variant category cancer
2022-06-30 09:12:34 vs842 scout.adapter.mongo.hgnc[14764] DEBUG Fetching gene 6342
2022-06-30 09:12:34 vs842 scout.adapter.mongo.omim[14764] DEBUG Fetching all diseases for gene 6342
2022-06-30 09:12:34 vs842 scout.server.utils[14764] WARNING VCF file does not seem to exist
2022-06-30 09:12:34 vs842 scout.adapter.mongo.event[14764] DEBUG Fetching all comments for institute clingen case somatic_ranking_test variant a76a271c34dd00584f03e8c5da097e77
2022-06-30 09:12:34 vs842 scout.adapter.mongo.institute[14764] DEBUG Fetching all institutes
2022-06-30 09:12:34 vs842 scout.server.blueprints.variant.views[14764] DEBUG Fetching loqusdb information for cfc2d0bd61fad4e05fc2d5e2590aecf3
[2022-06-30 09:12:34 +0200] [14764] [ERROR] Error handling request /clingen/somatic_ranking_test/cancer/cfc2d0bd61fad4e05fc2d5e2590aecf3?cancer=yes
Traceback (most recent call last):
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/gunicorn/workers/sync.py", line 136, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/gunicorn/workers/sync.py", line 179, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 2095, in __call__
    return self.wsgi_app(environ, start_response)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/werkzeug/middleware/proxy_fix.py", line 187, in __call__
    return self.app(environ, start_response)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 2080, in wsgi_app
    response = self.handle_exception(e)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 2077, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 1525, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 1523, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/app.py", line 1509, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/scout_prod/scout/scout/server/utils.py", line 90, in decorated_function
    return render_template(template_name, **context)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/templating.py", line 148, in render_template
    return _render(
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/flask/templating.py", line 128, in _render
    rv = template.render(context)
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/scout_prod/scout/scout/server/blueprints/variant/templates/variant/cancer-variant.html", line 280, in top-level template code
    {{ alignments(institute, case, variant, current_user, config, igv_tracks, splice_junctions_tracks) }}
  File "/scout_prod/scout/scout/server/templates/layout.html", line 1, in top-level template code
    {% extends "bootstrap_global.html" %}
  File "/scout_prod/scout/scout/server/templates/bootstrap_global.html", line 62, in top-level template code
    {% block body %}
  File "/scout_prod/scout/scout/server/templates/bootstrap_global.html", line 65, in block 'body'
    {% block content %}
  File "/scout_prod/scout/scout/server/templates/layout.html", line 93, in block 'content'
    {% block content_main %}{% endblock %}
  File "/scout_prod/scout/scout/server/blueprints/variant/templates/variant/cancer-variant.html", line 108, in block 'content_main'
    <div class="col-12">{{ rankscore_panel(variant) }}</div>
  File "/home/genetik/.pyenv/versions/scout/lib/python3.9/site-packages/jinja2/utils.py", line 83, in from_obj
    if hasattr(obj, "jinja_pass_arg"):
jinja2.exceptions.UndefinedError: the template 'variant/utils.html' (imported on line 3 in 'variant/cancer-variant.html') does not export the requested name 'rankscore_panel'
```

</details>

**How to test**:
1. Load a case with `vcf_cancer` set to a VCF file that has been ranked with genmod.
2. Navigate to the list of clinical variants in scout.
3. Click the link for any variant in the list.

**Expected outcome**:
The variant page should be displayed.

**Review:**
- [ ] code approved by
- [ ] tests executed by
