### PR TITLE
Fix phenomodels typeahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-## Added
+### Added
 - Mitochondrial deletion signatures (mitosign) can be uploaded and shown with mtDNA report
-## Changed
+### Changed
 - Hide removed gene panels by default in panels page
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF
 - Hide links to coverage repost if cancer analysis
 - Remove rerun emails and redirect users to the analysis order portal instead
 ### Fixed
 - If trying to load a badly formatted .tsv file an error message is displayed.
+- Dynamic autocomplete search not working on phenomodels page
 
 ## [4.59]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -365,7 +365,6 @@ class CaseHandler(object):
         if yield_query:
             return query
 
-        LOG.info(f"Get cases with query {query}")
         if order:
             return self.case_collection.find(query)
 
@@ -489,7 +488,6 @@ class CaseHandler(object):
         if institute_id:
             query["collaborators"] = institute_id
 
-        LOG.debug("Fetch all cases with query {0}".format(query))
         nr_cases = sum(1 for i in self.case_collection.find(query))
 
         return nr_cases
@@ -581,13 +579,11 @@ class CaseHandler(object):
         query = {}
         if case_id:
             query["_id"] = case_id
-            LOG.info("Fetching case %s", case_id)
         else:
             if not (institute_id and display_name):
                 raise ValueError(
                     "Please provide either case ID or both institute_id and display_name."
                 )
-            LOG.info("Fetching case %s institute %s", display_name, institute_id)
             query["owner"] = institute_id
             query["display_name"] = display_name
 
@@ -1038,7 +1034,6 @@ class CaseHandler(object):
         case_verif_variants = {"sanger_verified": [], "sanger_ordered": []}
 
         # Add the verified variants
-        LOG.info("Fetching all sanger variants and all validated variants")
         results = {
             "sanger_verified": self.validated(case_id=case_id),
             "sanger_ordered": self.sanger_ordered(case_id=case_id),

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -300,7 +300,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w=="></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"></script>
 <script type="text/javascript">
 
   function showDiv(showElem, hideElem) {

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -300,7 +300,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w=="></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script type="text/javascript">
 
   function showDiv(showElem, hideElem) {

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -300,7 +300,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script type="text/javascript">
 
   function showDiv(showElem, hideElem) {

--- a/scout/server/blueprints/institutes/templates/overview/phenomodel.html
+++ b/scout/server/blueprints/institutes/templates/overview/phenomodel.html
@@ -300,7 +300,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w=="></script>
 <script type="text/javascript">
 
   function showDiv(showElem, hideElem) {

--- a/tests/commands/load/test_load_research_cmd.py
+++ b/tests/commands/load/test_load_research_cmd.py
@@ -12,7 +12,6 @@ def test_load_research(mock_app, case_obj):
     # Test command without case_id:
     result = runner.invoke(cli, ["load", "research"])
     assert result.exit_code == 0
-    assert "Get cases with query {'research_requested': True}" in result.output
 
     # Test command providing a case_id:
     result = runner.invoke(cli, ["load", "research", "-c", case_obj["_id"]])

--- a/tests/commands/update/test_update_case_cmd.py
+++ b/tests/commands/update/test_update_case_cmd.py
@@ -39,8 +39,8 @@ def test_update_case_existing_collaborator(mock_app, case_obj):
     ## WHEN providing a case id and a valid collaborator
     result = runner.invoke(cli, ["update", "case", case_obj["_id"], "-c", "cust000"])
 
-    ## THEN assert that the case is fetched
-    assert "INFO Fetching case {}".format(case_obj["_id"]) in result.output
+    ## THEN command should have exit code 0 (success)
+    assert result.exit_code == 0
 
 
 def test_update_case_change_collaborator(mock_app, case_obj):


### PR DESCRIPTION
fix #3613 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on cg-vm1 (stage) and try creating/editing phenomodels using the typeahead:

<img width="925" alt="image" src="https://user-images.githubusercontent.com/28093618/193747103-ddb0226e-6597-4c03-acba-e82b99f55d14.png">

**Expected outcome**:
Using this branch it should work 

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
