### PR TITLE
Fix Sidebar Icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - State that loqusdb observation is in current case if observations count is one and no cases are shown  
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page
 - Refactored and simplified code used for collecting gene variants for `Search SNVs and INDELs` page
+- Fix sidebar panel icons in Case view
 
 ## [4.57.4]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -15,15 +15,6 @@
 {{ super() }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/css/bootstrap-select.min.css" integrity="sha512-g2SduJKxa4Lbn3GW+Q7rNz+pKP9AWMR++Ta8fgwsZRCUsawjPvF/BxSMkGS61VsR9yinGoEgrHPGPn2mrj8+4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="{{ url_for('cases.static', filename='case_styles.css') }}"></link>
-<style>
-  [data-bs-toggle="collapse"] .fa:before {
-    content: "\f139";
-  }
-
-  [data-bs-toggle="collapse"].collapsed .fa:before {
-    content: "\f13a";
-  }
-</style>
 {% endblock %}
 
 {% block top_nav %}


### PR DESCRIPTION
This PR adds a functionality.

Reference issue : https://github.com/Clinical-Genomics/scout/issues/3150

By removing redundant icon indicating expandable menu in sidebar, intended icons are shown and functionality and visual queues remain the same.


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data


![Screenshot 2022-07-20 at 12 04 48](https://user-images.githubusercontent.com/1150065/179956241-3a72f875-719d-4c5a-b5b0-4939a5e9d474.png)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

![Screenshot 2022-07-20 at 11 58 22](https://user-images.githubusercontent.com/1150065/179956289-1f582938-ba74-47f2-9c4d-f7ffdb0b94fc.png)

**Review:**
- [ ] code approved by
- [ ] tests executed by
