### PR TITLE
Fix #3629 - svdb_origin tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Mitochondrial deletion signatures (mitosign) can be uploaded and shown with mtDNA report
 - A `Type of analysis` column on Causatives and Validated variants pages
+- `svdb_origin` as a synonym for `FOUND_IN` to complement `set` for variants found by all callers
 ### Changed
 - Hide removed gene panels by default in panels page
 - Removed option for filtering cancer SVs by Tumor and Normal alt AF

--- a/docs/admin-guide/loading-variants.md
+++ b/docs/admin-guide/loading-variants.md
@@ -4,7 +4,7 @@ This document will describe the process of variant loading, how it is done and w
 
 ## Rank Score
 
-In Scout rank score is a central theme. Rank Scores is a estimation on how potentially dangerous a variant is, similar to the CADD score with the intention of work with all types of variation. 
+In Scout rank score is a central theme. Rank Scores is a estimation on how potentially dangerous a variant is, similar to the CADD score with the intention of work with all types of variation.
 The uploading of variants is based on a rank score threshold, this is to avoid to clog the database with millions of variants that we at the moment have a hard time to say anything about.
 
 The rank score is a summary of the annotations of a variant. Rank scores are calculated and annotated by [GENMOD][genmod]

--- a/docs/user-guide/variants.md
+++ b/docs/user-guide/variants.md
@@ -40,7 +40,9 @@ This is the first a user looks at when assesing the variant.
   - CLINSIG number
 
 #### SV frequency - SVDB
