### PR TITLE
Filter cases by submitted to ClinVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Filter case list by cases with variants in ClinVar submission
+
 ## [4.60]
 ### Added
 - Mitochondrial deletion signatures (mitosign) can be uploaded and shown with mtDNA report

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -13,6 +13,7 @@ from scout.parse.variant.ids import parse_document_id
 from scout.utils.algorithms import ui_score
 
 LOG = logging.getLogger(__name__)
+CASES_SEARCH_ACTIONS = {}
 
 
 class CaseHandler(object):
@@ -236,6 +237,21 @@ class CaseHandler(object):
 
         return order
 
+    def _update_case_id_query(self, query, id_list):
+        """Update a case query ["_id"]["$in"] values using an additional list of case _ids
+
+        Args:
+            query(dict): a query dictionary that contains a ["_id"]["$in"] key with case _ids as value
+            id_list(list): a list of case _ids to update query with
+        """
+        if query.get("_id"):  # Check if other filter already limits the search by case _id
+            preselected_ids = query["_id"].get("$in", [])
+            query["_id"]["$in"] = list(
+                set(preselected_ids).intersection(set(id_list))
+            )  # limit also by case _ids present in id_list
+        else:  # use id_list for filtering
+            query["_id"] = {"$in": id_list}
+
     def cases(
         self,
         owner=None,
@@ -258,6 +274,7 @@ class CaseHandler(object):
         within_days=None,
         assignee=None,
         verification_pending=None,
+        has_clinvar_submission=None,
     ):
         """Fetches all cases from the backend.
 
@@ -283,6 +300,7 @@ class CaseHandler(object):
             within_days(int): timespan (in days) for latest event on case
             assignee(str): email of an assignee
             verification_pending(bool): If search should be restricted to cases with verification_pending
+            has_clinvar_submission(bool): If search should be limited to cases with a ClinVar submission
 
         Returns:
             Cases ordered by date.
@@ -354,13 +372,11 @@ class CaseHandler(object):
 
         if verification_pending:  # Filter for cases with Sanger verification pending
             sanger_pending_cases = self.verification_missing_cases(owner)
-            if query.get("_id"):  # Check if other filter already limits the search by case _id
-                preselected_ids = query["_id"].get("$in", [])
-                query["_id"]["$in"] = list(
-                    set(preselected_ids).intersection(set(sanger_pending_cases))
-                )  # limit also by Sanger pending
-            else:  # Apply only Sanger pending filter
-                query["_id"] = {"$in": sanger_pending_cases}
+            self._update_case_id_query(query, sanger_pending_cases)
+
+        if has_clinvar_submission:
+            clinvar_subm_cases = self.clinvar_cases(collaborator or owner)
+            self._update_case_id_query(query, clinvar_subm_cases)
 
         if yield_query:
             return query
@@ -439,6 +455,21 @@ class CaseHandler(object):
                 sanger_missing_cases.append(case_variants["_id"])
 
         return sanger_missing_cases
+
+    def clinvar_cases(self, institute_id=None):
+        """Fetch all cases woth variants contained in a ClinVar submission object
+
+        Args:
+            institute_id(str): id of an institute
+        Returns:
+            clinvar_case_ids(list): list of case _ids
+        """
+        clinvar_case_ids = set()
+        inst_submissions = self.clinvar_submissions(institute_id=institute_id)
+        for subm in inst_submissions:
+            for var in subm.get("variant_data"):
+                clinvar_case_ids.add(var["case_id"])
+        return list(clinvar_case_ids)
 
     def prioritized_cases(self, institute_id=None):
         """Fetches any prioritized cases from the backend.

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -456,21 +456,6 @@ class CaseHandler(object):
 
         return sanger_missing_cases
 
