### PR TITLE
Fix #3620 - fix adding callers on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Better visualization of long lists of genes in large SVs on Causative and Verified Variants page
 - Reintroduced missing button to export Causative variants
 - Better linking and display of matching causatives and managed variants
+- Reduced code complexity in `scout/parse/variant/variant.py`
+- Reduced complexity of code in `scout/build/variant/variant.py`
+
 ### Changed
 - State that loqusdb observation is in current case if observations count is one and no cases are shown
 - Better pagination and number of variants returned by queries in `Search SNVs and INDELs` page
@@ -89,8 +92,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [4.57.4]
 ### Fixed
 - Parsing of variant.FORMAT "DR" key in parse variant file
-- Reduced code complexity in `scout/parse/variant/variant.py`
-- Reduced complexity of code in `scout/build/variant/variant.py`
 
 ## [4.57.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - If trying to load a badly formatted .tsv file an error message is displayed.
 - Avoid showing case as rerun when first attempt at case upload failed
 - Dynamic autocomplete search not working on phenomodels page
+- Callers added to variant when loading case
 
 ## [4.59]
 ### Added

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from scout.utils.dict_utils import remove_nonetype
 from scout.utils.convert import call_safe
+from scout.utils.dict_utils import remove_nonetype
+
 from . import build_clnsig, build_compound, build_gene, build_genotype
 
 LOG = logging.getLogger(__name__)
@@ -208,6 +209,8 @@ def build_variant(
     add_hgnc_symbols(variant_obj, variant_obj["hgnc_ids"], hgncid_to_gene)
     link_gene_panels(variant_obj, gene_to_panels)
     add_clnsig_objects(variant_obj, variant.get("clnsig", []))
+
+    add_callers(variant_obj, variant.get("callers", {}))
 
     ### Add the conservation
     conservation_info = variant.get("conservation", {})

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -31,7 +31,6 @@ def parse_callers(variant, category="snv"):
                 for caller in callers:
                     if caller in call:
                         callers[caller] = "Filtered"
-
             elif call in set(callers.keys()):
                 callers[call] = "Pass"
     # The following is parsing of a custom made merge


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Before: 
![Screenshot 2022-10-06 at 14 35 27](https://user-images.githubusercontent.com/758570/194314398-ddd5c5dc-918d-4881-98e6-e17f31cb75bb.png)
After:
![Screenshot 2022-10-06 at 14 36 12](https://user-images.githubusercontent.com/758570/194314430-3e45e1da-76c4-4ebc-9752-6e20e3d83000.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. load a case, preferably with both SVs and SNVs with caller details in the vcf (set or FOUND_IN tags).

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
