### PR TITLE
Updated clinical SVs igv.js track (dbVar) and added example of external track from trackhubregistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF
 - Hide links to coverage repost if cancer analysis
 - Remove rerun emails and redirect users to the analysis order portal instead
+- Updated clinical SVs igv.js track (dbVar) and added example of external track from `https://trackhubregistry.org/`
 ### Fixed
 - If trying to load a badly formatted .tsv file an error message is displayed.
 - Avoid showing case as rerun when first attempt at case upload failed

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -20,8 +20,12 @@ HG19GENES_INDEX_URL = "https://s3.amazonaws.com/igv.org.genomes/hg19/ncbiRefSeq.
 HG38CLINVAR_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarMain.bb"
 HG19CLINVAR_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarMain.bb"
 
-HG38CLINVAR_CNVS_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg38/bbi/clinvar/clinvarCnv.bb"
-HG19CLINVAR_CNVS_URL = "https://hgdownload.soe.ucsc.edu/gbdb/hg19/bbi/clinvar/clinvarCnv.bb"
+HG38CLINVAR_SVS_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhub/hg38/clinvar_pathogenic.bb"
+)
+HG19CLINVAR_SVS_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg19/clinvar_pathogenic.bb"
+)
 
 # Human genome reference genome build 37. Always displayed
 HUMAN_REFERENCE_37 = {
@@ -65,29 +69,29 @@ CLINVAR_SNV_38 = {
 }
 
 # ClinVar CNVs track genome build 37
-CLINVAR_CNV_37 = {
-    "name": "ClinVar CNVs",
-    "track_name": "clinvar_cnvs",
+CLINVAR_SV_37 = {
+    "name": "ClinVar SVs",
+    "track_name": "ClinVar SVs",
     "type": "annotation",
     "sourceType": "file",
     "displayMode": "SQUISHED",
     "visibilityWindow": 3000000000,
     "format": "bigBed",
     "height": 100,
-    "url": HG19CLINVAR_CNVS_URL,
+    "url": HG19CLINVAR_SVS_URL,
 }
 
 # ClinVar CNVs track genome build 38
-CLINVAR_CNV_38 = {
-    "name": "ClinVar CNVs",
-    "track_name": "clinvar_cnvs",
+CLINVAR_SV_38 = {
+    "name": "ClinVar SVs",
+    "track_name": "ClinVar SVs",
     "type": "annotation",
     "sourceType": "file",
     "displayMode": "SQUISHED",
     "visibilityWindow": 3000000000,
     "format": "bigBed",
     "height": 100,
-    "url": HG38CLINVAR_CNVS_URL,
+    "url": HG38CLINVAR_SVS_URL,
 }
 
 # Human genes track, build 37
@@ -130,6 +134,6 @@ USER_DEFAULT_TRACKS = ["Genes", "ClinVar", "ClinVar CNVs"]
 
 # Export selectable custom tracks into lists
 IGV_TRACKS = {
-    "37": [HUMAN_GENES_37, CLINVAR_SNV_37, CLINVAR_CNV_37],
-    "38": [HUMAN_GENES_38, CLINVAR_SNV_38, CLINVAR_CNV_38],
+    "37": [HUMAN_GENES_37, CLINVAR_SNV_37, CLINVAR_SV_37],
+    "38": [HUMAN_GENES_38, CLINVAR_SNV_38, CLINVAR_SV_38],
 }

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -24,7 +24,7 @@ HG38CLINVAR_SVS_URL = (
     "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhub/hg38/clinvar_pathogenic.bb"
 )
 HG19CLINVAR_SVS_URL = (
-    "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg19/clinvar_pathogenic.bb"
+    "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhub/hg19/clinvar_pathogenic.bb "
 )
 
 # Human genome reference genome build 37. Always displayed

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -71,7 +71,7 @@ CLINVAR_SNV_38 = {
 # ClinVar CNVs track genome build 37
 CLINVAR_SV_37 = {
     "name": "ClinVar SVs",
-    "track_name": "ClinVar SVs",
+    "track_name": "clinvar_svs",
     "type": "annotation",
     "sourceType": "file",
     "displayMode": "SQUISHED",
@@ -84,7 +84,7 @@ CLINVAR_SV_37 = {
 # ClinVar CNVs track genome build 38
 CLINVAR_SV_38 = {
     "name": "ClinVar SVs",
-    "track_name": "ClinVar SVs",
+    "track_name": "clinvar_svs",
     "type": "annotation",
     "sourceType": "file",
     "displayMode": "SQUISHED",

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -75,19 +75,26 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 
 #
 # Cloud IGV tracks can be configured here to allow users to enable them on their IGV views.
+# A number of publicly-available tracks can be found here: https://trackhubregistry.org/
 # CLOUD_IGV_TRACKS = [
 #    {
-#        "name": "custom_public_bucket",
+#        "name": "public_tracks",
 #        "access": "public",
 #        "tracks": [
 #            {
-#                "name": "dbVar Pathogenic or Likely Pathogenic",
-#                "type": "variant",
-#                "format": "vcf",
+#                "name": "dbVar common SVs (global)",
+#                "type": "annotation",
+#                "format": "bigbed",
 #                "build": "37",
-#                "url": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777457/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz",
-#                "indexURL": "https://s3-eu-west-1.amazonaws.com/pfigshare-u-files/25777460/GRCh37.variant_call.clinical.pathogenic_or_likely_pathogenic.vcf.gz.tbi",
-#            }
+#                "url": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg19/common_global.bb",
+#            },
+#            {
+#                "name": "dbVar common SVs (global)",
+#                "type": "annotation",
+#                "format": "bigbed",
+#                "build": "38",
+#                "url": "https://ftp.ncbi.nlm.nih.gov/pub/dbVar/sandbox/dbvarhubtest/hg38/common_global.bb",
+#            },
 #        ],
 #    },
 # ]


### PR DESCRIPTION
Fix #3561 --> Do not use our figshare dbVar track any more, but pull the same track from [trackhubregistry](https://trackhubregistry.org/)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. install on stage and make sure that the track named `ClinVar SVs` is usable.
2. Locally, on this branch, uncomment the config file and go for a MT variant (the only ones with viewable alignments)
3. click on igv.js on a MT variant and then go to someplace else in the genome. Common SVs track should be available

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