-    def clinvar_cases(self, institute_id=None):
-        """Fetch all cases woth variants contained in a ClinVar submission object
-
-        Args:
-            institute_id(str): id of an institute
-        Returns:
-            clinvar_case_ids(list): list of case _ids
-        """
-        clinvar_case_ids = set()
-        inst_submissions = self.clinvar_submissions(institute_id=institute_id)
-        for subm in inst_submissions:
-            for var in subm.get("variant_data"):
-                clinvar_case_ids.add(var["case_id"])
-        return list(clinvar_case_ids)
-
     def prioritized_cases(self, institute_id=None):
         """Fetches any prioritized cases from the backend.
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -13,7 +13,6 @@ from scout.parse.variant.ids import parse_document_id
 from scout.utils.algorithms import ui_score
 
 LOG = logging.getLogger(__name__)
-CASES_SEARCH_ACTIONS = {}
 
 
 class CaseHandler(object):

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -416,3 +416,18 @@ class ClinVarHandler(object):
             submitted_vars[clinvar.get("local_id")] = clinvar
 
         return submitted_vars
+
+    def clinvar_cases(self, institute_id=None):
+        """Fetch all cases woth variants contained in a ClinVar submission object
+
+        Args:
+            institute_id(str): id of an institute
+        Returns:
+            clinvar_case_ids(list): list of case _ids
+        """
+        clinvar_case_ids = set()
+        inst_submissions = self.clinvar_submissions(institute_id=institute_id)
+        for subm in inst_submissions:
+            for var in subm.get("variant_data"):
+                clinvar_case_ids.add(var["case_id"])
+        return list(clinvar_case_ids)

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -418,7 +418,7 @@ class ClinVarHandler(object):
         return submitted_vars
 
     def clinvar_cases(self, institute_id=None):
-        """Fetch all cases woth variants contained in a ClinVar submission object
+        """Fetch all cases with variants contained in a ClinVar submission object
 
         Args:
             institute_id(str): id of an institute

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -411,6 +411,7 @@ def cases(store, request, institute_id):
         skip_assigned=request.args.get("skip_assigned"),
         is_research=request.args.get("is_research"),
         verification_pending=request.args.get("validation_ordered"),
+        has_clinvar_submission=request.args.get("clinvar_submitted"),
     )
     all_cases = _sort_cases(data, request, all_cases)
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -143,7 +143,8 @@ class CaseFilterForm(FlaskForm):
     search_limit = IntegerField("Limit", [validators.Optional()], default=100)
     skip_assigned = BooleanField("Hide assigned")
     is_research = BooleanField("Research only")
-    validation_ordered = BooleanField("Validation pending")
+    clinvar_submitted = BooleanField("has ClinVar submissions")
+    validation_ordered = BooleanField("validation pending")
     search = SubmitField(label="Search")
 
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -144,7 +144,7 @@ class CaseFilterForm(FlaskForm):
     skip_assigned = BooleanField("Hide assigned")
     is_research = BooleanField("Research only")
     clinvar_submitted = BooleanField("has ClinVar submissions")
-    validation_ordered = BooleanField("validation pending")
+    validation_ordered = BooleanField("Validation pending")
     search = SubmitField(label="Search")
 
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -143,7 +143,7 @@ class CaseFilterForm(FlaskForm):
     search_limit = IntegerField("Limit", [validators.Optional()], default=100)
     skip_assigned = BooleanField("Hide assigned")
     is_research = BooleanField("Research only")
-    clinvar_submitted = BooleanField("has ClinVar submissions")
+    clinvar_submitted = BooleanField("Has ClinVar submissions")
     validation_ordered = BooleanField("Validation pending")
     search = SubmitField(label="Search")
 

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -52,6 +52,10 @@
       </div>
       <div class="col-2">
         <div class="form-check">
+          {{ form.clinvar_submitted(class="form-check-input") }}
+          {{ form.clinvar_submitted.label(class="form-check-label") }}
+        </div>
+        <div class="form-check">
           {{ form.validation_ordered(class="form-check-input") }}
           {{ form.validation_ordered.label(class="form-check-label") }}
         </div>

--- a/tests/adapter/mongo/test_clinvar_handler.py
+++ b/tests/adapter/mongo/test_clinvar_handler.py
@@ -217,3 +217,19 @@ def test_add_remove_subm_objects(adapter, institute_obj, case_obj):
     # assert that there are no objects left in clinvar collection
     submission_objects = list(adapter.clinvar_collection.find())
     assert len(submission_objects) == 0
+
+
+def test_clinvar_cases(adapter, institute_obj, case_obj):
+    """Test Mongo adapter functions that retrieves a list of case _ids with ClinVar submissions"""
+    # GIVEN a case with ClinVar submission:
+    adapter.case_collection.insert_one(case_obj)
+
+    submission_id = get_new_submission(adapter, institute_obj)
+    variant_data = [get_test_submission_variant(case_obj)]
+    case_data = [get_test_submission_case(case_obj)]  # a list of 1 dictionary element
+    subm_objs = (variant_data, case_data)
+    adapter.add_to_submission(submission_id, subm_objs)
+
+    # THEN the adapter clinvar_cases function should return the case _id
+    clinvar_case_ids = adapter.clinvar_cases(institute_id=institute_obj["_id"])
+    assert clinvar_case_ids[0] == case_obj["_id"]


### PR DESCRIPTION
Introduce a new checkbox on cases page to filter by cases with variants contained in ClinVar submissions (fix #849):

<img width="613" alt="image" src="https://user-images.githubusercontent.com/28093618/196446312-31736873-2694-4e1f-8eb6-bede2ef75fac.png">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. Install on cg-vm1 and add one variants for a case to a ClinVar submission (use a pinned variant from case page)
2. Go to institutes case and filter by cases with ClinVar submission
3. The case above should be returned in the list of filtered cases

**Review:**
- [ ] code approved by
- [ ] tests executed by
