### PR TITLE
Pass a complete HGVS to preClinVar (ClinVar subm API)

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,1 +1,2 @@
 scout/server/blueprints/login/static/aspirant.svg
+scout/demo/rnafusion_report_example.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Validate any ClinVar submission regardless of its status
 - Empty Phenopackets import crashes
 - Stop Spinner on Phenopacket JSON download
+- Pass a complete HGVS description to the preClinVar microservice (ClinVar API submission)
 ### Changed
 - Updated ClinVar submission instructions
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -211,8 +211,7 @@ def _parse_tx_hgvs(clinvar_var, form):
     tx_hgvs = form.get("tx_hgvs")
     if not tx_hgvs:
         return
-    clinvar_var["ref_seq"] = tx_hgvs.split(":")[0]
-    clinvar_var["hgvs"] = tx_hgvs.split(":")[1]
+    clinvar_var["hgvs"] = tx_hgvs
 
 
 def _set_conditions(clinvar_var, form):


### PR DESCRIPTION
FIx #3790 --> DO not split HGVS and refseq into 2 different fields when parsing ClinVar form data

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
