### PR TITLE
Fix #3677. Dark mode for add ClinVar variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Broken `Build Status - GitHub badge` on GitHub README page
 - Visibility of text on grey badges in gene panels PDF exports
 - Labels for dashboard search controls
+- Dark mode visibility for ClinVar submission
 
 ## [4.60]
 ### Added

--- a/scout/server/blueprints/clinvar/form.py
+++ b/scout/server/blueprints/clinvar/form.py
@@ -9,7 +9,6 @@ from wtforms import (
     SelectField,
     SelectMultipleField,
     StringField,
-    SubmitField,
     TextAreaField,
     validators,
     widgets,

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -30,7 +30,7 @@
                   <li>Inheritance Model</li>
                   <li>Clinical Significance</li>
                   <li>Associated conditions</li>
-                  <li>Observation Data</li>
+                   <li>Observation Data</li>
               </ul>
               <!-- fieldsets -->
               <fieldset>
@@ -151,7 +151,7 @@
                 <h2 class="fs-title">Inheritance model</h2>
                 <h3 class="fs-subtitle">The mode of inheritance specific to the variant-disease pair, not generally for the disease</h3>
                 {{variant_data.var_form.inheritance_mode.label(class="fw-bold, text-dark")}}
-                {{variant_data.var_form.inheritance_mode(class="form-control, bg-white")}}
+                {{variant_data.var_form.inheritance_mode(class="form-control, btn-secondary")}}
                 <input type="button" name="previous" class="previous action-button-previous" value="Previous"/>
                 <input type="button" name="next" class="next action-button" value="Next"/>
               </fieldset>
@@ -162,12 +162,12 @@
 
                 <div class="row">
                   <div class="col-4">
-                    Classification in Scout:<br>
+                    <span class="text-dark">Classification in Scout:</span><br>
                     <span class="badge bg-secondary">{{variant_data.var_obj.classification|replace("_"," ")|upper if variant_data.var_obj.classification else "n.a."}}</span>
                   </div>
                   <div class="col-8">
                     {{variant_data.var_form.clinsig.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field"><strong>*</strong></span>
-                    {{variant_data.var_form.clinsig(class="form-control, bg-white")}}
+                    {{variant_data.var_form.clinsig(class="form-control, btn-secondary")}}
                   </div>
                 </div>
                 <br><br><br>
@@ -188,7 +188,7 @@
                 <div class="row">
                   <div class="col-6">
                     {{variant_data.var_form.condition_type.label(class="fw-bold, text-dark")}}<span class="text-danger" data-bs-toggle='tooltip' title="Required field."><strong>*</strong></span>
-                    <select class="form-control, bg-white" name="condition_type" id="condition_type">
+                    <select class="form-control, btn-secondary" name="condition_type" id="condition_type">
                       {% for dbtype, _ in variant_data.var_form.condition_type.choices %}
                         {% if dbtype == "OMIM" and variant_data.var_form.omim_terms.choices %}
                           <option value="{{dbtype}}" selected>{{dbtype}}</option>
@@ -211,7 +211,6 @@
                           <option value="{{term}}" selected>{{term}}</option>
                         {% endfor %}
                       {% endif %}
-                      {
                     </select>
 
                   </div>
@@ -221,7 +220,7 @@
                     {% for term in variant_data.var_form.omim_terms %}
                       <li class="list-group-item">{{ term.label }}</li>
                     {% else %}
-                    n.a.
+                      <span class="text-dark">n.a.</span>
                     {% endfor %}
                     </ul>
                     <br><br>
@@ -259,15 +258,15 @@
                       </div>
                       <div class="col-2">
                         {{ cdata.affected_status.label(class="fw-bold, text-dark") }}
-                        {{ cdata.affected_status(class="form-control, bg-white") }}
+                        {{ cdata.affected_status(class="form-control, btn-secondary") }}
                       </div>
                       <div class="col-2">
                         {{ cdata.allele_of_origin.label(class="fw-bold, text-dark") }}
-                        {{ cdata.allele_of_origin(class="form-control, bg-white") }}
+                        {{ cdata.allele_of_origin(class="form-control, btn-secondary") }}
                       </div>
                       <div class="col-2">
                         {{ cdata.collection_method.label(class="fw-bold, text-dark") }}
-                        {{ cdata.collection_method(class="form-control, bg-white") }}
+                        {{ cdata.collection_method(class="form-control, btn-secondary") }}
                       </div>
                     </div>
                   </li>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Dropdowns and plain text on the explicitly white background now hopefully visible everywhere, even in dark mode!

![Screenshot 2022-11-23 at 11 11 32](https://user-images.githubusercontent.com/758570/203521810-9e766d9f-9c3a-4eb1-8db4-b51c61261024.png)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR
