### PR TITLE
Fix case search with string containing escapable chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Case search with search strings that contain characters that can be escaped
 
 ## [4.58]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -2,7 +2,6 @@
 import datetime
 import logging
 import operator
-import re
 from copy import deepcopy
 
 import pymongo
@@ -153,7 +152,7 @@ class CaseHandler(object):
         """
         order = None
         query_field = name_query.split(":")[0]  # example:status
-        query_term = re.escape(name_query[name_query.index(":") + 1 :].strip())
+        query_term = name_query[name_query.index(":") + 1 :].strip()
 
         if query_field == "case" and query_term != "":
             query["$or"] = [
@@ -230,9 +229,7 @@ class CaseHandler(object):
         if query_field == "user":
             query_terms = query_term.split(" ")
             user_query = {
-                "$and": [
-                    {"name": {"$regex": re.escape(term), "$options": "i"}} for term in query_terms
-                ]
+                "$and": [{"name": {"$regex": term, "$options": "i"}} for term in query_terms]
             }
             users = self.user_collection.find(user_query)
             query["assignees"] = {"$in": [user["email"] for user in users]}

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -1,5 +1,4 @@
 import logging
-import re
 
 from flask import flash, redirect, request, url_for
 from flask_login import current_user
@@ -77,9 +76,7 @@ def populate_dashboard_data(request):
     if institute_id == "All":
         institute_id = None
 
-    search_term = (
-        re.escape(request.form["search_term"].strip()) if request.form.get("search_term") else ""
-    )
+    search_term = request.form["search_term"].strip() if request.form.get("search_term") else ""
     slice_query = compose_slice_query(request.form.get("search_type"), search_term)
     get_dashboard_info(store, data, institute_id, slice_query)
     return data


### PR DESCRIPTION
Fix #3559 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on cg-vm1 and search for a case or individual containing "-" in their display name

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
