### PR TITLE
Expandible region anno for variants with many genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [4.58.1]
+### Changed
+- Better visualization of regional annotation for long lists of genes in large SVs in Variants tables
 ### Fixed
 - Case search with search strings that contain characters that can be escaped
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import cancer_sv_filters,cell_rank, pagination_footer, pagination_hidden_div, filter_form_footer, filter_script_main, update_stash_filter_button_status, dismiss_variants_block %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, variant_gene_symbols_cell, variant_funct_anno_cell, variant_region_anno_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -112,11 +112,7 @@
     <td>{{ 'inf' if variant.end == 100000000000 else variant.end }}</td>
     <td>{{ '-' if variant.length == 100000000000 else variant.length }}</td>
     <td>
-      {% if 'region_annotations' in variant %}
-        {% for annotation in variant.region_annotations[:3] %}
-          <div>{{ annotation }}</div>
-        {% endfor %}
-      {% endif %}
+      {{ variant_region_anno_cell(variant) }}
     </td>
     <td>
       {{ variant_funct_anno_cell(variant) }}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -40,6 +40,25 @@
   </div>
 {% endmacro %}
 
+{% macro variant_region_anno_cell(variant) %}
+  <div class="d-flex justify-content-between align-items-center">
+    <div>
+      {% if variant.functional_annotations|length >= 5 %}
+        <a class="mr-3" data-bs-toggle="collapse" href="#_regionanno_{{variant._id}}" role="button" aria-expanded="false" aria-controls="_{{variant._id}}">{% if variant.missing_data %}[first 30 genes]{% else %}[...]{% endif %}</a>
+        <div class="collapse" id="_regionanno_{{variant._id}}">
+          {% for annotation in variant.region_annotations|sort %}
+            {{ annotation }}<br>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div>
+          {{ variant.region_annotations|sort|join(", ") }}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+{% endmacro %}
+
 {% macro gene_cell(variant) %}
   <div class="align-items-center">
     {% if variant.category == "cancer" or variant.category == "sv_cancer" %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import sv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell, variant_region_anno_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -111,11 +111,7 @@ onsubmit="return validateForm()">
     <td>{{ 'inf' if variant.end == 100000000000 else variant.end }}</td>
     <td class="text-end">{{ '-' if variant.length == 100000000000 else variant.length }}</td>
     <td>
-      {% if 'region_annotations' in variant %}
-        {% for annotation in variant.region_annotations[:3] %}
-          <div>{{ annotation }}</div>
-        {% endfor %}
-      {% endif %}
+      {{ variant_region_anno_cell(variant) }}
     </td>
     <td>
       {{ variant_funct_anno_cell(variant) }}


### PR DESCRIPTION
Fix #3554 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Check SVs and cancer SVs pages and make sure that when the variant has more than 3 genes, the region anno are shown for all of them (they'r max 30 anyway)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
