### PR TITLE
Search for RNA cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Filter case list by cases with variants in ClinVar submission
+- Filter case list by cases containing RNA-seq data
 - Additional case category `Ignored`, to be used for cases that don't fall in the existing 'inactive', 'archived', 'solved', 'prioritized' categories
 - Display number of cases shown / total number of cases available for each category on Cases page
 - Moved buttons to modify case status from sidebar to main case page

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -437,7 +437,7 @@ class CaseHandler(object):
         Returns:
             list of case _ids
         """
-        EXISTS_NOT_NULL = {"$exists": True, "$nin": [null, ""]}
+        EXISTS_NOT_NULL = {"$exists": True, "$nin": [None, ""]}
         query = {
             "owner": owner,
             "$or": [

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -437,7 +437,7 @@ class CaseHandler(object):
         Returns:
             list of case _ids
         """
-        EXISTS_NOT_NULL = {"$exists": True, "$ne": None}
+        EXISTS_NOT_NULL = {"$exists": True, "$nin": [null, ""]}
         query = {
             "owner": owner,
             "$or": [

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -317,11 +317,11 @@ class CaseHandler(object):
 
             Args:
                 query(dict): case query dictionary
-                value(misc): a variable that could have a value or be None
+                condition(misc): a variable that could have a value or be None
                 set_key(str): new query key query[set_key]
                 set_value(misc): value to assign to query[set_key]
             """
-            if value:
+            if condition:
                 query[set_key] = set_value
 
         query = query or {}
@@ -330,71 +330,80 @@ class CaseHandler(object):
         if collaborator and owner:
             collaborator = None
 
-        _set_query_value(
-            query=query, value=collaborator, set_key="collaborators", set_value=collaborator
+        _conditional_set_query_value(
+            query=query, condition=collaborator, set_key="collaborators", set_value=collaborator
         )
 
-        _set_query_value(query=query, value=owner, set_key="owner", set_value=owner)
+        _conditional_set_query_value(query=query, condition=owner, set_key="owner", set_value=owner)
 
-        _set_query_value(
-            query=query, value=skip_assigned, set_key="assignees", set_value={"$exists": False}
+        _conditional_set_query_value(
+            query=query, condition=skip_assigned, set_key="assignees", set_value={"$exists": False}
         )
 
-        _set_query_value(
+        _conditional_set_query_value(
             query=query,
-            value=has_causatives,
+            condition=has_causatives,
             set_key="causatives",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(query=query, value=reruns, set_key="rerun_requested", set_value=True)
-
-        _set_query_value(
-            query=query, value=rerun_monitor, set_key="rerun_monitoring", set_value=True
+        _conditional_set_query_value(
+            query=query, condition=reruns, set_key="rerun_requested", set_value=True
         )
 
-        _set_query_value(query=query, value=status, set_key="status", set_value=status)
-
-        _set_query_value(
-            query=query, value=finished, set_key="status", set_value={"$in": ["solved", "archived"]}
+        _conditional_set_query_value(
+            query=query, condition=rerun_monitor, set_key="rerun_monitoring", set_value=True
         )
 
-        _set_query_value(
-            query=query, value=research_requested, set_key="research_requested", set_value=True
+        _conditional_set_query_value(
+            query=query, condition=status, set_key="status", set_value=status
         )
 
-        _set_query_value(
+        _conditional_set_query_value(
             query=query,
-            value=is_research,
+            condition=finished,
+            set_key="status",
+            set_value={"$in": ["solved", "archived"]},
+        )
+
+        _conditional_set_query_value(
+            query=query, condition=research_requested, set_key="research_requested", set_value=True
+        )
+
+        _conditional_set_query_value(
+            query=query,
+            condition=is_research,
             set_key="is_research",
             set_value={"$exists": True, "$eq": True},
         )
 
-        _set_query_value(
+        _conditional_set_query_value(
             query=query,
-            value=phenotype_terms,
+            condition=phenotype_terms,
             set_key="phenotype_terms",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(
+        _conditional_set_query_value(
             query=query,
-            value=pinned,
+            condition=pinned,
             set_key="suspects",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(
+        _conditional_set_query_value(
             query=query,
-            value=cohort,
+            condition=cohort,
             set_key="cohorts",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(query=query, value=group, set_key="group", set_value={"$in": [group]})
+        _conditional_set_query_value(
+            query=query, condition=group, set_key="group", set_value={"$in": [group]}
+        )
 
-        _set_query_value(
-            query=query, value=assignee, set_key="assignees", set_value={"$in": [assignee]}
+        _conditional_set_query_value(
+            query=query, condition=assignee, set_key="assignees", set_value={"$in": [assignee]}
         )
 
         if name_query:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -312,7 +312,7 @@ class CaseHandler(object):
 
         def _conditional_set_query_value(query, condition, set_key, set_value):
             """Adds kes/values to a growing query dictionary for selecting cases from db.
-            Checks if 'value' has a value. If it does, adds set_key/set_value as key/value to the growing
+            Checks if 'condition' has a value. If it does, adds set_key/set_value as key/value to the growing
             query dictionary
 
             Args:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -310,7 +310,7 @@ class CaseHandler(object):
                 that can be reused in compound queries or for testing.
         """
 
-        def _set_query_value(query, value, set_key, set_value):
+        def _conditional_set_query_value(query, condition, set_key, set_value):
             """Adds kes/values to a growing query dictionary for selecting cases from db.
             Checks if 'value' has a value. If it does, adds set_key/set_value as key/value to the growing
             query dictionary

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -310,14 +310,14 @@ class CaseHandler(object):
                 that can be reused in compound queries or for testing.
         """
 
-        def _set_query_value(self, query, var, set_key, set_value):
+        def _set_query_value(self, query, value, set_key, set_value):
             """Adds kes/values to a growing query dictionary for selecting cases from db.
-            Checks if 'var' has a value. If it does, adds set_key/set_value as key/value to the growing
+            Checks if 'value' has a value. If it does, adds set_key/set_value as key/value to the growing
             query dictionary
 
             Args:
                 query(dict): case query dictionary
-                var(misc): could have a value or be None
+                value(misc): a variable that could have a value or be None
                 set_key(str): new query key query[set_key]
                 set_value(misc): value to assign to query[set_key]
             """
@@ -331,68 +331,70 @@ class CaseHandler(object):
             collaborator = None
 
         _set_query_value(
-            query=query, var=collaborator, set_key="collaborators", set_value=collaborator
+            query=query, value=collaborator, set_key="collaborators", set_value=collaborator
         )
 
-        _set_query_value(query=query, var=owner, set_key="owner", set_value=owner)
+        _set_query_value(query=query, value=owner, set_key="owner", set_value=owner)
 
         _set_query_value(
-            query=query, var=skip_assigned, set_key="assignees", set_value={"$exists": False}
+            query=query, value=skip_assigned, set_key="assignees", set_value={"$exists": False}
         )
 
         _set_query_value(
             query=query,
-            var=has_causatives,
+            value=has_causatives,
             set_key="causatives",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(query=query, var=reruns, set_key="rerun_requested", set_value=True)
-
-        _set_query_value(query=query, var=rerun_monitor, set_key="rerun_monitoring", set_value=True)
-
-        _set_query_value(query=query, var=status, set_key="status", set_value=status)
+        _set_query_value(query=query, value=reruns, set_key="rerun_requested", set_value=True)
 
         _set_query_value(
-            query=query, var=finished, set_key="status", set_value={"$in": ["solved", "archived"]}
+            query=query, value=rerun_monitor, set_key="rerun_monitoring", set_value=True
+        )
+
+        _set_query_value(query=query, value=status, set_key="status", set_value=status)
+
+        _set_query_value(
+            query=query, value=finished, set_key="status", set_value={"$in": ["solved", "archived"]}
         )
 
         _set_query_value(
-            query=query, var=research_requested, set_key="research_requested", set_value=True
+            query=query, value=research_requested, set_key="research_requested", set_value=True
         )
 
         _set_query_value(
             query=query,
-            var=is_research,
+            value=is_research,
             set_key="is_research",
             set_value={"$exists": True, "$eq": True},
         )
 
         _set_query_value(
             query=query,
-            var=phenotype_terms,
+            value=phenotype_terms,
             set_key="phenotype_terms",
             set_value={"$exists": True, "$ne": []},
         )
 
         _set_query_value(
             query=query,
-            var=pinned,
+            value=pinned,
             set_key="suspects",
             set_value={"$exists": True, "$ne": []},
         )
 
         _set_query_value(
             query=query,
-            var=cohort,
+            value=cohort,
             set_key="cohorts",
             set_value={"$exists": True, "$ne": []},
         )
 
-        _set_query_value(query=query, var=group, set_key="group", set_value={"$in": [group]})
+        _set_query_value(query=query, value=group, set_key="group", set_value={"$in": [group]})
 
         _set_query_value(
-            query=query, var=assignee, set_key="assignees", set_value={"$in": [assignee]}
+            query=query, value=assignee, set_key="assignees", set_value={"$in": [assignee]}
         )
 
         if name_query:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -413,6 +413,7 @@ def cases(store, request, institute_id):
         name_query=name_query,
         skip_assigned=request.args.get("skip_assigned"),
         is_research=request.args.get("is_research"),
+        has_rna_data=request.args.get("has_rna"),
         verification_pending=request.args.get("validation_ordered"),
         has_clinvar_submission=request.args.get("clinvar_submitted"),
     )

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -144,6 +144,7 @@ class CaseFilterForm(FlaskForm):
     skip_assigned = BooleanField("Hide assigned")
     is_research = BooleanField("Research only")
     clinvar_submitted = BooleanField("Has ClinVar submissions")
+    has_rna = BooleanField("Has RNA-seq data")
     validation_ordered = BooleanField("Validation pending")
     search = SubmitField(label="Search")
 

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -49,6 +49,10 @@
           {{ form.is_research(class="form-check-input") }}
           {{ form.is_research.label(class="form-check-label") }}
         </div>
+        <div class="form-check">
+          {{ form.has_rna(class="form-check-input") }}
+          {{ form.has_rna.label(class="form-check-label") }}
+        </div>
       </div>
       <div class="col-2">
         <div class="form-check">

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -757,6 +757,19 @@ def test_verification_missing_cases(real_adapter, case_obj, user_obj, institute_
     assert len(adapter.verification_missing_cases(institute_obj["_id"])) == 1
 
 
+def test_rna_cases(real_adapter, case_obj):
+    """Test filter for cases with RNA-seq data available"""
+
+    adapter = real_adapter
+
+    # GIVEN a case with RNA data
+    assert case_obj["gene_fusion_report"]
+    assert adapter.case_collection.insert_one(case_obj)
+
+    # The adapter function rna_cases should return test case _id
+    assert adapter.rna_cases(owner=case_obj["owner"]) == [case_obj["_id"]]
+
+
 def test_keep_manual_rank_tag_after_reupload(
     adapter, case_obj, variant_obj, user_obj, institute_obj
 ):


### PR DESCRIPTION
Fix #3646 --> Filter cases for cases with RNA data

Adds a checkbox on cases filter to filter for cases using these conditions:

```
EXISTS_NOT_NULL = {"$exists": True, "$nin": [None, ""]}
query = {
   "owner": owner,
    "$or": [
                {"gene_fusion_report": EXISTS_NOT_NULL},
                {"individuals.splice_junctions_bed": EXISTS_NOT_NULL},
                {"individuals.rna_coverage_bigwig": EXISTS_NOT_NULL},
            ],
 }
```

These conditions might eventually be expanded when we add new RNA-seq data, for instance RNA multiqc etc



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the paxa software installed on `hasta`:
 - Log in into hasta: `ssh <USER.NAME>@hasta.scilifelab.se`
 - Activate the staging environment with the command `us` (Use Stage)
 - Run the command `paxa` and follow the instructions. Make sure to specify scout-stage as the resource you request and the server cg-vm1 as server.
1. Log out from the hasta server.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
