### PR TITLE
Fix #3568 - HPO SVs: fix one button, add another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Button to go directly to HPO SV filter variantS page from case
+### Fixed
+- HPO filter button on SV variantS page
+
+
 ## [4.58.1]
 ### Changed
 - Better visualization of regional annotation for long lists of genes in large SVs in Variants tables

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -146,33 +146,35 @@
           </form>
         </div>
         <div class="col align-content-center">
+          <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}
             <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.cancer_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               Clinical HPO SNV variants
+               Clinical HPO SNVs
              </a>
             <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               Clinical HPO SV variants
+               SVs
              </a>
           {% else %}
             <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               Clinical HPO SNV variants
+               Clinical HPO SNVs
              </a>
             <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.sv_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               Clinical HPO SV variants
+               SVs
              </a>
            {% endif %}
+          </div>
         </div>
       </div> <!-- End of Show variants in dynamic gene list -->
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -153,12 +153,24 @@
                                gene_panels=['hpo']) }}">
                Clinical HPO SNV variants
              </a>
+            <a class="btn btn-secondary btn-sm text-white"
+              href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
+                               case_name=case.display_name, variant_type='clinical',
+                               gene_panels=['hpo']) }}">
+               Clinical HPO SV variants
+             </a>
           {% else %}
             <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               Show clinical HPO SNV variants
+               Clinical HPO SNV variants
+             </a>
+            <a class="btn btn-secondary btn-sm text-white"
+              href="{{ url_for('variants.sv_variants', institute_id=institute._id,
+                               case_name=case.display_name, variant_type='clinical',
+                               gene_panels=['hpo']) }}">
+               Clinical HPO SV variants
              </a>
            {% endif %}
         </div>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -121,22 +121,22 @@
       </div>
 
     {% if case.dynamic_gene_list %}
-      <div class="row d-flex justify-content-between mt-3">
-        <div class="col align-content-center"><!-- Edit synamic gene list-->
+      <div class="row mt-3">
+        <div class="col"><!-- Edit dynamic gene list-->
           <div class="form-check form-switch">
             <input type="checkbox" class="form-check-input" id="checkAllGenes" onChange="dynamicGenesCheck(this)" name="checkAllGenes">
             <label for="checkAllGenes" class="form-check-label">Select all genes</label>
           </div>
         </div>
-        <div class="col align-content-center">
+        <div class="col d-flex justify-content-end">
           <button type="submit" form="dynamicGenes" class="btn btn-danger btn-sm text-white">
              Remove selected genes
            </button>
         </div>
       </div>
 
-      <div class="row d-flex justify-content-between mt-2"> <!-- Show variants in dynamic gene list -->
-        <div class="col align-content-center">
+      <div class="row mt-2"> <!-- Show variants in dynamic gene list -->
+        <div class="col">
           <form action="{{ url_for('cases.update_clinical_filter_hpo', institute_id=institute._id, case_name=case.display_name)+'#hpo_clinical_filter' }}" method="POST">
             <div class="form-check form-switch">
               <input type="checkbox" class="form-check-input" id="hpo_clinical_filter" onChange="this.form.submit()" name="hpo_clinical_filter"{% if case.hpo_clinical_filter %}checked{% endif %}>
@@ -145,7 +145,7 @@
             </div>
           </form>
         </div>
-        <div class="col align-content-center">
+        <div class="col d-flex justify-content-end">
           <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}
             <a class="btn btn-secondary btn-sm text-white"

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -158,7 +158,7 @@
               href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               SVs
+               Clinical HPO SVs
              </a>
           {% else %}
             <a class="btn btn-secondary btn-sm text-white"
@@ -171,7 +171,7 @@
               href="{{ url_for('variants.sv_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
-               SVs
+               Clinical HPO SVs
              </a>
            {% endif %}
           </div>

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1436,7 +1436,7 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
         form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request_obj.args.get("chrom", "")
-        if variant_type == "clinical":
+        if form.gene_panels.data == [] and variant_type == "clinical":
             form.gene_panels.data = case_default_panels(case_obj)
 
     else:  # POST

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -188,7 +188,7 @@
 
 {% macro snv_filters(form, institute, case, filters)%}
 <input type="hidden" name="variant_type" value="{{ form.variant_type.data }}">
-  <div class="row mb-2>
+  <div class="row mb-2">
     <div class="col-2">
       {{ form.gene_panels.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="This list can be modified from the institute settings page. Latest panel version is used in variants filtering.") }}
       {{ form.gene_panels(class="selectpicker", data_style="btn-secondary") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -188,7 +188,7 @@
 
 {% macro snv_filters(form, institute, case, filters)%}
 <input type="hidden" name="variant_type" value="{{ form.variant_type.data }}">
-  <div class="row">
+  <div class="row mb-2>
     <div class="col-2">
       {{ form.gene_panels.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="This list can be modified from the institute settings page. Latest panel version is used in variants filtering.") }}
       {{ form.gene_panels(class="selectpicker", data_style="btn-secondary") }}
@@ -210,15 +210,17 @@
       {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
     </div>
   </div>
-  <div class="row mt-2">
+  <div class="row mb-2">
     <div class="col-3">
       {{ form.hgnc_symbols.label(class="control-label") }}
       {{ form.hgnc_symbols(class="form-control") }}
     </div>
-    <div class="col-1 d-flex align-items-end">
-        <a class="btn btn-secondary" href="{{ url_for('variants.variants', institute_id=institute._id,
+    <div class="col-1 align-self-end">
+      <div class="d-flex btn-group">
+        <a class="btn btn-secondary text-white" href="{{ url_for('variants.variants', institute_id=institute._id,
           case_name=case.display_name, variant_type=form.variant_type.data,
           gene_panels=['hpo']) }}">HPO gene list</a>
+      </div>
     </div>
     <div class="col-1">
       {{ form.cadd_score.label(class="control-label") }}
@@ -246,7 +248,7 @@
       {{ form.clinvar_tag.label(class="ms-2") }}
     </div>
   </div>
-  <div class="row mt-2">
+  <div class="row mb-2">
     <div class="col-4">
       <div class ="row">
         <div class="col-4">
@@ -276,7 +278,7 @@
       {{ wtf.form_field(form.cytoband_end) }}
     </div>
   </div>
-  <div class="row mt-2">
+  <div class="row">
     <div class="col-2">
       <a class="btn btn-secondary btn-sm form-control" data-bs-toggle="collapse" href="#stringcoords" aria-expanded="false" aria-controls="stringcoords">
         String coordinates
@@ -339,7 +341,7 @@
   </div>
   <div class="col-1 align-self-end">
     <div class="btn-group d-flex">
-      <a class="btn btn-secondary btn-sm " href="{{ url_for('variants.str_variants', institute_id=institute._id,
+      <a class="btn btn-secondary text-white" href="{{ url_for('variants.str_variants', institute_id=institute._id,
         case_name=case.display_name, variant_type=form.variant_type.data,
         gene_panels=['hpo']) }}">HPO gene list</a>
     </div>
@@ -414,10 +416,12 @@
     {{ form.hgnc_symbols.label(class="control-label") }}
     {{ form.hgnc_symbols(class="form-control") }}
   </div>
-  <div class="col-1 mt-3">
-      <a class="btn btn-secondary btn-sm" href="{{ url_for('variants.sv_variants', institute_id=institute._id,
+  <div class="col-1 align-self-end">
+    <div class="d-flex btn-group">
+      <a class="btn btn-secondary text-white" href="{{ url_for('variants.sv_variants', institute_id=institute._id,
         case_name=case.display_name, variant_type=form.variant_type.data,
         gene_panels=['hpo']) }}">HPO gene list</a>
+    </div>
   </div>
   <div class="col-2">
     {{ form.size.label(class="control-label") }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Add a phenotype, and generate a HPO panel for a case
1. On main, go to SV Variants, and click the HPO gene list button in the SV Filters card
1. Note that nothing happens after the reload: the selected gene panel stays the same (the clinical default panel for the case)
1. Contrast this to e.g. selecting HPO from the Gene panels dropdown, which works. 
1. Do the same on the fix branch, and note that the HPO panel is now selected, and the HPO filter variantS are shown.
From:
![Screenshot 2022-09-06 at 17 24 25](https://user-images.githubusercontent.com/758570/188674456-059206ab-03bf-48a6-bc09-8d1b51565ee4.png) 
To:
![Screenshot 2022-09-06 at 17 24 44](https://user-images.githubusercontent.com/758570/188674478-1d92cb87-1bec-4a8f-8ef9-7766722abbdc.png)
 ✅ Ok!
1. Also test the new Clinical HPO SV button on the case page, which should give the same as above.
![Screenshot 2022-09-06 at 17 27 15](https://user-images.githubusercontent.com/758570/188674969-79adbd51-e244-4acb-9b48-d9f69f868b7f.png)
✅ Ok!

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
