### PR TITLE
Deleting last ACMG turns off variant evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Modify ACMG pathogenicity impact (most commonly PVS1, PS3) based on strength of evidence with lab director's professional judgement
 ### Changed
 - Display chrY for sex unknown
+- When all ACMG classifications are deleted from a variant, the current variant classification status is also reset.
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -127,6 +127,6 @@ class ACMGHandler(object):
         Returns:
             pymongo.cursor: database cursor
         """
-        query = dict(variant_specific=document_id])
+        query = dict(variant_specific=document_id)
         res = self.acmg_collection.find(query).sort([("created_at", pymongo.DESCENDING)])
         return res

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -125,7 +125,7 @@ class ACMGHandler(object):
             document_id: variant document id from the db; an md5 hash including the case id.
 
         Returns:
-            pymongo.cursor: database cursor
+            res: pymongo.cursor
         """
         query = dict(variant_specific=document_id)
         res = self.acmg_collection.find(query).sort([("created_at", pymongo.DESCENDING)])

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -117,3 +117,16 @@ class ACMGHandler(object):
         query = dict(variant_id=variant_obj["variant_id"])
         res = self.acmg_collection.find(query).sort([("created_at", pymongo.DESCENDING)])
         return res
+
+    def get_evaluations_case_specific(self, document_id):
+        """Return all evaluations for a certain variant, in a certain case as determined by document id.
+
+        Args:
+            document_id: variant document id from the db; an md5 hash including the case id.
+
+        Returns:
+            pymongo.cursor: database cursor
+        """
+        query = dict(variant_specific=document_id])
+        res = self.acmg_collection.find(query).sort([("created_at", pymongo.DESCENDING)])
+        return res

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -84,7 +84,7 @@ variant = dict(
     gene_lists=list,
     manual_rank=int,  # choices=[0, 1, 2, 3, 4, 5]
     dismiss_variant=list,
-    acmg_evaluation=str,  # choices=ACMG_TERMS
+    acmg_classification=str,  # choices=ACMG_TERMS
 )
 
 compound = dict(

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -629,6 +629,45 @@ def variant_acmg(store, institute_id, case_name, variant_id):
     )
 
 
+def check_reset_variant_classification(store, evaluation_obj, link):
+    """Check if this was the last ACMG evaluation left on the variant.
+    If there is still a classification we want to remove the classification.
+
+    Args:
+            stores(cout.adapter.MongoAdapter)
+            evaluation_obj(dict): ACMG evaluation object
+            link(str): link for event
+
+    Returns: reset(bool) - True if classification reset was attempted
+
+    """
+
+    if len(list(store.get_evaluations_case_specific(evaluation_obj["variant_specific"]))) == 0:
+
+        variant_obj = store.variant(document_id=evaluation_obj["variant_specific"])
+        acmg_classification = variant_obj.get("acmg_classification")
+        if isinstance(acmg_classification, int):
+            institute_obj, case_obj = institute_and_case(
+                store,
+                evaluation_obj["institute"]["_id"],
+                evaluation_obj["case"]["display_name"],
+            )
+            user_obj = store.user(current_user.email)
+
+            new_acmg = None
+            store.submit_evaluation(
+                variant_obj=variant_obj,
+                user_obj=user_obj,
+                institute_obj=institute_obj,
+                case_obj=case_obj,
+                link=link,
+                classification=new_acmg,
+            )
+            return True
+
+    return False
+
+
 def variant_acmg_post(store, institute_id, case_name, variant_id, user_email, criteria):
     """Calculate an ACMG classification based on a list of criteria.
 

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -391,34 +391,6 @@
   </form>
 {% endmacro %}
 
-{% macro acmg_classification_item(data) %}
-  {% set current_variant = (data.variant_specific == variant._id) %}
-  <li class="list-group-item {{ 'list-group-item-info' if current_variant }}">
-    <div class="d-flex">
-      <span>
-        <a href="{{ url_for('variant.evaluation', evaluation_id=data._id) }}">
-          {{ data.classification.label }}
-        </a>
-        <span class="badge bg-info">{{ data.classification.short }}</span>
-      </span>
-      <span>
-        {% if not current_variant %}
-          <small>{{ data.case.display_name }}</small>
-        {% endif %}
-      </span>
-    </div>
-    <small class="text-muted">
-      <form action="{{ url_for('variant.evaluation', evaluation_id=data._id) }}" method="POST">
-      {{ data.user_name }} on {{ data.created_at.date() }}
-      {% if current_variant %}
-        <button class="btn btn-xs btn-link">Delete</button>
-      {% endif %}
-      </form>
-    </small>
-  </li>
-{% endmacro %}
-
-
 {% block scripts %}
   {{ super() }}
   {{ external_scripts() }}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -378,19 +378,6 @@
   </div> <!--  end of card div -->
 {% endmacro %}
 
-{% macro acmg_form(selected=None) %}
-  <label class="mt-3">ACMG classification</label>
-  <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
-    <div class="d-flex justify-content-between">
-      {% for option in ACMG_OPTIONS %}
-        <button class="btn btn-{{ option.color if (option.code == selected or not selected) else 'outline-secondary' }} form-control {{ 'me-1' if not loop.last }}" name="acmg_classification" value="{{ option.code }}" title="{{ option.label }}">
-          {{ option.short }}
-        </button>
-      {% endfor %}
-    </div>
-  </form>
-{% endmacro %}
-
 {% block scripts %}
   {{ super() }}
   {{ external_scripts() }}

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -274,6 +274,24 @@ def evaluation(evaluation_id):
         return redirect(request.referrer)
     evaluation_controller(store, evaluation_obj)
     if request.method == "POST":
+
+        # check if this is the last acmg evaluation left on the variant
+        if len(list(get_evaluations_case_specific(self, evaluation_obj["variant_specific"]))) == 0:
+            # If there is still a classification we want to remove the classification
+            variant_obj = store.variant(document_id=evaluation_obj["variant_specific"])
+            acmg_classification = variant_obj.get("acmg_classification")
+            if isinstance(acmg_classification, int):
+                new_acmg = None
+                store.submit_evaluation(
+                    variant_obj=variant_obj,
+                    user_obj=user_obj,
+                    institute_obj=institute_obj,
+                    case_obj=case_obj,
+                    link=link,
+                    classification=new_acmg,
+                )
+            flash("Cleared ACMG classification.", "info")
+
         link = url_for(
             ".variant",
             institute_id=evaluation_obj["institute"]["_id"],
@@ -281,6 +299,7 @@ def evaluation(evaluation_id):
             variant_id=evaluation_obj["variant_specific"],
         )
         store.delete_evaluation(evaluation_obj)
+
         return redirect(link)
     return dict(
         evaluation=evaluation_obj,

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -2,8 +2,7 @@
 from urllib.parse import urlencode
 
 import pymongo
-from flask import current_app, url_for
-from flask_login import current_user
+from flask import url_for
 
 from scout.server.extensions import store
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. classify a variant with one or more acmg classifications (with a form page evaluation, not just one-click)
2. remove the last classification
3. note how the overall ACMG status remains set, as in the issue
4. apply patch
5. repeat step 1 - 2
6. note how you now get a flash saying ACMG was cleared, and the variant ACMG status is unset

![Screenshot 2023-01-16 at 16 08 16](https://user-images.githubusercontent.com/758570/212710985-e65c28e2-49c5-426f-b591-208ef44fb576.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
