### PR TITLE
Fix #3823 - always show case categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- Always show each case category on caseS page, even if 0 cases in total or after current query
+
 ## [4.64]
 ### Added
 - Create/Update a gene panel containing all PanelApp green genes (`scout update panelapp-green -i <cust_id>`)

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -79,7 +79,7 @@
     <table class="table table-hover table-bordered">
       <thead>
         <tr>
-          <th class="w-25">{{ group_name|capitalize }} cases ({{cases|length}}/{{status_ncases[group_name]}})</th>
+          <th class="w-25">{{ group_name|capitalize }} cases ({{cases|length}}/{{status_ncases[group_name] or 0}})</th>
           <th class="w-10">Status <a href="" id="{{group_name}}_status" onclick="updateArgs('{{group_name}}','sort=status','{{sort_option}}');" class="badge" style="color:{{'black' if sort_by=='status' else 'grey'}};background-color:white;">
             <i class="fa fa-sort{{'-'+sort_order if sort_by=='status' }}" aria-hidden="true" data-bs-toggle="tooltip" title="Sort cases by 'status'"></i>
           </a></th>
@@ -100,7 +100,7 @@
         {{ case_row(case) }}
       {% else %}
           <tr>
-            <td colspan="">No cases found.</td>
+            <td colspan=7>No cases found with this query.</td>
           </tr>
       {% endfor %}
       </tbody>
@@ -248,7 +248,7 @@
         {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'ignored'] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}
-            {% if status == group_name and case_group|length > 0 %}
+            {% if status == group_name %}
               <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Show all case categories, to make sure the case counters are displayed, and mildly edit the "No cases found" statements to hopefully nudge the user to search for actually desired categories.

![Screenshot 2023-02-23 at 15 37 17](https://user-images.githubusercontent.com/758570/220938004-36d5cea9-24f7-4fd8-ad65-8230b76c772c.png)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
