### PR TITLE
ClinVar submissions via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Validate ClinVar submission objects using the ClinVar API
 - Wrote tests for case and variant API endpoints
+- Create ClinVar submissions from Scout using the ClinVar API
 
 ## [4.61.1]
 ### Fixed

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -182,20 +182,19 @@ class ClinVarHandler(object):
         """Set a clinvar submission ID to 'closed'
 
         Args:
-            submission_id(str): the ID of the clinvar submission to close
+            submission_id(str): the ID of the clinvar submission to updte status for
 
         Return
             updated_submission(obj): the submission object with a 'closed' status
 
         """
-        LOG.info('closing clinvar submission "%s"', submission_id)
 
         if (
             status == "open"
         ):  # just close the submission its status does not affect the other submissions
             # Close all other submissions for this institute and then open the desired one
             self.clinvar_submission_collection.update_many(
-                {"institute_id": institute_id},
+                {"institute_id": institute_id, "status": "open"},
                 {"$set": {"status": "closed", "updated_at": datetime.now()}},
             )
         updated_submission = self.clinvar_submission_collection.find_one_and_update(

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -188,11 +188,9 @@ class ClinVarHandler(object):
             updated_submission(obj): the submission object with a 'closed' status
 
         """
-
-        if (
-            status == "open"
-        ):  # just close the submission its status does not affect the other submissions
-            # Close all other submissions for this institute and then open the desired one
+        # When setting one submission as open
+        # Close all other submissions for this institute first
+        if status == "open":
             self.clinvar_submission_collection.update_many(
                 {"institute_id": institute_id, "status": "open"},
                 {"$set": {"status": "closed", "updated_at": datetime.now()}},

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -1,4 +1,4 @@
-CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
+CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/"
 PRECLINVAR_URL = "https://preclinvar.scilifelab.se"
 
 ASSERTION_METHOD = "ACMG Guidelines, 2015"

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -1,3 +1,4 @@
+CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/?dry-run=true"
 PRECLINVAR_URL = "https://preclinvar.scilifelab.se"
 
 ASSERTION_METHOD = "ACMG Guidelines, 2015"

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -327,7 +327,7 @@ def update_clinvar_submission_status(request_obj, institute_id, submission_id):
         )
     if update_status == "submit":
         submitter_key = request_obj.form.get("apiKey")
-        send_api_submission(submission_id, submitter_key)
+        send_api_submission(institute_id, submission_id, submitter_key)
 
 
 def json_api_submission(submission_id):
@@ -409,11 +409,12 @@ def validate_submission(submission_id):
     return valid_res.json().get("id")
 
 
-def send_api_submission(submission_id, key):
+def send_api_submission(institute_id, submission_id, key):
     """Convert and validate ClinVar submission data to json.
        If json submission is validated, submit it using the ClinVar API
 
     Args:
+        institute_id(str): _id of an institute
         submission_id(str): the database id of a clinvar submission
         key(str): a 64 alphanumeric characters' key
     """
@@ -431,6 +432,10 @@ def send_api_submission(submission_id, key):
 
     if code in [200, 201, 204]:  # 204 is returned only for dry runs - used for testing
         flash("Submission saved successfully", "success")
+        store.update_clinvar_submission_status(
+            institute_id=institute_id, submission_id=submission_id, status="submitted"
+        )
+
     else:
         flash(str(submit_res.json()), "warning")
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -424,10 +424,8 @@ def send_api_submission(submission_id, key):
         flash(str(conversion_res), "warning")
         return
 
-    # Check is user has already received an ID for this submission from ClinVar
-    subm_id = store.get_clinvar_id(submission_id)
-    if subm_id:
-        conversion_res["submissionName"] = subm_id
+    # Send submission with the same name (SUBxyz) that was assigned by ClinVar
+    conversion_res["submissionName"] = store.get_clinvar_id(submission_id)
 
     code, submit_res = clinvar_api.submit_json(conversion_res, key)
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -325,6 +325,9 @@ def update_clinvar_submission_status(request_obj, institute_id, submission_id):
             f"Removed {deleted_objects} objects and {deleted_submissions} submission from database",
             "info",
         )
+    if update_status == "submit":
+        submitter_key = request_obj.form.get("apiKey")
+        send_api_submission(submission_id, submitter_key)
 
 
 def json_api_submission(submission_id):
@@ -406,12 +409,13 @@ def validate_submission(submission_id):
     return valid_res.get("id")
 
 
-def send_api_submission(submission_id):
+def send_api_submission(submission_id, key):
     """Convert and validate ClinVar submission data to json.
        If json submission is validated, submit it using the ClinVar API
 
     Args:
         submission_id(str): the database id of a clinvar submission
+        key(str): a 64 alphanumeric characters' key
 
     Returns:
         str/None: A submission ID (i.e. SUB2192122) or None if submission contained errors
@@ -423,7 +427,7 @@ def send_api_submission(submission_id):
         flash(str(conversion_res), "warning")
         return
 
-    code, submit_res = clinvar_api.submit_json(json_data=conversion_res)
+    code, submit_res = clinvar_api.submit_json(conversion_res, key)
 
     if code != 201:  # Connection or conversion object errors
         flash(str(submit_res), "warning")

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -416,9 +416,6 @@ def send_api_submission(submission_id, key):
     Args:
         submission_id(str): the database id of a clinvar submission
         key(str): a 64 alphanumeric characters' key
-
-    Returns:
-        str/None: A submission ID (i.e. SUB2192122) or None if submission contained errors
     """
     # Convert submission objects to json:
     code, conversion_res = json_api_submission(submission_id)

--- a/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
@@ -75,7 +75,7 @@
 
 {% macro submission_panel(subm_obj) %}
   <div class="card w-100 mt-3">
-    <div class="card-header, text-white {{ 'bg-primary' if subm_obj.status=='open' else 'bg-secondary' }}">
+    <div class="card-header, text-white {% if subm_obj.status=='open' %} bg-primary {% elif subm_obj.status=='submitted' %} bg-success {% else %} bg-secondary {% endif%}">
       Submission <strong>{{subm_obj._id}} - ({{subm_obj.status|upper}})</strong> / Created: <strong>{{subm_obj.created_at.strftime('%Y-%m-%d')}}</strong> / Last updated: <strong>{{subm_obj.updated_at.strftime('%Y-%m-%d')}}</strong>
     </div><!-- end of card header-->
     <div class="card-body">

--- a/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
@@ -109,7 +109,7 @@
             <label for="clinvar_id" class="form-text">Submission ID</label>
           </div>
           <div class="col-2">
-            <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required>
+            <input type="password" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required>
           </div>
           <div class="col-2">
             <button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button>
@@ -120,11 +120,12 @@
             </div>
             {% if subm_obj.clinvar_subm_id and subm_obj.status != "submitted" %}
               <div class="col-2">
-                <a href="{{ url_for('clinvar.clinvar_submit', submission=subm_obj._id) }}" class="btn btn-sm btn-success text-white">Submit to ClinVar</a>
+                <button type="button" class="btn btn-sm btn-success form-control" name="update_submission" value="api_submit" data-bs-toggle="modal" data-bs-target="#submitModal">Submit to ClinVar</button>
               </div>
             {% endif %}
           {% endif %}
         </div>
+        {{ submit_modal(subm_obj) }}
       </form>
       <div> <!--variant data div -->
         <h4>Variant data:</h4>
@@ -256,6 +257,27 @@
       {% endif %}
     </div><!-- end of card body-->
   </div><!-- end of card -->
+{% endmacro %}
+
+{% macro submit_modal(subm_obj) %}
+<div class="modal fade" id="submitModal" tabindex="-1">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">ClinVar API submission</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <label for="apiKey">Submitter's <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/" target="_blank" rel="noopener">API key</a></label>
+        <input type="text" class="form-control" name="apiKey" id="apiKey" placeholder="64 alphanumeric characters" required>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        <button type="submit" name="update_submission" value="submit" class="btn btn-primary">Submit variants</button>
+      </div>
+    </div>
+  </div>
+</div>
 {% endmacro %}
 
 {% block content_main %}

--- a/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
@@ -109,7 +109,7 @@
             <label for="clinvar_id" class="form-text">Submission ID</label>
           </div>
           <div class="col-2">
-            <input type="password" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required>
+            <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required>
           </div>
           <div class="col-2">
             <button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button>
@@ -269,7 +269,7 @@
       </div>
       <div class="modal-body">
         <label for="apiKey">Submitter's <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/" target="_blank" rel="noopener">API key</a></label>
-        <input type="text" class="form-control" name="apiKey" id="apiKey" placeholder="64 alphanumeric characters" required>
+        <input type="password" class="form-control" name="apiKey" id="apiKey" placeholder="64 alphanumeric characters" required>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
@@ -105,18 +105,25 @@
         </form>
         <form id="updateName_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
         <div class="row mb-3">
-          <div class="col-2">
+          <div class="col-1">
             <label for="clinvar_id" class="form-text">Submission ID</label>
           </div>
-          <div class="col-3">
+          <div class="col-2">
             <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required>
           </div>
-          <div class="col-1">
+          <div class="col-2">
             <button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button>
           </div>
-          <div class="col-2">
-            <a href="{{ url_for('clinvar.clinvar_validate', submission=subm_obj._id, save_id='y') }}" class="btn btn-sm btn-primary text-white">Validate and obtain ID from ClinVar</a>
-          </div>
+          {% if config.CLINVAR_API_KEY %}
+            <div class="col-3">
+              <a href="{{ url_for('clinvar.clinvar_validate', submission=subm_obj._id, save_id='y') }}" class="btn btn-sm btn-primary text-white">Validate and obtain ID from ClinVar</a>
+            </div>
+            {% if subm_obj.clinvar_subm_id and subm_obj.status != "submitted" %}
+              <div class="col-2">
+                <a href="{{ url_for('clinvar.clinvar_submit', submission=subm_obj._id) }}" class="btn btn-sm btn-success text-white">Submit to ClinVar</a>
+              </div>
+            {% endif %}
+          {% endif %}
         </div>
       </form>
       <div> <!--variant data div -->

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -102,18 +102,9 @@ def clinvar_validate(submission, save_id=False):
     return redirect(request.referrer)
 
 
-@blueprint.route("/<submission>/submit")
-def clinvar_submit(submission):
-    """Submit to ClinVar using the ClinVar API"""
-
-    clinvar_id = controllers.send_api_submission(submission)
-    return redirect(request.referrer)
-
-
 @blueprint.route("/<institute_id>/<submission>/update_status", methods=["POST"])
 def clinvar_update_submission(institute_id, submission):
     """Update a submission status to open/closed, register an official SUB number or delete the entire submission"""
-
     controllers.update_clinvar_submission_status(request, institute_id, submission)
     return redirect(request.referrer)
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -102,6 +102,14 @@ def clinvar_validate(submission, save_id=False):
     return redirect(request.referrer)
 
 
+@blueprint.route("/<submission>/submit")
+def clinvar_submit(submission):
+    """Submit to ClinVar using the ClinVar API"""
+
+    clinvar_id = controllers.send_api_submission(submission)
+    return redirect(request.referrer)
+
+
 @blueprint.route("/<institute_id>/<submission>/update_status", methods=["POST"])
 def clinvar_update_submission(institute_id, submission):
     """Update a submission status to open/closed, register an official SUB number or delete the entire submission"""

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -105,6 +105,7 @@ def clinvar_validate(submission, save_id=False):
 @blueprint.route("/<institute_id>/<submission>/update_status", methods=["POST"])
 def clinvar_update_submission(institute_id, submission):
     """Update a submission status to open/closed, register an official SUB number or delete the entire submission"""
+
     controllers.update_clinvar_submission_status(request, institute_id, submission)
     return redirect(request.referrer)
 

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -52,7 +52,7 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 
 # ClinVar API key - used for validating (not submitting) ClinVar submissions for all institutes
 # Obtain a key by following these instructions: https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
-CLINVAR_API_KEY = "esnGvDPfhSKooMZrGNl3gH6RXObq0FA9KIrFlFJIuYv0jYb72HYDxXIoqm8yk5PE"
+# CLINVAR_API_KEY = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
 
 # Matchmaker connection parameters
 # - Tested with PatientMatcher (https://github.com/Clinical-Genomics/patientMatcher) -
@@ -74,7 +74,6 @@ CLINVAR_API_KEY = "esnGvDPfhSKooMZrGNl3gH6RXObq0FA9KIrFlFJIuYv0jYb72HYDxXIoqm8yk
 # }
 
 # Connection details for Scout REViewer service
-# URL
 # SCOUT_REVIEWER_URL = "http://127.0.0.1:8000/reviewer"
 
 #

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -52,7 +52,7 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 
 # ClinVar API key - used for validating (not submitting) ClinVar submissions for all institutes
 # Obtain a key by following these instructions: https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
-# CLINVAR_API_KEY = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+CLINVAR_API_KEY = "esnGvDPfhSKooMZrGNl3gH6RXObq0FA9KIrFlFJIuYv0jYb72HYDxXIoqm8yk5PE"
 
 # Matchmaker connection parameters
 # - Tested with PatientMatcher (https://github.com/Clinical-Genomics/patientMatcher) -

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -20,7 +20,7 @@ class ClinVarApi:
         self.validate_service = "/".join([PRECLINVAR_URL, "validate"])
         self.submit_service = CLINVAR_API_URL
 
-    def build_header(self, api_key):
+    def set_header(self, api_key):
         """Creates a header to be submitted a in a POST rquest to the CLinVar API
         Args:
             api_key(str): API key to be used to submit to ClinVar (64 alphanumeric characters)
@@ -96,12 +96,12 @@ class ClinVarApi:
                            -> 201, {"id": "SUB12387166"} # Success is 201 - Created - According to the ClinVar API
 
         """
-        header = self.build_header(api_key)
+        header = self.set_header(api_key)
         data = {
             "actions": [{"type": "AddData", "targetDb": "clinvar", "data": {"content": json_data}}]
         }
         try:
-            resp = requests.post(CLINVAR_API_URL, data=json.dumps(data), headers=header)
+            resp = requests.post(self.submit_service, data=json.dumps(data), headers=header)
             return resp.status_code, resp.json()
 
         except Exception as ex:

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -79,7 +79,7 @@ class ClinVarApi:
                 resp = requests.post(
                     self.validate_service, data={"api_key": api_key}, files=json_file
                 )
-                return resp.status_code, resp.json()
+                return resp.status_code, resp
 
         except Exception as ex:
             return None, ex
@@ -89,12 +89,12 @@ class ClinVarApi:
 
         Args:
             json_data(dict): a json submission object compliant with the ClinVar API
-            api_key(str): institute or user specific ClinVar submission key
+            api_key(str): institute or user-specific ClinVar submission key.
+                          Provided by user in ClinVar submission form.
 
         Returns:
             tuple: example -> 400, "{Validation errors}"
-                           -> 201, {"id": "SUB12387166"} # Success is 201 - Created - According to the ClinVar API
-
+                           -> 201, {} # Success is 201 - Created - According to the ClinVar API
         """
         header = self.set_header(api_key)
         data = {
@@ -102,7 +102,7 @@ class ClinVarApi:
         }
         try:
             resp = requests.post(self.submit_service, data=json.dumps(data), headers=header)
-            return resp.status_code, resp.json()
+            return resp.status_code, resp
 
         except Exception as ex:
             return None, ex

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -94,7 +94,7 @@ class ClinVarApi:
 
         Returns:
             tuple: example -> 400, "{Validation errors}"
-                           -> 201, {} # Success is 201 - Created - According to the ClinVar API
+                           -> [201, 200, 204], Response object
         """
         header = self.set_header(api_key)
         data = {

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -310,6 +310,10 @@ def test_clinvar_api_submit(app, institute_obj, case_obj, clinvar_form):
         # SHOULD result in a redirect to submissions page (code 302)
         assert resp.status_code == 302
 
+        # AND the submission object in database should be marked as submitted
+        updated_submission = store.clinvar_submission_collection.find_one()
+        assert updated_submission["status"] == "submitted"
+
 
 @responses.activate
 def test_clinvar_validate(app, institute_obj, case_obj, clinvar_form):


### PR DESCRIPTION
Adds the functionality to send a json submission object to the ClinVar API (fix #2900):

![image](https://user-images.githubusercontent.com/28093618/207360256-0adbf214-f8eb-4091-93d8-29d7c2096466.png)

If submission is successful the submission status is set to `submitted` (basically same as closed, but green):

<img width="722" alt="image" src="https://user-images.githubusercontent.com/28093618/207360659-14f3a665-82e9-447c-baab-a019ddbe7894.png">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

**How to test**:
1. Install this branch on cg-vm1 (stage)
2. Make sure you have a valid [ClinVar API key](https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/)
3. Submit to your data using Scout (the URL used will perform a dry-run, check my comment in the code)
4. The submission should be successful
5. Re-open the submission and make sure its status changes from `submitted` to `open`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN

