### PR TITLE
Fix visited gene coverage button link style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO filter button on SV variantS page
 - Spacing between region|function cells in SVs lists
 - Labels on gene panel Chanjo report
+- Fixed ambigious duplicated response headers when requesting a BAM file from /static
 
 ## [4.58.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Spacing between region|function cells in SVs lists
 - Labels on gene panel Chanjo report
 - Fixed ambigious duplicated response headers when requesting a BAM file from /static
+- Visited color link on gene coverage button (Variant page)
 
 ## [4.58.1]
 ### Fixed

--- a/scout/server/blueprints/alignviewers/partial.py
+++ b/scout/server/blueprints/alignviewers/partial.py
@@ -58,8 +58,8 @@ def send_file_partial(path):
 
     resp = Response(data, 206, mimetype=mimetypes.guess_type(path)[0], direct_passthrough=True)
 
-    resp.headers.add("Content-type", "application/octet-stream")
-    resp.headers.add("Accept-Ranges", "bytes")
-    resp.headers.add("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
-    resp.headers.add("Content-Length", str(response_length))
+    resp.headers.set("Content-type", "application/octet-stream")
+    resp.headers.set("Accept-Ranges", "bytes")
+    resp.headers.set("Content-Range", "bytes %s-%s/%s" % (first, last, file_len))
+    resp.headers.set("Content-Length", str(response_length))
     return resp

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -81,7 +81,7 @@
           {% if config.SQLALCHEMY_DATABASE_URI %}
             <div class="d-flex flex-wrap">
               {% for gene in variant.genes %}
-                <a class="btn btn-sm btn-secondary" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
+                <a class="btn btn-sm btn-secondary" target="_blank" rel="noopener noreferrer" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
                   Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
               {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -81,11 +81,9 @@
           {% if config.SQLALCHEMY_DATABASE_URI %}
             <div class="d-flex flex-wrap">
               {% for gene in variant.genes %}
-                <span class="ms-5">
-                  <a class="btn btn-sm btn-secondary" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
-                    Gene coverage:{{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-                  </a>
-                </span>
+                <a class="btn btn-sm btn-secondary" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
+                  Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+                </a>
               {% endfor %}
             </div>
           {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -81,7 +81,7 @@
           {% if config.SQLALCHEMY_DATABASE_URI %}
             <div class="d-flex flex-wrap">
               {% for gene in variant.genes %}
-                <a class="btn btn-sm btn-secondary text-white" rel=”noopener noreferrer” target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
+                <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
                   Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
               {% endfor %}


### PR DESCRIPTION
fix #3586 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR, DNIL
