### PR TITLE
Assign phenotype less cramped on Case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved gene info for large SVs and cancer SVs
 - Remove the unused `variant.str_variant` endpoint from variant views
 - Easier editing of HPO gene panel on case page
+- Assign phenotype panel less cramped on Case page
 
 ## [4.57.4]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -111,12 +111,12 @@
 
 {% macro diagnosis_form(case, institute) %}
   <form action="{{ url_for('cases.case_diagnosis', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
-    <div class="row ms-1 me-1" id="omim_assign">
-      <div class="col-4">
+    <div class="d-flex justify-content-around" id="omim_assign">
+      <div>
         <input name="omim_term" id="assign-omim-term" class="form-control typeahead_omim" data-provide="typeahead" autocomplete="off"
             required placeholder="Search..." oninput="toggleClickableButtons('assign-omim-button', 'assign-omim-term');">
       </div>
-      <div class="col-3">
+      <div>
         <select name="omim_inds" multiple class="selectpicker" data-style="btn-secondary">
           {% for ind in case.individuals %}
             <option value="{{ind.individual_id}}|{{ind.display_name}}" {{"selected" if ind.phenotype==2 }}>
@@ -125,7 +125,7 @@
           {% endfor %}
         </select>
       </div>
-      <div class="col-5">
+      <div>
         <button class="ms-3 btn no-hover btn-secondary form-control" type="submit" id="assign-omim-button">Assign Diagnosis</button>
       </div>
     </div>
@@ -202,11 +202,11 @@
 
     <!-- Add new HPO terms to case/individuals -->
     <form method="POST" action="{{ url_for('cases.phenotypes', institute_id=institute._id, case_name=case.display_name) }}">
-      <div class="row ms-1 me-1">
-        <div class="col-4">
+      <div class="d-flex justify-content-around">
+        <div>
           <input name="hpo_term" id="hpo_term" class="typeahead_hpo form-control" data-provide="typeahead" autocomplete="off" required placeholder="Search..." oninput="toggleClickableButtons('assign-phenotype-button', 'hpo_term');">
         </div>
-        <div class="col-3">
+        <div>
           <select name="phenotype_inds" multiple class="selectpicker" data-style="btn-secondary">
             {% for ind in case.individuals %}
               <option value="{{ind.individual_id}}|{{ind.display_name}}" {{"selected" if ind.phenotype==2 }}>
@@ -215,7 +215,7 @@
             {% endfor %}
           </select>
         </div>
-        <div class="col-5">
+        <div class="mr-3">
           <button class="ms-3 btn no-hover btn-secondary form-control"  id="assign-phenotype-button">Assign Phenotype</button>
         </div>
       </div>


### PR DESCRIPTION
Fix #3529 

From this:

<img width="382" alt="image" src="https://user-images.githubusercontent.com/28093618/185552482-7d5ec7cc-fb7d-4aea-885c-364e5b8d1dbc.png">


To this:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/28093618/185552425-0a073743-4cb5-4696-aebc-ce81f6666c74.png">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
