### PR TITLE
Loqus priv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Non-admin users saving institute settings would clear loqusdb instance selection
+
 ## [4.60]
 ### Added
 - Mitochondrial deletion signatures (mitosign) can be uploaded and shown with mtDNA report

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -48,7 +48,7 @@ class InstituteHandler(object):
         add_groups=None,
         sharing_institutes=None,
         cohorts=None,
-        loqusdb_ids=[],
+        loqusdb_ids=None,
         alamut_key=None,
         check_show_all_vars=None,
     ):

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -48,7 +48,7 @@ class InstituteHandler(object):
         add_groups=None,
         sharing_institutes=None,
         cohorts=None,
-        loqusdb_ids=None,
+        loqusdb_ids=[],
         alamut_key=None,
         check_show_all_vars=None,
     ):

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -328,6 +328,10 @@ def update_institute_settings(store, institute_obj, form):
     for cohort in form.getlist("cohorts"):
         cohorts.append(cohort.strip())
 
+    loqusdb_ids = form.getlist("loqusdb_id")
+    if current_user.is_admin is False:
+        loqusdb_ids = None
+
     updated_institute = store.update_institute(
         internal_id=institute_obj["_id"],
         sanger_recipients=sanger_recipients,
@@ -341,7 +345,7 @@ def update_institute_settings(store, institute_obj, form):
         add_groups=False,
         sharing_institutes=sharing_institutes,
         cohorts=cohorts,
-        loqusdb_ids=form.getlist("loqusdb_id"),
+        loqusdb_ids=loqusdb_ids,
         alamut_key=form.get("alamut_key"),
         check_show_all_vars=form.get("check_show_all_vars"),
     )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The issue here is that `getlist` will return the `[]` also if the control does not exist on the form, not `None`. Actually check if user is admin, else set it to `None`.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. With current main (4.60), as an admin user, ensure an institute has a loqusdb instance selected. Switch to an unprivileged user, change some other random setting, and notice that loqus db connectivity is gone for the institute (`loqusdb_ids` is `[]`). 
2. After patch, unprivileged user saving other settings should not reset loqusdb_ids.
3. Also ensure that privileged users can still change loqusdb_ids when needed.

 how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, CR
