### PR TITLE
New 'ignored' case status and display number of cases by status in case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Additional case category `unused`, to be used for cases that won't be analysed, as opposite to the archived ones
 -  Display number of cases shown / total number of cases available for each category on Cases page
+### Changed
+- Moved buttons to modify case status from sidebar to main case page
 
 ## [4.60]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Filter case list by cases with variants in ClinVar submission
-- Additional case category `unused`, to be used for cases that won't be analysed, as opposite to the archived ones
+- Additional case category `Ignored`, to be used for cases that don't fall in the existing 'inactive', 'archived', 'solved', 'prioritized' categories
 - Display number of cases shown / total number of cases available for each category on Cases page
 - Moved buttons to modify case status from sidebar to main case page
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Additional case category `unused`, to be used for cases that won't be analysed, as opposite to the archived ones
--  
+-  Display number of cases shown / total number of cases available for each category on Cases page
 
 ## [4.60]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Additional case category `unused`, to be used for cases that won't be analysed, as opposite to the archived ones
+-  
+
 ## [4.60]
 ### Added
 - Mitochondrial deletion signatures (mitosign) can be uploaded and shown with mtDNA report

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -271,7 +271,7 @@ class CaseHandler(object):
             finished(bool)
             research_requested(bool)
             is_research(bool)
-            status(str)
+            status(str or dict expression)
             group(ObjectId): fetch all cases in a named case group
             cohort(bool): Fetch all cases with cohort tags
             phenotype_terms(bool): Fetch all cases with phenotype

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -478,7 +478,7 @@ class CaseHandler(object):
         This function will change when we migrate to 3.7.1
 
         Args:
-            collaborator(str): Institute id
+            institute_id(str): Institute id
 
         Returns:
             nr_cases(int)
@@ -491,6 +491,21 @@ class CaseHandler(object):
         nr_cases = sum(1 for i in self.case_collection.find(query))
 
         return nr_cases
+
+    def nr_cases_by_status(self, institute_id=None):
+        """For an institute, retrieves number of cases in each case status category
+        Args:
+            institute_id(str): Institute id
+
+        Returns:
+            dict with case.status as keys and nr cases as value
+        """
+        pipeline = []
+        if institute_id:
+            pipeline.append({"$match": {"collaborators": institute_id}})
+        pipeline.append({"$group": {"_id": "$status", "count": {"$sum": 1}}})
+        result = self.case_collection.aggregate(pipeline)
+        return {res["_id"]: res["count"] for res in result}
 
     def update_dynamic_gene_list(
         self,

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -490,7 +490,6 @@ class CaseHandler(object):
     def nr_cases(self, institute_id=None):
         """Return the number of cases
 
-        This function will change when we migrate to 3.7.1
 
         Args:
             institute_id(str): Institute id

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -57,7 +57,7 @@ PHENOTYPE_MAP = {1: "unaffected", 2: "affected", 0: "unknown", -9: "unknown"}
 CANCER_PHENOTYPE_MAP = {1: "normal", 2: "tumor", 0: "unknown", -9: "unknown"}
 REV_PHENOTYPE_MAP = {value: key for key, value in PHENOTYPE_MAP.items()}
 
-CASE_STATUSES = ("prioritized", "inactive", "active", "solved", "archived", "unused")
+CASE_STATUSES = ("prioritized", "inactive", "active", "solved", "archived", "ignored")
 
 VERBS_MAP = {
     "assign": "was assigned to",

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -57,7 +57,7 @@ PHENOTYPE_MAP = {1: "unaffected", 2: "affected", 0: "unknown", -9: "unknown"}
 CANCER_PHENOTYPE_MAP = {1: "normal", 2: "tumor", 0: "unknown", -9: "unknown"}
 REV_PHENOTYPE_MAP = {value: key for key, value in PHENOTYPE_MAP.items()}
 
-CASE_STATUSES = ("prioritized", "inactive", "active", "solved", "archived")
+CASE_STATUSES = ("prioritized", "inactive", "active", "solved", "archived", "unused")
 
 VERBS_MAP = {
     "assign": "was assigned to",

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -55,6 +55,7 @@
                   <div>
                     Set
                     <div class="btn-group">
+                      <!-- archived/active-->
                       {% if case.status != 'archived' %}
                         <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
                           Archived
@@ -64,24 +65,24 @@
                           Unarchived
                         </button>
                       {% endif %}
-                    </div>
-                    {% if case.status != 'solved' %}
-                      <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
-                        Solved
-                      </button>
-                    {% else %}
-                      <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                        Unsolved
-                      </button>
-                    {% endif %}
 
-                    <div class="btn-group">
+                      <!-- solved/active -->
+                      {% if case.status != 'solved' %}
+                        <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
+                          Solved
+                        </button>
+                      {% else %}
+                        <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
+                          Unsolved
+                        </button>
+                      {% endif %}
+
+                      <!-- prioritized/active -->
                       <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
                         {{ 'de-prioritized' if case.status == 'prioritized' else 'prioritized' }}
                       </button>
-                    </div>
 
-                    <div class="btn-group">
+                        <!-- unused/active -->
                       <button name="status" value="{{ 'unused' if case.status == 'unused' else 'inactive' }}" type="submit" class="btn btn-light btn-sm">
                         {{ 'unused' if case.status != 'unused' else 'active' }}
                       </button>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -50,7 +50,7 @@
             <div class="col-sm-4">
               <h4 class="">
                 Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">{{case._id}}</span><br>
-                Status: {{case.status}} {%if case.status=="unused"%}<em class="fa fa-question-circle" data-bs-toggle="tooltip" data-bs-placement="top" title="Unused cases are excluded from the statistics shown on the dashboad page"></em>{%endif%}<br>
+                Status: {{case.status}}
                 <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
                   <div>
                     Set

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -49,45 +49,44 @@
         <div class="row">
             <div class="col-sm-4">
               <h4 class="">
-                  Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">Internal ID: {{case._id}}</span><br>
-                  Status: {{case.status}}<br>
-                  <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
-                    <div>
-                      <div class="btn-group">
-                        {% if case.status != 'archived' %}
-                          <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
-                            Archive
-                          </button>
-                        {% else %}
-                          <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                            Unarchive
-                          </button>
-                        {% endif %}
-                      </div>
-                      {% if case.status != 'solved' %}
-                        <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
-                          Solve
+                Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">Internal ID: {{case._id}}</span><br>
+                Status: {{case.status}}<br>
+                <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
+                  <div>
+                    Set
+                    <div class="btn-group">
+                      {% if case.status != 'archived' %}
+                        <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
+                          Archived
                         </button>
                       {% else %}
                         <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                          Unsolve
+                          Unarchived
                         </button>
                       {% endif %}
+                    </div>
+                    {% if case.status != 'solved' %}
+                      <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
+                        Solved
+                      </button>
+                    {% else %}
+                      <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
+                        Unsolved
+                      </button>
+                    {% endif %}
 
-                      <div class="btn-group">
-                        <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
-                          {{ 'De-prioritize' if case.status == 'prioritized' else 'Prioritize' }}
-                        </button>
-                      </div>
+                    <div class="btn-group">
+                      <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
+                        {{ 'de-prioritized' if case.status == 'prioritized' else 'prioritized' }}
+                      </button>
+                    </div>
 
-                      {% if case.status!= 'unused' %}
-                        <div class="btn-group">
-                          <button name="status" value="unused" type="submit" class="btn btn-light btn-sm">Unused
-                          </button>
-                        </div>
-                      {% endif %}
-                      
-                  </form>
+                    <div class="btn-group">
+                      <button name="status" value="{{ 'unused' if case.status == 'unused' else 'inactive' }}" type="submit" class="btn btn-light btn-sm">
+                        {{ 'unused' if case.status != 'unused' else 'active' }}
+                      </button>
+                    </div>
+                </form>
               </h4>
             </div>
             <div class="col-sm-6">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -45,50 +45,50 @@
 {% macro case_page() %}
 <div class="col ms-3"> <!-- This is the main container -->
   <div class="container_spaced">
-      <div class="card-body {% if case.status == 'solved' %} bg-success {% elif case.status == 'archived' %} bg-danger-light {% endif %}">
+      <div class="card-body {% if case.status == 'solved' %} bg-success {% elif case.status == 'archived' %} bg-warning {% elif case.status == 'prioritized' %} bg-info {% endif %}">
         <div class="row">
-            <div class="col-sm-4">
+          <div class="col-sm-4">
               <h4 class="">
                 Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">{{case._id}}</span><br>
                 Status: {{case.status}}
-                <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
-                  <div>
-                    Set
-                    <div class="btn-group">
-                      <!-- archived/active-->
-                      {% if case.status != 'archived' %}
-                        <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
-                          Archived
-                        </button>
-                      {% else %}
-                        <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                          Unarchived
-                        </button>
-                      {% endif %}
-
-                      <!-- solved/active -->
-                      {% if case.status != 'solved' %}
-                        <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
-                          Solved
-                        </button>
-                      {% else %}
-                        <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                          Unsolved
-                        </button>
-                      {% endif %}
-
-                      <!-- prioritized/active -->
-                      <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
-                        {{ 'De-prioritized' if case.status == 'prioritized' else 'Prioritized' }}
-                      </button>
-
-                        <!-- unused/inactive -->
-                      <button name="status" value="{{ 'inactive' if case.status == 'unused' else 'unused' }}" type="submit" class="btn btn-light btn-sm">
-                        {{ 'Inactive' if case.status == 'unused' else 'Unused' }}
-                      </button>
-                    </div>
-                </form>
               </h4>
+              <br>
+              <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
+                  Set:
+                  <div class="btn-group">
+                    <!-- archived/active-->
+                    {% if case.status != 'archived' %}
+                      <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
+                        Archived
+                      </button>
+                    {% else %}
+                      <button type="submit" class="btn btn-warning btn-sm" name="status" value="active">
+                        Unarchived
+                      </button>
+                    {% endif %}
+
+                    <!-- solved/active -->
+                    {% if case.status != 'solved' %}
+                      <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
+                        Solved
+                      </button>
+                    {% else %}
+                      <button type="submit" class="btn btn-success btn-sm" name="status" value="active">
+                        Unsolved
+                      </button>
+                    {% endif %}
+
+                    <!-- prioritized/active -->
+                    <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
+                      {{ 'De-prioritized' if case.status == 'prioritized' else 'Prioritized' }}
+                    </button>
+
+                      <!-- unused/inactive -->
+                    <button name="status" value="{{ 'inactive' if case.status == 'ignored' else 'ignored' }}" type="submit" class="btn btn-light btn-sm">
+                      {{ 'Inactive' if case.status == 'ignored' else 'Ignored' }}
+                    </button>
+                  </div>
+              </form>
             </div>
             <div class="col-sm-6">
               {{ variants_buttons() }}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -49,7 +49,7 @@
         <div class="row">
             <div class="col-sm-4">
               <h4 class="">
-                Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">Internal ID: {{case._id}}</span><br>
+                Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">ID:{{case._id}}</span><br>
                 Status: {{case.status}}<br>
                 <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
                   <div>
@@ -82,9 +82,9 @@
                         {{ 'de-prioritized' if case.status == 'prioritized' else 'prioritized' }}
                       </button>
 
-                        <!-- unused/active -->
-                      <button name="status" value="{{ 'unused' if case.status == 'unused' else 'inactive' }}" type="submit" class="btn btn-light btn-sm">
-                        {{ 'unused' if case.status != 'unused' else 'active' }}
+                        <!-- unused/inactive -->
+                      <button name="status" value="{{ 'inactive' if case.status == 'unused' else 'unused' }}" type="submit" class="btn btn-light btn-sm">
+                        {{ 'inactive' if case.status == 'unused' else 'unused' }}
                       </button>
                     </div>
                 </form>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -79,7 +79,7 @@
 
                       <!-- prioritized/active -->
                       <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
-                        {{ 'de-prioritized' if case.status == 'prioritized' else 'prioritized' }}
+                        {{ 'De-prioritized' if case.status == 'prioritized' else 'Prioritized' }}
                       </button>
 
                         <!-- unused/inactive -->

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -84,7 +84,7 @@
 
                         <!-- unused/inactive -->
                       <button name="status" value="{{ 'inactive' if case.status == 'unused' else 'unused' }}" type="submit" class="btn btn-light btn-sm">
-                        {{ 'inactive' if case.status == 'unused' else 'unused' }}
+                        {{ 'Inactive' if case.status == 'unused' else 'Unused' }}
                       </button>
                     </div>
                 </form>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -49,9 +49,45 @@
         <div class="row">
             <div class="col-sm-4">
               <h4 class="">
-                  Case: {{case.display_name}}<br>
+                  Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">Internal ID: {{case._id}}</span><br>
                   Status: {{case.status}}<br>
-                  <span class="badge bg-sm bg-secondary">Internal ID: {{case._id}}</span>
+                  <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
+                    <div>
+                      <div class="btn-group">
+                        {% if case.status != 'archived' %}
+                          <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
+                            Archive
+                          </button>
+                        {% else %}
+                          <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
+                            Unarchive
+                          </button>
+                        {% endif %}
+                      </div>
+                      {% if case.status != 'solved' %}
+                        <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
+                          Solve
+                        </button>
+                      {% else %}
+                        <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
+                          Unsolve
+                        </button>
+                      {% endif %}
+
+                      <div class="btn-group">
+                        <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-info btn-sm">
+                          {{ 'De-prioritize' if case.status == 'prioritized' else 'Prioritize' }}
+                        </button>
+                      </div>
+
+                      {% if case.status!= 'unused' %}
+                        <div class="btn-group">
+                          <button name="status" value="unused" type="submit" class="btn btn-light btn-sm">Unused
+                          </button>
+                        </div>
+                      {% endif %}
+                      
+                  </form>
               </h4>
             </div>
             <div class="col-sm-6">

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -49,8 +49,8 @@
         <div class="row">
             <div class="col-sm-4">
               <h4 class="">
-                Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">ID:{{case._id}}</span><br>
-                Status: {{case.status}}<br>
+                Case: {{case.display_name}} <span class="badge bg-sm bg-secondary">{{case._id}}</span><br>
+                Status: {{case.status}} {%if case.status=="unused"%}<em class="fa fa-question-circle" data-bs-toggle="tooltip" data-bs-placement="top" title="Unused cases are excluded from the statistics shown on the dashboad page"></em>{%endif%}<br>
                 <form method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
                   <div>
                     Set

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -194,43 +194,11 @@
 
 {% macro status(institute, case) %}
   <div class="list-group-item d-inline-block bg-dark">
-    <form method="POST"
-          action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
-      <div class="nav-sidebar-item" style="color: #FFFFFF;">
-          <span class="fa fa-star fa-fw me-3"></span>
-          <span class="menu-collapsed">
-          Status: {{ case.status|capitalize }}<br><br>
-          <div class="btn-group btn-group-justified">
-            <div class="btn-group">
-              {% if case.status != 'archived' %}
-                <button type="button" class="btn btn-warning btn-sm" data-bs-toggle="modal" data-bs-target="#archive_modal">
-                  Archive
-                </button>
-              {% else %}
-                <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                  Unarchive
-                </button>
-              {% endif %}
-            </div>
-            {% if case.status != 'solved' %}
-              <button type="button" class="btn btn-success btn-sm" data-bs-toggle="modal" data-bs-target="#solve_modal">
-                Solve
-              </button>
-            {% else %}
-              <button type="submit" class="btn btn-info btn-sm" name="status" value="active">
-                Unsolve
-              </button>
-            {% endif %}
-
-            <div class="btn-group">
-              <button name="status" value="{{ 'active' if case.status == 'prioritized' else 'prioritized' }}" type="submit" class="btn btn-light btn-sm">
-                {{ 'De-prioritize' if case.status == 'prioritized' else 'Prioritize' }}
-              </button>
-            </div>
-          </div>
-        </span>
-      </div>
-    </form>
+    <div class="nav-sidebar-item" style="color: #FFFFFF;">
+      <span class="fa fa-star fa-fw me-3"></span>
+      <span class="menu-collapsed">
+      Status: {{ case.status|capitalize }}<br><br>
+    </div>
   </div>
 {% endmacro %}
 

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -197,7 +197,7 @@
     <div class="nav-sidebar-item" style="color: #FFFFFF;">
       <span class="fa fa-star fa-fw me-3"></span>
       <span class="menu-collapsed">
-      Status: {{ case.status|capitalize }}<br><br>
+      Status: {{ case.status|capitalize }}
     </div>
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -16,7 +16,7 @@
           {{ genome_build(case, case_groups) }}
           {{ rank_model(case) }}
           <li class="list-group-item bg-dark sidebar-separator menu-collapsed"></li>
-          {{ status(institute, case) }}
+          {{ status(case) }}
           {{ assign(institute, case) }}
           {% if not (case.is_archived or case.is_research) %}
             {{ research(case) }}
@@ -192,7 +192,7 @@
 {% endif %}
 {% endmacro %}
 
-{% macro status(institute, case) %}
+{% macro status(case) %}
   <div class="list-group-item d-inline-block bg-dark">
     <div class="nav-sidebar-item" style="color: #FFFFFF;">
       <span class="fa fa-star fa-fw me-3"></span>

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -10,6 +10,7 @@ from scout.server.utils import user_institutes
 from .forms import DashboardFilterForm
 
 LOG = logging.getLogger(__name__)
+CASE_STATUS = {"$ne": "unused"}
 
 
 def institute_select_choices():
@@ -162,7 +163,7 @@ def get_general_case_info(adapter, institute_id=None, slice_query=None):
     # Potentially sensitive slice queries are assumed allowed if we have got this far
     name_query = slice_query
 
-    cases = adapter.cases(owner=institute_id, name_query=name_query)
+    cases = adapter.cases(owner=institute_id, name_query=name_query, status=CASE_STATUS)
 
     phenotype_cases = 0
     causative_cases = 0
@@ -228,11 +229,13 @@ def get_case_groups(adapter, total_cases, institute_id=None, slice_query=None):
 
     subquery = {}
     if institute_id and slice_query:
-        subquery = adapter.cases(owner=institute_id, name_query=slice_query, yield_query=True)
+        subquery = adapter.cases(
+            owner=institute_id, name_query=slice_query, status=CASE_STATUS, yield_query=True
+        )
     elif institute_id:
-        subquery = adapter.cases(owner=institute_id, yield_query=True)
+        subquery = adapter.cases(owner=institute_id, status=CASE_STATUS, yield_query=True)
     elif slice_query:
-        subquery = adapter.cases(name_query=slice_query, yield_query=True)
+        subquery = adapter.cases(name_query=slice_query, status=CASE_STATUS, yield_query=True)
 
     query = {"$match": subquery} if subquery else {}
 

--- a/scout/server/blueprints/dashboard/controllers.py
+++ b/scout/server/blueprints/dashboard/controllers.py
@@ -10,7 +10,6 @@ from scout.server.utils import user_institutes
 from .forms import DashboardFilterForm
 
 LOG = logging.getLogger(__name__)
-CASE_STATUS = {"$ne": "unused"}
 
 
 def institute_select_choices():
@@ -163,7 +162,7 @@ def get_general_case_info(adapter, institute_id=None, slice_query=None):
     # Potentially sensitive slice queries are assumed allowed if we have got this far
     name_query = slice_query
 
-    cases = adapter.cases(owner=institute_id, name_query=name_query, status=CASE_STATUS)
+    cases = adapter.cases(owner=institute_id, name_query=name_query)
 
     phenotype_cases = 0
     causative_cases = 0
@@ -229,13 +228,11 @@ def get_case_groups(adapter, total_cases, institute_id=None, slice_query=None):
 
     subquery = {}
     if institute_id and slice_query:
-        subquery = adapter.cases(
-            owner=institute_id, name_query=slice_query, status=CASE_STATUS, yield_query=True
-        )
+        subquery = adapter.cases(owner=institute_id, name_query=slice_query, yield_query=True)
     elif institute_id:
-        subquery = adapter.cases(owner=institute_id, status=CASE_STATUS, yield_query=True)
+        subquery = adapter.cases(owner=institute_id, yield_query=True)
     elif slice_query:
-        subquery = adapter.cases(name_query=slice_query, status=CASE_STATUS, yield_query=True)
+        subquery = adapter.cases(name_query=slice_query, yield_query=True)
 
     query = {"$match": subquery} if subquery else {}
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -449,9 +449,7 @@ def cases(store, request, institute_id):
 
     for nr_cases, case_obj in enumerate(all_cases.limit(limit), 1):
         case_obj = populate_case_obj(case_obj)
-        status = case_obj["status"]
-        if status in case_groups:
-            case_groups[status].append(case_obj)
+        case_groups[case_obj["status"]].append(case_obj)
 
     if prioritized_cases:
         extra_prioritized = 0

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -415,6 +415,8 @@ def cases(store, request, institute_id):
     all_cases = _sort_cases(data, request, all_cases)
 
     data["nr_cases"] = store.nr_cases(institute_id=institute_id)
+    data["status_ncases"] = store.nr_cases_by_status(institute_id=institute_id)
+    LOG.error(data["status_ncases"])
     data["sanger_unevaluated"] = get_sanger_unevaluated(store, institute_id, current_user.email)
 
     case_groups = {status: [] for status in CASE_STATUSES}

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -416,7 +416,6 @@ def cases(store, request, institute_id):
 
     data["nr_cases"] = store.nr_cases(institute_id=institute_id)
     data["status_ncases"] = store.nr_cases_by_status(institute_id=institute_id)
-    LOG.error(data["status_ncases"])
     data["sanger_unevaluated"] = get_sanger_unevaluated(store, institute_id, current_user.email)
 
     case_groups = {status: [] for status in CASE_STATUSES}

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -449,7 +449,9 @@ def cases(store, request, institute_id):
 
     for nr_cases, case_obj in enumerate(all_cases.limit(limit), 1):
         case_obj = populate_case_obj(case_obj)
-        case_groups[case_obj["status"]].append(case_obj)
+        status = case_obj["status"]
+        if status in case_groups:
+            case_groups[status].append(case_obj)
 
     if prioritized_cases:
         extra_prioritized = 0

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -256,7 +256,7 @@
         </div>
       {% endif %}
       <div>
-        {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', ] -%}
+        {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'unused'] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}
             {% if status == group_name and case_group|length > 0 %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -71,7 +71,7 @@
     <table class="table table-hover table-bordered">
       <thead>
         <tr>
-          <th style="width: 25%">{{ group_name|capitalize }} cases</th>
+          <th style="width: 25%">{{ group_name|capitalize }} cases ({{cases|length}}/{{status_ncases[group_name]}})</th>
           <th style="width: 10%">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status','{{sort_option}}');" class="badge" style="color:{{'black' if sort_by=='status' else 'grey'}};background-color:white;">
             <i class="fa fa-sort{{'-'+sort_order if sort_by=='status' }}" aria-hidden="true" data-bs-toggle="tooltip" title="Sort cases by 'status'"></i>
           </a></th>

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -260,7 +260,7 @@
         </div>
       {% endif %}
       <div>
-        {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'unused'] -%}
+        {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'ignored'] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}
             {% if status == group_name and case_group|length > 0 %}


### PR DESCRIPTION
- Fix #3633 
- Fix #3605 

<img width="198" alt="image" src="https://user-images.githubusercontent.com/28093618/196398708-1d4fd5fc-734e-40e2-ba70-8b0dae16f63a.png">

- Moved code to assign case status from sidebar to main case page:

<img width="311" alt="image" src="https://user-images.githubusercontent.com/28093618/196398863-05d7ffb1-77de-40fa-9418-14daa04f98a2.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
