### PR TITLE
JAX CKB link in cancer variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Search for a specific gene in all gene panels
 - Institute settings option to force show all variants on VariantS page for all cases of an institute
 - Filter cases by validation pending status
+- Link to The Clinical Knowledgebase (CKB) (https://ckb.jax.org/) in cancer variant's page
 ### Fixed
 - Added a not-authorized `auto-login` fixture according to changes in Flask-Login 0.6.2
 - Renamed `cache_timeout` param name of flask.send_file function to `max_age` (Flask 2.2 compliant)

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -255,6 +255,7 @@
             <a href="{{ gene.cbioportal_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">cBioPortal</a>
             <a href="{{ gene.oncokb_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">OncoKB</a>
             <a href="{{ gene.civic_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">CIViC</a>
+            <a href="{{ gene.ckb_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">CKB</a>
           {% endif %}
           {% if str %}
             <a href="{{ gene.stripy_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">STRipy</a>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -67,7 +67,6 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["oncokb_link"] = oncokb(hgnc_symbol)
     gene_obj["cbioportal_link"] = cbioportal_gene(hgnc_symbol)
     gene_obj["civic_link"] = civic_gene(hgnc_symbol)
-
     gene_obj["iarctp53_link"] = iarctp53(hgnc_symbol)
     gene_obj["stripy_link"] = stripy_gene(hgnc_symbol)
     gene_obj["gnomad_str_link"] = gnomad_str_gene(hgnc_symbol)

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -1,9 +1,12 @@
+import logging
+
 from flask import current_app
 
 from scout.constants import SPIDEX_HUMAN
 from scout.utils.convert import amino_acid_residue_change_3_to_1
 
 SHALLOW_REFERENCE_STR_LOCI = ["ARX", "HOXA13"]
+LOG = logging.getLogger(__name__)
 
 
 def add_gene_links(gene_obj, build=37):
@@ -22,7 +25,6 @@ def add_gene_links(gene_obj, build=37):
         build = 37
     # Add links that use the hgnc_id
     hgnc_id = gene_obj["hgnc_id"]
-
     gene_obj["hgnc_link"] = genenames(hgnc_id)
     gene_obj["omim_link"] = omim(hgnc_id)
     # Add links that use ensembl_id
@@ -50,7 +52,9 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["exac_link"] = exac(ensembl_id)
     gene_obj["gnomad_link"] = gnomad(ensembl_id, build)
     # Add links that use entrez_id
-    gene_obj["entrez_link"] = entrez(gene_obj.get("entrez_id"))
+    entrez_id = gene_obj.get("common", {}).get("entrez_id")
+    gene_obj["entrez_link"] = entrez(entrez_id)
+    gene_obj["ckb_link"] = ckb_gene(entrez_id)
     # Add links that use omim id
     gene_obj["omim_link"] = omim(gene_obj.get("omim_id"))
     # Add links that use hgnc_symbol
@@ -63,7 +67,7 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["oncokb_link"] = oncokb(hgnc_symbol)
     gene_obj["cbioportal_link"] = cbioportal_gene(hgnc_symbol)
     gene_obj["civic_link"] = civic_gene(hgnc_symbol)
-    gene_obj["ckb_link"] = ckb_gene(hgnc_id)
+
     gene_obj["iarctp53_link"] = iarctp53(hgnc_symbol)
     gene_obj["stripy_link"] = stripy_gene(hgnc_symbol)
     gene_obj["gnomad_str_link"] = gnomad_str_gene(hgnc_symbol)
@@ -101,11 +105,11 @@ def gnomad_str_gene(hgnc_symbol):
     return link.format(hgnc_symbol)
 
 
-def ckb_gene(hgnc_id):
+def ckb_gene(entrez_id):
     link = "https://ckb.jax.org/gene/show?geneId={}"
-    if not hgnc_id:
+    if not entrez_id:
         return None
-    return link.format(hgnc_id)
+    return link.format(entrez_id)
 
 
 def civic_gene(hgnc_symbol):

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -63,6 +63,7 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["oncokb_link"] = oncokb(hgnc_symbol)
     gene_obj["cbioportal_link"] = cbioportal_gene(hgnc_symbol)
     gene_obj["civic_link"] = civic_gene(hgnc_symbol)
+    gene_obj["ckb_link"] = ckb_gene(hgnc_id)
     gene_obj["iarctp53_link"] = iarctp53(hgnc_symbol)
     gene_obj["stripy_link"] = stripy_gene(hgnc_symbol)
     gene_obj["gnomad_str_link"] = gnomad_str_gene(hgnc_symbol)
@@ -98,6 +99,13 @@ def gnomad_str_gene(hgnc_symbol):
         return "https://gnomad.broadinstitute.org/short-tandem-repeats?dataset=gnomad_r3"
 
     return link.format(hgnc_symbol)
+
+
+def ckb_gene(hgnc_id):
+    link = "https://ckb.jax.org/gene/show?geneId={}"
+    if not hgnc_id:
+        return None
+    return link.format(hgnc_id)
 
 
 def civic_gene(hgnc_symbol):

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -1,12 +1,9 @@
-import logging
-
 from flask import current_app
 
 from scout.constants import SPIDEX_HUMAN
 from scout.utils.convert import amino_acid_residue_change_3_to_1
 
 SHALLOW_REFERENCE_STR_LOCI = ["ARX", "HOXA13"]
-LOG = logging.getLogger(__name__)
 
 
 def add_gene_links(gene_obj, build=37):

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -2,7 +2,14 @@
 
 from flask import url_for
 
-from scout.server.links import add_gene_links, alamut_link, cbioportal, mycancergenome, snp_links
+from scout.server.links import (
+    add_gene_links,
+    alamut_link,
+    cbioportal,
+    ckb_gene,
+    mycancergenome,
+    snp_links,
+)
 
 
 def test_alamut_link(app, institute_obj, variant_obj):
@@ -80,6 +87,13 @@ def test_mycancergenome_link():
     protein_change = "p.Ser241Phe"
 
     link = mycancergenome(hgnc_symbol, protein_change)
+    assert link is not None
+
+
+def test_ckb_link():
+    """Test building the link for The Clinical KnowledgeBase (Jackson Lab)"""
+    entrez_id = 7015
+    link = ckb_gene(entrez_id)
     assert link is not None
 
 


### PR DESCRIPTION
Fix #3540 .

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Test it locally with demo cancer case and TP53 variant or on cg-vm1

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
