### PR TITLE
Fix broken filter cases by pinned gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Prevent typing special characters `^<>?!=\/` in case search form
 - Search matching causatives also among research variants in other cases
 - Links to variants in Verified variants page
+- Filter institute cases by variants with a given pinned gene
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown  
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Prevent typing special characters `^<>?!=\/` in case search form
 - Search matching causatives also among research variants in other cases
 - Links to variants in Verified variants page
-- Filter institute cases by variants with a given pinned gene
+- Broken filter institute cases by pinned gene
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown  
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -112,7 +112,6 @@ class CaseHandler(object):
             query_field(str) "pinned" or "causative"
             query_term(str) example:"POT1"
         """
-        LOG.warning(f"IN GENES OF INTEREST--->{query_field}:{query_term}")
         hgnc_id = self.hgnc_id(hgnc_symbol=query_term)
         if hgnc_id is None:
             LOG.debug(f"No gene with the HGNC symbol {query_term} found.")

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -112,21 +112,21 @@ class CaseHandler(object):
             query_field(str) "pinned" or "causative"
             query_term(str) example:"POT1"
         """
+        LOG.warning(f"IN GENES OF INTEREST--->{query_field}:{query_term}")
         hgnc_id = self.hgnc_id(hgnc_symbol=query_term)
         if hgnc_id is None:
             LOG.debug(f"No gene with the HGNC symbol {query_term} found.")
             query["_id"] = {"$in": []}  # No result should be returned by query
+            return
 
         unwind = "$causatives"
         lookup_local = "causatives"
-        lookups_as = "causative_variant"
-        match = "causative_variant.hgnc_ids"
-
         if query_field == "pinned":
             unwind = "$suspects"
             lookup_local = "suspects"
-            lookups_as = "suspect_variant"
-            match = "suspect_variant.hgnc_ids.hgnc_ids"
+
+        lookups_as = "lookedup_variant"
+        match = "lookedup_variant.hgnc_ids"
 
         cases_with_gene_doc = self.case_collection.aggregate(
             [
@@ -304,11 +304,9 @@ class CaseHandler(object):
             collaborator = None
 
         if collaborator:
-            LOG.debug("Use collaborator {0}".format(collaborator))
             query["collaborators"] = collaborator
 
         if owner:
-            LOG.debug("Use owner {0}".format(owner))
             query["owner"] = owner
 
         if skip_assigned:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -124,8 +124,8 @@ class CaseHandler(object):
             unwind = "$suspects"
             lookup_local = "suspects"
 
-        lookups_as = "lookedup_variant"
-        match = "lookedup_variant.hgnc_ids"
+        LOOKUP_VAR = "lookup_variant"
+        match = f"{LOOKUP_VAR}.hgnc_ids"
 
         cases_with_gene_doc = self.case_collection.aggregate(
             [
@@ -135,7 +135,7 @@ class CaseHandler(object):
                         "from": "variant",
                         "localField": lookup_local,
                         "foreignField": "_id",
-                        "as": lookups_as,
+                        "as": LOOKUP_VAR,
                     }
                 },
                 {"$match": {match: hgnc_id}},

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -124,9 +124,6 @@ class CaseHandler(object):
             unwind = "$suspects"
             lookup_local = "suspects"
 
-        LOOKUP_VAR = "lookup_variant"
-        match = f"{LOOKUP_VAR}.hgnc_ids"
-
         cases_with_gene_doc = self.case_collection.aggregate(
             [
                 {"$unwind": unwind},
@@ -135,10 +132,10 @@ class CaseHandler(object):
                         "from": "variant",
                         "localField": lookup_local,
                         "foreignField": "_id",
-                        "as": LOOKUP_VAR,
+                        "as": "lookup_variant",
                     }
                 },
-                {"$match": {match: hgnc_id}},
+                {"$match": {"lookup_variant.hgnc_ids": hgnc_id}},
                 {"$project": {"_id": 1}},
             ]
         )

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -29,7 +29,7 @@
       </div>
       <div class="col-4">
           <label class="control-label" for="search_term">Search cases</label>
-          <input class="form-control" id="search_term" name="search_term" placeholder="example:18201" type="text" pattern="[^<>?!=\\/]*" title="Characters ^<>?!=\/ are not allowed">
+          <input class="form-control" id="search_term" name="search_term" value="{{form.search_term.data}}" placeholder="example:18201" type="text" pattern="[^<>?!=\\/]*" title="Characters ^<>?!=\/ are not allowed">
       </div>
       <div class="col-2">
         {{ form.search(class="btn btn-primary form-control") }}


### PR DESCRIPTION
Fix #3538.

Locally or on stage, compare the behavior when you try to filter cases by pinned genes.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Pin a variant and go to the institute cases. Filter by pinned gene using the gene symbol of the pinned variant
2. On main branch the search shouldn't return any case
3. On this branch the search should return one or more cases

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
