### PR TITLE
Fix #3766 - add other matching variants for SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator
 - Thaw Flask-Babel and fix according to v3 standard. Thank you @TkTech!
+- Show matching causatives on somatic structural variant page
 
 ## [4.62.1]
 ### Fixed

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% from "utils.html" import comments_panel, activity_panel, pedigree_panel %}
 {% from "variant/variant_details.html" import old_observations %}
-{% from "variant/components.html" import external_scripts, external_stylesheets %}
+{% from "variant/components.html" import external_scripts, external_stylesheets, matching_variants %}
 {% from "variant/utils.html" import modal_causative, overlapping_panel, genes_panel, transcripts_panel, sv_alignments, pin_button, causative_button, igv_track_selection %}
 {% from "variant/rank_score_results.html" import rankscore_panel %}
 {% from "variant/gene_disease_relations.html" import omim_phenotypes %}
@@ -67,8 +67,17 @@
          {{variant.hgnc_symbols|sort|join(", ")}}
        </div>
     </div>
-
   {% endif %}
+
+   <div class="row">
+     <div class="col-12">
+      {% if variant.category == "cancer_sv" %}
+        {{matching_variants(managed_variant, causatives, variant.matching_tiered) }}
+       {% else %}
+        {{matching_variants(managed_variant, causatives) }}
+      </div>
+   </div>
+
   <div class="row">
     <div class="col-md-4">
       {{ panel_basics() }}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -71,10 +71,11 @@
 
    <div class="row">
      <div class="col-12">
-      {% if variant.category == "cancer_sv" %}
+       {% if variant.category == "cancer_sv" %}
         {{matching_variants(managed_variant, causatives, variant.matching_tiered) }}
        {% else %}
         {{matching_variants(managed_variant, causatives) }}
+       {% endif %}
       </div>
    </div>
 

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -88,7 +88,7 @@ def cancer_variant(institute_id, case_name, variant_id):
 @templated("variant/sv-variant.html")
 def sv_variant(institute_id, case_name, variant_id):
     """Display a specific structural variant."""
-    data = variant_controller(store, institute_id, case_name, variant_id, add_other=False)
+    data = variant_controller(store, institute_id, case_name, variant_id)
 
     if data is None:
         flash("An error occurred while retrieving variant object", "danger")


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. find an SV with a matching causative (or create one by marking an SV shared between two cases causative), e.g. https://scout-stage.scilifelab.se/cust002/F0013364/sv/variants/7df95a2accbbba110c75062a7dc1d8b5
2. see that the other variant is not displayed on main
3. apply patch and see the matching causative displayed on the variant page.
4. Ideally rinse and repeat for somatic

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
