### PR TITLE
Fix causatives page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator
 - Thaw Flask-Babel and fix according to v3 standard. Thank you @TkTech!
 - Show matching causatives on somatic structural variant page
+- Causatives page showing also non-causative variants matching causatives in other cases
 
 ## [4.62.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display chrY for sex unknown
 - Deprecate legacy scout_load() method API call.
 - Message shown when variant tag is updated for a variant
+- Refactored the functions that collect causative variants
 ### Fixed
 - Default IGV tracks (genes, ClinVar, ClinVar CNVs) showing even if user unselects them all
 - Freeze Flask-Babel below v3.0 due to issue with a locale decorator

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -502,7 +502,7 @@ class VariantHandler(VariantLoader):
 
         return self.variant_collection.find(filters)
 
-    def instutute_causatives(institute_obj, limit_genes=None):
+    def instutute_causatives(self, institute_obj, limit_genes=None):
         """Return all causative variants for an institute - eventually within the provided list of genes
 
         Args:
@@ -515,7 +515,7 @@ class VariantHandler(VariantLoader):
         causatives = []
         var_causative_events = self.event_collection.find(
             {
-                "institute": institute_id,
+                "institute": institute_obj["_id"],
                 "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
                 "category": "variant",
             }

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -16,7 +16,9 @@ from scout.utils.md5 import generate_md5_key
 from .variant_loader import VariantLoader
 
 LOG = logging.getLogger(__name__)
+
 MATCHQ = "$match"
+CARRIER = r"[12]"  # same as re.compile()"1|2")
 
 
 class VariantHandler(VariantLoader):
@@ -491,15 +493,11 @@ class VariantHandler(VariantLoader):
         if len(affected_ids) == 0:
             return []
 
-        has_allele = re.compile(
-            "1|2"
-        )  # a non wild-type allele is called at least once in this sample
-
         filters["case_id"] = case_obj["_id"]
         filters["samples"] = {
             "$elemMatch": {
                 "sample_id": {"$in": affected_ids},
-                "genotype_call": {"$regex": has_allele},
+                "genotype_call": {"$regex": CARRIER},
             }
         }
 
@@ -959,11 +957,6 @@ class VariantHandler(VariantLoader):
         Returns:
             result(iterable(Variant))
         """
