### PR TITLE
Matching SV links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Search matching causatives also among research variants in other cases
 - Links to variants in Verified variants page
 - Broken filter institute cases by pinned gene
+- Better linking and display of matching causatives and managed variants
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -312,6 +312,7 @@ def set_sample(variant_obj, sample_list, sample_info):
             }
     variant_obj["samples"] = gt_types
 
+
 def add_compounds(variant_obj, compound_list):
     """Add compound list to variant_obj
     Args: variant_obj (Dict)

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -572,10 +572,7 @@
     <ul class="list-group collapse" id="matchingCausatives">
       {% for variant in other_causatives %}
         <li class="list-group-item">
-          <a href="{{ url_for('variant.variant', institute_id=institute._id,
-                              case_name=case.display_name, variant_id=variant._id) }}">
-            {{ variant.hgnc_symbols|join(', ') or variant.hgnc_ids|join(', ') or variant.str_repid }}
-          </a>
+          {{ pretty_link_variant(variant, case)}}
         </li>
       {% else %}
         <li class="list-group-item">No matching causative variants.</li>
@@ -593,10 +590,7 @@
     <ul class="list-group">
       {% for variant in managed_variants %}
         <li class="list-group-item collapse" id="matchingManaged">
-          <a href="{{ url_for('variant.variant', institute_id=institute._id,
-                              case_name=case.display_name, variant_id=variant._id) }}">
-            {{ variant.hgnc_symbols|join(', ') }}
-          </a>
+           {{ pretty_link_variant(variant, case)}}
         </li>
       {% else %}
         <li class="list-group-item">No managed variants.</li>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Hiding variant details a bit longer may or not be good, but linking to the wrong kind of page is just confusing - and e.g. a random STR match may not display well as it was. Reusing macros is nice.

![Screenshot 2022-08-30 at 14 13 46](https://user-images.githubusercontent.com/758570/187434501-5f6e5f07-2776-4fd0-9926-70d50ce0ffa9.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
