### PR TITLE
Compatibility fixes for Flask 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Documentation on how to create/update PanelApp panels
 - Add filter by local observations (archive) to structural variants filters
+### Fixed
+- Added a not-authorized `auto-login` fixture according to changes in Flask-Login 0.6.2
+- Renamed `cache_timeout` param name of flask.send_file function to `max_age` (Flask 2.2 compliant)
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown  
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -280,7 +280,7 @@ def mt_report(institute_id, case_name):
             mimetype="application/zip",
             as_attachment=True,
             download_name="_".join(["scout", case_name, "MT_report", today]) + ".zip",
-            cache_timeout=0,
+            max_age=0,
         )
 
     shutil.rmtree(temp_excel_dir)

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -106,7 +106,7 @@ def test_igv_not_authorized(app, user_obj, case_obj, variant_obj):
     # GIVEN an initialized app
     with app.test_client() as client:
 
-        # GIVEN that the user is logged in but not wuthorized to see the page
+        # GIVEN that the user is logged in but not authorized to see the page
         client.get(url_for("auto_login_not_authorized"))
 
         # WHEN the igv endpoint is invoked with the right parameters

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -103,17 +103,11 @@ def test_remote_cors(app):
 def test_igv_not_authorized(app, user_obj, case_obj, variant_obj):
     """Test view requests and produces igv alignments, when the user dosn't have access to the case"""
 
-    # GIVEN a user that is not an admin nor has access to demo case:
-    store.user_collection.find_one_and_update(
-        {"_id": user_obj["_id"]},
-        {"$set": {"roles": [], "institutes": []}},
-    )
-
     # GIVEN an initialized app
     with app.test_client() as client:
 
-        # GIVEN that the user is logged in
-        client.get(url_for("auto_login"))
+        # GIVEN that the user is logged in but not wuthorized to see the page
+        client.get(url_for("auto_login_not_authorized"))
 
         # WHEN the igv endpoint is invoked with the right parameters
         resp = client.get(

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import requests
 from flask import session, url_for
 
 from scout.server.extensions import store

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -81,6 +81,14 @@ def app(real_database_name, real_variant_database, user_obj, loqusdburl):
         assert login_user(user_inst, remember=True)
         return "ok"
 
+    @app.route("/auto_login_not_authorized")
+    def auto_login_not_authorized():
+        user_obj["roles"] = []
+        user_obj["institutes"] = []
+        user_inst = LoginUser(user_obj)
+        assert login_user(user_inst, remember=True)
+        return "ok"
+
     return app
 
 


### PR DESCRIPTION
Fix #3510 and things broken by Flask updated to version 2.2 (https://flask.palletsprojects.com/en/2.2.x/changes/#version-2-2-0)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
