### PR TITLE
Validate ClinVar submission using the dry-run endpoint

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,1 +1,2 @@
 scout/server/blueprints/login/static/aspirant.svg
+scout/demo/rnafusion_report_example.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Panel version can be manually set to floating point numbers, when modified
 - Causatives page showing also non-causative variants matching causatives in other cases
 - ClinVar form submission for variants with no selected transcript and HGVS
+- Replaced the ClinVar validation URL to use the dry-run endpoint
 
 ## [4.62.1]
 ### Fixed

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -17,7 +17,7 @@ class ClinVarApi:
 
     def __init__(self):
         self.convert_service = "/".join([PRECLINVAR_URL, "csv_2_json"])
-        self.validate_service = "/".join([PRECLINVAR_URL, "validate"])
+        self.validate_service = "/".join([PRECLINVAR_URL, "dry-run"])
         self.submit_service = CLINVAR_API_URL
 
     def set_header(self, api_key):
@@ -56,7 +56,7 @@ class ClinVarApi:
             return None, ex
 
     def validate_json(self, subm_data, api_key):
-        """Sends a POST request to the API (validate endpoint) and tries to validate a json submission object.
+        """Sends a POST request to the API proxy (dry-run endpoint) which tries to validate a json submission object.
         Requires a valid ClinVar API key (obtained from scout config file in order to be able to forward the request)
 
         Args:

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -1,5 +1,4 @@
 import responses
-from bson.objectid import ObjectId
 from flask import url_for
 
 from scout.constants.clinvar import CLINVAR_API_URL, PRECLINVAR_URL

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -9,7 +9,7 @@ SAVE_ENDPOINT = "clinvar.clinvar_save"
 UPDATE_ENDPOINT = "clinvar.clinvar_update_submission"
 VALIDATE_ENDPOINT = "clinvar.clinvar_validate"
 API_CSV_2_JSON_URL = "/".join([PRECLINVAR_URL, "csv_2_json"])
-API_VALIDATE_ENDPOINT = "/".join([PRECLINVAR_URL, "validate"])
+API_VALIDATE_ENDPOINT = "/".join([PRECLINVAR_URL, "dry-run"])
 
 
 def test_clinvar_add_variant(app, institute_obj, case_obj, variant_obj):


### PR DESCRIPTION
Fixes partially #3795 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Try to validate a ClinVar submission object from Scout stage

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
