### PR TITLE
Show chrY also for sex unknown - Fix #3750

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display data sharing info for ClinVar, Matchmaker Exchange and Beacon in a dedicated column on Cases page
 - Test for `commands.download.omim.print_omim`
 - Display dismissed variants comments on general case report
+### Changed
+- Display chrY for sex unknown
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 

--- a/scout/server/blueprints/cases/static/case_images.js
+++ b/scout/server/blueprints/cases/static/case_images.js
@@ -247,13 +247,13 @@ function chromosome_text(text, x, y){
  * Males shall display 24 png:s. Females shall display 23 png:s
  *
  */
-function get_chromosomes(sex){
-    if(sex=="1"){
-        return CHROMSPECS_LIST}
-    else{
-        return CHROMSPECS_LIST.slice(0, CHROMSPECS_LIST.length-1)}
-    }
-
+function get_chromosomes(sex) {
+	if (sex == "2") {
+		return CHROMSPECS_LIST.slice(0, CHROMSPECS_LIST.length - 1)
+	} else {
+		return CHROMSPECS_LIST
+	}
+}
 
 /**
  * Create a polygon path. Used to give cytoband images -rectangular- rounded


### PR DESCRIPTION
This PR adds changes chromograph display to only restrict view of sex chromosomes to X only for designated females. All other (male, other and unknown) show coverage for both.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. set a test individual with chromograph images, ideally including Y, to sex unknown.
2. before change, note how only autosomes and X are shown
3. after change, Y should also be displayed

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
