### PR TITLE
Validate all submissions regardless of their status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Truncate IDs and HGVS representations in ClinVar pages if longer than 25 characters
 - Update ClinVar submission ID form
 - Handle connection timeout when sending requests requests to external web services
+- Validate any ClinVar submission regardless of its status
 
 ## [4.61.1]
 ### Fixed

--- a/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar_submissions.html
@@ -94,11 +94,11 @@
             </li>
             {% if subm_obj.status=='open'%}
               <li class="breadcrumb-item"><button type="submit" name="update_submission" value="closed" class="btn btn-warning btn-xs">Close submission</button></li>
-              {% if config.CLINVAR_API_KEY %}
-                <li class="breadcrumb-item"><a href="{{ url_for('clinvar.clinvar_validate', submission=subm_obj._id) }}" class="btn btn-info btn-xs">Validate submission</a></li>
-              {% endif %}
             {% else %}
               <li class="breadcrumb-item"><button type="submit" name="update_submission" value="open" class="btn btn-success btn-xs">Re-open submission</button></li>
+            {% endif %}
+            {% if config.CLINVAR_API_KEY %}
+              <li class="breadcrumb-item"><a href="{{ url_for('clinvar.clinvar_validate', submission=subm_obj._id) }}" class="btn btn-info btn-xs">Validate submission</a></li>
             {% endif %}
               <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission</button></li>
           </ol>


### PR DESCRIPTION
Fix #3729 

- Added the option to validate any type of submission:

Main branch:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/28093618/208634259-c99074f8-a672-4c59-bc21-e01e4db0dd34.png">


This branch:

<img width="694" alt="image" src="https://user-images.githubusercontent.com/28093618/208634059-7da1abfa-6946-4ee8-ab35-95fa244db9fd.png">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
