### PR TITLE
Checkbox to show/hide removed gene panels from Panels page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+## Changed
+- Hide removed gene panels by default in panels page
 
 ## [4.59]
 ### Added

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -35,9 +35,6 @@
   </div>
 {% endblock %} <!-- end of content_main -->
 
-
-
-
 <!-- Create a Bootstrap card containing text bar and submit button for searching -->
 {% macro search_gene_card() %}
 <div class="container-float">
@@ -84,22 +81,18 @@
           </table>
           {% elif search_string  %}
           <strong> <em>{{search_string}} </em> not found. </strong>
-
-          {% else  %}
-          <!-- Do nothing -->
           {% endif %}
         </div>
       </div>
       </div>
     </div>
   </div>
-</div>
 {% endmacro %}
 
 
 {% macro new_panel() %}
 <div class="container-float">
-  <div class="card mt-3">
+  <div class="card">
     <div class="card-body">
       <form action="{{ url_for('panels.panels') }}" enctype="multipart/form-data" method="POST">
         <div class="row">
@@ -147,24 +140,27 @@
 
 {% macro panel_view(institute, panels) %}
   <div class="card panel-default w-100 mt-3 justify-content-center">
-    <div class="panel-heading">
-      <strong>{{ institute.display_name }}</strong> - Panels
+    <div class="card-title d-flex justify-content-between">
+      <span><strong>{{ institute.display_name }}</strong> - Panels</span>
+      <span>
+        <input type="checkbox" name="hideLine" checked onclick="toggleHidden(this)"> Hide removed panels</input
+      </span>
     </div>
     <div class="card-body">
-        <table class="table table-striped">
+        <table class="table table-striped" id="panelTable" style="table-layout: fixed;"">
         <thead>
           <tr>
-            <th width="30%">Name</th>
-            <th width="20%">Version</th>
-            <th width="15%">Number of genes</th>
-            <th width="25%">History</th>
-            <th width="10%"></th>
+            <th>Name</th>
+            <th>Version</th>
+            <th>Number of genes</th>
+            <th>History</th>
+            <th></th>
           </tr>
         </thead>
       {% for panel in panels|sort(attribute="display_name",case_sensitive=False) %}
         <!--create table for each panel-->
         <tbody>
-          <tr>
+          <tr {% if panel.hidden %} class="hidableRow" style="visibility:collapse;" {% endif %}>
             <td>
               <a href="{{ url_for('panels.panel', panel_id=panel._id) }}">{{ panel.display_name }}</a>
               {% if panel.hidden %}
@@ -272,6 +268,17 @@
 <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
+function toggleHidden(hideCheck) {
+  var els = document.getElementsByClassName("hidableRow");
+  for(var i=0;i<els.length;i++){
+    if(hideCheck.checked){
+      els[i].style.visibility = 'collapse';
+    }
+    else{
+      els[i].style.visibility = 'visible';
+    }
+  }
+}
 
 $('.history_btn').on('click', function(){
     var bid = $(this)[0].id;
@@ -296,7 +303,6 @@ $('.modify_btn').on('click', function(){
 });
 
 $(function(){
-console.log("called!")
       function getNameTerms(query, process) {
         $.get("{{ url_for('genes.api_genes') }}", {query: query}, function(data) {
           process(data)

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -147,7 +147,7 @@
       </span>
     </div>
     <div class="card-body">
-        <table class="table table-striped" id="panelTable" style="table-layout: fixed;"">
+        <table class="table table-striped" id="panelTable" style="table-layout: fixed;">
         <thead>
           <tr>
             <th>Name</th>

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -143,7 +143,7 @@
     <div class="card-title d-flex justify-content-between">
       <span><strong>{{ institute.display_name }}</strong> - Panels</span>
       <span>
-        <input type="checkbox" name="hideLine" checked onclick="toggleRow(this)"> Hide removed panels</input
+        <input type="checkbox" name="hideLine" checked onclick="toggleRow(this)"> Hide removed panels</input>
       </span>
     </div>
     <div class="card-body">

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -143,7 +143,7 @@
     <div class="card-title d-flex justify-content-between">
       <span><strong>{{ institute.display_name }}</strong> - Panels</span>
       <span>
-        <input type="checkbox" name="hideLine" checked onclick="toggleHidden(this)"> Hide removed panels</input
+        <input type="checkbox" name="hideLine" checked onclick="toggleRow(this)"> Hide removed panels</input
       </span>
     </div>
     <div class="card-body">
@@ -268,7 +268,7 @@
 <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
-function toggleHidden(hideCheck) {
+function toggleRow(hideCheck) {
   var els = document.getElementsByClassName("hidableRow");
   for(var i=0;i<els.length;i++){
     if(hideCheck.checked){


### PR DESCRIPTION
Fix #3593 


https://user-images.githubusercontent.com/28093618/191482322-e0aaf495-b91b-4f7c-8852-315b9cd4e253.mov



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on stage and go to panels page
2. Remove one or more panels and notice that the table rows of removed panels are not shown by default
3. Uncheck the "Hide removed panels" checkbox and all panels should be shown

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
