### PR TITLE
Make Safe variant matching badge more visible on case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not export `Assertion method` and `Assertion method citation` to ClinVar submission files according to changes to ClinVar's submission spreadsheet templates.
 - Simplified code to create and download ClinVar CSV files
 - Colorize inheritance models badges by category on VariantS page
+- `Safe variants matching` badge more visible on case page
 ### Fixed
 - Non-admin users saving institute settings would clear loqusdb instance selection
 - Layout of variant position, cytoband and type in SV variant summary

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -98,7 +98,7 @@
               {% if institute.gene_panels_matching %}
                 <span class="badge rounded-pill bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="left" title="To avoid incidental findings, eventual matching causatives and managed variants displayed on case page are filteres using a list of 'safe' panels. Modify institute settings to edit list of 'safe' panels. Current safe panels: {{ institute.gene_panels_matching.values()|list }}">on</span>
               {% else %}
-                <span class="badge rounded-pill bg-info" data-bs-toggle="tooltip" data-bs-placement="left" title="Matching causatives and managed variants displayed on case page are NOT filtered by gene panel. Use caution to avoid incidental findings.">off</span>
+                <span class="badge rounded-pill bg-info text-dark" data-bs-toggle="tooltip" data-bs-placement="left" title="Matching causatives and managed variants displayed on case page are NOT filtered by gene panel. Use caution to avoid incidental findings.">off</span>
               {% endif %}
             </div>
         </div> <!--end of div class="row" -->

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -98,7 +98,7 @@
               {% if institute.gene_panels_matching %}
                 <span class="badge rounded-pill bg-warning text-dark" data-bs-toggle="tooltip" data-bs-placement="left" title="To avoid incidental findings, eventual matching causatives and managed variants displayed on case page are filteres using a list of 'safe' panels. Modify institute settings to edit list of 'safe' panels. Current safe panels: {{ institute.gene_panels_matching.values()|list }}">on</span>
               {% else %}
-                <span class="badge rounded-pill bg-info text-dark" data-bs-toggle="tooltip" data-bs-placement="left" title="Matching causatives and managed variants displayed on case page are NOT filtered by gene panel. Use caution to avoid incidental findings.">off</span>
+                <span class="badge rounded-pill bg-info text-body" data-bs-toggle="tooltip" data-bs-placement="left" title="Matching causatives and managed variants displayed on case page are NOT filtered by gene panel. Use caution to avoid incidental findings.">off</span>
               {% endif %}
             </div>
         </div> <!--end of div class="row" -->


### PR DESCRIPTION
Fix this badge on case page:

<img width="191" alt="image" src="https://user-images.githubusercontent.com/28093618/203543855-04eb031d-0962-4719-b3e6-8ed94987b8c0.png">


To be like this:

<img width="194" alt="image" src="https://user-images.githubusercontent.com/28093618/203543770-1bbaafdb-93c2-44d2-8aeb-b06917f774a1.png">


and this:

<img width="202" alt="image" src="https://user-images.githubusercontent.com/28093618/203543723-d8a722cd-c677-40d3-a441-b1fe22191f54.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, log out from `cg-vm1` and log in again in the `hasta` server, repeat the `hasta` and `paxa` procedure, which will release the allocated resource (scout-stage) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
