### PR TITLE
Fix beacon link...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - VarSome links to hg19/GRCh37
 - Managed variants filter settings lost when navigating to additional pages
 - Collect the right variant category after submitting filter form from research variantS page
-- Beacon links support variants in genome build 38
+- Beacon links are templated and support variants in genome build 38
 
 ## [4.63]
 ### Added

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -4,9 +4,11 @@ from scout.constants import SPIDEX_HUMAN
 from scout.utils.convert import amino_acid_residue_change_3_to_1
 
 SHALLOW_REFERENCE_STR_LOCI = ["ARX", "HOXA13"]
-BEACON_LINK_TEMPLATE = "https://beacon-network.org/#/search?pos={this[position]}&"
-"chrom={this[chromosome]}&allele={this[alternative]}&"
-"ref={this[reference]}&rs={build}"
+BEACON_LINK_TEMPLATE = (
+    "https://beacon-network.org/#/search?pos={this[position]}&"
+    "chrom={this[chromosome]}&allele={this[alternative]}&"
+    "ref={this[reference]}&rs={build}"
+)
 
 
 def add_gene_links(gene_obj, build=37):

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -609,6 +609,8 @@ def beacon_link(variant_obj: dict, build: int):
     """Compose link to Beacon Network."""
     url_template = BEACON_LINK_TEMPLATE
 
+    build = "GRCh38" if build == 38 else "GRCh37"
+
     return url_template.format(this=variant_obj, build=build)
 
 

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -17,6 +17,9 @@ from scout.server.links import (
 BUILD_37 = 37
 BUILD_38 = 38
 
+ = "GRCh37"
+BEACON_BUILD_38 = "GRCh38"
+
 
 def test_beacon_link_37(variant_obj):
     """Test building a beacon link for a variant in build 37"""
@@ -24,7 +27,7 @@ def test_beacon_link_37(variant_obj):
     build = BUILD_37
 
     # THEN the Beacon link should reflect the variant build
-    expected_link = BEACON_LINK_TEMPLATE.format(this=variant_obj, build=build)
+    expected_link = BEACON_LINK_TEMPLATE.format(this=variant_obj, build=BEACON_BUILD_37)
     link = beacon_link(variant_obj, build)
     assert expected_link == link
 
@@ -36,7 +39,7 @@ def test_beacon_link_38(variant_obj):
     build = BUILD_38
 
     # THEN the Beacon link should reflect the variant build
-    expected_link = BEACON_LINK_TEMPLATE.format(this=variant_obj, build=build)
+    expected_link = BEACON_LINK_TEMPLATE.format(this=variant_obj, build=BEACON_BUILD_38)
     link = beacon_link(variant_obj, build)
     assert expected_link == link
 

--- a/tests/server/test_links.py
+++ b/tests/server/test_links.py
@@ -17,7 +17,7 @@ from scout.server.links import (
 BUILD_37 = 37
 BUILD_38 = 38
 
- = "GRCh37"
+BEACON_BUILD_37 = "GRCh37"
 BEACON_BUILD_38 = "GRCh38"
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Beacon links..

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. on main, click a beacon link - or inspect it on the page. Notice two lines from the template missing.
2. apply patch and find link working as before - and with that build 38 potential!

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by actual clicking on local (DN)
