### PR TITLE
Clinvar sv fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Always show each case category on caseS page, even if 0 cases in total or after current query
 - Improved sorting of ClinVar submissions
+- Pre-populate SV type select in ClinVar submission form, when possible
 ### Fixed
 - Fixed Sanger order / Cancel order modal close buttons
+- Visibility of SV type in ClinVar submission form
 
 ## [4.64]
 ### Added

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -142,6 +142,14 @@ CLINVAR_SV_TYPES = [
     "Complex",
 ]
 
+SCOUT_CLINVAR_SV_TYPES_MAP = {
+    "ins": "Insertion",
+    "del": "Deletion",
+    "dup": "Duplication",
+    "inv": "Inversion",
+    "bnd": "Complex",
+}
+
 AFFECTED_STATUS = ["yes", "no", "unknown", NOT_PROVIDED, "not applicable"]
 
 ALLELE_OF_ORIGIN = [

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 from flask import current_app, flash
 
 from scout.constants.acmg import ACMG_MAP
-from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER
+from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, SCOUT_CLINVAR_SV_TYPES_MAP
 from scout.constants.variant_tags import MANUAL_RANK_OPTIONS
 from scout.models.clinvar import clinvar_variant
 from scout.server.extensions import clinvar_api, store
@@ -110,6 +110,10 @@ def _get_sv_var_form(variant_obj, case_obj):
     var_form.end_chromosome.data = variant_obj.get("end_chrom")
     var_form.breakpoint1.data = variant_obj.get("position")
     var_form.breakpoint2.data = variant_obj.get("end")
+
+    # try to preselect variant type from variant subcategory
+    if variant_obj["sub_category"] in SCOUT_CLINVAR_SV_TYPES_MAP:
+        var_form.var_type.data = SCOUT_CLINVAR_SV_TYPES_MAP[variant_obj["sub_category"]]
 
     return var_form
 

--- a/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/multistep_add_variant.html
@@ -136,7 +136,7 @@
                       <div class="col-6">
                       <!-- Variant type -->
                         {{variant_data.var_form.var_type.label(class="fw-bold, text-dark")}}
-                        {{variant_data.var_form.var_type(class="form-control, bg-white")}}
+                        {{variant_data.var_form.var_type(class="form-control, btn-secondary")}}
                         <br><br>
                       <!-- Reference copy number -->
                         {{variant_data.var_form.ref_copy.label(class="fw-bold, text-dark")}}


### PR DESCRIPTION
Fix #3829 
- Fixed visibility of SV type in ClinVar submission form
- Try to pre-populate the SV type select given the SV subtype

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test locally using a SV variant of the following types: "ins", "del", "dup", "inv", "bnd"

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
