### PR TITLE
Display SV Variants AFs in Cancer SVs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Changed
 - Hide removed gene panels by default in panels page
-- Parse and display AF values from cancer SVs in cancer SV variantS page (not retroactive)
+- Parse and display AF values for cancer SVs in cancer SV variantS page (only cases loaded after this change)
 
 ## [4.59]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Changed
 - Hide removed gene panels by default in panels page
+- Parse and display AF values from cancer SVs in cancer SV variantS page (not retroactive)
 
 ## [4.59]
 ### Added

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -1,7 +1,3 @@
-import logging
-
-LOG = logging.getLogger(__name__)
-
 # encoding: utf-8
 """
 parse_genotypes will try to collect and merge information from vcf with

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -1,3 +1,7 @@
+import logging
+
+LOG = logging.getLogger(__name__)
+
 # encoding: utf-8
 """
 parse_genotypes will try to collect and merge information from vcf with
@@ -106,6 +110,9 @@ def parse_genotype(variant, ind, pos):
     gt_call["ref_depth"] = ref_depth
     gt_call["read_depth"] = get_read_depth(variant, pos, alt_depth, ref_depth)
     gt_call["alt_frequency"] = get_alt_frequency(variant, pos)
+    if gt_call["alt_frequency"] == -1 and -1 not in (gt_call["alt_depth"], gt_call["ref_depth"]):
+        gt_call["alt_frequency"] = gt_call["alt_depth"] / gt_call["ref_depth"]
+
     gt_call["genotype_quality"] = int(variant.gt_quals[pos])
 
     return gt_call

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import cancer_sv_filters,cell_rank, pagination_footer, pagination_hidden_div, filter_form_footer, filter_script_main, update_stash_filter_button_status, dismiss_variants_block %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, variant_gene_symbols_cell, variant_funct_anno_cell, variant_region_anno_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, variant_gene_symbols_cell, variant_funct_anno_cell, variant_region_anno_cell, allele_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -128,20 +128,6 @@
     <td>{{ allele_cell(variant.tumor or {}) }}</td>
     <td>{{ allele_cell(variant.normal or {}) }}</td>
   </tr>
-{% endmacro %}
-
-{% macro allele_cell(allele) %}
-  {% if 'alt_freq' in allele %}
-    {% if allele.alt_freq == -1 %}
-      <span class="text-muted">.</span>
-    {% else %}
-      {{ allele.alt_freq|round(4) }}
-    {% endif %}
-    <br>
-    <small class="text-muted">{% if allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
-  {% else %}
-    <span class="text-muted">N/A</span>
-  {% endif %}
 {% endmacro %}
 
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 
-{% from "variants/components.html" import external_scripts, external_stylesheets, gene_cell, frequency_cell_general, observed_cell_general %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, gene_cell, frequency_cell_general, observed_cell_general, allele_cell %}
 {% from "variants/utils.html" import cancer_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status %}
 {% from "variants/indicators.html" import pin_indicator, causative_badge, comments_badge, dismissals_badge, evaluations_badge, research_assessments_badge, clinical_assessments_badge, group_assessments_badge, other_tiered_variants %}
 
@@ -170,15 +170,6 @@
   {{ variant.chromosome }}<span class="text-muted">:{{ variant.position }}</span>
 {% endmacro %}
 
-{% macro allele_cell(allele) %}
-  {% if 'alt_freq' in allele %}
-    {{ allele.alt_freq|round(4)  }}
-    <br>
-    <small class="text-muted">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
-  {% else %}
-    <span class="text-muted">N/A</span>
-  {% endif %}
-{% endmacro %}
 
 {% block scripts %}
   {{ super() }}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -1,3 +1,13 @@
+{% macro allele_cell(allele) %}
+  {% if 'alt_freq' in allele %}
+    {{ allele.alt_freq|round(4)  }}
+    <br>
+    <small class="text-muted">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
+  {% else %}
+    <span class="text-muted">N/A</span>
+  {% endif %}
+{% endmacro %}
+
 {% macro variant_gene_symbols_cell(variant) %}
   <div class="d-flex justify-content-between align-items-center">
     <div>


### PR DESCRIPTION
Fix #3595 

Before:

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/28093618/192221629-c70d6323-ec11-4c09-9ff9-747340792b6b.png">



After:

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/28093618/192221404-2a7099e9-87c5-464e-bbe3-7d35f68c4d59.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Locally, delete the demo cancer case: `scout --demo delete case -i cust000 -c cancer_test`
2. Reupload it from this branch : `scout --demo load case scout/demo/cancer.load_config.yaml`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
