### PR TITLE
Only ACMG terms in ClinVar clinsig when user selects ACMG 2015 as assertion criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Source link out for MIP 11.1 reference STR annotation
 - Avoid duplicate causatives and pinned variants
+- ClinVar clinical significance displays only the ACMG terms when user selects ACMG 2015 as assertion criteria
 
 
 ## [4.61.1]

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -74,7 +74,7 @@ CASEDATA_HEADER = {
 # The following items are defined in the ClinVar API specifications:
 # https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
 ####################################################################
-CLNSIG_TERMS = {
+CLNSIG_TERMS = [
     "Pathogenic",
     "Likely pathogenic",
     "Uncertain significance",
@@ -92,7 +92,7 @@ CLNSIG_TERMS = {
     "protective",
     "other",
     NOT_PROVIDED,
-}
+]
 
 REVSTAT_TERMS = {
     "conflicting_interpretations",

--- a/scout/server/blueprints/clinvar/form.py
+++ b/scout/server/blueprints/clinvar/form.py
@@ -50,7 +50,9 @@ class ClinVarVariantForm(FlaskForm):
         "Inheritance model",
         choices=[("", "-")] + [(item, item) for item in CLINVAR_INHERITANCE_MODELS],
     )
-    clinsig = SelectField("Clinical Significance", choices=[(item, item) for item in CLNSIG_TERMS])
+    clinsig = SelectField(
+        "Clinical Significance", choices=[(item, item) for item in CLNSIG_TERMS[:5]]
+    )
     clinsig_comment = TextAreaField("Comment on clinical significance")
     clinsig_cit = TextAreaField("Clinical significance citations (with identifier)")
     last_evaluated = DateField("Date evaluated")

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -71,7 +71,6 @@
                   <br><br>
                   {{variant_data.var_form.assertion_method_cit.label(class="fw-bold text-dark")}}
                   {{variant_data.var_form.assertion_method_cit(class="bg-white")}}
-
                 <input type="button" name="next" class="next action-button" value="Next"/>
               </fieldset>
               <fieldset>
@@ -415,5 +414,22 @@ $(function(){
   });
 });
 
+// Modify variant classification options based on selected assertion_method_cit (ACMG-based or not)
+$(function(){
+  $("#assertion_method_cit").change(function(){
+    var assertCit = document.getElementById('assertion_method_cit').value;
+    var choices = {{clinsig_terms|safe}};
+    if (assertCit.includes("PMID:2574186")){ // populate select with ACMG terms only
+      choices = {{clinsig_terms[:5]|safe}};
+    }
+    $("#clinsig").empty(); // remove all options from clinsig select
+    //Create and append the conditional options to the clinsig select
+    for (var i = 0; i < choices.length; i++){
+      var newOption = new Option(choices[i], choices[i], true, false);
+      $('#clinsig').append(newOption).trigger('change');
+    }
+
+  });
+});
 </script>
 {% endblock %}

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -418,7 +418,7 @@ $(function(){
 $(function(){
   $("#assertion_method_cit").change(function(){
     var assertCit = document.getElementById('assertion_method_cit').value;
-    var choices = {{clinsig_terms|safe}};
+    var choices = {{clinsig_terms|safe}}; // all clinsig terms
     if (assertCit.includes("PMID:2574186")){ // populate select with ACMG terms only
       choices = {{clinsig_terms[:5]|safe}};
     }

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -419,7 +419,7 @@ $(function(){
   $("#assertion_method_cit").change(function(){
     var assertCit = document.getElementById('assertion_method_cit').value;
     var choices = {{clinsig_terms|safe}}; // all clinsig terms
-    if (assertCit.includes("PMID:2574186")){ // populate select with ACMG terms only
+    if (assertCit.includes("PMID:25741868")){ // populate select with ACMG terms only
       choices = {{clinsig_terms[:5]|safe}};
     }
     $("#clinsig").empty(); // remove all options from clinsig select

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -4,7 +4,7 @@ from tempfile import NamedTemporaryFile
 
 from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
 
-from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER
+from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, CLNSIG_TERMS
 from scout.server.extensions import store
 from scout.server.utils import institute_and_case
 
@@ -25,7 +25,7 @@ blueprint = Blueprint(
 def clinvar_add_variant(institute_id, case_name):
     """Create a ClinVar submission document in database for one or more variants from a case."""
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
-    data = {"institute": institute_obj, "case": case_obj}
+    data = {"institute": institute_obj, "case": case_obj, "clinsig_terms": CLNSIG_TERMS}
     controllers.set_clinvar_form(request.form.get("var_id"), data)
     return render_template("multistep_add_variant.html", **data)
 
@@ -105,7 +105,6 @@ def clinvar_validate(submission, save_id=False):
 @blueprint.route("/<institute_id>/<submission>/update_status", methods=["POST"])
 def clinvar_update_submission(institute_id, submission):
     """Update a submission status to open/closed, register an official SUB number or delete the entire submission"""
-
     controllers.update_clinvar_submission_status(request, institute_id, submission)
     return redirect(request.referrer)
 


### PR DESCRIPTION
Fix #3715. Fixes also the order of the items in that select, which now is random.

### Default assertion criteria is ACMG, so clinsig will just show the ACMG criteria by default:

<img width="337" alt="image" src="https://user-images.githubusercontent.com/28093618/207289382-0a5c5589-fc5b-45bf-8844-d21a7679fd46.png">

### When user removes the ACMG assertion method citation field:

<img width="593" alt="image" src="https://user-images.githubusercontent.com/28093618/207289894-738128ed-aabd-48e2-ad97-953a7e6d030f.png">

### Then all clinsig options will be shown:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/28093618/207289789-a73d2105-eb9e-4178-bbe7-250c286b76ae.png">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
