### PR TITLE
Fix #3776: show panel gene comments on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Option to mark a ClinVar submission as submitted
 - Docs on how to create/update the PanelApp green genes as a system admin
+- Panel gene comments: genes in panels can have comments that describe the gene in a panel context
 ### Changed
 - Always show each case category on caseS page, even if 0 cases in total or after current query
 - Improved sorting of ClinVar submissions

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-
 from datetime import datetime as datetime
 
-from scout.exceptions import IntegrityError
 from scout.constants import VALID_MODELS
+from scout.exceptions import IntegrityError
 
 LOG = logging.getLogger(__name__)
 
@@ -69,6 +68,9 @@ def build_gene(gene_info, adapter):
 
     if gene_info.get("transcripts"):
         gene_obj["disease_associated_transcripts"] = gene_info["transcripts"]
+
+    if gene_info.get("comment"):
+        gene_obj["comment"] = gene_info["comment"]
 
     if gene_info.get("reduced_penetrance"):
         gene_obj["reduced_penetrance"] = True

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -25,6 +25,7 @@ def build_gene(gene_info, adapter):
             reduced_penetrance = bool,
             mosaicism = bool,
             database_entry_version = str,
+            comment = str, # panel level gene comment str
 
             ar = bool,
             ad = bool,
@@ -69,17 +70,13 @@ def build_gene(gene_info, adapter):
     if gene_info.get("transcripts"):
         gene_obj["disease_associated_transcripts"] = gene_info["transcripts"]
 
-    if gene_info.get("comment"):
-        gene_obj["comment"] = gene_info["comment"]
+    for gene_member_variable_str in ["comment", "database_entry_version"]:
+        if gene_info.get(gene_member_variable_str):
+            gene_obj[gene_member_variable_str] = gene_info[gene_member_variable_str]
 
-    if gene_info.get("reduced_penetrance"):
-        gene_obj["reduced_penetrance"] = True
-
-    if gene_info.get("mosaicism"):
-        gene_obj["mosaicism"] = True
-
-    if gene_info.get("database_entry_version"):
-        gene_obj["database_entry_version"] = gene_info["database_entry_version"]
+    for gene_member_variable_bool in ["reduced_penetrance", "mosaicism"]:
+        if gene_info.get(gene_member_variable_bool):
+            gene_obj[gene_member_variable_bool] = True
 
     if gene_info.get("inheritance_models"):
         gene_obj["inheritance_models"] = []

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -123,7 +123,7 @@ delivery_report: scout/demo/delivery_report.html
 gene_fusion_report: scout/demo/draw-fusions-example.pdf
 
 default_gene_panels: [panel1]
-gene_panels: [panel1]
+gene_panels: [panel1, test2]
 
 # meta data
 rank_model_version: '1.20'

--- a/scout/models/panel.py
+++ b/scout/models/panel.py
@@ -9,6 +9,8 @@ panel_gene = dict(
     mosaicism=bool,
     database_entry_version=str,
     inheritance_models=list,
+    custom_inheritance_models=list,
+    comment=str,  # panel context gene comment
 )
 
 

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -151,9 +151,9 @@
           </thead>
           <tbody>
             {% for gene in variant.genes %}
-              {% if gene.comment %}
-                <tr><td>{{ gene.hgnc_symbol }}</td><td>{{ gene.comment }}</td></tr>
-              {% endif %}
+              {% for comment in gene.comment %}
+                <tr><td>{{ gene.hgnc_symbol }}</td><td>{{ comment }}</td></tr>
+              {% endfor %}
             {% endfor %}
           </tbody>
         </table>

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -145,7 +145,7 @@
         </tbody>
       </table>
       {% if ns.comments_exist %}
-        <table class="table table-bordered table-sm">
+        <table class="table table-bordered table-sm" aria-label="Gene comments in case gene panels">
           <thead class="thead table-light">
             <th>Gene</th><th>Panel comments</th>
           </thead>

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -109,6 +109,7 @@
           </tr>
         </thead>
         <tbody>
+          {% set ns = namespace(comments_exist=false) %}
           {% for gene in variant.genes %}
             <tr>
               <td>{{ gene.hgnc_symbol }}</td>
