### PR TITLE
Causatives and validated using the same macro + fixed links to single variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Broken export of causatives table
 - Query for genes in build 38 on `Search SNVs and INDELs` page
 - Prevent typing special characters `^<>?!=\/` in case search form
+- Links to variants in Verified variants page
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown  
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page
@@ -26,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Verified variants displayed in a dedicated page reachable from institute sidebar
 - Unified stats in dashboard page
 - Improved gene info for large SVs and cancer SVs
+- Causatives and Verified variants pages to use the same template macro
 
 ## [4.57.4]
 ### Fixed

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -382,6 +382,7 @@ class VariantHandler(VariantLoader):
                 "display_name": case_obj["display_name"],
                 "individuals": case_obj["individuals"],
                 "status": case_obj["status"],
+                "partial_causatives": case_obj.get("partial_causatives", []),
             }
             res.append(var_obj)
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -378,7 +378,11 @@ class VariantHandler(VariantLoader):
             if var_obj.get("validation") is None or var_obj.get("validation") == "Not validated":
                 continue
 
-            var_obj["case_obj"] = case_obj
+            var_obj["case_obj"] = {
+                "display_name": case_obj["display_name"],
+                "individuals": case_obj["individuals"],
+                "status": case_obj["status"],
+            }
             res.append(var_obj)
 
         return res

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -378,10 +378,7 @@ class VariantHandler(VariantLoader):
             if var_obj.get("validation") is None or var_obj.get("validation") == "Not validated":
                 continue
 
-            var_obj["case_obj"] = {
-                "display_name": case_obj["display_name"],
-                "individuals": case_obj["individuals"],
-            }
+            var_obj["case_obj"] = case_obj
             res.append(var_obj)
 
         return res

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -149,7 +149,12 @@ def causatives(institute_obj, request):
         case_obj = store.case(variant_obj["case_id"])
         if not case_obj:
             continue
-        variant_obj["case_obj"] = case_obj
+        variant_obj["case_obj"] = {
+            "display_name": case_obj["display_name"],
+            "individuals": case_obj["individuals"],
+            "status": case_obj.get("status"),
+            "partial_causatives": case_obj.get("partial_causatives", []),
+        }
 
         causatives.append(variant_obj)
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -149,10 +149,7 @@ def causatives(institute_obj, request):
         case_obj = store.case(variant_obj["case_id"])
         if not case_obj:
             continue
-        variant_obj["case_obj"] = {
-            "display_name": case_obj["display_name"],
-            "individuals": case_obj["individuals"],
-        }
+        variant_obj["case_obj"] = case_obj
 
         causatives.append(variant_obj)
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -127,7 +127,7 @@ def causatives(institute_obj, request):
         request(flask.request) request sent by user's browser
 
     Returns:
-        data(dict)
+        causatives(list of dictionaries)
     """
     # Retrieve variants grouped by case
     query = request.args.get("query", "")
@@ -139,37 +139,24 @@ def causatives(institute_obj, request):
         except ValueError:
             flash("Provided gene info could not be parsed!", "warning")
 
-    variants = list(store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id))
-    if variants:
-        variants = sorted(
-            variants,
-            key=lambda k: k.get("hgnc_symbols", [None])[0] or k.get("str_repid") or "",
-        )
+    causatives = []
 
-    all_variants = {}
-    all_cases = {}
-    for variant_obj in variants:
+    for variant_obj in store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id):
         if variant_obj["category"] in ["snv", "cancer"]:
             update_representative_gene(
                 variant_obj, variant_obj.get("genes", [])
             )  # required to display cDNA and protein change
-        if variant_obj["case_id"] not in all_cases:
-            case_obj = store.case(variant_obj["case_id"])
-            all_cases[variant_obj["case_id"]] = case_obj
-        else:
-            case_obj = all_cases[variant_obj["case_id"]]
+        case_obj = store.case(variant_obj["case_id"])
+        if not case_obj:
+            continue
+        variant_obj["case_obj"] = {
+            "display_name": case_obj["display_name"],
+            "individuals": case_obj["individuals"],
+        }
 
-        if variant_obj["variant_id"] not in all_variants:
-            all_variants[variant_obj["variant_id"]] = []
+        causatives.append(variant_obj)
 
-        all_variants[variant_obj["variant_id"]].append((case_obj, variant_obj))
-
-    data = dict(
-        institute=institute_obj,
-        variant_groups=all_variants,
-        acmg_map={key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()},
-    )
-    return data
+    return causatives
 
 
 def institutes():

--- a/scout/server/blueprints/institutes/templates/overview/causatives.html
+++ b/scout/server/blueprints/institutes/templates/overview/causatives.html
@@ -1,5 +1,6 @@
 {% extends "layout.html" %}
 {% from "overview/institute_sidebar.html" import institute_actionbar %}
+{% from "overview/utils.html" import variant_list_content %}
 {% from "utils.html" import db_table_external_scripts, db_table_external_stylesheets %}
 
 {% block title %}
@@ -28,7 +29,7 @@
 <div class="container-float">
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     <div class="col">
-        {{ causatives() }}
+        {{ variant_list_content(institute, causatives, acmg_map, callers) }}
     </div>
   </div> <!-- end of div id body-row -->
 </div>
@@ -55,122 +56,3 @@
     } );
   </script>
 {% endblock %}
-
-{% macro causatives() %}
-<div class="card mt-3">
-  <div class="card-body">
-      <table id="causatives_table" class="table display table-sm" cellspacing="0">
-        <thead class="thead table-light sticky-offset">
-          <tr>
-            <th>Gene</th>
-            <th>Variant</th>
-            <th>Change</th>
-            <th>HGVS[c]</th>
-            <th>HGVS[p]</th>
-            <th>Category</th>
-            <th data-bs-toggle='tooltip' data-bs-container='body' title="score(model version)">Rank score</th>
-            <th data-bs-toggle='tooltip' data-bs-container='body' title="ref/alt-GQ">Zygosity</th>
-            <th>Inheritance</th>
-            <th>ACMG</th>
-            <th>Case</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for _, group in variant_groups.items() %}
-          {% set group_variant = group[0][1] %}
-          {% for case, variant in group %}
-          {% if (case.causatives and variant._id in case.causatives) or (case.partial_causatives and variant._id in case.partial_causatives) %}
-          <tr>
-            <td>
-              <span class="text-body">{{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}</span>
-            </td>
-            <td><a href="{{ url_for('variant.variant',
-                institute_id=institute._id,
-                case_name=case.display_name,
-                variant_id=variant._id) }}">{{ variant.display_name|truncate(10, True) }}
-              </a>
-            </td>
-            <td>
-              <span class="text-muted">
-                {% if group_variant.category in 'str' %}
-                    {{ group_variant.alternative|truncate(10, True) | replace("<", " ") | replace(">", "")}}
-                {% else %}
-                    {{ group_variant.reference|truncate(10, True) }} → {{ group_variant.alternative|truncate(10, True) }}
-                {% endif%}
-              </span>
-            </td>
-            <td>
-              {% if variant.first_rep_gene and variant.first_rep_gene.hgvs_identifier %}
-                <span class="text-muted">
-                  {{variant.first_rep_gene.hgvs_identifier|truncate(15, True)}}
-                </span>
-              {% else %}
-                -
-              {% endif %}
-            </td>
-            <td>
-              {% if variant.first_rep_gene and variant.first_rep_gene.hgvsp_identifier %}
-                <span class="text-muted">
-                  {{variant.first_rep_gene.hgvsp_identifier|truncate(15, True)}}
-                </span>
-              {% else %}
-                -
-              {% endif %}
-            </td>
-            <td><span class="badge bg-secondary">{{ variant.category|upper }}</span></td>
-            <td><a href="#"><span class="badge rounded-pill bg-secondary">
-
-              {{ variant.rank_score }}
-              {% if variant.category == 'sv' %}
-                (v. {{case.sv_rank_model_version or 'na'}})
-              {% else %}
-                (v. {{case.rank_model_version or 'na'}})
-              {% endif %}
-            </span></a></td>
-            <td>
-              {%- for sample in variant.samples -%}
-                {%- for ind in case.individuals -%}
-                  {%- if sample.sample_id == ind.individual_id -%}
-                    {% set allele_depths = ['ref depth', sample.allele_depths[0]]|join(":") + ' - ' + ['alt depth', sample.allele_depths[1]]|join(":") %}
-                    <span data-bs-toggle='tooltip' data-bs-container='body' title="{{allele_depths}}" class="badge bg-{{'danger' if ind.phenotype == 2 else 'success' }}">{{sample.genotype_call}} GQ:{{sample.genotype_quality}}</span>
-                  {%- endif -%}
-                {%- endfor -%}
-              {%- endfor -%}
-            </td>
-            <td>{% for model in variant.genetic_models %}
-              <span class="badge bg-info">{{model}}</span>
-              {% endfor %}
-            </td>
-            <td>
-              <a href="#" data-bs-toggle="tooltip" title="ACMG classification assigned by Scout users (not Clinvar)"
-                style="text-decoration: none; color: #000;">
-                {% if 'acmg_classification' in variant %}
-                <span class="badge bg-{{acmg_map[variant.acmg_classification].color}}">{{acmg_map[variant.acmg_classification].short}}</span>
-                {% else %}
-                -
-                {% endif %}
-              </a>
-            </td>
-            <td >
-              <a href="{{ url_for('cases.case',
-                                        institute_id=institute._id,
-                                        case_name=case.display_name) }}">
-                {{ case.display_name }}
-              </a>
-              {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
-                <span class="badge bg-warning" data-bs-toggle="tooltip" title="Partial causative variants explain part of the case phenotype">partial</span>
-              {% endif %}
-
-              <span class="badge bg-{{ 'success' if case.status == 'solved' else 'default' }} me-1">
-                {{ case.status }}
-              </span>
-            </td>
-          </tr>
-          {% endif %}
-          {% endfor %}
-          {% endfor %}
-        </tbody>
-      </table>
-  </div>
-</div>
-{% endmacro %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -314,14 +314,19 @@
                                         case_name=case.display_name) }}">
                 {{ case.display_name }}
               </a>
-              <span class="badge bg-{{ 'success' if case.status == 'solved' else 'default' }} me-1">
+              <span class="badge bg-{{ 'success' if case.status == 'solved' else 'default' }}">
                 {{ case.status }}
               </span>
+              {% if (case.partial_causatives and variant._id in case.partial_causatives) %}
+                <span class="badge bg-warning" data-bs-toggle="tooltip" title="Partial causative variants explain part of the case phenotype">partial</span>
+              {% endif %}
             </td>
             <td><!-- Validated status -->
-              <span class="badge bg-{{ 'success' if variant.validation == 'True positive' else 'danger' }} me-1">
-                {{ variant.validation }}
-              </span>
+              {% if variant.validation %}
+                <span class="badge bg-{{ 'success' if variant.validation == 'True positive' else 'danger' }} me-1">
+                  {{ variant.validation }}
+                </span>
+              {% endif %}
             </td>
           </tr>
         {% endfor %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -211,7 +211,7 @@
               {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant"} %}
               {% for key, page in var_type_page.items() %}
                 {% if variant.category == key %}
-                  <a target="_blank" rel=”noopener noreferrer” href="{{ url_for(page,
+                  <a target="_blank" rel="noopener noreferrer" href="{{ url_for(page,
                       institute_id=institute._id,
                       case_name=case.display_name,
                       variant_id=variant._id) }}">{{ variant.display_name|truncate(15, True) }}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -211,7 +211,7 @@
               {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant"} %}
               {% for key, page in var_type_page.items() %}
                 {% if variant.category == key %}
-                  <a href="{{ url_for(page,
+                  <a target="_blank" rel=”noopener noreferrer” href="{{ url_for(page,
                       institute_id=institute._id,
                       case_name=case.display_name,
                       variant_id=variant._id) }}">{{ variant.display_name|truncate(15, True) }}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -207,12 +207,17 @@
             <td><!-- Gene -->
               <span class="text-body">{{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}</span>
             </td>
-            <td><!-- Variant -->
-              <a href="{{ url_for('variant.variant',
-                  institute_id=institute._id,
-                  case_name=case.display_name,
-                  variant_id=variant._id) }}">{{ variant.display_name|truncate(15, True) }}
-              </a>
+            <td><!-- Variant link -->
+              {% set var_type_page = {"snv":"variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "str":"variant.str_variant"} %}
+              {% for key, page in var_type_page.items() %}
+                {% if variant.category == key %}
+                  <a href="{{ url_for(page,
+                      institute_id=institute._id,
+                      case_name=case.display_name,
+                      variant_id=variant._id) }}">{{ variant.display_name|truncate(15, True) }}
+                  </a>
+                {% endif %}
+              {% endfor %}
             </td>
             <td><!-- Change -->
               <span class="text-muted">

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -208,7 +208,7 @@
               <span class="text-body">{{ variant.hgnc_symbols|join(', ') if variant.hgnc_symbols else '--'}}</span>
             </td>
             <td><!-- Variant link -->
-              {% set var_type_page = {"snv":"variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "str":"variant.str_variant"} %}
+              {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant"} %}
               {% for key, page in var_type_page.items() %}
                 {% if variant.category == key %}
                   <a href="{{ url_for(page,

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -95,7 +95,12 @@ def verified(institute_id):
 @templated("overview/causatives.html")
 def causatives(institute_id):
     institute_obj = institute_and_case(store, institute_id)
-    return controllers.causatives(institute_obj, request)
+    return dict(
+        institute=institute_obj,
+        causatives=controllers.causatives(institute_obj, request),
+        acmg_map={key: ACMG_COMPLETE_MAP[value] for key, value in ACMG_MAP.items()},
+        callers=CALLERS,
+    )
 
 
 @blueprint.route("/<institute_id>/filters", methods=["GET"])


### PR DESCRIPTION
- Fix #3528
- Fix links to variants in verified and causatives page to reflect the different types of vars

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
