### PR TITLE
Reset and change placeholder for conditions in ClinVar when condition ID changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-### Added
-- Added `UMLS` as an option of `Condition ID type` in ClinVar Variant downloaded files
 ### Fixed
+- Added `UMLS` as an option of `Condition ID type` in ClinVar Variant downloaded files
 - Missing value for `Condition ID type` in ClinVar Variant downloaded files
 - Possibility to open, close or delete a ClinVar submission even if it doesn't have an associated name
 - Save SV type, ref and alt n. copies to exported ClinVar files
 - Inner and outer start and stop SV coordinates not exported in ClinVar files
 - ClinVar submissions page crashing when SV files don't contain breakpoint exact coordinates
+- In ClinVar form, reset condition list and customize help when condition ID changes
 
 
 ## [4.61]

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -213,6 +213,12 @@ def register_filters(app):
         return round(number, ndigits)
 
     @app.template_filter()
+    def tuples_element_n(tuple_list, n):
+        """Return a list containing the element at position n of each tuple in a list of tuples"""
+        LOG.warning(tuple_list)
+        return [tup[n] for tup in tuple_list]
+
+    @app.template_filter()
     def url_decode(string):
         """Decode a string with encoded hex values."""
         return unquote(string)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -213,10 +213,10 @@ def register_filters(app):
         return round(number, ndigits)
 
     @app.template_filter()
-    def tuples_element_n(tuple_list, n):
-        """Return a list containing the element at position n of each tuple in a list of tuples"""
-        LOG.warning(tuple_list)
-        return [tup[n] for tup in tuple_list]
+    def tuple_list_to_dict(tuple_list, key_elem, value_elem):
+        """Accepts a list of tuples and returns a dictionary with tuple element = key_elem as keys and tuple element = value_elem as values"""
+
+        return {tup[key_elem]: tup[value_elem] for tup in tuple_list}
 
     @app.template_filter()
     def url_decode(string):

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -56,7 +56,7 @@ def _set_var_form_common_fields(var_form, variant_obj, case_obj):
         for hpo in case_obj.get("phenotype_terms", [])
     ]
     var_form.omim_terms.choices = [
-        (omim.get("disease_id"), " - ".join([omim.get("disease_id"), omim.get("description")]))
+        (omim.get("disease_nr"), " - ".join([str(omim.get("disease_nr")), omim.get("description")]))
         for omim in case_obj.get("diagnosis_phenotypes", [])
     ]
 

--- a/scout/server/blueprints/clinvar/form.py
+++ b/scout/server/blueprints/clinvar/form.py
@@ -60,7 +60,7 @@ class ClinVarVariantForm(FlaskForm):
     condition_type = SelectField(
         "Condition ID type", choices=[(key, value) for key, value in PHENO_DBS.items()]
     )
-    conditions = SelectMultipleField("Condition ID values, comma separated)")
+    conditions = SelectMultipleField("Condition ID values, comma-separated)")
 
     # Extra fields:
     assertion_method = StringField("Assertion method", default=ASSERTION_METHOD)

--- a/scout/server/blueprints/clinvar/form.py
+++ b/scout/server/blueprints/clinvar/form.py
@@ -58,9 +58,9 @@ class ClinVarVariantForm(FlaskForm):
     omim_terms = MultiCheckboxField("Case-associated OMIM terms", choices=[])
     condition_comment = TextAreaField("Additional comments describing condition")
     condition_type = SelectField(
-        "Condition type", choices=[(key, value) for key, value in PHENO_DBS.items()]
+        "Condition ID type", choices=[(key, value) for key, value in PHENO_DBS.items()]
     )
-    conditions = SelectMultipleField("List of conditions, comma-separated)")
+    conditions = SelectMultipleField("Condition ID values, comma separated)")
 
     # Extra fields:
     assertion_method = StringField("Assertion method", default=ASSERTION_METHOD)

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -206,7 +206,7 @@
                         {% for term, _ in variant_data.var_form.omim_terms.choices %}
                           <option value="{{term}}" selected>{{term}}</option>
                         {% endfor %}
-                      {% elif variant_data.var_form.hpo_terms.choices%}
+                      {% elif variant_data.var_form.hpo_terms.choices %}
                         {% for term, _ in variant_data.var_form.hpo_terms.choices %}
                           <option value="{{term}}" selected>{{term}}</option>
                         {% endfor %}
@@ -381,17 +381,32 @@ $('#condition_tags').select2({
   tags: true,
   theme: 'bootstrap-5',
   tokenSeparators: [','],
-  allowClear: true
+  allowClear: true,
 });
 
 // reset and modify conditions field's placeholder when condition ID type changes
 $(function(){
   $("#condition_type").change(function(){
-    $('#condition_tags').val(null).trigger('change');
+    $('#condition_tags').val(null).trigger('change'); // reset conditions multiselect
+
+    var choices = [];
+    // Load preselected choices for OMIM and HPO terms, if available
+    if ($('#condition_type').val() == 'OMIM'){
+      choices = {{ variant_data.var_form.omim_terms.choices|tuples_element_n(0)|safe }};
+    }
+    if ($('#condition_type').val() == 'HPO'){
+      choices = {{ variant_data.var_form.hpo_terms.choices|tuples_element_n(0)|safe }};
+    }
+
+    $('#condition_tags').val(choices);
+    $('#condition_tags').trigger('change'); // Notify any JS components that the value changed
+
+    // Change placeholder
     selectedCondId = $("#condition_type option:selected").text();
     $('#condition_tags').select2({
-      placeholder: conditionsPlaceHolders[selectedCondId]
+      placeholder: conditionsPlaceHolders[selectedCondId],
     });
+
   });
 });
 

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -374,7 +374,7 @@ $(".previous").click(function(){
 	});
 });
 
-var conditionsPlaceHolders = {"OMIM": "e.g. 100800, ..", "HPO": "e.g. HP:0002839, ..", "MedGen": "e.g. C0001080, ..", "Mesh": "e.g. D000130, ..", "MONDO": "e.g. MONDO:0007947, ..", "Orphanet": "e.g. ORPHA155, .."};
+var conditionsPlaceHolders = {"OMIM": "e.g. 100800, ..", "HPO": "e.g. HP:0002839, ..", "MedGen": "e.g. C0001080, ..", "MeSh": "e.g. D000130, ..", "MONDO": "e.g. MONDO:0007947, ..", "Orphanet": "e.g. ORPHA155, .."};
 
 // Populate condition list
 $('#condition_tags').select2({

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -76,7 +76,6 @@
               </fieldset>
               <fieldset>
                   <h2 class="fs-title">Variant Details</h2>
-
                   {{variant_data.var_form.gene_symbol.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Gene symbol should be provided only to indicate the gene-disease relationship supporting the variant interpretation. Gene symbol is not expected for SVs, except to make a statement that a specific gene within the variant has a relationship to the interpreted condition."><strong>?</strong></span>
                   {{variant_data.var_form.gene_symbol(class="bg-white")}}
                   <br>
@@ -184,7 +183,7 @@
 
               <fieldset>
                 <h2 class="fs-title">Associated Conditions</h2>
-                <h3 class="fs-subtitle">The condition for which the variant is interpreted. Detailed information about reporting condition is available at <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/faq_submitters/#pheno" target="_blank" rel="noopener">https://www.ncbi.nlm.nih.gov/clinvar/docs/faq_submitters/#pheno</a>. If multiple conditions are submitted for a variant, this indicates that the variant was interpreted for the combination of conditions in the same individual(s).  i.e. this variant causes both condition A and condition B in the same individual. This scenario is most common for a new disease or syndrome that does not yet have a name and is described by several clinical features.  If you want to indicate that the variant has been interpreted for more than one condition, please submit these as separate records. i.e. this variant causes condition A in some individuals and causes disease B in other individuals. Provide only one name or identifier for a condition; do not provide multiple names or identifiers for the same condition."</h3>
+                <h3 class="fs-subtitle">The condition for which the variant is interpreted. Examples available at <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/spreadsheet/#condition" target="_blank" rel="noopener">ClinVar</a>"</h3>
 
                 <div class="row">
                   <div class="col-6">
@@ -201,7 +200,7 @@
                       {% endfor %}
                     </select>
                     <br><br>
-                    {{variant_data.var_form.conditions.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field. Include data from one database type only (i.e. only OMIM terms, only HPO terms etc)"><strong>*?</strong></span>
+                    {{variant_data.var_form.conditions.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field. Include data from ONE DATABASE TYPE ONLY (i.e. only OMIM terms, only HPO terms etc)"><strong>*?</strong></span>
                     <select class="select2" id="condition_tags" name="conditions" multiple="true" style="width:100%;">
                       {% if variant_data.var_form.omim_terms.choices %}
                         {% for term, _ in variant_data.var_form.omim_terms.choices %}
@@ -375,12 +374,25 @@ $(".previous").click(function(){
 	});
 });
 
+var conditionsPlaceHolders = {"OMIM": "e.g. 100800, ..", "HPO": "e.g. HP:0002839, ..", "MedGen": "e.g. C0001080, ..", "Mesh": "e.g. D000130, ..", "MONDO": "e.g. MONDO:0007947, ..", "Orphanet": "e.g. ORPHA155, .."};
+
 // Populate condition list
 $('#condition_tags').select2({
   tags: true,
   theme: 'bootstrap-5',
   tokenSeparators: [','],
-  placeholder: "e.g. OMIM:604233,OMIM:300491,..",
+  allowClear: true
+});
+
+// reset and modify conditions field's placeholder when condition ID type changes
+$(function(){
+  $("#condition_type").change(function(){
+    $('#condition_tags').val(null).trigger('change');
+    selectedCondId = $("#condition_type option:selected").text();
+    $('#condition_tags').select2({
+      placeholder: conditionsPlaceHolders[selectedCondId]
+    });
+  });
 });
 
 </script>

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -393,6 +393,10 @@ $(function(){
     selectedCondId = $("#condition_type option:selected").text();
     $('#condition_tags').select2({
       placeholder: conditionsPlaceHolders[selectedCondId],
+      theme: 'bootstrap-5',
+      tags: true,
+      tokenSeparators: [','],
+      allowClear: true,
     });
 
     // repopulate option values according to the selected condition ID

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -404,7 +404,7 @@ $(function(){
       choices = {{ variant_data.var_form.hpo_terms.choices|tuple_list_to_dict(0,1)|safe }};
     }
     for (var key in choices) {
-      var newOption = new Option(key, choices[key], true, true);
+      var newOption = new Option(key, key, true, true);
       $('#condition_tags').append(newOption).trigger('change');
     }
 

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -389,23 +389,24 @@ $(function(){
   $("#condition_type").change(function(){
     $('#condition_tags').val(null).trigger('change'); // reset conditions multiselect
 
-    var choices = [];
-    // Load preselected choices for OMIM and HPO terms, if available
-    if ($('#condition_type').val() == 'OMIM'){
-      choices = {{ variant_data.var_form.omim_terms.choices|tuples_element_n(0)|safe }};
-    }
-    if ($('#condition_type').val() == 'HPO'){
-      choices = {{ variant_data.var_form.hpo_terms.choices|tuples_element_n(0)|safe }};
-    }
-
-    $('#condition_tags').val(choices);
-    $('#condition_tags').trigger('change'); // Notify any JS components that the value changed
-
     // Change placeholder
     selectedCondId = $("#condition_type option:selected").text();
     $('#condition_tags').select2({
       placeholder: conditionsPlaceHolders[selectedCondId],
     });
+
+    // repopulate option values according to the selected condition ID
+    choices = {};
+    if ($('#condition_type').val() == 'OMIM'){
+      choices = {{ variant_data.var_form.omim_terms.choices|tuple_list_to_dict(0,1)|safe }};
+    }
+    if ($('#condition_type').val() == 'HPO'){
+      choices = {{ variant_data.var_form.hpo_terms.choices|tuple_list_to_dict(0,1)|safe }};
+    }
+    for (var key in choices) {
+      var newOption = new Option(key, choices[key], true, true);
+      $('#condition_tags').append(newOption).trigger('change');
+    }
 
   });
 });


### PR DESCRIPTION
Fix #3699 
When condition ID changes in ClinVar form:
- Reset the list of conditions already provided
- Modify conditions placeholder to reflect the format of the condition ID

I'm not adding any validation that the provided values for the conditions are consistent with the condition ID type, just a simpler explanation of the expected values. On the other hand all the other values in this form are not validated either. **Validation of these values will be performed in the future by the ClinVar API**, which will return specific error messages when validation fails.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