-     Structural variant database freqency is annotated with [SVDB](https://github.com/J35P312/SVDB), using a clustering algorithm [DBSCAN](https://en.wikipedia.org/wiki/DBSCAN). Variant type and chromosome are exact, but start and end positions for matches are approximate, and depend on previous cases from the database. In a region with multiple, inexactly positioned events, matching will be more relaxed than if only tightly clustered variants with near similar start and end coordinates have been found. Databases include research cases from Clinical genetics (WGS at NGI), clinical cases with arrayCGH (benign or pathogenic collections), Decipher, SweGen and local cases.
+Structural variant database freqency is annotated with [SVDB](https://github.com/J35P312/SVDB), using a clustering algorithm [DBSCAN](https://en.wikipedia.org/wiki/DBSCAN).
+Variant type and chromosome are exact, but start and end positions for matches are approximate, and depend on previous cases from the database. In a region with multiple, inexactly positioned events, matching will be more relaxed than if only tightly clustered variants with near similar start and end coordinates have been found.
+Databases include research cases from Clinical genetics (WGS at NGI), clinical cases with arrayCGH (benign or pathogenic collections), Decipher, SweGen and local cases.
 
 ## Details
 

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -50,10 +50,9 @@ def parse_callers(variant, category="snv"):
             elif call in set(callers.keys()):
                 callers[call] = "Pass"
 
-    # The following is parsing of a custom made merge
-
     if raw_info or svdb_origin or other_info:
         return callers
+
     if category == "snv":
         # cyvcf2 FILTER is None if VCF file column FILTER is "PASS"
         filter_status = "Pass"

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -34,7 +34,7 @@ def parse_callers(variant, category="snv"):
             elif call in set(callers.keys()):
                 callers[call] = "Pass"
     # The following is parsing of a custom made merge
-    other_info = variant.INFO.get("FOUND_IN")
+    other_info = variant.INFO.get("FOUND_IN") or variant.INFO.get("svdb_origin")
     if other_info:
         for info in other_info.split(","):
             called_by = info.split("|")[0]

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -8,6 +8,11 @@ LOG = logging.getLogger(__name__)
 def parse_callers(variant, category="snv"):
     """Parse how the different variant callers have performed
 
+    Caller information can be passed in one of three ways, in order of priority:
+    1. If a FOUND_IN tag (comma separated) is found, callers listed will be marked Pass
+    2. If a svdb_origin tag (pipe separated) is found, callers listed will be marked Pass
+    3. If a set tag (dash separated, GATK CombineVariants) is found, callers will be marked Pass or Filtered accordingly
+
     Args:
         variant (cyvcf2.Variant): A variant object
 
@@ -17,8 +22,19 @@ def parse_callers(variant, category="snv"):
     """
     relevant_callers = CALLERS[category]
     callers = {caller["id"]: None for caller in relevant_callers}
+
+    other_info = variant.INFO.get("FOUND_IN")
+    svdb_origin = variant.INFO.get("svdb_origin")
     raw_info = variant.INFO.get("set")
-    if raw_info:
+
+    if other_info:
+        for info in other_info.split(","):
+            called_by = info.split("|")[0]
+            callers[called_by] = "Pass"
+    elif svdb_origin:
+        for called_by in svdb_origin.split("|"):
+            callers[called_by] = "Pass"
+    elif raw_info:
         info = raw_info.split("-")
         for call in info:
             if call == "FilteredInAll":
@@ -33,17 +49,8 @@ def parse_callers(variant, category="snv"):
                         callers[caller] = "Filtered"
             elif call in set(callers.keys()):
                 callers[call] = "Pass"
-    # The following is parsing of a custom made merge
-    svdb_origin = variant.INFO.get("svdb_origin")
-    if svdb_origin:
-        for called_by in svdb_origin.split("|"):
-            callers[called_by] = "Pass"
 
-    other_info = variant.INFO.get("FOUND_IN")
-    if other_info:
-        for info in other_info.split(","):
-            called_by = info.split("|")[0]
-            callers[called_by] = "Pass"
+    # The following is parsing of a custom made merge
 
     if raw_info or svdb_origin or other_info:
         return callers

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -34,13 +34,18 @@ def parse_callers(variant, category="snv"):
             elif call in set(callers.keys()):
                 callers[call] = "Pass"
     # The following is parsing of a custom made merge
-    other_info = variant.INFO.get("FOUND_IN") or variant.INFO.get("svdb_origin")
+    svdb_origin = variant.INFO.get("svdb_origin")
+    if svdb_origin:
+        for called_by in svdb_origin.split("|"):
+            callers[called_by] = "Pass"
+
+    other_info = variant.INFO.get("FOUND_IN")
     if other_info:
         for info in other_info.split(","):
             called_by = info.split("|")[0]
             callers[called_by] = "Pass"
 
-    if raw_info or other_info:
+    if raw_info or svdb_origin or other_info:
         return callers
     if category == "snv":
         # cyvcf2 FILTER is None if VCF file column FILTER is "PASS"

--- a/tests/parse/test_parse_callers.py
+++ b/tests/parse/test_parse_callers.py
@@ -60,6 +60,21 @@ def test_parse_callers_intersection(cyvcf2_variant):
     assert callers["samtools"] == "Pass"
 
 
+def test_parse_callers_intersection_svdb_info(cyvcf2_variant):
+    variant = cyvcf2_variant
+    # GIVEN information that all callers agree on Pass
+    variant.INFO["svdb_origin"] = "gatk|deepvariant"
+    variant.INFO["set"] = "Intersection"
+
+    # WHEN parsing the information
+    callers = parse_callers(variant)
+
+    # THEN the svdb info selected callers should be passed
+    assert callers["gatk"] == "Pass"
+    assert callers["deepvariant"] == "Pass"
+    assert callers["samtools"] is None
+
+
 def test_parse_callers_filtered_all(cyvcf2_variant):
     variant = cyvcf2_variant
     # GIVEN information that all callers agree on filtered


### PR DESCRIPTION
This PR adds a functionality.

`svdb_origin` is now parsed in addition to `FOUND_IN` and `set`.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. pick a case merged with a recent svdb version, producing svdb_origin tags, and a variant found by all callers
2. note it is shown as called by some callers not used in the analysis
3. reload with this patch, and see only the actual callers found

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
