### PR TITLE
Fix #3548 - allow hyphens as well in panel id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Links to variants in Verified variants page
 - Broken filter institute cases by pinned gene
 ### Changed
-- State that loqusdb observation is in current case if observations count is one and no cases are shown  
+- State that loqusdb observation is in current case if observations count is one and no cases are shown
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page
 - Refactored and simplified code used for collecting gene variants for `Search SNVs and INDELs` page
 - Fix sidebar panel icons in Case view
@@ -37,6 +37,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Easier editing of HPO gene panel on case page
 - Assign phenotype panel less cramped on Case page
 - Causatives and Verified variants pages to use the same template macro
+- Allow hyphens in panel names
 
 ## [4.57.4]
 ### Fixed

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -47,7 +47,7 @@
         <div class="row">
           <div class="col-5">
             <input type="text" name="search_for" class="form-control typeahead_gene mb-1" data-provide="typeahead" autocomplete="off" placeholder="Search Gene in Panels" required
-                   pattern="^[0-9]+\s*\|\s*.*" title="Search for gene symold, and allow the autocomplete to work for you. Allowed patterns have a numerical hgnc id and a pipe character.">
+                   pattern="^[0-9]+\s*\|\s*.*" title="Search for gene symbol. Type name or number and the field autocompletes a full description. Allowed patterns have a numerical hgnc id and a pipe character.">
           </div>
           <div class="col">
             <button type="submit" name="action" value="ADDGENE" class="btn btn-secondary">Search!</button>
@@ -116,7 +116,7 @@
           </div>
           <div class="col-sm-3 text-center">
               <input type="text" name="new_panel_name" class="form-control" placeholder="Panel ID" required
-                pattern="^[a-zA-Z0-9_-]*$" title="Only alphanumeric characters (A-Z+a-z+0-9) and underscores allowed.">
+                pattern="^[a-zA-Z0-9_-]*$" title="Only alphanumeric characters (A-Z+a-z+0-9), hyphens, and underscores allowed.">
             </div>
             <div class="col-sm-4 text-center">
               <input type="text" name="display_name" class="form-control" placeholder="Full name">

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -4,6 +4,13 @@
   {{ super() }} - {{ current_user.name }} - Gene Panels
 {% endblock %}
 
+
+{% block css %}
+  {{ super() }}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/css/bootstrap-select.min.css" integrity="sha512-g2SduJKxa4Lbn3GW+Q7rNz+pKP9AWMR++Ta8fgwsZRCUsawjPvF/BxSMkGS61VsR9yinGoEgrHPGPn2mrj8+4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+{% endblock %}
+
+
 {% block top_nav %}
   {{ super() }}
   <li class="nav-item">
@@ -30,7 +37,7 @@
 
 
 
- 
+
 <!-- Create a Bootstrap card containing text bar and submit button for searching -->
 {% macro search_gene_card() %}
 <div class="container-float">
@@ -40,7 +47,7 @@
         <div class="row">
           <div class="col-5">
             <input type="text" name="search_for" class="form-control typeahead_gene mb-1" data-provide="typeahead" autocomplete="off" placeholder="Search Gene in Panels" required
-                   pattern="^[0-9]+\s*\|\s*.*" title="Only alphanumeric characters (A-Z+a-z+0-9) and underscores allowed.">
+                   pattern="^[0-9]+\s*\|\s*.*" title="Search for gene symold, and allow the autocomplete to work for you. Allowed patterns have a numerical hgnc id and a pipe character.">
           </div>
           <div class="col">
             <button type="submit" name="action" value="ADDGENE" class="btn btn-secondary">Search!</button>
@@ -77,7 +84,7 @@
           </table>
           {% elif search_string  %}
           <strong> <em>{{search_string}} </em> not found. </strong>
-          
+
           {% else  %}
           <!-- Do nothing -->
           {% endif %}
@@ -109,7 +116,7 @@
           </div>
           <div class="col-sm-3 text-center">
               <input type="text" name="new_panel_name" class="form-control" placeholder="Panel ID" required
-                pattern="^[a-zA-Z0-9_]*$" title="Only alphanumeric characters (A-Z+a-z+0-9) and underscores allowed.">
+                pattern="^[a-zA-Z0-9_-]*$" title="Only alphanumeric characters (A-Z+a-z+0-9) and underscores allowed.">
             </div>
             <div class="col-sm-4 text-center">
               <input type="text" name="display_name" class="form-control" placeholder="Full name">
@@ -260,7 +267,7 @@
 
 {% block scripts %}
 {{ super() }}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha384-EEbPKCLAcxVCiXCi8k9bdeuayzAxVSmBzP/wLpmpd0LVW+Lvh2mjS1W02kdYm5z1" referrerpolicy="no-referrer" crossorigin="anonymous"></script>  
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha384-EEbPKCLAcxVCiXCi8k9bdeuayzAxVSmBzP/wLpmpd0LVW+Lvh2mjS1W02kdYm5z1" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/js/bootstrap-select.min.js" integrity="sha512-yrOmjPdp8qH8hgLfWpSFhC/+R9Cj9USL8uJxYIveJZGAiedxyIxwNw4RsLDlcjNlIRR4kkHaDHSmNHAkxFTmgg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 <script type="text/javascript">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Test in particular that there are no downstream ill effects of hyphens like dots - compare #2400.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
