### PR TITLE
Round CADD and GnomAD values in variants export files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Order of cells in variants tables
 - More evident links to gene coverage from Variant page
 - Gene panels sorted by display name in the entire Case page
+- Round CADD and GnomAD values in variants export files
 ### Fixed
 - HPO filter button on SV variantS page
 - Spacing between region|function cells in SVs lists

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -968,8 +968,11 @@ def variant_export_lines(store, case_obj, variants_query):
                 )  # empty HGNC id, empty gene name and empty transcripts columns
                 empty_col += 1
 
-        variant_line.append(variant.get("cadd_score", "N/A"))
-        variant_line.append(variant.get("gnomad_frequency", "N/A"))
+        for item in ["cadd_score", "gnomad_frequency"]:
+            if variant.get(item):
+                variant_line.append(round(variant["cadd_score"], 2))
+            else:
+                variant_line.append("N/A")
 
         if case_obj.get("track") == "cancer":
             # Add cancer and normal VAFs

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -968,11 +968,15 @@ def variant_export_lines(store, case_obj, variants_query):
                 )  # empty HGNC id, empty gene name and empty transcripts columns
                 empty_col += 1
 
-        for item in ["cadd_score", "gnomad_frequency"]:
-            if variant.get(item):
-                variant_line.append(round(variant[item], 3))
-            else:
-                variant_line.append("N/A")
+        if variant.get("cadd_score"):
+            variant_line.append(round(variant["cadd_score"], 2))
+        else:
+            variant_line.append("N/A")
+
+        if variant.get("gnomad_frequency"):
+            variant_line.append(round(variant["gnomad_frequency"], 5))
+        else:
+            variant_line.append("N/A")
 
         if case_obj.get("track") == "cancer":
             # Add cancer and normal VAFs

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -970,7 +970,7 @@ def variant_export_lines(store, case_obj, variants_query):
 
         for item in ["cadd_score", "gnomad_frequency"]:
             if variant.get(item):
-                variant_line.append(round(variant["cadd_score"], 2))
+                variant_line.append(round(variant[item], 2))
             else:
                 variant_line.append("N/A")
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -970,7 +970,7 @@ def variant_export_lines(store, case_obj, variants_query):
 
         for item in ["cadd_score", "gnomad_frequency"]:
             if variant.get(item):
-                variant_line.append(round(variant[item], 2))
+                variant_line.append(round(variant[item], 3))
             else:
                 variant_line.append("N/A")
 


### PR DESCRIPTION
Fix #3591 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
