### PR TITLE
Tests for API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Wrote tests for case and variant API endpoints
 
 ## [4.61.1]
 ### Fixed

--- a/tests/server/blueprints/api/test_api_views.py
+++ b/tests/server/blueprints/api/test_api_views.py
@@ -1,0 +1,47 @@
+from flask import url_for
+
+
+def test_case(app, case_obj):
+    """Test the API that returns a case as a json object"""
+
+    case_name = case_obj["display_name"]
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+        # WHEN the API is invoked with the right params
+        resp = client.get(
+            url_for(
+                "api.case",
+                institute_id=case_obj["owner"],
+                case_name=case_name,
+            )
+        )
+        # THEN it should return a valid response
+        assert resp.status_code == 200
+        assert resp.json["display_name"] == case_name
+
+
+def test_variant(app, case_obj, variant_obj):
+    """Test the API that returns a variant as a json object"""
+
+    case_name = case_obj["display_name"]
+    variant_id = variant_obj["_id"]
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+        # WHEN the API is invoked with the right params
+        resp = client.get(
+            url_for(
+                "api.variant",
+                institute_id=case_obj["owner"],
+                case_name=case_name,
+                variant_id=variant_id,
+            )
+        )
+        # THEN it should return a valid response
+        assert resp.status_code == 200
+        assert resp.json["_id"] == variant_id


### PR DESCRIPTION
There are 2 API endpoints that are [not well covered](https://app.codecov.io/gh/Clinical-Genomics/scout/blob/main/scout/server/blueprints/api/views.py) by tests. This PR adds simple tests for them

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Coverage should increase

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by automatic tests
