### PR TITLE
Improve layout of variant position, cytoband and type in SV variant s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Deprecated CLI commands `scout load <delivery_report, gene_fusion_report, coverage_qc_report, cnv_report>` to replace them with command `scout load report -t <report type>`
 ### Fixed
 - Non-admin users saving institute settings would clear loqusdb instance selection
-
+- Layout of variant position, cytoband and type in SV variant summary
 
 ## [4.60]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -197,12 +197,10 @@
     <div class="card-body">
       <ul class="list-group">
         <li class="list-group-item">
-          <div class="row d-flex justify-content-between">
-            <div>Position</div>
-            <div>
-              {{ variant.chromosome }}:{{ variant.position }}{{ "-" if variant.end_chrom == variant.chromosome else " / " + variant.end_chrom+":" }}{{ variant.end }}
-            </div>
-          </div>
+          <span class="d-inline">Position</span>
+          <span class="d-inline ms-3">
+            {{ variant.chromosome }}:{{ variant.position }}{{ "-" if variant.end_chrom == variant.chromosome else " / " + variant.end_chrom+":" }}{{ variant.end }}
+          </span>
         </li>
         {% if gens_info.display %}
         <li class="list-group-item">
@@ -227,16 +225,14 @@
           </div>
         </li>
         <li class="list-group-item">
-          <div class="row d-flex align-items-center">
-          <div>Cytoband</div>
-            <div class="offset-9">
-              {% if variant.end_chrom == variant.chromosome %}
-                {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end if variant.cytoband_end != variant.cytoband_start else "" }}
-              {% else %}
-                ({{ variant.chromosome + ";" + variant.end_chrom}})({{ variant.cytoband_start + ";" + variant.cytoband_end }})
-              {% endif %}
-            </div>
-          </div>
+          <span class="d-inline">Cytoband</span>
+          <span class="d-inline ms-3">
+            {% if variant.end_chrom == variant.chromosome %}
+              {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end if variant.cytoband_end != variant.cytoband_start else "" }}
+            {% else %}
+              ({{ variant.chromosome + ";" + variant.end_chrom}})({{ variant.cytoband_start + ";" + variant.cytoband_end }})
+            {% endif %}
+          </span>
         </li>
         <li class="list-group-item">
           <div class="row d-flex align-items-center">
@@ -255,9 +251,8 @@
           </li>
         {% endif %}
       <li class="list-group-item">
-        <div class="row d-flex justify-content-between">
-          <div class="col d-flex justify-content-between align-items-center"><div>Type</div><div>{{ variant.sub_category|upper }}</div></div>
-        </div>
+        <span class="d-inline">Type</span>
+        <span class="d-inline ms-3">{{ variant.sub_category|upper }}</span>
       </li>
       {% if variant.custom %}
         {% for pair in variant.custom %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -219,7 +219,7 @@
         {% if gens_info.display %}
         <li class="list-group-item">
           <span class="d-inline">Copy number profile</span>
-          <span class="d-inline float-end">
+          <span class="d-inline ms-3">
             {% for sample in variant.samples %}
               <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
             {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -198,18 +198,32 @@
       <ul class="list-group">
         <li class="list-group-item">
           <span class="d-inline">Position</span>
-          <span class="d-inline ms-3">
+          <span class="d-inline float-end">
             {{ variant.chromosome }}:{{ variant.position }}{{ "-" if variant.end_chrom == variant.chromosome else " / " + variant.end_chrom+":" }}{{ variant.end }}
           </span>
         </li>
+        <li class="list-group-item">
+          <span class="d-inline">Cytoband</span>
+          <span class="d-inline float-end">
+            {% if variant.end_chrom == variant.chromosome %}
+              {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end if variant.cytoband_end != variant.cytoband_start else "" }}
+            {% else %}
+              ({{ variant.chromosome + ";" + variant.end_chrom}})({{ variant.cytoband_start + ";" + variant.cytoband_end }})
+            {% endif %}
+          </span>
+        </li>
+        <li class="list-group-item">
+          <span class="d-inline">Type</span>
+          <span class="d-inline float-end">{{ variant.sub_category|upper }}</span>
+        </li>
         {% if gens_info.display %}
         <li class="list-group-item">
-          Copy number profile
-          <div class="float-end">
+          <span class="d-inline">Copy number profile</span>
+          <span class="d-inline float-end">
             {% for sample in variant.samples %}
               <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
             {% endfor %}
-          </div>
+          </span>
         </li>
         {% endif %}
         <li class="list-group-item">
@@ -223,16 +237,6 @@
             <div>Breakpoint 2</div>
             {{ sv_alignments(variant, case, "end") }}
           </div>
-        </li>
-        <li class="list-group-item">
-          <span class="d-inline">Cytoband</span>
-          <span class="d-inline ms-3">
-            {% if variant.end_chrom == variant.chromosome %}
-              {{ variant.chromosome }}{{ variant.cytoband_start }}{{ variant.cytoband_end if variant.cytoband_end != variant.cytoband_start else "" }}
-            {% else %}
-              ({{ variant.chromosome + ";" + variant.end_chrom}})({{ variant.cytoband_start + ";" + variant.cytoband_end }})
-            {% endif %}
-          </span>
         </li>
         <li class="list-group-item">
           <div class="row d-flex align-items-center">
@@ -250,10 +254,6 @@
             {{ splice_junctions_button(institute._id, case.display_name, variant._id) }}
           </li>
         {% endif %}
-      <li class="list-group-item">
-        <span class="d-inline">Type</span>
-        <span class="d-inline ms-3">{{ variant.sub_category|upper }}</span>
-      </li>
       {% if variant.custom %}
         {% for pair in variant.custom %}
         <li class="list-group-item">


### PR DESCRIPTION
Fix #3655

Modify SV variant layout from this:

<img width="481" alt="image" src="https://user-images.githubusercontent.com/28093618/200531587-20b39979-411d-4155-ac98-71a207883ab2.png">


To this:

<img width="465" alt="image" src="https://user-images.githubusercontent.com/28093618/200531428-c9816bcd-8657-4250-9934-95e588c7187a.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
