### PR TITLE
Fix missing preselected chromosome when editing a managed variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - If trying to load a badly formatted .tsv file an error message is displayed.
 - Avoid showing case as rerun when first attempt at case upload failed
 - Dynamic autocomplete search not working on phenomodels page
+- Missing preselected chromosome when editing a managed variant
 
 ## [4.59]
 ### Added

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -146,7 +146,7 @@
       <td>
         <select name="chromosome" class="form-control">
           {% for chr,_  in modify_form.chromosome.choices %}
-            <option value="{{chr}}" {% if variant.chromosome==chr or variant.chromosome=="M" and chr=="MT"%} selected {% endif %}>{{chr}}</option>
+            <option value="{{chr}}" {% if variant.chromosome==chr %} selected {% endif %}>{{chr}}</option>
           {% endfor %}
         </select>
       </td>

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -143,7 +143,13 @@
   <form id="modify_variant" method="POST" action="{{ url_for('managed_variants.modify_managed_variant', variant_id=variant.managed_variant_id) }}" enctype="multipart/form-data" class="form-horizontal">
       {{ modify_form.csrf_token }}
       <input type="hidden" name="variant_id" value="{{ variant._id }}">
-      <td>{{ modify_form.chromosome(class_="form-control") }}</td>
+      <td>
+        <select name="chromosome" class="form-control">
+          {% for chr,_  in modify_form.chromosome.choices %}
+            <option value="{{chr}}" {% if variant.chromosome==chr or variant.chromosome=="M" and chr=="MT"%} selected {% endif %}>{{chr}}</option>
+          {% endfor %}
+        </select>
+      </td>
       <td><input type="number" class="form-control" name="position" id="position" value="{{ variant.position }}" required></td>
       <td><input type="number" class="form-control" name="end" id="end" value="{{ variant.end }}"></td>
       <td><input type="text" class="form-control" name="reference" id="reference" value="{{ variant.reference }}" required></td>


### PR DESCRIPTION
Fix partially #3619 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Test according to the case scenario described in #3619 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
