### PR TITLE
Hide Links to Coverage If Cancer Track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## Changed
 - Hide removed gene panels by default in panels page
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF
+- Hide links to coverage repost if cancer analysis
 
 ## [4.59]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -91,7 +91,7 @@
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
-        {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 and case.track != 'cancer' %}
+        {% if case.track != 'cancer' and config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
           <span class="pull-right">
             <a href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -91,7 +91,7 @@
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
-        {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
+        {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 and config.track != cancer %}
           <span class="pull-right">
             <a href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -91,7 +91,7 @@
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
-        {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 and config.track != cancer %}
+        {% if config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 and case.track != 'cancer' %}
           <span class="pull-right">
             <a href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
             <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug: hides links to coverage reports if the scout case is configured for _cancer_.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data2. 

Find one cancer and one not-cancer case. Both should display links to coverage on the main branch.

<img width="874" alt="image" src="https://user-images.githubusercontent.com/1150065/193057043-525bb642-8b27-4896-92d8-a32787630ddf.png">

**Expected outcome**:
Apply this patch. Afterwards the cancer-case will not display links to coverage. The rare disease case will show links to coverage. 

The functionality should be working.


<img width="879" alt="image" src="https://user-images.githubusercontent.com/1150065/193053782-f7d76485-aff1-42dc-bb2a-c74a5f6ea23d.png">

**Review:**
- [ ] code approved by
- [ ] tests executed by
