### PR TITLE
Updated actions and Ubuntu versions in GitHub actions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -8,10 +8,10 @@ on:
 jobs:
  build-n-publish:
   name: Build and publish Python distribution to PyPI
-  runs-on: ubuntu-18.04
+  runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v2
+     uses: actions/checkout@v3
 
    - name: Set up Python 3.7
      uses: actions/setup-python@v2
@@ -45,7 +45,7 @@ jobs:
    steps:
 
     - name: Check out git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Publish main image (Dockerfile) to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
@@ -69,7 +69,7 @@ jobs:
    runs-on: ubuntu-latest
    steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup environment for docs deployment
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dangoslen/changelog-enforcer@v1.1.1
+    - uses: dangoslen/changelog-enforcer@v3.3
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabel: 'Skip-Changelog'

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -8,7 +8,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: dangoslen/changelog-enforcer@v1.1.1
       with:
         changeLogPath: 'CHANGELOG.md'

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: dangoslen/changelog-enforcer@v3.3
+    - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabel: 'Skip-Changelog'

--- a/.github/workflows/linting_and_fixing.yml
+++ b/.github/workflows/linting_and_fixing.yml
@@ -16,11 +16,11 @@ jobs:
 
     # Check out Scout code
     - name: Check out git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Set up python
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version}}
 

--- a/.github/workflows/linting_only.yml
+++ b/.github/workflows/linting_only.yml
@@ -16,11 +16,11 @@ jobs:
 
     # Check out Scout code
     - name: Check out git repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Set up python
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version}}
 

--- a/.github/workflows/server_stage_docker_push.yml
+++ b/.github/workflows/server_stage_docker_push.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: Check out git repository
-       uses: actions/checkout@v2
+       uses: actions/checkout@v3
 
      - name: Get branch name
        id: branch-name

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -12,7 +12,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -43,7 +43,7 @@ jobs:
         with:
          mongodb-version: ${{ matrix.mongodb-version }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -76,7 +76,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -7,7 +7,7 @@ jobs:
     name: vulture
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Find changed Python files
         id: files

--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: woke
         uses: get-woke/woke-action@v0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Improved sorting of ClinVar submissions
 - Pre-populate SV type select in ClinVar submission form, when possible
 - Show comment badges in related comments tables on general report
+- Updated version of several GitHub actions
 ### Fixed
 - Fixed Sanger order / Cancel order modal close buttons
 - Visibility of SV type in ClinVar submission form
 - Fixed a couple of creations where now was called twice, so updated_at and created_at could differ
+- Deprecated Ubuntu version 18.04 in one GitHub action
 
 
 ## [4.64]


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Updated version of several GitHub actions used in workflows
- Updated deprecated version of Ubuntu in GitHub action

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Automatic tests should pass

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions
