### PR TITLE
Prepopulate variant type and subtype when editing a managed var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid showing case as rerun when first attempt at case upload failed
 - Dynamic autocomplete search not working on phenomodels page
 - Callers added to variant when loading case
+- Preselected variant type and subtype when editing a managed variant
 
 ## [4.59]
 ### Added

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -286,7 +286,7 @@
     setChromosomes();
     populateSubTypeSelect('add_variant');
     {% for variant in managed_variants %}
-      populateSubTypeSelect('modify_variant_'.concat('{{variant.variant_id|safe}}'));
+      populateSubTypeSelect('modify_variant_{{variant.variant_id|safe}}');
     {% endfor %}
   })
 

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -140,7 +140,7 @@
 {% endmacro %}
 
 {% macro modify_variant_form(variant) %}
-  <form id="modify_variant" method="POST" action="{{ url_for('managed_variants.modify_managed_variant', variant_id=variant.managed_variant_id) }}" enctype="multipart/form-data" class="form-horizontal">
+  <form id="modify_variant_{{variant.variant_id}}" method="POST" action="{{ url_for('managed_variants.modify_managed_variant', variant_id=variant.managed_variant_id) }}" enctype="multipart/form-data" class="form-horizontal">
       {{ modify_form.csrf_token }}
       <input type="hidden" name="variant_id" value="{{ variant._id }}">
       <td>{{ modify_form.chromosome(class_="form-control") }}</td>
@@ -149,18 +149,19 @@
       <td><input type="text" class="form-control" name="reference" id="reference" value="{{ variant.reference }}" required></td>
       <td><input type="text" class="form-control" name="alternative" id="alternative" value="{{ variant.alternative }}" required></td>
       <td>
-        <select name="category" class="form-control" onchange="populateSubTypeSelect('modify_variant')">
+        <select name="category" id="category" class="form-control" onchange="populateSubTypeSelect('modify_variant_{{variant.variant_id}}')">
           {% for ctg,ctg_display in modify_form.category.choices %}
             <option value="{{ctg}}" {% if ctg == variant.category %} selected {% endif %}>{{ctg_display}}</option>
           {% endfor %}
         </select>
       </td>
       <td>
-        <select name="sub_category" class="form-control">
+        <select name="sub_category" id="sub_category" class="form-control">
           {% for subctg,subctg_display in modify_form.sub_category.choices %}
             <option value="{{subctg}}" {% if subctg == variant.sub_category %} selected {% endif %}>{{subctg_display}}</option>
           {% endfor %}
         </select>
+      </td>
       <td>
          <div class="input-group">
            <input type="text" class="form-control" name="description" id="description" value="{{ variant.description }}">
@@ -317,7 +318,7 @@
 
   // populate variant subtype select in add_variant form according to pre-selected variant category
   function populateSubTypeSelect(formId){
-    selectedCategory = document.forms[formId].elements["category"].value; // can be add_variant or modify_variant
+    selectedCategory = document.forms[formId].elements["category"].value;
     subCategorySelect = document.forms[formId].elements["sub_category"];
 
     clearSelect(subCategorySelect) // Reset subcategory select options

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -148,8 +148,19 @@
       <td><input type="number" class="form-control" name="end" id="end" value="{{ variant.end }}"></td>
       <td><input type="text" class="form-control" name="reference" id="reference" value="{{ variant.reference }}" required></td>
       <td><input type="text" class="form-control" name="alternative" id="alternative" value="{{ variant.alternative }}" required></td>
-      <td>{{ modify_form.category(class_="form-control", onchange="populateSubTypeSelect('modify_variant')") }}</td>
-      <td>{{ modify_form.sub_category(class_="form-control") }}</td>
+      <td>
+        <select name="category" class="form-control" onchange="populateSubTypeSelect('modify_variant')">
+          {% for ctg,ctg_display in modify_form.category.choices %}
+            <option value="{{ctg}}" {% if ctg == variant.category %} selected {% endif %}>{{ctg_display}}</option>
+          {% endfor %}
+        </select>
+      </td>
+      <td>
+        <select name="sub_category" class="form-control">
+          {% for subctg,subctg_display in modify_form.sub_category.choices %}
+            <option value="{{subctg}}" {% if subctg == variant.sub_category %} selected {% endif %}>{{subctg_display}}</option>
+          {% endfor %}
+        </select>
       <td>
          <div class="input-group">
            <input type="text" class="form-control" name="description" id="description" value="{{ variant.description }}">

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -285,7 +285,9 @@
   $(document).ready(function(){
     setChromosomes();
     populateSubTypeSelect('add_variant');
-    populateSubTypeSelect('modify_variant')
+    {% for variant in managed_variants %}
+      populateSubTypeSelect('modify_variant_'.concat('{{variant.variant_id|safe}}'));
+    {% endfor %}
   })
 
   var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))


### PR DESCRIPTION
Fixes partially #3619

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
