### PR TITLE
Fix #3808 - VarSome link to hg19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Create/Update a gene panel contaning all PanelApp green genes (`scout update panelapp-green -i <cust_id>`)
 ### Fixed
 - Matching manual ranked variants are now shown also on the somatic variant page
+- VarSome links to hg19/GRCh37
 
 ## [4.63]
 ### Added

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -367,11 +367,11 @@ def smart(smart_domain):
     return link.format(smart_domain)
 
 
-def varsome(build, refseq_id, protein_sequence_name):
+def varsome(build: int, refseq_id: str, protein_sequence_name: str):
     """Return a string corresponding to a link to varsome page
 
     Args:
-        build(str): chromosome build
+        build(int): chromosome build
         refseq_id(str): transcript refseq id
         protein_sequence_name(str): transcript sequence name
 
@@ -380,8 +380,8 @@ def varsome(build, refseq_id, protein_sequence_name):
     if not all([refseq_id, protein_sequence_name]):
         return None
 
-    if build == "37":
-        build = "19"
+    if build == 37:
+        build = 19
 
     link = "https://varsome.com/variant/hg{}/{}:{}"
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -380,6 +380,9 @@ def varsome(build, refseq_id, protein_sequence_name):
     if not all([refseq_id, protein_sequence_name]):
         return None
 
+    if build == "37":
+        build = "19"
+
     link = "https://varsome.com/variant/hg{}/{}:{}"
 
     return link.format(build, refseq_id, protein_sequence_name)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug (well, or a changed API on another resource, but to the effect of the usability it becomes bugged as the recipient API is not versioned, at least not when making get requests).

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. click a VarSome link from a variant. Notice a page apologising for nothing found. 
2. apply patch. Click, and find the variant in VarSome.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
