### PR TITLE
Add rnafusion reports

### DIFF
--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -15,7 +15,11 @@ CUSTOM_CASE_REPORTS = {
         "pdf_export": False,
     },
     "reference_info": {"key_name": "reference_info", "format": "YAML", "pdf_export": True},
-    "RNAfusion_inspector": {"key_name": "RNAfusion_inspector", "format": "HTML", "pdf_export": False},
+    "RNAfusion_inspector": {
+        "key_name": "RNAfusion_inspector",
+        "format": "HTML",
+        "pdf_export": False,
+    },
     "RNAfusion_report": {"key_name": "RNAfusion_report", "format": "HTML", "pdf_export": False},
 }
 

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -15,6 +15,8 @@ CUSTOM_CASE_REPORTS = {
         "pdf_export": False,
     },
     "reference_info": {"key_name": "reference_info", "format": "YAML", "pdf_export": True},
+    "RNAfusion_inspector": {"key_name": "RNAfusion_inspector", "format": "HTML", "pdf_export": False},
+    "RNAfusion_report": {"key_name": "RNAfusion_report", "format": "HTML", "pdf_export": False},
 }
 
 CASE_REPORT_CASE_FEATURES = [


### PR DESCRIPTION
This PR adds support for RNAfusion specific reports (`RNAfusion_report` and `RNAfusion_inspector`). 

Related to: https://github.com/Clinical-Genomics/scout/issues/3658 and https://github.com/Clinical-Genomics/scout/issues/3648

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
