### PR TITLE
Fix #3733 - stop spinner on json export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update ClinVar submission ID form
 - Handle connection timeout when sending requests requests to external web services
 - Validate any ClinVar submission regardless of its status
+- Stop Spinner on Phenopacket JSON download
 ### Changed
-- Updated ClinVar submission instructions 
+- Updated ClinVar submission instructions
 
 ## [4.61.1]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -544,6 +544,7 @@
         container: 'body'})
   })
 
+
   $(function(){
       function getHpoTerms(query, process) {
         $.get("{{ url_for('cases.hpoterms') }}", {query: query}, function(data) {
@@ -596,6 +597,11 @@
 
   });
 
+function StopSpinner() {
+   // Avoid page spinner being stuck on file download
+  $(window).unbind('beforeunload');
+  return true;
+}
 function SidebarCollapse () {
     $('.menu-collapsed').toggleClass('d-none');
     $('.sidebar-submenu').toggleClass('d-none');

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -228,8 +228,8 @@
         <button class="btn btn-secondary form-control" id="import-phenotype-modal-btn" data-bs-toggle="modal" data-bs-target="#import-phenotype">Import</button>
       </div>
       <div class="col">
-        <form method="POST" action="{{ url_for('cases.phenotype_export', institute_id=institute._id, case_name=case.display_name) }}">
-            <button class="btn btn-secondary form-control" id="export-phenotype-button" type="submit" data-bs-toggle='tooltip' title="Export Phenopacket JSON for affected individual">Export</button>
+        <form method="POST" action="{{ url_for('cases.phenotype_export', institute_id=institute._id, case_name=case.display_name) }}" onsubmit="return StopSpinner()">
+            <button class="btn btn-secondary form-control" id="export-phenotype-button" type="submit" data-bs-toggle="tooltip" title="Export Phenopacket JSON for affected individual">Export</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
This PR adds fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. add a phenotype to a case, and export phenopacket json
2. notice how before patch the spinner does not stop
3. after patch, the spinner stops

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR, DN