-        LOG.info("Retrieving variants for subject : {0}".format(sample_name))
-        has_allele = re.compile(
-            "1|2"
-        )  # a non wild-type allele is called at least once in this sample
-
         query = {
             "$and": [
                 {"_id": variant_id},
@@ -972,7 +965,7 @@ class VariantHandler(VariantLoader):
                     "samples": {
                         "$elemMatch": {
                             "display_name": sample_name,
-                            "genotype_call": {"$regex": has_allele},
+                            "genotype_call": {"$regex": CARRIER},
                         }
                     }
                 },

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -481,7 +481,7 @@ class VariantHandler(VariantLoader):
             limit_genes (list): list of gene hgnc_ids to limit the search to
 
         Returns:
-            causatives(iterable(Variant))
+            (iterable(Variant))
         """
 
         filters = {"variant_id": {"$in": list(positional_variant_ids)}}
@@ -493,14 +493,12 @@ class VariantHandler(VariantLoader):
         filters["samples"] = {
             "$elemMatch": {
                 "sample_id": {"$in": affected_ids},
-                "genotype_call": {"$regex": CARRIER},
+                "genotype_call": {"$regex": "1"},
             }
         }
 
         if limit_genes:
             filters["genes.hgnc_id"] = {"$in": limit_genes}
-
-        LOG.error(filters)
 
         return self.variant_collection.find(filters)
 
@@ -550,34 +548,43 @@ class VariantHandler(VariantLoader):
             limit_genes (list): list of gene hgnc_ids to limit the search to
 
         Returns:
-            causatives(list[Variant])
+            iterable(Variant)
         """
         causatives = []
-        causative_events = self.event_collection.find(
+        var_causative_events = self.event_collection.find(
             {
                 "institute": case_obj["owner"],
                 "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
-                "category": "case",
+                "category": "variant",
             }
         )
+        positional_variant_ids = set()
+        for var_event in var_causative_events:
+            if var_event["case"] == case_obj["_id"]:
+                # exclude causatives from the same case
+                continue
+            other_case = self.case(var_event["case"])
+            if other_case is None:
+                # Other variant belongs to a case that doesn't exist any more
+                continue
+            other_link = var_event["link"]
+            # link contains other variant ID
+            other_causative_id = other_link.split("/")[-1]  # md5-key _id of a variant
 
-        for case_event in causative_events:
-
-            causative_ids = set()
-            other_case = self.case(case_event.get("case"))
-
-            if other_case is None or other_case["_id"] == case_obj["_id"]:
+            if (
+                other_causative_id not in other_case.get("causatives", [])
+                and other_causative_id not in other_case.get("partial_causatives", {}).keys()
+            ):
                 continue
 
-            for var_id in other_case.get("causatives", []):
-                causative_ids.add(var_id)
+            other_var_simple = var_event.get("subject").split("_")[
+                0:4
+            ]  # example: [ "17", "7577559", "G" "A"]
 
-            for var_id, _ in other_case.get("patial_causatives", {}).items():
-                causative_ids.add(var_id)
+            for variant_type in ["clinical", "reseach"]:
+                positional_variant_ids.add(generate_md5_key(other_var_simple + [variant_type]))
 
-            causatives += self.match_affected_gt(case_obj, causative_ids, limit_genes)
-
-        return causatives
+        return self.match_affected_gt(case_obj, positional_variant_ids, limit_genes)
 
     def other_causatives(self, case_obj, variant_obj):
         """Find the same variant marked causative in other cases.

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -557,13 +557,12 @@ class VariantHandler(VariantLoader):
             for variant_type in ["clinical", "reseach"]:
                 positional_variant_ids.add(generate_md5_key(other_var_simple + [variant_type]))
 
-            causatives.append(
-                list(
-                    self.match_affected_gt(
-                        other_case, institute_obj, positional_variant_ids, limit_genes
-                    )
-                )[0]
-            )
+            causatives += [
+                var
+                for var in self.match_affected_gt(
+                    other_case, institute_obj, positional_variant_ids, limit_genes
+                )
+            ]
 
         return causatives
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -538,7 +538,7 @@ class VariantHandler(VariantLoader):
 
         return self.variant_collection.find(filters)
 
-    def case_matching_causatives(self, case_obj=None, limit_genes=None):
+    def case_matching_causatives(self, case_obj, limit_genes=None):
         """Returns the variants of a case that were marked as causatives in other cases of the same institute.
            Checks that the individuals of the case that are carriers of the variant are affected
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -503,7 +503,7 @@ class VariantHandler(VariantLoader):
         return self.variant_collection.find(filters)
 
     def institute_causatives(self, institute_obj, limit_genes=None):
-        """Return all causative variants for an institute - eventually within the provided list of genes
+        """Return all causative variants for an institute - conditionally within the provided list of genes
 
         Args:
             institute_obj (dict): an Institute object

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -510,9 +510,8 @@ class VariantHandler(VariantLoader):
             limit_genes (list): list of gene hgnc_ids to limit the search to
 
         Returns:
-            a list of variant objects
+            iterable(Variant)
         """
-        causatives = []
         causative_events = self.event_collection.find(
             {
                 "institute": institute_obj["_id"],
@@ -550,7 +549,6 @@ class VariantHandler(VariantLoader):
         Returns:
             iterable(Variant)
         """
-        causatives = []
         var_causative_events = self.event_collection.find(
             {
                 "institute": case_obj["owner"],

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -493,7 +493,7 @@ class VariantHandler(VariantLoader):
         filters["samples"] = {
             "$elemMatch": {
                 "sample_id": {"$in": affected_ids},
-                "genotype_call": {"$regex": "1"},
+                "genotype_call": {"$regex": CARRIER},
             }
         }
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -446,7 +446,7 @@ class VariantHandler(VariantLoader):
         if len(positional_variant_ids) == 0:
             return []
 
-        return self.match_affected_gt(case_obj, institute_obj, positional_variant_ids, limit_genes)
+        return self.match_affected_gt(case_obj, positional_variant_ids, limit_genes)
 
     def _find_affected(self, case_obj):
         """Internal method to find affected individuals.
@@ -469,13 +469,12 @@ class VariantHandler(VariantLoader):
 
         return affected_ids
 
-    def match_affected_gt(self, case_obj, institute_obj, positional_variant_ids, limit_genes):
+    def match_affected_gt(self, case_obj, positional_variant_ids, limit_genes):
         """Match positional_variant_ids against variants from affected individuals
         in a case, ensuring that they at least are carriers.
 
         Args:
             case_obj (dict): A Case object.
-            institute_obj (dict): An Institute object.
             positional_variant_ids (iterable): A set of possible variant_ids (md5 key based upon a list like this: [ "17", "7577559", "G" "A", "research"]
             limit_genes (list): list of gene hgnc_ids to limit the search to
 
@@ -561,10 +560,7 @@ class VariantHandler(VariantLoader):
                 positional_variant_ids.add(generate_md5_key(other_var_simple + [variant_type]))
 
             causatives += [
-                var
-                for var in self.match_affected_gt(
-                    case_obj, institute_obj, positional_variant_ids, limit_genes
-                )
+                var for var in self.match_affected_gt(case_obj, positional_variant_ids, limit_genes)
             ]
 
         return causatives

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -476,13 +476,13 @@ class VariantHandler(VariantLoader):
         in a case, ensuring that they at least are carriers.
 
         Args:
-            case_objs(list): set of case objects to use in variant filtering
+            case_objs(list): list of case objects to use in variant filtering
             institute_obj (dict): An Institute object.
             positional_variant_ids (iterable): A set of possible variant_ids (md5 key based upon a list like this: [ "17", "7577559", "G" "A", "research"]
             limit_genes (list): list of gene hgnc_ids to limit the search to
 
         Returns:
-            gt_var_matches(list)
+            gt_matches(list): a list of variant objects with affected individuals
         """
         gt_var_matches = []
         if len(positional_variant_ids) == 0:
@@ -504,7 +504,6 @@ class VariantHandler(VariantLoader):
                 filters["genes.hgnc_id"] = {"$in": limit_genes}
             gt_var_matches.append(self.variant_collection.find_one(filters))
 
-        LOG.warning(len(gt_var_matches))
         return gt_var_matches
 
     def check_causatives(self, case_obj=None, institute_obj=None, limit_genes=None):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -338,7 +338,8 @@ def case(store, institute_obj, case_obj):
         "case": case_obj,
         "status_class": STATUS_MAP.get(case_obj["status"]),
         "other_causatives": [
-            var for var in store.check_causatives(case_obj=case_obj, limit_genes=limit_genes)
+            var
+            for var in store.case_matching_causatives(case_obj=case_obj, limit_genes=limit_genes)
         ],
         "managed_variants": [
             var for var in store.check_managed(case_obj=case_obj, limit_genes=limit_genes)

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -135,7 +135,7 @@ def causatives(institute_obj, request):
 
     causatives = []
 
-    for variant_obj in store.check_causatives(institute_obj=institute_obj, limit_genes=hgnc_id):
+    for variant_obj in store.instutute_causatives(institute_obj=institute_obj, limit_genes=hgnc_id):
         variant_genes = variant_obj.get("genes", [])
         if variant_obj["category"] in ["snv", "cancer"]:
             update_representative_gene(

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -151,7 +151,6 @@ def causatives(institute_obj, request):
             "status": case_obj.get("status"),
             "partial_causatives": case_obj.get("partial_causatives", []),
         }
-
         causatives.append(variant_obj)
 
     return causatives

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -135,7 +135,7 @@ def causatives(institute_obj, request):
 
     causatives = []
 
-    for variant_obj in store.instutute_causatives(institute_obj=institute_obj, limit_genes=hgnc_id):
+    for variant_obj in store.institute_causatives(institute_obj=institute_obj, limit_genes=hgnc_id):
         variant_genes = variant_obj.get("genes", [])
         if variant_obj["category"] in ["snv", "cancer"]:
             update_representative_gene(

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -262,6 +262,10 @@ def test_case_matching_causatives(
     other_case["_id"] = "other_case"
     other_case["internal_id"] = "other_case"
     other_case["display_name"] = "other_case"
+    # GIVEN that the other case contains the variant in one affected individual
+    for ind in other_case["individuals"]:
+        ind["phenotype"] = 2  # affected
+
     adapter.case_collection.insert_one(other_case)
 
     # GIVEN that the other case shares a variant with the original case,

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -247,15 +247,21 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
     assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
 
 
-def test_case_matching_causatives(
-    app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
-):
+def test_case_matching_causatives(app, real_variant_database):
     """Testing the case_matching_causatives function, that returns variants for a case that
     were found causatives in other cases from the same institutet.
     - given that the variant is found in an affected individual of the case
     """
-    # GIVEN a populated database with variants
+    # GIVEN a populated database
     adapter = real_variant_database
+    case_obj = adapter.case_collection.find_one()
+    assert case_obj
+    institute_obj = adapter.institute_collection.find_one()
+    assert institute_obj
+    user_obj = adapter.user_collection.find_one()
+    assert user_obj
+    variant_obj = adapter.variant_collection.find_one()
+    assert variant_obj
 
     # WHEN inserting another case into the database,
     other_case = copy.deepcopy(case_obj)
@@ -299,14 +305,20 @@ def test_case_matching_causatives(
         assert sum(1 for _ in other_causatives) == 1
 
 
-def test_case_matching_causatives_carrier(
-    app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
-):
+def test_case_matching_causatives_carrier(app, real_variant_database):
     """Testing the case_matching_causatives function, which should NOT return matching causatives
     when the the case has not affected individuals with the variant"""
 
-    # GIVEN a populated database with variants
+    # GIVEN a populated database
     adapter = real_variant_database
+    case_obj = adapter.case_collection.find_one()
+    assert case_obj
+    institute_obj = adapter.institute_collection.find_one()
+    assert institute_obj
+    user_obj = adapter.user_collection.find_one()
+    assert user_obj
+    variant_obj = adapter.variant_collection.find_one()
+    assert variant_obj
 
     # WHEN inserting another case into the database,
     other_case = copy.deepcopy(case_obj)

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -250,8 +250,9 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
 def test_case_matching_causatives(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
-    """Testing the function that returns a matching causative from another case
-    - given that the variant is found in an affected individual
+    """Testing the case_matching_causatives function, that returns variants for a case that
+    were found causatives in other cases from the same institutet.
+    - given that the variant is found in an affected individual of the case
     """
     # GIVEN a populated database with variants
     adapter = real_variant_database
@@ -297,7 +298,7 @@ def test_case_matching_causatives(
 def test_case_matching_causatives_carrier(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
-    """Testing the check_causatives function, which should NOT return matching causatives
+    """Testing the case_matching_causatives function, which should NOT return matching causatives
     when the the case has not affected individuals with the variant"""
 
     # GIVEN a populated database with variants
@@ -336,7 +337,7 @@ def test_case_matching_causatives_carrier(
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
         other_causatives = adapter.case_matching_causatives(
-            case_obj=other_case, institute_obj=institute_obj
+            case_obj=other_case,
         )
         assert sum(1 for _ in other_causatives) == 0
 

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -269,7 +269,7 @@ def test_case_variant_check_causatives(
     other_variant["_id"] = "other_variant"
     adapter.variant_collection.insert_one(other_variant)
 
-    assert sum(1 for i in adapter.event_collection.find()) == 0
+    assert sum(1 for _ in adapter.event_collection.find()) == 0
 
     # WHEN the original case has a causative variant flagged,
     link = "junk/{}".format(variant_obj["_id"])
@@ -291,7 +291,7 @@ def test_case_variant_check_causatives(
         other_causatives = adapter.check_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
-        assert sum(1 for i in other_causatives) == 1
+        assert sum(1 for _ in other_causatives) == 1
 
 
 def test_case_variant_check_causatives_carrier(

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -311,7 +311,7 @@ def test_case_variant_check_causatives_carrier(
 
     # GIVEN that the another case has the variant in an unaffected individual
     for ind in other_case["individuals"]:
-        ind["phenotype"] == 1  # unaffected
+        ind["phenotype"] = 1  # unaffected
 
     # insert this case into database
     adapter.case_collection.insert_one(other_case)

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -247,7 +247,7 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
     assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
 
 
-def test_case_variant_check_causatives(
+def test_case_matching_causatives(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
     """Testing the function that returns a matching causative from another case
@@ -288,13 +288,13 @@ def test_case_variant_check_causatives(
     # THEN an function will find the matching causative
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
-        other_causatives = adapter.check_causatives(
-            case_obj=other_case, institute_obj=institute_obj
+        other_causatives = adapter.case_matching_causatives(
+            case_obj=other_case,
         )
         assert sum(1 for _ in other_causatives) == 1
 
 
-def test_case_variant_check_causatives_carrier(
+def test_case_matching_causatives_carrier(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
     """Testing the check_causatives function, which should NOT return matching causatives
@@ -335,7 +335,7 @@ def test_case_variant_check_causatives_carrier(
     # THEN the function will NOT return the matching causative from the first case
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
-        other_causatives = adapter.check_causatives(
+        other_causatives = adapter.case_matching_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
         assert sum(1 for _ in other_causatives) == 0

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -251,7 +251,7 @@ def test_case_variant_check_causatives(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
     """Testing the function that returns a matching causative from another case
-    - given that the other case has at least one affected individual
+    - given that the variant is found in an affected individual
     """
     # GIVEN a populated database with variants
     adapter = real_variant_database
@@ -298,7 +298,7 @@ def test_case_variant_check_causatives_carrier(
     app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
 ):
     """Testing the check_causatives function, which should NOT return matching causatives
-    when the other case has not affected individuals with the variant"""
+    when the the case has not affected individuals with the variant"""
 
     # GIVEN a populated database with variants
     adapter = real_variant_database

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -357,7 +357,7 @@ def test_case_variant_check_causatives_carrier(app, real_variant_database):
         other_causatives = adapter.check_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
-        assert sum(1 for i in other_causatives) == 1
+        assert sum(1 for _ in other_causatives) == 1
 
 
 def test_variant_controller_with_compounds(app, institute_obj, case_obj):

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -357,8 +357,7 @@ def test_case_variant_check_causatives_carrier(app, real_variant_database):
         other_causatives = adapter.check_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
-        LOG.debug("other causatives: {}".format(other_causatives))
-        assert sum(1 for i in other_causatives) == 0
+        assert sum(1 for i in other_causatives) == 1
 
 
 def test_variant_controller_with_compounds(app, institute_obj, case_obj):

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -247,25 +247,20 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
     assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
 
 
-def test_case_variant_check_causatives(app, real_variant_database):
-    adapter = real_variant_database
-
+def test_case_variant_check_causatives(
+    app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
+):
+    """Testing the function that returns a matching causative from another case
+    - given that the other case has at least one affected individual
+    """
     # GIVEN a populated database with variants
-    case_obj = adapter.case_collection.find_one()
-    assert case_obj
-    institute_obj = adapter.institute_collection.find_one()
-    assert institute_obj
-    user_obj = adapter.user_collection.find_one()
-    assert user_obj
-    variant_obj = adapter.variant_collection.find_one()
-    assert variant_obj
+    adapter = real_variant_database
 
     # WHEN inserting another case into the database,
     other_case = copy.deepcopy(case_obj)
     other_case["_id"] = "other_case"
     other_case["internal_id"] = "other_case"
     other_case["display_name"] = "other_case"
-    # insert this case into database
     adapter.case_collection.insert_one(other_case)
 
     # GIVEN that the other case shares a variant with the original case,
@@ -274,7 +269,6 @@ def test_case_variant_check_causatives(app, real_variant_database):
     other_variant["_id"] = "other_variant"
     adapter.variant_collection.insert_one(other_variant)
 
-    LOG.debug("other variant: {}".format(other_variant))
     assert sum(1 for i in adapter.event_collection.find()) == 0
 
     # WHEN the original case has a causative variant flagged,
@@ -291,40 +285,34 @@ def test_case_variant_check_causatives(app, real_variant_database):
     event_obj = adapter.event_collection.find_one()
     assert event_obj["link"] == link
 
-    # THEN an app will find the matching causative
+    # THEN an function will find the matching causative
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
         other_causatives = adapter.check_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
-        LOG.debug("other causatives: {}".format(other_causatives))
-        assert sum(1 for i in other_causatives) > 0
+        assert sum(1 for i in other_causatives) == 1
 
 
-def test_case_variant_check_causatives_carrier(app, real_variant_database):
-    # GIVEN a case with a causative variant flagged,
-
-    adapter = real_variant_database
+def test_case_variant_check_causatives_carrier(
+    app, real_variant_database, institute_obj, case_obj, user_obj, variant_obj
+):
+    """Testing the check_causatives function, which should NOT return matching causatives
+    when the other case has not affected individuals with the variant"""
 
     # GIVEN a populated database with variants
-    case_obj = adapter.case_collection.find_one()
-    assert case_obj
-    institute_obj = adapter.institute_collection.find_one()
-    assert institute_obj
-    user_obj = adapter.user_collection.find_one()
-    assert user_obj
-    variant_obj = adapter.variant_collection.find_one()
-    assert variant_obj
+    adapter = real_variant_database
 
     # WHEN inserting another case into the database,
     other_case = copy.deepcopy(case_obj)
     other_case["_id"] = "other_case"
     other_case["internal_id"] = "other_case"
     other_case["display_name"] = "other_case"
-    # GIVEN another case with the same variant for an unaffected individual,
-    other_case["individuals"][0]["phenotype"] = 1
-    other_case["individuals"][1]["phenotype"] = 1
-    other_case["individuals"][2]["phenotype"] = 1
+
+    # GIVEN that the another case has the variant in an unaffected individual
+    for ind in other_case["individuals"]:
+        ind["phenotype"] == 1  # unaffected
+
     # insert this case into database
     adapter.case_collection.insert_one(other_case)
 
@@ -333,9 +321,6 @@ def test_case_variant_check_causatives_carrier(app, real_variant_database):
     other_variant["case_id"] = "other_case"
     other_variant["_id"] = "other_variant"
     adapter.variant_collection.insert_one(other_variant)
-
-    LOG.debug("other variant: {}".format(other_variant))
-    assert sum(1 for i in adapter.event_collection.find()) == 0
 
     # WHEN the original case has a causative variant flagged,
     link = "junk/{}".format(variant_obj["_id"])
@@ -347,17 +332,13 @@ def test_case_variant_check_causatives_carrier(app, real_variant_database):
         variant=variant_obj,
     )
 
-    # THEN an event object should have been created linking the variant
-    event_obj = adapter.event_collection.find_one()
-    assert event_obj["link"] == link
-
-    # THEN an app will find the matching causative
+    # THEN the function will NOT return the matching causative from the first case
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
         other_causatives = adapter.check_causatives(
             case_obj=other_case, institute_obj=institute_obj
         )
-        assert sum(1 for _ in other_causatives) == 1
+        assert sum(1 for _ in other_causatives) == 0
 
 
 def test_variant_controller_with_compounds(app, institute_obj, case_obj):


### PR DESCRIPTION
Fix #3771  - Show only causative and not matching causatives

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, with the 2 RD demo cases.
2. On main branch, go to a variant of a case and mark it as causative
3. Go to causatives page and check that the same variant from the other case is shown (also if it's not causative)
4. Repeat on this branch

**Expected outcome**:
This branch should only show 1 variant on the Causatives page (the original causative)
 
**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
