### PR TITLE
Somatic matching classified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Matching manual ranked variants are now shown also on the somatic variant page
 
 ## [4.63]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -71,7 +71,7 @@
     </div>
     {% endif %}
 
-    {{ matching_variants(managed_variant, causatives, variant.matching_manual_ranked, variant.matching_tiered) }}
+    {{ matching_variants(managed_variant, causatives, variant.matching_ranked, variant.matching_tiered) }}
     <div class="row">
       <div class="col-sm-3">
         {{ panel_classify(variant, institute, case, ACMG_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations) }}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -190,7 +190,7 @@
       <div class="card-body mt-1 ms-3 mb-1" style="padding: 0;">
         Matching manually ranked variants:&nbsp;
         {% for manual_rank, manual_rank_info in matching_manual_ranked.items() %}
-          <a style="padding: 0;" class="btn btn-{{manual_rank_info.label_class}} btn-xs" data-bs-toggle="collapse" href="#collapse_mr{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
+          <a style="padding: 0;" class="btn btn-{{manual_rank_info.label_class}} btn-small" data-bs-toggle="collapse" href="#collapse_mr{{manual_rank}}" role="button" aria-expanded="false" aria-controls="collapseExample">
             {{manual_rank_info.label}} ({{manual_rank_info.links|length}}x)
           </a>
           <div class="collapse" id="collapse_mr{{manual_rank}}">

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -147,9 +147,9 @@
 
 
 {% macro score_cell(variant) %}
-  {% if variant.rank_score %}
+  {% if variant.rank_score is defined %}
     {% if variant.rank_score <= 4 %}
-      {% set label_class = 'default' %}
+      {% set label_class = 'secondary' %}
     {% elif variant.rank_score == 5 %}
       {% set label_class = 'info' %}
     {% elif variant.rank_score == 6 %}
@@ -159,8 +159,9 @@
     {% elif variant.rank_score > 8 %}
       {% set label_class = 'danger' %}
     {% endif %}
+    <div class="badge bg-{{ label_class }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Rank score">{{ variant.rank_score }}</div>
   {% endif %}
-  <div class="badge bg-{{ label_class }}">{{ variant.rank_score }}</div>
+
   {% for filter in variant.filters %}
     <div data-bs-toggle="tooltip" data-bs-placement="top" title="{{ filter.description }}" class="badge bg-{{ filter.label_class }}">{{ filter.label }}</div>
   {% endfor %}


### PR DESCRIPTION
This PR fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. load a duplicate cancer case and manually classify a variant in one of the duplicate cases
2. note that it can now be seen both on the variant as well as variantS pages.

![Screenshot 2023-02-07 at 11 35 03](https://user-images.githubusercontent.com/758570/217222616-10921128-c2d7-4dcd-a8a4-02f83d2b618b.png)

![Screenshot 2023-02-07 at 11 39 16](https://user-images.githubusercontent.com/758570/217222558-7bdb6361-79a5-44ee-87a1-502e67081e9f.png)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
