### PR TITLE
Catch Crash For Badly Formatted TSV-Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide removed gene panels by default in panels page
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF
 - Hide links to coverage repost if cancer analysis
+## Fixed
+- If trying to load a badly formatted .tsv file an error message is displayed.
 
 ## [4.59]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide removed gene panels by default in panels page
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF
 - Hide links to coverage repost if cancer analysis
-## Fixed
+### Fixed
 - If trying to load a badly formatted .tsv file an error message is displayed.
 
 ## [4.59]

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -133,21 +133,29 @@ def upload_managed_variants(store, lines, institutes, current_user_id):
     total_variant_lines = 0
     new_managed_variants = 0
 
-    for managed_variant_info in parse_managed_variant_lines(lines):
-        total_variant_lines += 1
+    try:
+        for managed_variant_info in parse_managed_variant_lines(lines):
+            total_variant_lines += 1
 
-        if not validate_managed_variant(managed_variant_info):
-            flash(
-                f"Managed variant info line {total_variant_lines} has errors ({managed_variant_info})",
-                "warning",
-            )
-            continue
+            if not validate_managed_variant(managed_variant_info):
+                flash(
+                    f"Managed variant info line {total_variant_lines} has errors ({managed_variant_info})",
+                    "warning",
+                )
+                continue
 
-        managed_variant_info.update({"maintainer": [current_user_id], "institutes": institutes})
-        managed_variant_obj = build_managed_variant(managed_variant_info)
+            managed_variant_info.update({"maintainer": [current_user_id], "institutes": institutes})
+            managed_variant_obj = build_managed_variant(managed_variant_info)
 
-        if store.upsert_managed_variant(managed_variant_obj):
-            new_managed_variants += 1
+            if store.upsert_managed_variant(managed_variant_obj):
+                new_managed_variants += 1
+
+    except UnboundLocalError:
+        flash(
+            f"Bad format on variant file. Line {total_variant_lines}",
+            "warning",
+        )
+
 
     return new_managed_variants, total_variant_lines
 

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -156,7 +156,6 @@ def upload_managed_variants(store, lines, institutes, current_user_id):
             "warning",
         )
 
-
     return new_managed_variants, total_variant_lines
 
 

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -152,7 +152,7 @@ def upload_managed_variants(store, lines, institutes, current_user_id):
 
     except UnboundLocalError:
         flash(
-            f"Bad format on variant file. Line {total_variant_lines}",
+            f"Invalid format on variant file. Line {total_variant_lines}",
             "warning",
         )
 


### PR DESCRIPTION
This PR adds a functionality. Now Scout will not crash, but instead display an error message when trying to load a badly formatted tsv-file.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data
Create an erroneous tsv-file. For example (note the blank line):

```

chromosome;position;end;reference;alternative;category;sub_category;description
14;76548781;76548781;CTGGACC;G;snv;indel;IFT43 indel test
17;48696925;48696925;G;T;snv;snv;CACNA1G intronic test
;;;;;;;
7;124491972;124491972;C;A;snv;snv;POT1 test snv
```

If unpatched trying to load the file will raise UnboundLocalError.

**Expected outcome**:
Patch.
Now loading the same file will not crash Scout, instead display an error message.
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/1150065/193275944-9f51dc99-cff0-497b-a2e6-cd9480a9ecd7.png">


**Review:**
- [ ] code approved by
- [ ] tests executed by
