### PR TITLE
Fix parsing of variant.FORMAT DR key in parse variant file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Parsing of variant.FORMAT "DR" key in parse variant file
+
 ## [4.57.3]
 ### Fixed
 - Export of STR verified variants

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -152,7 +152,7 @@ def get_paired_ends(variant, pos):
     if "DR" in variant.FORMAT:
         values = variant.format("DR")[pos]
         ref_value = int(values[0])
-        if alt_value >= 0:
+        if ref_value >= 0:
             paired_end_ref = ref_value
     return (paired_end_ref, paired_end_alt)
 


### PR DESCRIPTION
Fix #3490 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on hasta stage and try loading one MIP case and one Balsamic case (latest Balsamic) using the code from this branch. 
2. Follow the deployment/testing docs present [here](https://github.com/Clinical-Genomics/deployment/blob/master/Scout.md): 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