@@ -137,9 +138,26 @@
                 {% endif %}
               </td>
             </tr>
+            {% if gene.comment %}
+              {% set ns.comments_exist = true %}
+            {% endif %}
           {% endfor %}
         </tbody>
       </table>
+      {% if ns.comments_exist %}
+        <table class="table table-bordered table-sm">
+          <thead class="thead table-light">
+            <th>Gene</th><th>Panel comments</th>
+          </thead>
+          <tbody>
+            {% for gene in variant.genes %}
+              {% if gene.comment %}
+                <tr><td>{{ gene.hgnc_symbol }}</td><td>{{ gene.comment }}</td></tr>
+              {% endif %}
+            {% endfor %}
+          </tbody>
+        </table>
+      {% endif %}
     </div>
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -7,7 +7,7 @@ LOG = logging.getLogger(__name__)
 
 
 def add_panel_specific_gene_info(panel_info):
-    """Adds manualy curated information from a gene panel to a gene
+    """Adds manually curated information from a gene panel to a gene
 
     The panel info is a list of dictionaries since there can be multiple infos about a panel.
 
@@ -25,7 +25,7 @@ def add_panel_specific_gene_info(panel_info):
     manual_penetrance = False
     mosaicism = False
     manual_inheritance = set()
-    comment = ""
+    comment = list()
 
     # We need to loop since there can be information from multiple panels
     for gene_info in panel_info:
@@ -43,10 +43,9 @@ def add_panel_specific_gene_info(panel_info):
             mosaicism = True
 
         if gene_info.get("comment"):
-            if comment == "":
-                comment = gene_info.get("comment") or ""
-            elif gene_info.get("comment"):
-                comment += " - {}".format(gene_info.get("comment"))
+            panel_gene_comment = gene_info.get("comment")
+            if panel_gene_comment:
+                comment.append(panel_gene_comment)
 
         manual_inheritance.update(gene_info.get("inheritance_models", []))
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -25,6 +25,7 @@ def add_panel_specific_gene_info(panel_info):
     manual_penetrance = False
     mosaicism = False
     manual_inheritance = set()
+    comment = ""
 
     # We need to loop since there can be information from multiple panels
     for gene_info in panel_info:
@@ -41,6 +42,9 @@ def add_panel_specific_gene_info(panel_info):
         if gene_info.get("mosaicism"):
             mosaicism = True
 
+        if gene_info.get("comment"):
+            comment += gene_info.get("comment") or ""
+
         manual_inheritance.update(gene_info.get("inheritance_models", []))
 
     panel_specific["disease_associated_transcripts"] = list(disease_associated)
@@ -48,6 +52,7 @@ def add_panel_specific_gene_info(panel_info):
     panel_specific["manual_penetrance"] = manual_penetrance
     panel_specific["mosaicism"] = mosaicism
     panel_specific["manual_inheritance"] = list(manual_inheritance)
+    panel_specific["comment"] = comment
 
     return panel_specific
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -43,7 +43,10 @@ def add_panel_specific_gene_info(panel_info):
             mosaicism = True
 
         if gene_info.get("comment"):
-            comment += gene_info.get("comment") or ""
+            if comment == "":
+                comment = gene_info.get("comment") or ""
+            elif gene_info.get("comment"):
+                comment += " - {}".format(gene_info.get("comment"))
 
         manual_inheritance.update(gene_info.get("inheritance_models", []))
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

This shows comments from panel genes on the variant page:
![Screenshot 2023-03-03 at 17 34 58](https://user-images.githubusercontent.com/758570/222776056-d880b808-520b-4d24-8407-c8cea136c5ac.png)

Edited here:
![Screenshot 2023-03-03 at 17 36 55](https://user-images.githubusercontent.com/758570/222776236-3d4500e2-8310-47f4-8877-f065b7a71052.png)

This solves the issue in a traditional Scout fashion. I can't help feel that much as with gene panel gene content, this as well as the other panel gene things, like disease transcript, would benefit from refresh from current panels when visiting an older case. Different PR.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
