### PR TITLE
Fix #3679 - panel extent report truncated lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Broken `Build Status - GitHub badge` on GitHub README page
 - Visibility of text on grey badges in gene panels PDF exports
 - Labels for dashboard search controls
+- Whitespaces on outdated panel in extent report
 
 ## [4.60]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -48,7 +48,7 @@
               {{ panel.display_name|truncate(18, True) }}
             </a>
             {% if case.outdated_panels and panel.panel_name in case.outdated_panels %}
-              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
+              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(', ') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(', ') or '-'}}.">!</span></a>
             {% endif %}
           </span>
         </div>

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -66,7 +66,7 @@
         <label for="version">Version</label>
         <span class="float-end" id="version">{{ panel.version }}</span>
          {% if case and case.outdated_panels and panel.panel_name in case.outdated_panels %}
-              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
+              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(', ') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(', ') or '-'}}.">!</span></a>
          {% endif %}
       </li>
       <li class="list-group-item">

--- a/scout/server/blueprints/panels/templates/panels/panel_pdf_case_hits.html
+++ b/scout/server/blueprints/panels/templates/panels/panel_pdf_case_hits.html
@@ -21,7 +21,7 @@
       Gene panel: <strong>{{panel.name_and_version}}</strong><br>
       Last updated: <strong>{{ panel.date.strftime('%Y-%m-%d') }}</strong>
       {% if case.outdated_panels and panel.panel_name in case.outdated_panels %}
-              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.">!</span></a>
+              <a><span class="badge rounded-pill badge-sm bg-warning" data-bs-toggle="popover" data-bs-placement="left" data-bs-html="true" data-bs-content="Panel version used in the analysis ({{panel.version}}) is outdated. Latest panel version is used in variants filtering.<br /><strong>Genes present in case panel and not in latest version</strong>: {{case.outdated_panels[panel.panel_name]['extra_genes']|join(', ') or '-'}}.<br /><strong>Genes present only in latest version</strong>: {{case.outdated_panels[panel.panel_name]['missing_genes']|join(', ') or '-'}}.">!</span></a>
       {% endif %}<br>
       Panel ID: {{ panel.panel_name }}<br>
       Description: {{ panel.description }}<br>

--- a/scout/server/blueprints/panels/templates/panels/panel_pdf_case_hits.html
+++ b/scout/server/blueprints/panels/templates/panels/panel_pdf_case_hits.html
@@ -57,13 +57,14 @@
     <td>
       Panel version used in the analysis ({{panel.version}}) is outdated.<br>
       <strong>Genes present in case panel and not in latest version</strong><br>
-      {{case.outdated_panels[panel.panel_name]['extra_genes']|join(',') or '-'}}<br>
+      {{case.outdated_panels[panel.panel_name]['extra_genes']|join(', ') or '-'}}<br>
       <strong>Genes present only in latest version</strong>
-      <br>{{case.outdated_panels[panel.panel_name]['missing_genes']|join(',') or '-'}}.
+      <br>{{case.outdated_panels[panel.panel_name]['missing_genes']|join(', ') or '-'}}.
     </td>
   </tr>
 </table><br>
 {% endif %}
+{% if variant_hits.str %}
 <table>
   <tr><th scope="col">Panel genes investigated for STRs</th></tr>
   <tr>
@@ -73,6 +74,7 @@
   </tr>
 </table>
 <br>
+{% endif %}
 {% if variant_hits.smn and case.smn_tsv %}
 <table>
   <tr><th scope="col">SMN Copy Number</th></tr>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<img width="1037" alt="Screenshot 2022-11-23 at 11 34 00" src="https://user-images.githubusercontent.com/758570/203527783-6ecbe671-ae09-4409-8ab6-af979c79f49d.png">

and

![Screenshot 2022-11-23 at 11 55 05](https://user-images.githubusercontent.com/758570/203529712-6f9396a0-d32a-4a73-b7e3-553ff0fde453.png)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
