### PR TITLE
Hide panels improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed Sanger order / Cancel order modal close buttons
 - Visibility of SV type in ClinVar submission form
 - Fixed a couple of creations where now was called twice, so updated_at and created_at could differ
-
+- Panels that have been removed (hidden) should not be visible in views where overlapping gene panels for genes are shown
 
 ## [4.64]
 ### Added

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -52,7 +52,7 @@ variant = dict(
     # Gene ids:
     hgnc_ids=list,  # list of hgnc ids (int)
     hgnc_symbols=list,  # list of hgnc symbols (str)
-    panels=list,  # list of panel names that the variant ovelapps
+    panels=list,  # list of panel names that the variant overlaps
     # Frequencies:
     thousand_genomes_frequency=float,
     thousand_genomes_frequency_left=float,

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -157,10 +157,10 @@
             <th></th>
           </tr>
         </thead>
+        <tbody>
       {% for panel in panels|sort(attribute="display_name",case_sensitive=False) %}
         <!--create table for each panel-->
-        <tbody>
-          <tr {% if panel.hidden %} class="hidableRow" style="visibility:collapse;" {% endif %}>
+          <tr {% if panel.hidden %} class="hidableRow collapse" {% endif %}>
             <td>
               <a href="{{ url_for('panels.panel', panel_id=panel._id) }}">{{ panel.display_name }}</a>
               {% if panel.hidden %}
@@ -182,9 +182,10 @@
             </td>
           </tr>
           {{ modify_panel(panel._id, panel) }}
-        </tbody>
+
         {{ remove_gene_panel_modal(institute, panel) }}
-      {% endfor %}
+        {% endfor %}
+        </tbody>
       </table>
     </div>
   </div>
@@ -268,18 +269,6 @@
 <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 <script type="text/javascript">
 
-function toggleRow(hideCheck) {
-  var els = document.getElementsByClassName("hidableRow");
-  for(var i=0;i<els.length;i++){
-    if(hideCheck.checked){
-      els[i].style.visibility = 'collapse';
-    }
-    else{
-      els[i].style.visibility = 'visible';
-    }
-  }
-}
-
 $('.history_btn').on('click', function(){
     var bid = $(this)[0].id;
     var sel = '#paneldiv_' + bid;
@@ -302,6 +291,20 @@ $('.modify_btn').on('click', function(){
     }
 });
 
+function toggleRow(hideCheck) {
+  var els = document.getElementsByClassName("hidableRow");
+  for(var i=0;i<els.length;i++){
+    collapse = bootstrap.Collapse.getOrCreateInstance(els[i])
+    if(hideCheck.checked){
+      collapse.hide();
+    }
+    else{
+      collapse.show();
+    }
+  }
+}
+
+
 $(function(){
       function getNameTerms(query, process) {
         $.get("{{ url_for('genes.api_genes') }}", {query: query}, function(data) {
@@ -314,6 +317,8 @@ $(function(){
         source: getNameTerms,
         minLength: 3,
       });
+
+
   });
 
 </script>

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -20,7 +20,11 @@ from scout.constants import (
     MOSAICISM_OPTIONS,
     VERBS_MAP,
 )
-from scout.server.blueprints.variant.utils import update_representative_gene
+from scout.server.blueprints.variant.utils import (
+    update_representative_gene,
+    update_variant_case_panels,
+)
+from scout.server.blueprints.variants.utils import update_case_panels
 from scout.server.extensions import cloud_tracks, gens
 from scout.server.links import get_variant_links
 from scout.server.utils import (
@@ -245,6 +249,10 @@ def variant(
     # add default panels extra gene information
     panels = default_panels(store, case_obj)
     add_gene_info(store, variant_obj, gene_panels=panels, genome_build=genome_build)
+
+    # Update some case panels info from db and populate it on variant to avoid showing removed panels
+    update_case_panels(store, case_obj)
+    update_variant_case_panels(store, case_obj, variant_obj)
 
     # Add information about bam files and create a region vcf
     if add_case:

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -252,6 +252,7 @@ def variant(
 
     # Update some case panels info from db and populate it on variant to avoid showing removed panels
     update_case_panels(store, case_obj)
+    # The hierarchical call order is relevant: cases are used to populate variants
     update_variant_case_panels(store, case_obj, variant_obj)
 
     # Add information about bam files and create a region vcf

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -344,8 +344,8 @@
       <ul class="list-group">
         <div class="list-group-item">
           <strong>Gene panels:</strong><br>
-          {% for panel_id in variant.panels|sort(case_sensitive=False) %}
-            <a href="{{ url_for('panels.panel', panel_id=panel_id) }}">{{ panel_id }}</a>&nbsp;&nbsp;
+          {% for panel in variant.case_panels|sort(attribute='panel_name', case_sensitive=False)|rejectattr('removed') %}
+            <a href="{{ url_for('panels.panel', panel_id=panel.panel_id) }}">{{ panel.panel_name}}</a>&nbsp;&nbsp;
           {% endfor %}
         </div>
       </ul>

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -158,9 +158,11 @@ def update_variant_case_panels(store, case_obj, variant_obj):
         variant_obj(dict)
     """
 
-    variant_panel_names = variant_obj.get("panels", [])
+    variant_panel_names = variant_obj.get("panels") or []
     case_panel_objs = [
-        panel for panel in case_obj.get("panels", []) if panel["panel_name"] in variant_panel_names
+        panel
+        for panel in (case_obj.get("panels") or [])
+        if panel["panel_name"] in variant_panel_names
     ]
 
     variant_obj["case_panels"] = case_panel_objs

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -152,9 +152,12 @@ def update_variant_case_panels(store, case_obj, variant_obj):
     """Populate variant with case gene panels with info on e.g. if a panel was removed on variant_obj.
     Variant objects panels are only a list of matching panel names.
 
+    The case_obj should be up to date first. Call update_case_panels() as needed in context:
+    to save some resources we do not call it here for each variant.
+
     Args:
         store(adapter.MongoAdapter)
-        case_obj(dict)
+        case_obj(dict):     case_obj with updated panels - update_case_panels() first
         variant_obj(dict)
     """
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -148,6 +148,24 @@ def update_transcripts_information(variant_gene, hgnc_gene, variant_obj, genome_
         transcript["change_str"] = transcript_str(transcript, hgnc_symbol)
 
 
+def update_variant_case_panels(store, case_obj, variant_obj):
+    """Populate variant with case gene panels with info on e.g. if a panel was removed on variant_obj.
+    Variant objects panels are only a list of matching panel names.
+
+    Args:
+        store(adapter.MongoAdapter)
+        case_obj(dict)
+        variant_obj(dict)
+    """
+
+    variant_panel_names = variant_obj.get("panels", [])
+    case_panel_objs = [
+        panel for panel in case_obj.get("panels", []) if panel["panel_name"] in variant_panel_names
+    ]
+
+    variant_obj["case_panels"] = case_panel_objs
+
+
 def add_gene_info(store, variant_obj, gene_panels=None, genome_build=None):
     """Adds information to variant genes from hgnc genes and selected gene panels.
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -27,6 +27,7 @@ from scout.server.blueprints.variant.utils import (
     clinsig_human,
     predictions,
     update_representative_gene,
+    update_variant_case_panels,
 )
 from scout.server.links import add_gene_links, cosmic_links, str_source_link
 from scout.server.utils import (
@@ -37,6 +38,7 @@ from scout.server.utils import (
 )
 
 from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, SvFiltersForm
+from .utils import update_case_panels
 
 LOG = logging.getLogger(__name__)
 
@@ -901,44 +903,6 @@ def download_str_variants(case_obj, variant_objs):
         mimetype="text/csv",
         headers=headers,
     )
-
-
-def update_case_panels(store, case_obj):
-    """Refresh case gene panels with info on if a panel was removed.
-
-    Also return these more populated panels for optional storage on the variant_obj.
-
-    store(adapter.MongoAdapter)
-    case_obj(dict)
-
-    Returns:
-        list(panel_info)
-    """
-
-    for panel_info in case_obj.get("panels", []):
-        panel_name = panel_info["panel_name"]
-        latest_panel = store.gene_panel(panel_name)
-        panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
-
-    return case_obj.get("panels", [])
-
-
-def update_variant_case_panels(store, case_obj, variant_obj):
-    """Populate case gene panels with info on e.g. if a panel was removed on variant_obj.
-    Variant objects only have a list of matching panel names.
-
-    Args:
-        store(adapter.MongoAdapter)
-        case_obj(dict)
-        variant_obj(dict)
-    """
-
-    variant_panel_names = variant_obj.get("panels", [])
-    case_panel_objs = [
-        panel for panel in case_obj.get("panels", []) if panel["panel_name"] in variant_panel_names
-    ]
-
-    variant_obj["case_panels"] = case_panel_objs
 
 
 def download_variants(store, case_obj, variant_objs):

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -899,6 +899,20 @@ def download_str_variants(case_obj, variant_objs):
     )
 
 
+def update_panels(store, case_obj):
+    """Refresh case gene panels with info on if a panel was removed.
+
+
+    Returns:
+
+    """
+
+    for panel_info in case_obj.get("panels", []):
+        panel_name = panel_info["panel_name"]
+        latest_panel = store.gene_panel(panel_name)
+        panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
+
+
 def download_variants(store, case_obj, variant_objs):
     """Download filtered variants for a case to an excel file
 

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -152,7 +152,9 @@
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
-            data-bs-content="{{variant.case_panels|rejectattr('removed')|join('<br>')|safe}}"
+            data-bs-content="{% for panel in variant.case_panels|rejectattr('removed') %}
+              {{ panel.panel_name|safe }}<br>
+              {% endfor %}"
             title="Overlapping gene panels">{{ns.panel_count}}
           </a>
       {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -97,13 +97,8 @@
         {% endif %}
       </a>
 
-      {% set ns = namespace(panel_count = 0) %}
-      {% for panel in variant.case_panels %}
-        {% if not panel.removed %}
-          {% set ns.panel_count = ns.panel_count + 1 %}
-        {% endif %}
-      {% endfor %}
-      {% if ns.panel_count > 0%}
+      {% set panel_count = variant.case_panels|rejectattr('removed')|list|length %}
+      {% if panel_count > 0%}
           <a
             class="badge bg-secondary text-white"
             data-bs-toggle="popover"
@@ -142,13 +137,9 @@
         </a>
       {% endfor %}
 
-      {% set ns = namespace(panel_count = 0) %}
-      {% for panel in variant.case_panels %}
-        {% if not panel.removed %}
-          {% set ns.panel_count = ns.panel_count + 1 %}
-        {% endif %}
-      {% endfor %}
-      {% if ns.panel_count > 0 %}
+
+      {% set panel_count = variant.case_panels|rejectattr('removed')|list|count %}
+      {% if panel_count > 0 %}
           <a
             class="badge bg-secondary text-white"
             data-bs-toggle="popover"
@@ -157,7 +148,7 @@
             data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
               {{ panel.panel_name|safe }}<br>
               {% endfor %}"
-            title="Overlapping gene panels">{{ns.panel_count}}
+            title="Overlapping gene panels">{{panel_count}}
           </a>
       {% endif %}
     {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -110,7 +110,9 @@
             data-bs-html="true"
             data-bs-trigger="hover click"
             title="Overlapping gene panels"
-            data-bs-content="{{variant.case_panels|rejectattr('removed')|join('<br>')|safe}}"
+            data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
+              {{ panel.panel_name|safe }}<br>
+              {% endfor %}"
             >{{panel_count}}
           </a>
       {% endif %}
@@ -152,7 +154,7 @@
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
-            data-bs-content="{% for panel in variant.case_panels|rejectattr('removed') %}
+            data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
               {{ panel.panel_name|safe }}<br>
               {% endfor %}"
             title="Overlapping gene panels">{{ns.panel_count}}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -96,15 +96,22 @@
           </span>
         {% endif %}
       </a>
-      {% if variant.panels|count > 0 %}
+
+      {% set panel_count = 0 %}
+      {% for panel in variant.panels %}
+        {% if not panel.removed %}
+          {% set panel_count = panel_count + 1 %}
+        {% endif %}
+      {% endfor %}
+      {% if panel_count > 0%}
           <a
             class="badge bg-secondary text-white"
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
             title="Overlapping gene panels"
-            data-bs-content="{{variant.panels|join('<br>')|safe}}"
-            >{{variant.panels|count}}
+            data-bs-content="{{variant.panels|rejectattr('removed')|join('<br>')|safe}}"
+            >{{panel_count}}
           </a>
       {% endif %}
     {% else %}
@@ -132,14 +139,23 @@
           href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
         </a>
       {% endfor %}
-      {% if variant.panels|count > 0 %}
+
+      {% set ns = namespace(panel_count = 0) %}
+      {% for panel in variant.panels %}
+        {% if panel.removed %}
+          {% set ns.panel_count = 42 %}
+        {% else %}
+          {% set ns.panel_count = ns.panel_count + 1 %}
+        {% endif %}
+      {% endfor %}
+      {% if ns.panel_count > 0 %}
           <a
             class="badge bg-secondary text-white"
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
-            data-bs-content="{{variant.panels|join('<br>')|safe}}"
-            title="Overlapping gene panels">{{variant.panels|count}}
+            data-bs-content="{{variant.panels|rejectattr('removed')|join('<br>')|safe}}"
+            title="Overlapping gene panels">{{ns.panel_count}}
           </a>
       {% endif %}
     {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -97,20 +97,20 @@
         {% endif %}
       </a>
 
-      {% set panel_count = 0 %}
-      {% for panel in variant.panels %}
+      {% set ns = namespace(panel_count = 0) %}
+      {% for panel in variant.case_panels %}
         {% if not panel.removed %}
-          {% set panel_count = panel_count + 1 %}
+          {% set ns.panel_count = ns.panel_count + 1 %}
         {% endif %}
       {% endfor %}
-      {% if panel_count > 0%}
+      {% if ns.panel_count > 0%}
           <a
             class="badge bg-secondary text-white"
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
             title="Overlapping gene panels"
-            data-bs-content="{{variant.panels|rejectattr('removed')|join('<br>')|safe}}"
+            data-bs-content="{{variant.case_panels|rejectattr('removed')|join('<br>')|safe}}"
             >{{panel_count}}
           </a>
       {% endif %}
@@ -141,10 +141,8 @@
       {% endfor %}
 
       {% set ns = namespace(panel_count = 0) %}
-      {% for panel in variant.panels %}
-        {% if panel.removed %}
-          {% set ns.panel_count = 42 %}
-        {% else %}
+      {% for panel in variant.case_panels %}
+        {% if not panel.removed %}
           {% set ns.panel_count = ns.panel_count + 1 %}
         {% endif %}
       {% endfor %}
@@ -154,7 +152,7 @@
             data-bs-toggle="popover"
             data-bs-html="true"
             data-bs-trigger="hover click"
-            data-bs-content="{{variant.panels|rejectattr('removed')|join('<br>')|safe}}"
+            data-bs-content="{{variant.case_panels|rejectattr('removed')|join('<br>')|safe}}"
             title="Overlapping gene panels">{{ns.panel_count}}
           </a>
       {% endif %}

--- a/scout/server/blueprints/variants/utils.py
+++ b/scout/server/blueprints/variants/utils.py
@@ -5,6 +5,8 @@ def update_case_panels(store, case_obj):
     """Refresh case gene panels with info on if a panel was removed.
 
     Also return these more populated panels for optional storage on the variant_obj.
+    If you do not use the returned variants, but rely on the update, please remember
+    to call this function before updating the variants.
 
     store(adapter.MongoAdapter)
     case_obj(dict)

--- a/scout/server/blueprints/variants/utils.py
+++ b/scout/server/blueprints/variants/utils.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+
+def update_case_panels(store, case_obj):
+    """Refresh case gene panels with info on if a panel was removed.
+
+    Also return these more populated panels for optional storage on the variant_obj.
+
+    store(adapter.MongoAdapter)
+    case_obj(dict)
+
+    Returns:
+        list(panel_info)
+    """
+
+    for panel_info in case_obj.get("panels", []):
+        panel_name = panel_info["panel_name"]
+        latest_panel = store.gene_panel(panel_name)
+        panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
+
+    return case_obj.get("panels", [])

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -129,6 +129,9 @@ def variants(institute_id, case_name):
     data = controllers.variants(
         store, institute_obj, case_obj, variants_query, result_size, page, query_form=form.data
     )
+
+    controllers.update_panels(store, case_obj)
+
     expand_search = request.method == "POST" and request.form.get("expand_search") in [
         "True",
         "",

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -130,8 +130,6 @@ def variants(institute_id, case_name):
         store, institute_obj, case_obj, variants_query, result_size, page, query_form=form.data
     )
 
-    controllers.update_panels(store, case_obj)
-
     expand_search = request.method == "POST" and request.form.get("expand_search") in [
         "True",
         "",


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #3794: browser support for visibility:collapse is rather sketchy, with a lot of them only accepting certain elements, and essentially just doing visibility:hidden instead, giving the empty-line phenomenon in the panelS list. Use bootstrap collapse instead.

<img width="1690" alt="Screenshot 2023-03-02 at 14 31 55" src="https://user-images.githubusercontent.com/758570/222480734-b6c5758c-8765-44b1-aae7-fb0b75f74b40.png">
<img width="1701" alt="Screenshot 2023-03-02 at 14 31 16" src="https://user-images.githubusercontent.com/758570/222480748-da63b848-65af-4b60-8c27-f2267896a425.png">
Instead of blank lines for the hidden ones.

- Fix #3793: this was a bit more complicated than anticipated, since several aspects of the panel view on e.g. the variantS page relies on the case version of the panel, which will not have been updated with recent panel hiding/removal since the time of case creation. Add updates.

Looks like before with the case panel active: 
<img width="563" alt="Screenshot 2023-03-02 at 16 49 26" src="https://user-images.githubusercontent.com/758570/222479962-1ff9e8e4-b2a8-4bad-acce-469e6c9896be.png">

Then if we remove the panel, count drops and the removed panel is not shown.
<img width="209" alt="Screenshot 2023-03-02 at 16 50 01" src="https://user-images.githubusercontent.com/758570/222479893-e0ae7411-8b2b-4558-a44d-36eac37c743a.png">
<img width="626" alt="Screenshot 2023-03-02 at 16 50 54" src="https://user-images.githubusercontent.com/758570/222479900-05ac5d92-8c08-4f69-bcdc-2ec10740f6bb.png">

Also, from the same issue, on the variant page, with panel removed:
<img width="412" alt="Screenshot 2023-03-03 at 08 43 45" src="https://user-images.githubusercontent.com/758570/222661531-f3873460-68d1-4a4f-9ef8-06b7bde61705.png">

and panel shown again:
<img width="415" alt="Screenshot 2023-03-03 at 08 44 15" src="https://user-images.githubusercontent.com/758570/222661456-857749b0-ace4-4639-b7e1-dcfdfd4d58f2.png">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. on stage, pick a case with several panels
1. hide some of them and note the hidden ones shown and counted on variantS page, and on the variant page
1. also see that the collapse of the panel rows is rendered as hidden on e.g. Safari
1. apply patch and note the count change and panels hide appropriately
1. see that the collapse of the panel rows is now rendered as collapsed on e.g. Safari
1. make sure the panel sorting is alphabetical on affected views

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
