### PR TITLE
Deprecate load_scout - fix #2204.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Modify ACMG pathogenicity impact (most commonly PVS1, PS3) based on strength of evidence with lab director's professional judgement
 ### Changed
 - Display chrY for sex unknown
+- Deprecate legacy scout_load() method API call.
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator

--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 import traceback
-from pprint import pprint as pp
 
 import click
 import yaml
-from cyvcf2 import VCF
 from flask.cli import with_appcontext
 
 from scout.parse.case import parse_case_data
@@ -60,7 +58,6 @@ def case(
     ped,
     update,
     config,
-    no_variants,
     peddy_ped,
     peddy_sex,
     peddy_check,

--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -8,8 +8,6 @@ import yaml
 from cyvcf2 import VCF
 from flask.cli import with_appcontext
 
-from scout.exceptions import ConfigError, IntegrityError
-from scout.load import load_scout
 from scout.parse.case import parse_case_data
 from scout.server.extensions import store
 

--- a/scout/commands/load/case.py
+++ b/scout/commands/load/case.py
@@ -58,6 +58,7 @@ def case(
     ped,
     update,
     config,
+    no_variants,
     peddy_ped,
     peddy_sex,
     peddy_check,

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -145,7 +145,10 @@ def load_scout(adapter, config, ped=None, update=False):
         ped(Iterable(str)): Pedigree ingformation
         update(bool): If existing case should be updated
 
+    DEPRECATED method, historically used by the CG monolith, which has since switched to call the Scout CLI instead.
     """
+    LOG.warning("Deprecated method. Be advised it will no longer available in Scout v5.")
+
     LOG.info("Check that the panels exists")
     if not check_panels(adapter, config.get("gene_panels", []), config.get("default_gene_panels")):
         raise ConfigError("Some panel(s) does not exist in the database")


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
