### PR TITLE
Avoid duplicate causatives and pinned variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Validate ClinVar submission objects using the ClinVar API
 ### Fixed
-- Avoid duplicated causatives and pinned variants
+- Avoid duplicate causatives and pinned variants
 
 ## [4.61.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Validate ClinVar submission objects using the ClinVar API
+### Fixed
+- Avoid duplicated causatives and pinned variants
 
 ## [4.61.1]
 ### Fixed

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -406,7 +406,7 @@ class VariantEventHandler(object):
         )
         return updated_case
 
-    def mark_causative(self, institute, case, user, link, variant, partial_causative=False):
+    def mark_causative(self, institute, case, user, link, variant):
         """Create an event for marking a variant causative.
 
         Arguments:

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -31,7 +31,7 @@ class VariantEventHandler(object):
         # add variant to list of pinned references in the case model
         updated_case = self.case_collection.find_one_and_update(
             {"_id": case["_id"]},
-            {"$push": {"suspects": variant["_id"]}},
+            {"$addToSet": {"suspects": variant["_id"]}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
 
@@ -430,7 +430,7 @@ class VariantEventHandler(object):
 
         updated_case = self.case_collection.find_one_and_update(
             {"_id": case["_id"]},
-            {"$push": {"causatives": variant["_id"]}, "$set": {"status": "solved"}},
+            {"$addToSet": {"causatives": variant["_id"]}, "$set": {"status": "solved"}},
             return_document=pymongo.ReturnDocument.AFTER,
         )
 


### PR DESCRIPTION
Fix #3710

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On a local instance, main branch, reproduce the bug by opening the variant on more than one tab and marking it as causative and pinning it
2. Switch to this branch and try to do the same. it shouldn't happen

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
