### PR TITLE
Handle connection timeout when sending requests to external web services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ClinVar clinical significance displays only the ACMG terms when user selects ACMG 2015 as assertion criteria
 - Spacing between icon and text on Beacon and MatchMaker links on case page sidebar
 - Truncate IDs and HGVS representations in ClinVar pages if longer than 25 characters
+- Handle connection timeout when sending requests requests to external web services
 
 ## [4.61.1]
 ### Fixed

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -82,9 +82,19 @@
                     <br><br>
                     <!-- Transcripts & HGVS:(optional) -->
                     {{variant_data.var_form.tx_hgvs.label(class="fw-bold, text-dark")}}
+
                     <span class="text-danger" data-bs-toggle='tooltip' title="If you do not provide any HGVS expression, chromosome coordinates will be used to describe this variant instead (automatic). HGVS expressions were validated using VariantValidator"><strong>?</strong></span>
                     <span class="badge bg-primary float-end"><a class="text-white" href="https://variantvalidator.org/service/validate/" target="_blank" rel="noopener">VariantValidator</a></span>
                     <br><br>
+
+                    {% with messages = get_flashed_messages() %}
+                      {% if messages %}
+                        {% for message in messages %}
+                          <span class="ml-3" style="color:red">{{ message }}</span><br>
+                        {% endfor %}
+                        <br><br>
+                      {% endif %}
+                    {% endwith %}
 
                     <table role="presentation" style="width:100%; table-layout: auto; border-collapse: collapse;">
                     {% set ns = namespace(label='', validated=false) %}

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -118,9 +118,12 @@ def get_request(url):
         error = "Something went wrong, perhaps url is invalid?"
     except requests.exceptions.Timeout:
         error = f"socket timed out - URL {url}"
+    except Exception as ex:
+        error = f"Exception while connecting to {url}: {ex}"
 
     if error:
         LOG.error(error)
+        return
 
     return response
 
@@ -438,7 +441,8 @@ def fetch_refseq_version(refseq_acc):
     try:
         resp = get_request(base_url.format(refseq_acc))
         if resp is None:
-            flash("Could not retrieve HGVS descriptors from Entrez eutils", "warning")
+            flash(f"Error: could not retrieve HGVS version for {refseq_acc} from Entrez eutils!")
+            return version
         tree = ElementTree.fromstring(resp.content)
         version = tree.find("IdList").find("Id").text or version
 

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -105,6 +105,7 @@ def get_request(url):
     Returns:
         decoded_data(str): Decoded response
     """
+    response = None
     try:
         LOG.info("Requesting %s", url)
         response = requests.get(url, timeout=TIMEOUT)
@@ -113,13 +114,10 @@ def get_request(url):
         LOG.info("Encoded to %s", response.encoding)
     except requests.exceptions.HTTPError as err:
         LOG.warning("Something went wrong, perhaps the api key is not valid?")
-        raise err
     except requests.exceptions.MissingSchema as err:
         LOG.warning("Something went wrong, perhaps url is invalid?")
-        raise err
     except requests.exceptions.Timeout as err:
         LOG.error("socket timed out - URL %s", url)
-        raise err
 
     return response
 

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -120,7 +120,6 @@ def get_request(url):
         error = f"socket timed out - URL {url}"
 
     if error:
-        flash(error, "warning")
         LOG.error(error)
 
     return response
@@ -438,6 +437,8 @@ def fetch_refseq_version(refseq_acc):
 
     try:
         resp = get_request(base_url.format(refseq_acc))
+        if resp is None:
+            flash("Could not retrieve HGVS descriptors from Entrez eutils", "warning")
         tree = ElementTree.fromstring(resp.content)
         version = tree.find("IdList").find("Id").text or version
 

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -7,6 +7,7 @@ from urllib.error import HTTPError
 
 import requests
 from defusedxml import ElementTree
+from flask import flash
 
 from scout.constants import CHROMOSOMES, HPO_URL, HPOTERMS_URL
 from scout.utils.ensembl_rest_clients import EnsemblBiomartClient
@@ -106,18 +107,21 @@ def get_request(url):
         decoded_data(str): Decoded response
     """
     response = None
+    error = None
     try:
-        LOG.info("Requesting %s", url)
         response = requests.get(url, timeout=TIMEOUT)
         if response.status_code != 200:
             response.raise_for_status()
-        LOG.info("Encoded to %s", response.encoding)
     except requests.exceptions.HTTPError:
-        LOG.warning("Something went wrong, perhaps the api key is not valid?")
+        error = "Something went wrong, perhaps the api key is not valid?"
     except requests.exceptions.MissingSchema:
-        LOG.warning("Something went wrong, perhaps url is invalid?")
+        error = "Something went wrong, perhaps url is invalid?"
     except requests.exceptions.Timeout:
-        LOG.error("socket timed out - URL %s", url)
+        error = f"socket timed out - URL {url}"
+
+    if error:
+        flash(error, "warning")
+        LOG.error(error)
 
     return response
 

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -112,11 +112,11 @@ def get_request(url):
         if response.status_code != 200:
             response.raise_for_status()
         LOG.info("Encoded to %s", response.encoding)
