### PR TITLE
Fix #3579 - chanjo report labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Button to go directly to HPO SV filter variantS page from case
+- `Scout-REViewer-Service` integration - show `REViewer` picture if available
+### Changed
+- Better visualization of regional annotation for long lists of genes in large SVs in Variants tables
 ### Fixed
 - HPO filter button on SV variantS page
+- Labels on
 
 
 ## [4.58.1]
-### Changed
-- Better visualization of regional annotation for long lists of genes in large SVs in Variants tables
 ### Fixed
 - Case search with search strings that contain characters that can be escaped
 
@@ -26,7 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Institute settings option to force show all variants on VariantS page for all cases of an institute
 - Filter cases by validation pending status
 - Link to The Clinical Knowledgebase (CKB) (https://ckb.jax.org/) in cancer variant's page
-- `Scout-REViewer-Service` integration - show `REViewer` picture if available
+
 ### Fixed
 - Added a not-authorized `auto-login` fixture according to changes in Flask-Login 0.6.2
 - Renamed `cache_timeout` param name of flask.send_file function to `max_age` (Flask 2.2 compliant)

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -80,7 +80,6 @@
       {% if config.SQLALCHEMY_DATABASE_URI and case %}
         <li class="list-group-item">
           <label for="coverage_report">Coverage report</label>
-          Coverage report
           <a class="float-end" id="coverage_report" href="#" onclick="document.getElementById('report-form').submit();">
             {{ case.display_name }}
           </a>
@@ -89,7 +88,7 @@
           </form>
         </li>
         <li class="list-group-item">
-          Coverage overview
+          <label for="report-genes-form">Coverage overview</label>
           <span class="float-end">
             <a class="float-end" href="#" onclick="document.getElementById('report-genes-form').submit();">
               {{ case.display_name }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

From 
![Screenshot 2022-09-09 at 09 30 38](https://user-images.githubusercontent.com/758570/189298797-fe626e3b-1f0b-47fb-a492-25f5b678dbe0.png)

To
![Screenshot 2022-09-09 at 09 39 32](https://user-images.githubusercontent.com/758570/189298820-36b7598f-d089-42c7-b19b-258e052360f1.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
