### PR TITLE
Fix #3705 - use GENS case_name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- Use the new case name option for GENS requests
+
 
 ## [4.61.1]
 ### Fixed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -334,7 +334,7 @@ def case(store, institute_obj, case_obj):
     limit_genes = store.safe_genes_filter(institute_obj["_id"])
 
     # Make sure build is either "37" or "38"
-    build = "38" if "38" in str(case_obj["genome_build"]) else "37"
+    build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
 
     data = {
         "institute": institute_obj,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -333,9 +333,6 @@ def case(store, institute_obj, case_obj):
     # Limit secondary findings according to institute settings
     limit_genes = store.safe_genes_filter(institute_obj["_id"])
 
-    # Make sure build is either "37" or "38"
-    build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
-
     data = {
         "institute": institute_obj,
         "case": case_obj,
@@ -363,7 +360,7 @@ def case(store, institute_obj, case_obj):
         "tissue_types": SAMPLE_SOURCE,
         "report_types": CUSTOM_CASE_REPORTS,
         "mme_nodes": matchmaker.connected_nodes,
-        "gens_info": gens.connection_settings(build),
+        "gens_info": gens.connection_settings(case_obj["genome_build"]),
         "display_rerunner": rerunner.connection_settings.get("display", False),
     }
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -333,6 +333,9 @@ def case(store, institute_obj, case_obj):
     # Limit secondary findings according to institute settings
     limit_genes = store.safe_genes_filter(institute_obj["_id"])
 
+    # Make sure build is either "37" or "38"
+    build = "38" if "38" in str(case_obj["genome_build"]) else "37"
+
     data = {
         "institute": institute_obj,
         "case": case_obj,
@@ -360,7 +363,7 @@ def case(store, institute_obj, case_obj):
         "tissue_types": SAMPLE_SOURCE,
         "report_types": CUSTOM_CASE_REPORTS,
         "mme_nodes": matchmaker.connected_nodes,
-        "gens_info": gens.connection_settings(case_obj.get("genome_build")),
+        "gens_info": gens.connection_settings(build),
         "display_rerunner": rerunner.connection_settings.get("display", False),
     }
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -360,7 +360,7 @@ def case(store, institute_obj, case_obj):
         "tissue_types": SAMPLE_SOURCE,
         "report_types": CUSTOM_CASE_REPORTS,
         "mme_nodes": matchmaker.connected_nodes,
-        "gens_info": gens.connection_settings(case_obj["genome_build"]),
+        "gens_info": gens.connection_settings(case_obj.get("genome_build")),
         "display_rerunner": rerunner.connection_settings.get("display", False),
     }
 

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -126,7 +126,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -126,7 +126,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case.case_id}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -126,7 +126,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_name={{case.case_id}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -126,7 +126,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_name={{case.case_id}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case.case_id}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -221,7 +221,7 @@
           <span class="d-inline">Copy number profile</span>
           <span class="d-inline ms-3">
             {% for sample in variant.samples %}
-              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
+              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_name={{case.case_id}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
             {% endfor %}
           </span>
         </li>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -221,7 +221,7 @@
           <span class="d-inline">Copy number profile</span>
           <span class="d-inline ms-3">
             {% for sample in variant.samples %}
-              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case.case_id}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
+              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case._id}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
             {% endfor %}
           </span>
         </li>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -221,7 +221,7 @@
           <span class="d-inline">Copy number profile</span>
           <span class="d-inline ms-3">
             {% for sample in variant.samples %}
-              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_name={{case.case_id}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
+              <a class="btn btn-secondary" target="_blank" href="http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case.case_id}}", {{variant.chromosome}})>Gens {{ sample.display_name }}</a>
             {% endfor %}
           </span>
         </li>

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -114,7 +114,7 @@ def institute_and_case(store, institute_id, case_name=None):
             return abort(404)
 
         # Make sure build is either "37" or "38"
-        case_obj["genome_build"] = "38" if "38" in str(case_obj["genome_build"]) else "37"
+        case_obj["genome_build"] = "38" if "38" in str(case_obj.get("genome_build")) else "37"
 
     # validate that user has access to the institute
 

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -113,6 +113,9 @@ def institute_and_case(store, institute_id, case_name=None):
         if case_obj is None:
             return abort(404)
 
+        # Make sure build is either "37" or "38"
+        case_obj["genome_build"] = "38" if "38" in str(case_obj["genome_build"]) else "37"
+
     # validate that user has access to the institute
 
     if not current_user.is_admin:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Could be tested with latest GENS on stage. Or just check in output that `case_name` is added to the two places where we link out to GENS.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
