### PR TITLE
Remove option for filtering cancer SVs by Tumor alt AF and Normal AF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Changed
 - Hide removed gene panels by default in panels page
+- Remove option for filtering cancer SVs by Tumor alt AF and Normal AF
 
 ## [4.59]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Changed
 - Hide removed gene panels by default in panels page
-- Removed option for filtering cancer SVs by Tumor alt AF and Normal AF
+- Removed option for filtering cancer SVs by Tumor and Normal alt AF
 
 ## [4.59]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Changed
 - Hide removed gene panels by default in panels page
-- Remove option for filtering cancer SVs by Tumor alt AF and Normal AF
+- Removed option for filtering cancer SVs by Tumor alt AF and Normal AF
 
 ## [4.59]
 ### Added

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -187,12 +187,6 @@ class CancerSvFiltersForm(SvFiltersForm):
 
     depth = IntegerField("Depth >", validators=[validators.Optional()])
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
-    control_frequency = BetterDecimalField(
-        "Normal alt AF <", places=2, validators=[validators.Optional()]
-    )
-    tumor_frequency = BetterDecimalField(
-        "Tumor alt AF >", places=2, validators=[validators.Optional()]
-    )
 
 
 FILTERSFORMCLASS = {

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -67,8 +67,8 @@
           <th>Gene(s)</th>
           <th>Region</th>
           <th>Function</th>
-          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Tumor alt. AF. &#013; Alt. allele count | Ref. allele count">Tumor</th>
-          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Normal alt. AF. &#013; Alt. allele count | Ref. allele count">Normal</th>
+          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Tumor alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele count | Ref. allele count">Tumor</th>
+          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Normal alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele count | Ref. allele count">Normal</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -68,7 +68,7 @@
           <th>Region</th>
           <th>Function</th>
           <th data-bs-toggle="tooltip" data-bs-placement="top" title="Tumor alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele support | Ref. allele support">Tumor</th>
-          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Normal alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele count | Ref. allele count">Normal</th>
+          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Normal alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele support | Ref. allele support">Normal</th>
         </tr>
       </thead>
       <tbody>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -67,7 +67,7 @@
           <th>Gene(s)</th>
           <th>Region</th>
           <th>Function</th>
-          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Tumor alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele count | Ref. allele count">Tumor</th>
+          <th data-bs-toggle="tooltip" data-bs-placement="top" title="Tumor alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele support | Ref. allele support">Tumor</th>
           <th data-bs-toggle="tooltip" data-bs-placement="top" title="Normal alt. AF not computed as it varies with variant type and caller. &#013; Alt. allele count | Ref. allele count">Normal</th>
         </tr>
       </thead>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -696,14 +696,6 @@
         {{ form.alt_count.label(class="control-label") }}
         {{ form.alt_count(class="form-control") }}
       </div>
-      <div class="col-1">
-        {{ form.tumor_frequency.label(class="control-label") }}
-        {{ form.tumor_frequency(class="form-control") }}
-      </div>
-      <div class="col-1">
-        {{ form.control_frequency.label(class="control-label") }}
-        {{ form.control_frequency(class="form-control") }}
-      </div>
     </div>
     <div id="chromosome_search">
       <div class="row" style="margin-top:20px;">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -684,7 +684,7 @@
           {{ form.size_shorter(class="form-check-input",type="checkbox") }}
         </div>
       </div>
-      <div class="col-1">
+      <div class="col-2">
         {{ form.gnomad_frequency.label(class="control-label") }}
         {{ form.gnomad_frequency(class="form-control") }}
       </div>
@@ -692,7 +692,7 @@
         {{ form.depth.label(class="control-label", data_toggle="tooltip", data_placement="top", title="Tumor read depth") }}
         {{ form.depth(class="form-control") }}
       </div>
-      <div class="col-1">
+      <div class="col-2">
         {{ form.alt_count.label(class="control-label") }}
         {{ form.alt_count(class="form-control") }}
       </div>


### PR DESCRIPTION
Fix #3595 

- Removes option for filtering cancer SVs by Tumor alt AF and Normal AF
- Modifies a tooltip already present to explain why tumor VAFs are missing

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
