### PR TITLE
Fix #3755 - REViewer button on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - REViewer button on str variant page
 ### Changed
 - Display chrY for sex unknown
-- REViewer button opens new window
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Test for `commands.download.omim.print_omim`
 - Display dismissed variants comments on general case report
 - Modify ACMG pathogenicity impact (most commonly PVS1, PS3) based on strength of evidence with lab director's professional judgement
+- REViewer button on str variant page
 ### Changed
 - Display chrY for sex unknown
+- REViewer button opens new window
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Test for `commands.download.omim.print_omim`
 - Display dismissed variants comments on general case report
 - Modify ACMG pathogenicity impact (most commonly PVS1, PS3) based on strength of evidence with lab director's professional judgement
-- REViewer button on str variant page
+- REViewer button on STR variant page
 ### Changed
 - Display chrY for sex unknown
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-WTF
 Flask-Mail
 coloredlogs<=14.0
 query_phenomizer
-Flask-Babel
+Flask-Babel<3
 livereload
 python-dateutil
 pymongo>=3.7,<4.0

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -132,7 +132,5 @@
     {% else %}
       <button class="btn btn-secondary btn-sm" title="No REViewer aln" disabled>REViewer</button>
     {% endif %}
-  {% else %}
-    <button class="btn btn-secondary btn-sm" title="REViewer not configured" disabled>REViewer</button>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -126,6 +126,7 @@
       <a
       href="{{url_for('variant.reviewer_aln', institute_id=institute_id, case_name=case.display_name, variant_id=variant._id)}}"
       class="btn btn-secondary btn-sm text-white" role="button"
+      target="_blank" rel="noopener"
       title="View REViewer graph alignments for {{variant.str_repid}} using external service."
       >REViewer</a>
     {% else %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -1,7 +1,7 @@
 {% from "variant/buttons.html" import variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button %}
 {% from "variants/utils.html" import compounds_table %}
 {% from "variant/variant_details.html" import severity_list %}
-{% from "variant/buttons.html" import splice_junctions_button %}
+{% from "variant/buttons.html" import reviewer_button, splice_junctions_button %}
 {% from "variant/utils.html" import igv_track_selection  %}
 
 {% macro clinsig_table(variant) %}
@@ -67,6 +67,11 @@
             <span><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}" target="_blank">IGV viewer</a></span>
           {% else %}
             <span class="text-muted">BAM file(s) missing</span>
+          {% endif %}
+          {% if variant.category == "str" %}
+            <div>
+              {{ reviewer_button(case,variant,case_groups,institute._id) }}
+            </div>
           {% endif %}
           {% if splice_junctions_tracks %}
             <div>


### PR DESCRIPTION
This PR adds a functionality.

The REViwer button now targets a new blank window, and it is also shown on the str variant page.

![Screenshot 2023-01-16 at 11 24 21](https://user-images.githubusercontent.com/758570/212656498-9dfd7529-3e5e-4713-9413-237f530e9a3f.png)

Working on stage as well.
![Screenshot 2023-01-16 at 12 26 02](https://user-images.githubusercontent.com/758570/212668204-a9e2a47f-c771-45e3-aac0-a48f48fc13bf.png)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. check a case with reviewer data, and not the reviewer button on the variant page 
2. see that the reviewer button opens the review page in a new `_blank` tab.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN