### PR TITLE
Add link to HPO panel coverage overview on Case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Button to go directly to HPO SV filter variantS page from case
 - `Scout-REViewer-Service` integration - show `REViewer` picture if available
+- Link to HPO panel coverage overview on Case page
 ### Changed
 - Better visualization of regional annotation for long lists of genes in large SVs in Variants tables
 - Order of cells in variants tables

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -93,8 +93,13 @@
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage</a>
+          <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
           <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+            <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+          </form>
+          &nbsp
+          <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage overview</a>
+          <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
             <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
           </form>
         {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -92,18 +92,20 @@
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <div class="d-inline p-2">Coverage:</div>
-          <div class="d-inline p-2">
-            <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
-            <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-            </form>
-          </div>
-          <div class="d-inline p-2">
-            <a class="pull-right" href="#" onclick="document.getElementById('hpo-overview-form').submit();">overview</a>
-            <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-            </form>
+          <div class="pull-right">
+            <div class="d-inline p-2">Coverage:</div>
+            <div class="d-inline p-2">
+              <a href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
+              <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+              </form>
+            </div>
+            <div class="d-inline p-2">
+              <a href="#" onclick="document.getElementById('hpo-overview-form').submit();">overview</a>
+              <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+              </form>
+            </div>
           </div>
         {% endif %}
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -92,18 +92,19 @@
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <span class="pull-right">
-            Coverage:&nbsp
+          <div class="d-inline p-2">Coverage:</div>
+          <div class="d-inline p-2">
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
-            &nbsp|&nbsp
+          </div>
+          <div class="d-inline p-2">
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-overview-form').submit();">overview</a>
             <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
-          </span>
+          </div>
         {% endif %}
 
       </h6>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -104,10 +104,7 @@
             <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
-
           </div>
-
-
         {% endif %}
 
       </h6>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -87,24 +87,23 @@
         {%- if case.dynamic_panel_phenotypes %},
           <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
               {{ case.dynamic_panel_phenotypes|length }} phenotypes
-
           </span>
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <div class="pull-right">
+          <span class="pull-right">
             Coverage:&nbsp
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
             &nbsp|&nbsp
-            <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">overview</a>
-            <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+            <a class="pull-right" href="#" onclick="document.getElementById('hpo-overview-form').submit();">overview</a>
+            <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
-          </div>
+          </span>
         {% endif %}
 
       </h6>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -93,15 +93,21 @@
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
-          <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-            <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-          </form>
-          &nbsp
-          <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage overview</a>
-          <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-            <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-          </form>
+          <div class="pull-right">
+            Coverage:
+            <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
+            <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+            </form>
+            &nbsp|nbsp
+            <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">overview</a>
+            <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+            </form>
+
+          </div>
+
+
         {% endif %}
 
       </h6>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -94,12 +94,12 @@
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
           <div class="pull-right">
-            Coverage:
+            Coverage:&nbsp
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
-            &nbsp|nbsp
+            &nbsp|&nbsp
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">overview</a>
             <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -99,7 +99,7 @@
           </form>
           &nbsp
           <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage overview</a>
-          <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+          <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
             <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
           </form>
         {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -92,23 +92,20 @@
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <div class="ml-3">
-            <div class="d-inline p-2">Coverage:</div>
-            <div class="d-inline p-2">
-              <a href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>
-              <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-              </form>
-            </div>
-            <div class="d-inline p-2">
-              <a href="#" onclick="document.getElementById('hpo-overview-form').submit();">overview</a>
-              <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-              </form>
-            </div>
-          </div>
+          <span class="pull-right">
+            <a href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
+            <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+            </form>
+          </span>
+          <span class="pull-right">&nbsp;&nbsp;&nbsp;</span>
+          <span class="pull-right">
+            <a href="#" onclick="document.getElementById('hpo-overview-form').submit();">Coverage overview</a>
+            <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+            </form>
+          </span>
         {% endif %}
-
       </h6>
     </div>
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -101,7 +101,7 @@
             </form>
             &nbsp|nbsp
             <a class="pull-right" href="#" onclick="document.getElementById('hpo-report-form').submit();">overview</a>
-            <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+            <form id="hpo-report-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, level=institute.coverage_cutoff) }}" method="POST" target="_blank">
               <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
             </form>
           </div>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -85,14 +85,14 @@
     <div>
       <h6 class="ms-3 mt-3"><span class="fas fa-clipboard-list"></span>&nbsp;HPO gene panel ({{ case.dynamic_gene_list|length }} genes
         {%- if case.dynamic_panel_phenotypes %},
-          <span data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
+          <span class="mr-3" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
               {{ case.dynamic_panel_phenotypes|length }} phenotypes
           </span>
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
         {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <div class="pull-right">
+          <div class="ml-3">
             <div class="d-inline p-2">Coverage:</div>
             <div class="d-inline p-2">
               <a href="#" onclick="document.getElementById('hpo-report-form').submit();">report</a>


### PR DESCRIPTION
Fix #3581 

Added Coverage overview to HPO dynamic panel:

<img width="596" alt="image" src="https://user-images.githubusercontent.com/28093618/189353946-4d5d6b78-eef6-445d-ba08-e6ce39fbf8b4.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
