### PR TITLE
Fix research vars counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Matching manual ranked variants are now shown also on the somatic variant page
 - VarSome links to hg19/GRCh37
 - Managed variants filter settings lost when navigating to additional pages
+- Collect the right variant category after submitting filter form from research variantS page
 
 
 ## [4.63]

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -48,7 +48,7 @@ def variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
 
     variant_type = Markup.escape(
-        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+        request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
@@ -244,7 +244,7 @@ def sv_variants(institute_id, case_name):
 
     page = int(Markup.escape(request.form.get("page", "1")))
     variant_type = Markup.escape(
-        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+        request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
     category = "sv"
     # Define case and institute objects
@@ -321,7 +321,7 @@ def cancer_variants(institute_id, case_name):
     """Show cancer variants overview."""
     category = "cancer"
     variant_type = Markup.escape(
-        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+        request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
@@ -434,7 +434,7 @@ def cancer_sv_variants(institute_id, case_name):
 
     page = int(Markup.escape(request.form.get("page", "1")))
     variant_type = Markup.escape(
-        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+        request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
     category = "cancer_sv"
     # Define case and institute objects

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -47,11 +47,15 @@ def variants(institute_id, case_name):
     category = "snv"
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
 
-    variant_type = request.args.get("variant_type", "clinical")
+    variant_type = Markup.escape(
+        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+    )
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
+
+    flash(request.form.__dict__)
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
@@ -71,7 +75,6 @@ def variants(institute_id, case_name):
     else:
         form = FiltersForm(request.args)
         # set form variant data type the first time around
-        form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
 
@@ -241,7 +244,9 @@ def sv_variants(institute_id, case_name):
     """Display a list of structural variants."""
 
     page = int(Markup.escape(request.form.get("page", "1")))
-    variant_type = Markup.escape(request.args.get("variant_type", "clinical"))
+    variant_type = Markup.escape(
+        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+    )
     category = "sv"
     # Define case and institute objects
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
@@ -316,7 +321,9 @@ def sv_variants(institute_id, case_name):
 def cancer_variants(institute_id, case_name):
     """Show cancer variants overview."""
     category = "cancer"
-    variant_type = Markup.escape(request.args.get("variant_type", "clinical"))
+    variant_type = Markup.escape(
+        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+    )
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
@@ -427,7 +434,9 @@ def cancer_sv_variants(institute_id, case_name):
     """Display a list of cancer structural variants."""
 
     page = int(Markup.escape(request.form.get("page", "1")))
-    variant_type = Markup.escape(request.args.get("variant_type", "clinical"))
+    variant_type = Markup.escape(
+        request.args.get("variant_type") or request.form.get("variant_type", "clinical")
+    )
     category = "cancer_sv"
     # Define case and institute objects
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -55,8 +55,6 @@ def variants(institute_id, case_name):
     if request.form.get("hpo_clinical_filter"):
         case_obj["hpo_clinical_filter"] = True
 
-    flash(request.form.__dict__)
-
     user_obj = store.user(current_user.email)
     if request.method == "POST":
         if "dismiss_submit" in request.form:  # dismiss a list of variants

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -73,6 +73,7 @@ def variants(institute_id, case_name):
     else:
         form = FiltersForm(request.args)
         # set form variant data type the first time around
+        form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
 


### PR DESCRIPTION
Fix #3818 

The specific problem is that from research variantS page, after filtering with the variantS filter, the type of variant (clinical, research) is not collected correctly and defaults to clinical. This way the variant numbers are taken from the wrong category.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On a local **main branch**, load research SNVs (`scout --demo load research -c internal_id -i cust000 --force`), it should be very few. Go to research SNVs page:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/28093618/219355308-b94df9e3-1e80-4005-83de-da5de8bdd732.png">

1. Without adding any filter option, just press on filter variants, so you'll send a POST request to the variantS page

<img width="496" alt="image" src="https://user-images.githubusercontent.com/28093618/219355432-4655900b-d5cd-4f97-a5fa-1937e3ceea2e.png">

1. Observe that total number of variants now is the total number of clinical variants:

<img width="316" alt="image" src="https://user-images.githubusercontent.com/28093618/219355738-f3dc2341-ab08-4199-a778-23f008835655.png">

1. Switch to this branch and make sure the bug is gone



**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
