### PR TITLE
Manual rank updates: add risk factor, show on matching variants in other cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Test for `commands.download.omim.print_omim`
 - Display dismissed variants comments on general case report
 - Modify ACMG pathogenicity impact (most commonly PVS1, PS3) based on strength of evidence with lab director's professional judgement
+- Added Manual Ranks Risk Factor, Likely Risk Factor and Uncertain Risk Factor
+- Display matching manual ranks from previous cases the user has access to on VariantS and Variant pages
 ### Changed
 - Display chrY for sex unknown
 ### Fixed

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -284,7 +284,10 @@ class VariantEventHandler(object):
             else:
                 ranked[rank_id] = {
                     "links": {ranked_event["link"]},
-                    "label": MANUAL_RANK_OPTIONS.get(rank_id, {}).get("label_class", "secondary"),
+                    "label_class": MANUAL_RANK_OPTIONS.get(rank_id, {}).get(
+                        "label_class", "secondary"
+                    ),
+                    "label": MANUAL_RANK_OPTIONS.get(rank_id, {}).get("label", "NOS"),
                 }
         return ranked
 

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -273,7 +273,7 @@ class VariantEventHandler(object):
                 ranked_matching_variant is None
                 or ranked_matching_variant["_id"] == query_variant["_id"]
                 or ranked_matching_variant.get("manual_rank") is None
-                or ranked_matching_variant.get("case_id") in exclude_case
+                or ranked_matching_variant.get("case_id") in exclude_cases
             ):
                 continue
 

--- a/scout/adapter/mongo/variant_events.py
+++ b/scout/adapter/mongo/variant_events.py
@@ -287,6 +287,7 @@ class VariantEventHandler(object):
                     "label_class": MANUAL_RANK_OPTIONS.get(rank_id, {}).get(
                         "label_class", "secondary"
                     ),
+                    "description": MANUAL_RANK_OPTIONS.get(rank_id, {}).get("description", "NOS"),
                     "label": MANUAL_RANK_OPTIONS.get(rank_id, {}).get("label", "NOS"),
                 }
         return ranked

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -295,6 +295,24 @@ CANCER_TIER_OPTIONS = {
 }
 
 MANUAL_RANK_OPTIONS = {
+    12: {
+        "label": "URF",
+        "name": "Uncertain Risk Factor",
+        "description": "Uncertain risk allele - uncertain evidence for a small risk increase",
+        "label_class": "default",
+    },
+    11: {
+        "label": "LRF",
+        "name": "Likely Risk Factor",
+        "description": "Likely risk allele - some evidence for a small risk increase",
+        "label_class": "default",
+    },
+    10: {
+        "label": "RF",
+        "name": "Risk Factor",
+        "description": "Established risk allele - strong evidence for a small risk increase",
+        "label_class": "default",
+    },
     9: {
         "label": "VUS",
         "name": "Unknown Significance",

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -386,6 +386,24 @@ MANUAL_RANK_OPTIONS = OrderedDict(
             },
         ),
         (
+            13,
+            {
+                "label": "PLP",
+                "name": "Pathogenic Low Penetrance",
+                "description": "Pathogenic allele with low or reduced penetrance - robust evidence for an intermediate risk increase",
+                "label_class": "warning",
+            },
+        ),
+        (
+            14,
+            {
+                "label": "LPLP",
+                "name": "Likely Pathogenic Low Penetrance",
+                "description": "Likely pathogenic allele with low or reduced penetrance - some evidence for an intermediate risk increase",
+                "label_class": "warning",
+            },
+        ),
+        (
             10,
             {
                 "label": "RF",

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from .gene_tags import INHERITANCE_PALETTE
 
 VARIANT_REPORT_VARIANT_FEATURES = [
@@ -294,92 +296,133 @@ CANCER_TIER_OPTIONS = {
     },
 }
 
-MANUAL_RANK_OPTIONS = {
-    12: {
-        "label": "URF",
-        "name": "Uncertain Risk Factor",
-        "description": "Uncertain risk allele - uncertain evidence for a small risk increase",
-        "label_class": "default",
-    },
-    11: {
-        "label": "LRF",
-        "name": "Likely Risk Factor",
-        "description": "Likely risk allele - some evidence for a small risk increase",
-        "label_class": "default",
-    },
-    10: {
-        "label": "RF",
-        "name": "Risk Factor",
-        "description": "Established risk allele - strong evidence for a small risk increase",
-        "label_class": "default",
-    },
-    9: {
-        "label": "VUS",
-        "name": "Unknown Significance",
-        "description": "Variant of unknown significance",
-        "label_class": "default",
-    },
-    8: {
-        "label": "KP",
-        "name": "Known pathogenic",
-        "description": "Known pathogenic, previously known pathogenic in ClinVar, HGMD, literature, etc",
-        "label_class": "danger",
-    },
-    7: {
-        "label": "P",
-        "name": "Pathogenic",
-        "description": (
-            "Pathogenic, novel mutation but overlapping phenotype with known pathogenic, "
-            "no further experimental validation needed"
+MANUAL_RANK_OPTIONS = OrderedDict(
+    [
+        (
+            8,
+            {
+                "label": "KP",
+                "name": "Known pathogenic",
+                "description": "Known pathogenic, previously known pathogenic in ClinVar, HGMD, literature, etc",
+                "label_class": "danger",
+            },
         ),
-        "label_class": "danger",
-    },
-    6: {
-        "label": "NVP",
-        "name": "Novel validated pathogenic",
-        "description": "Novel validated pathogenic, novel mutation and validated experimentally",
-        "label_class": "danger",
-    },
-    5: {
-        "label": "PPP",
-        "name": "Pathogenic partial phenotype",
-        "description": (
-            "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but "
-            "not all symptoms"
+        (
+            7,
+            {
+                "label": "P",
+                "name": "Pathogenic",
+                "description": (
+                    "Pathogenic, novel mutation but overlapping phenotype with known pathogenic, "
+                    "no further experimental validation needed"
+                ),
+                "label_class": "danger",
+            },
         ),
-        "label_class": "danger",
-    },
-    4: {
-        "label": "LP",
-        "name": "Likely pathogenic",
-        "description": "Likely pathogenic, experimental validation required to prove causality",
-        "label_class": "warning",
-    },
-    3: {
-        "label": "PP",
-        "name": "Possibly pathogenic",
-        "description": "Possibly pathogenic, uncertain significance, but cannot disregard yet",
-        "label_class": "primary",
-    },
-    2: {
-        "label": "LB",
-        "name": "Likely benign",
-        "description": "Likely benign, uncertain significance, but can discard",
-        "label_class": "info",
-    },
-    1: {
-        "label": "B",
-        "name": "Benign",
-        "description": "Benign, does not cause phenotype",
-        "label_class": "success",
-    },
-    0: {
-        "label": "O",
-        "name": "Other",
-        "description": "Other, phenotype not related to disease",
-        "label_class": "default",
-    },
-}
+        (
+            6,
+            {
+                "label": "NVP",
+                "name": "Novel validated pathogenic",
+                "description": "Novel validated pathogenic, novel mutation and validated experimentally",
+                "label_class": "danger",
+            },
+        ),
+        (
+            5,
+            {
+                "label": "PPP",
+                "name": "Pathogenic partial phenotype",
+                "description": (
+                    "Pathogenic partial phenotype, pathogenic variant explains part of patients phenotype, but "
+                    "not all symptoms"
+                ),
+                "label_class": "danger",
+            },
+        ),
+        (
+            4,
+            {
+                "label": "LP",
+                "name": "Likely pathogenic",
+                "description": "Likely pathogenic, experimental validation required to prove causality",
+                "label_class": "warning",
+            },
+        ),
+        (
+            3,
+            {
+                "label": "PP",
+                "name": "Possibly pathogenic",
+                "description": "Possibly pathogenic, uncertain significance, but cannot disregard yet",
+                "label_class": "primary",
+            },
+        ),
+        (
+            2,
+            {
+                "label": "LB",
+                "name": "Likely benign",
+                "description": "Likely benign, uncertain significance, but can discard",
+                "label_class": "info",
+            },
+        ),
+        (
+            1,
+            {
+                "label": "B",
+                "name": "Benign",
+                "description": "Benign, does not cause phenotype",
+                "label_class": "success",
+            },
+        ),
+        (
+            9,
+            {
+                "label": "VUS",
+                "name": "Unknown Significance",
+                "description": "Variant of unknown significance",
+                "label_class": "default",
+            },
+        ),
+        (
+            10,
+            {
+                "label": "RF",
+                "name": "Risk Factor",
+                "description": "Established risk allele - strong evidence for a small risk increase",
+                "label_class": "default",
+            },
+        ),
+        (
+            11,
+            {
+                "label": "LRF",
+                "name": "Likely Risk Factor",
+                "description": "Likely risk allele - some evidence for a small risk increase",
+                "label_class": "default",
+            },
+        ),
+        (
+            12,
+            {
+                "label": "URF",
+                "name": "Uncertain Risk Factor",
+                "description": "Uncertain risk allele - uncertain evidence for a small risk increase",
+                "label_class": "default",
+            },
+        ),
+        (
+            0,
+            {
+                "label": "O",
+                "name": "Other",
+                "description": "Other, phenotype not related to disease",
+                "label_class": "default",
+            },
+        ),
+    ]
+)
 
 DISMISS_VARIANT_OPTIONS = {
     2: {

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -278,6 +278,10 @@ def variant(
             variant_obj, user_institutes(store, current_user)
         )
 
+    variant_obj["matching_ranked"] = store.get_matching_manual_ranked_variants(
+        variant_obj, user_institutes(store, current_user), exclude_cases=[case_obj["_id"]]
+    )
+
     # Gather display information for the genes
     variant_obj.update(predictions(variant_obj.get("genes", [])))
 

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -71,7 +71,7 @@
     </div>
     {% endif %}
 
-    {{ matching_variants(managed_variant, causatives, variant.matching_tiered) }}
+    {{ matching_variants(managed_variant, causatives, variant.matching_manual_ranked, variant.matching_tiered) }}
     <div class="row">
       <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -185,12 +185,12 @@
       <div class="card-body mt-1 ms-3 mb-1 d-flex" style="padding: 0;">
         Matching manually ranked variants:&nbsp;
         {% for manual_rank, manual_rank_info in matching_manual_ranked.items() %}
-          <a class="btn btn-{{manual_rank_info.label}} btn-xs" data-bs-toggle="collapse" href="#collapse_{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
-            {{manual_rank}} ({{manual_rank_info.links|length}}x)
+          <a class="btn btn-{{manual_rank_info.label_class}} btn-xs" data-bs-toggle="collapse" href="#collapse_mr{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+            {{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)
           </a>
-          <div class="collapse" id="collapse_{{manual_rank}}">
+          <div class="collapse" id="collapse_mr{{manual_rank}}">
             <div>
-              {{manual_rank}}:
+              {{manual_rank_info.label}}:
               {% for link in manual_rank_info["links"] %}
                 {% set match_case = link.split('/') %}
                   <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -138,7 +138,7 @@
 {% endmacro %}
 
 
-{% macro matching_variants(managed_variant, causatives, matching_tiered=None) %}
+{% macro matching_variants(managed_variant, causatives, matching_manual_ranked=None, matching_tiered=None) %}
   {% if causatives %}
     <div class="card mt-3">
       <div class="card-body mt-1 ms-3 mb-1" style="padding: 0;">
@@ -178,6 +178,28 @@
         <h6>No matching causative or managed variants</h6>
       </div> <!--end of card body-->
     </div><!--end of card-->
+  {% endif %}
+
+  {% if matching_manual_ranked %}
+    <div class="card">
+      <div class="card-body mt-1 ms-3 mb-1 d-flex align-items-center" style="padding: 0;">
+        Matching previous manually ranked variants:
+        {% for manual_rank, manual_rank_info in matching_manual_ranked.items() %}
+          <a class="btn btn-{{manual_rank_info.label}} btn-xs" data-bs-toggle="collapse" href="#collapse_{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+            {{manual_rank}} ({{manual_rank_info.links|length}}x)
+          </a>
+          <div class="collapse" id="collapse_{{manual_rank}}">
+            <div>
+              {{manual_rank}}:
+              {% for link in manual_rank_info["links"] %}
+                {% set match_case = link.split('/') %}
+                  <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
   {% endif %}
 
   {% if matching_tiered %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -164,7 +164,7 @@
   {% endif %}
   {% if managed_variant %}
     <div class="card mt-3">
-      <div class="card-body mt-1 ms-3 mb-1">
+      <div class="card-body mt-1 ms-3 mb-1" style="padding: 0;">
         Matching managed variant:
         <div class="row">
           <div class="col-2">
@@ -187,10 +187,10 @@
 
   {% if matching_manual_ranked %}
     <div class="card">
-      <div class="card-body mt-1 ms-3 mb-1 d-flex" style="padding: 0;">
+      <div class="card-body mt-1 ms-3 mb-1" style="padding: 0;">
         Matching manually ranked variants:&nbsp;
         {% for manual_rank, manual_rank_info in matching_manual_ranked.items() %}
-          <a class="btn btn-{{manual_rank_info.label_class}} btn-xs" data-bs-toggle="collapse" href="#collapse_mr{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+          <a style="padding: 0;" class="btn btn-{{manual_rank_info.label_class}} btn-xs" data-bs-toggle="collapse" href="#collapse_mr{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
             {{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)
           </a>
           <div class="collapse" id="collapse_mr{{manual_rank}}">
@@ -198,7 +198,7 @@
               {{manual_rank_info.label}}:
               {% for link in manual_rank_info["links"] %}
                 {% set match_case = link.split('/') %}
-                  <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
+                  <a style="padding: 0;" href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
               {% endfor %}
             </div>
           </div>
@@ -209,10 +209,10 @@
 
   {% if matching_tiered %}
     <div class="card">
-      <div class="card-body mt-1 ms-3 mb-1 d-flex align-items-center" style="padding: 0;">
+      <div class="card-body mt-1 ms-3 mb-1" style="padding: 0;">
         Matching tiered:&nbsp;
         {% for tier, tiered_info in matching_tiered.items() %}
-          <a class="btn btn-{{tiered_info.label}} btn-xs" data-bs-toggle="collapse" href="#collapse_{{tier}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+          <a style="padding: 0;" class="btn btn-{{tiered_info.label}} btn-xs" data-bs-toggle="collapse" href="#collapse_{{tier}}" role="button" aria-expanded="false" aria-controls="collapseExample">
             {{tier}} ({{tiered_info.links|length}}x)
           </a>
           <div class="collapse" id="collapse_{{tier}}">
@@ -220,7 +220,7 @@
               {{tier}}:
               {% for link in tiered_info["links"] %}
                 {% set match_case = link.split('/') %}
-                  <a href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
+                  <a style="padding: 0;" href="{{link}}" target="_blank">{{match_case[4]}}</a>&nbsp;
               {% endfor %}
             </div>
           </div>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -174,16 +174,16 @@
   {% endif %}
   {% if not managed_variant and not causatives %}
     <div class="card mt-3">
-      <div class="card-body mt-1 ms-1" style="padding: 0;">
-        <h6>No matching causative or managed variants</h6>
+      <div class="card-body mt-1 ms-3" style="padding: 0;">
+        No matching causative or managed variants
       </div> <!--end of card body-->
     </div><!--end of card-->
   {% endif %}
 
   {% if matching_manual_ranked %}
     <div class="card">
-      <div class="card-body mt-1 ms-3 mb-1 d-flex align-items-center" style="padding: 0;">
-        Matching previous manually ranked variants:
+      <div class="card-body mt-1 ms-3 mb-1 d-flex" style="padding: 0;">
+        Matching manually ranked variants:&nbsp;
         {% for manual_rank, manual_rank_info in matching_manual_ranked.items() %}
           <a class="btn btn-{{manual_rank_info.label}} btn-xs" data-bs-toggle="collapse" href="#collapse_{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
             {{manual_rank}} ({{manual_rank_info.links|length}}x)

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -72,7 +72,7 @@
     </div>
     {% endif %}
 
-    <div class="row"><div class="col-12">{{ matching_variants(managed_variant, causatives) }}</div></div>
+    <div class="row"><div class="col-12">{{ matching_variants(managed_variant, causatives, variant.matching_ranked) }}</div></div>
 
     <div class="row">
       <div class="col-lg-3 col-md-6">

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -786,6 +786,10 @@ def parse_variant(
         variant_obj, user_institutes(store, current_user)
     )
 
+    variant_obj["matching_ranked"] = store.get_matching_manual_ranked_variants(
+        variant_obj, user_institutes(store, current_user), exclude_cases=[case_obj["_id"]]
+    )
+
     variant_genes = variant_obj.get("genes")
     if variant_genes:
         variant_obj.update(predictions(variant_genes))

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -2,7 +2,7 @@
 
 {% from "variants/components.html" import external_scripts, external_stylesheets, gene_cell, frequency_cell_general, observed_cell_general %}
 {% from "variants/utils.html" import cancer_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status %}
-{% from "variants/indicators.html" import pin_indicator, causative_badge, comments_badge, dismissals_badge, evaluations_badge, research_assessments_badge, clinical_assessments_badge, group_assessments_badge, other_tiered_variants %}
+{% from "variants/indicators.html" import pin_indicator, causative_badge, clinical_assessments_badge, comments_badge, dismissals_badge, evaluations_badge, group_assessments_badge, matching_manual_rank, other_tiered_variants, research_assessments_badge %}
 
 {% block title %}
   {{ variant_type|capitalize }} somatic variants

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -100,6 +100,7 @@
             <td>
               {{ evaluations_badge(variant) }}
               {{ dismissals_badge(variant) }}
+              {{ matching_manual_rank(variant) }}
               {{ research_assessments_badge(variant) }}
               {{ clinical_assessments_badge(variant) }}
               {{ group_assessments_badge(variant) }}

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -51,6 +51,17 @@
   {% endif %} <!-- end of if variant.matching_tiered -->
 {% endmacro %}
 
+{% macro matching_manual_rank(variant) %}
+  {% if variant.matching_ranked %}
+    <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true" title=""
+        data-bs-content="
+          {% for manual_rank, manual_rank_info in variant.matching_tiered.items() %}
+            <span class='badge bg-{{matching_rank_info.label}}'>{{manual_rank}} ({{manual_rank_info.links|length}}x)</span>
+          {% endfor %}
+        "
+       data-original-title="Previously ranked as">M</span>
+  {% endif %}
+{% endmacro %}
 
 {% macro evaluations_badge(variant) %}
   {% if variant.evaluations %}

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -53,10 +53,10 @@
 
 {% macro matching_manual_rank(variant) %}
   {% if variant.matching_ranked %}
-    <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true" title=""
+    <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true"
         data-bs-content="
           {% for manual_rank, manual_rank_info in variant.matching_ranked.items() %}
-            <span class='badge bg-{{manual_rank_info.label_class}}'>{{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)</span>
+            <span>{{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)</span>
           {% endfor %}
         "
        data-original-title="Previously ranked as">M</span>

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -56,7 +56,7 @@
     <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true" title=""
         data-bs-content="
           {% for manual_rank, manual_rank_info in variant.matching_ranked.items() %}
-            <span class='badge bg-{{manual_rank_info.label}}'>{{manual_rank}} ({{manual_rank_info.links|length}}x)</span>
+            <span class='badge bg-{{manual_rank_info.label_class}}'>{{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)</span>
           {% endfor %}
         "
        data-original-title="Previously ranked as">M</span>

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -55,8 +55,8 @@
   {% if variant.matching_ranked %}
     <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true" title=""
         data-bs-content="
-          {% for manual_rank, manual_rank_info in variant.matching_tiered.items() %}
-            <span class='badge bg-{{matching_rank_info.label}}'>{{manual_rank}} ({{manual_rank_info.links|length}}x)</span>
+          {% for manual_rank, manual_rank_info in variant.matching_ranked.items() %}
+            <span class='badge bg-{{manual_rank_info.label}}'>{{manual_rank}} ({{manual_rank_info.links|length}}x)</span>
           {% endfor %}
         "
        data-original-title="Previously ranked as">M</span>

--- a/scout/server/blueprints/variants/templates/variants/indicators.html
+++ b/scout/server/blueprints/variants/templates/variants/indicators.html
@@ -56,7 +56,7 @@
     <span class="popovers badge bg-dark" data-bs-toggle="popover" data-bs-html="true"
         data-bs-content="
           {% for manual_rank, manual_rank_info in variant.matching_ranked.items() %}
-            <span>{{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)</span>
+            <div>{{manual_rank_info.label}} - {{manual_rank_info.description}} ({{manual_rank_info.links|length}}x)</div>
           {% endfor %}
         "
        data-original-title="Previously ranked as">M</span>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -829,6 +829,7 @@
   {{ clinical_assessments_badge(variant) }}
   {{ group_assessments_badge(variant) }}
   {{ dismissals_badge(variant) }}
+  {{ matching_manual_rank(variant) }}
 
   {{ comments_badge(institute, case, variant) }}
   {{ causative_badge(variant, case) }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1,6 +1,6 @@
 {% import "bootstrap/wtf.html" as wtf %}
 {% from "utils.html" import comments_table %}
-{% from "variants/indicators.html" import pin_indicator, causative_badge, comments_badge, dismissals_badge, evaluations_badge, research_assessments_badge, clinical_assessments_badge, group_assessments_badge %}
+{% from "variants/indicators.html" import pin_indicator, causative_badge, clinical_assessments_badge, comments_badge, dismissals_badge, evaluations_badge, group_assessments_badge, matching_manual_rank, research_assessments_badge %}
 
 {% macro filter_script_main(cytobands) %}
   <script type="text/javascript">

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -64,7 +64,14 @@ def test_matching_manual_rank(
     )
 
     # THEN it should return a set with the other variant tier info
-    assert matching_ranked == {10: {"label_class": "default", "label": "RF", "links": {"link"}}}
+    assert matching_ranked == {
+        10: {
+            "description": "Established risk allele - strong evidence for a small risk increase",
+            "label_class": "default",
+            "label": "RF",
+            "links": {"link"},
+        }
+    }
 
 
 def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -40,6 +40,40 @@ def test_matching_tiered(adapter, institute_obj, cancer_case_obj, user_obj, canc
     assert matching_tiered == {"1A": {"label": "danger", "links": {"link"}}}
 
 
+def test_matching_manual_rank(
+    adapter, institute_obj, cancer_case_obj, user_obj, cancer_variant_obj
+):
+    """Test retrieving matching manual ranked variants from other cases"""
+
+    # GIVEN a database containing a variant in another case
+    other_var = deepcopy(cancer_variant_obj)
+    other_var["_id"] = "another_id"
+    other_var["case"] = cancer_case_obj["_id"]
+    other_var["manual_rank"] = 10
+    other_var["owner"] = institute_obj["_id"]
+    adapter.variant_collection.insert_one(other_var)
+
+    manual_rank = 10
+
+    # GIVEN that the other variant is ranked
+    adapter.update_manual_rank(
+        institute=institute_obj,
+        case=cancer_case_obj,
+        user=user_obj,
+        link="link",
+        variant=other_var,
+        manual_rank=manual_rank,
+    )
+
+    # WHEN retrieving other manually ranked variants matching the query variant
+    matching_ranked = adapter.get_matching_manual_ranked_variants(
+        query_variant=cancer_variant_obj, user_institutes=[{"_id": "cust000"}]
+    )
+
+    # THEN it should return a set with the other variant tier info
+    assert matching_ranked == {10: {"label_class": "default", "label": "RF", "links": {"link"}}}
+
+
 def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
 
     # GIVEN a populated database with variants

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -1,11 +1,4 @@
-import datetime
-import logging
 from copy import deepcopy
-
-import pymongo
-import pytest
-
-from scout.constants import VERBS_MAP
 
 
 def test_matching_tiered(adapter, institute_obj, cancer_case_obj, user_obj, cancer_variant_obj):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fix #2414. 

Adds options for risk factors in line with ACMG recommendations to keep this outside the classification, and consider separating into different categories for the strength of evidence for the risk increase (RF, likely RF and uncertain RF).
![Screenshot 2023-01-13 at 17 39 09](https://user-images.githubusercontent.com/758570/212372992-a777c8fe-3afa-4f3a-8f36-2692da5ebdc2.png)

These are shown as usual manual ranks, e.g.:
![Screenshot 2023-01-13 at 17 38 55](https://user-images.githubusercontent.com/758570/212373218-ea3cb9f8-9701-46c3-bf4e-43b08768c985.png)

In order to make them more useful, this PR allows to show them on matching variants from other cases, on the variantS list:
![Screenshot 2023-01-13 at 17 37 12](https://user-images.githubusercontent.com/758570/212373656-e794353d-ad94-4006-a0d0-645ae745d693.png)

And then with details on the variant page:
![Screenshot 2023-01-13 at 17 38 26](https://user-images.githubusercontent.com/758570/212373652-54315bca-a16b-41d4-b4a6-101654bcea0d.png)

All pretty much as for the matching tiered variants from the cancer side.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. classify a variant shared between two cases as a risk factor (or other manual rank)
2. see it displayed on the case
3. see it displayed on the matching case

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
