### PR TITLE
Set response headers instead of appending them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO filter button on SV variantS page
 - Spacing between region|function cells in SVs lists
 - Labels on gene panel Chanjo report
+- Fixed ambigious duplicated response headers when requesting a BAM file from /static
 
 ## [4.58.1]
 ### Fixed

--- a/scout/server/blueprints/alignviewers/partial.py
+++ b/scout/server/blueprints/alignviewers/partial.py
@@ -58,8 +58,8 @@ def send_file_partial(path):
 
     resp = Response(data, 206, mimetype=mimetypes.guess_type(path)[0], direct_passthrough=True)
 
-    resp.headers.add("Content-type", "application/octet-stream")
-    resp.headers.add("Accept-Ranges", "bytes")
-    resp.headers.add("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
-    resp.headers.add("Content-Length", str(response_length))
+    resp.headers.set("Content-type", "application/octet-stream")
+    resp.headers.set("Accept-Ranges", "bytes")
+    resp.headers.set("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
+    resp.headers.set("Content-Length", str(response_length))
     return resp


### PR DESCRIPTION
This PR fixes a bug where Scout responded with duplicated response header when returning a BAM file causing a 502 error.

Response headers without the fix
```
Content-Type: text/html; charset=utf-8
Content-Length: 26
Content-type: application/octet-stream
Accept-Ranges: bytes
Content-Range: bytes 3285-3310/45531713695
Content-Length: 26
```

Response headers with fix
```
Content-type: application/octet-stream
Content-Length: 26
Accept-Ranges: bytes
Content-Range: bytes 3285-3310/45531713695
```

**How to test**:
1. Print headers before and after alteration, (`print(resp.headers)`)
2. Ensure that IGV can display the alignment track

**Expected outcome**:
1. The Content-Type and Content-Length header should be overwritten and not appended
3. IGV can display alignment tracks again

**Review:**
- [ ] code approved by
- [ ] tests executed by