-    except requests.exceptions.HTTPError as err:
+    except requests.exceptions.HTTPError:
         LOG.warning("Something went wrong, perhaps the api key is not valid?")
-    except requests.exceptions.MissingSchema as err:
+    except requests.exceptions.MissingSchema:
         LOG.warning("Something went wrong, perhaps url is invalid?")
-    except requests.exceptions.Timeout as err:
+    except requests.exceptions.Timeout:
         LOG.error("socket timed out - URL %s", url)
 
     return response

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -3,7 +3,6 @@ import tempfile
 import zlib
 from urllib.error import HTTPError
 
-import pytest
 import requests
 import responses
 

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -5,6 +5,7 @@ from urllib.error import HTTPError
 
 import requests
 import responses
+from flask import url_for
 
 from scout.utils import scout_requests
 
@@ -460,7 +461,7 @@ def test_fetch_resource_json():
     assert data[0]["first"] == "second"
 
 
-def test_fetch_refseq_version_timeout(mocker):
+def test_fetch_refseq_version_timeout(mocker, mock_app):
     """Test a connection error when retrieving refseq version from entrez utils service"""
 
     # GIVEN a patched requests module
@@ -469,11 +470,13 @@ def test_fetch_refseq_version_timeout(mocker):
         return_value=requests.exceptions.Timeout("Connection timed out."),
     )
 
-    # WHEN fetching complete refseq version for accession that has version
-    refseq_version = scout_requests.fetch_refseq_version(REFSEQ_ACC)
+    with mock_app.app_context():
 
-    # THEN refseq returned is the same as refseq provided
-    assert REFSEQ_ACC == refseq_version
+        # WHEN fetching complete refseq version for accession that has version
+        refseq_version = scout_requests.fetch_refseq_version(REFSEQ_ACC)
+
+        # THEN refseq returned is the same as refseq provided
+        assert REFSEQ_ACC == refseq_version
 
 
 @responses.activate

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -469,7 +469,7 @@ def test_fetch_refseq_version_timeout(mocker, mock_app):
         return_value=requests.exceptions.Timeout("Connection timed out."),
     )
 
-    with mock_app.app_context():
+    with mock_app.test_request_context():
 
         # WHEN fetching complete refseq version for accession that has version
         refseq_version = scout_requests.fetch_refseq_version(REFSEQ_ACC)

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -460,7 +460,7 @@ def test_fetch_resource_json():
     assert data[0]["first"] == "second"
 
 
-def test_fetch_refseq_version_timeout(mocker, mock_app):
+def test_fetch_refseq_version_timeout(mocker, empty_mock_app):
     """Test a connection error when retrieving refseq version from entrez utils service"""
 
     # GIVEN a patched requests module
@@ -469,7 +469,7 @@ def test_fetch_refseq_version_timeout(mocker, mock_app):
         return_value=requests.exceptions.Timeout("Connection timed out."),
     )
 
-    with mock_app.test_request_context():
+    with empty_mock_app.test_request_context():
 
         # WHEN fetching complete refseq version for accession that has version
         refseq_version = scout_requests.fetch_refseq_version(REFSEQ_ACC)

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -461,6 +461,37 @@ def test_fetch_resource_json():
 
 
 @responses.activate
+def test_fetch_refseq_version_timeout():
+    """Test a connection error when retrieving refseq version from entrez utils service"""
+
+    # GIVEN a refseq accession number
+    refseq_acc = "NM_020533"
+    # GIVEN the base url
+    base_url = (
+        "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=nuccore&"
+        "term={}&idtype=acc"
+    )
+    url = base_url.format(refseq_acc)
+
+    # GIVEN a patched request that triggers timeout
+    def exception_callback():
+        return requests.exceptions.Timeout("Connection timed out.")
+
+    responses.add(
+        responses.GET,
+        url,
+        body=exception_callback(),
+        status=200,
+    )
+
+    # WHEN fetching complete refseq version for accession that has version
+    refseq_version = scout_requests.fetch_refseq_version(refseq_acc)
+
+    # THEN refseq returned is the same as refseq provided
+    assert refseq_acc == refseq_version
+
+
+@responses.activate
 def test_fetch_refseq_version(refseq_response):
     """Test utils service from entrez that retrieves refseq version"""
 

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -5,7 +5,6 @@ from urllib.error import HTTPError
 
 import requests
 import responses
-from flask import url_for
 
 from scout.utils import scout_requests
 
@@ -114,7 +113,7 @@ def test_get_request_bad_request():
     # WHEN requesting
     response = scout_requests.get_request(url)
     # THEN response should have 404 code
-    assert response.status_code == 404
+    assert response == None
 
 
 @responses.activate


### PR DESCRIPTION
Fix #3724. The problem was that in the try - except block of scout_requests, the except block was raising an exception itself, causing the app to crash.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR
