### PR TITLE
Fixed gene panel test pointing to the right function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed a couple of creations where now was called twice, so updated_at and created_at could differ
 - Deprecated Ubuntu version 18.04 in one GitHub action
 - Panels that have been removed (hidden) should not be visible in views where overlapping gene panels for genes are shown
+- Gene panel test pointing to the right function
 
 ## [4.64]
 ### Added

--- a/tests/server/blueprints/panels/test_panels_views.py
+++ b/tests/server/blueprints/panels/test_panels_views.py
@@ -155,7 +155,7 @@ def test_panel_export(client, real_panel_database):
     assert resp.status_code == 200
 
 
-def test_panel_export_case_hits(client, real_panel_database):
+def test_panel_export_case_hits(app, real_panel_database):
     """Test function used for exporting all genes with variant hits for a case"""
 
     # GIVEN a case and a gene panel in the database
@@ -163,14 +163,19 @@ def test_panel_export_case_hits(client, real_panel_database):
     panel_obj = adapter.panel_collection.find_one()
     case_obj = adapter.case_collection.find_one()
 
-    # WHEN downloading the case variants hits report
-    form_data = {"case_name": " - ".join([case_obj["owner"], case_obj["display_name"]])}
-    resp = client.post(url_for("panels.panel_export", panel_id=panel_obj["_id"]), data=form_data)
+    # GIVEN an initialized app and a valid user
+    with app.test_client() as client:
+        client.get(url_for("auto_login"))
 
-    # THEN the response should be successful
-    assert resp.status_code == 200
-    # And should download a PDF file
-    assert resp.mimetype == "application/pdf"
+        # WHEN downloading the case variants hits report
+        form_data = {"case_name": " - ".join([case_obj["owner"], case_obj["display_name"]])}
+        resp = client.post(
+            url_for("panels.panel_export_case_hits", panel_id=panel_obj["_id"]), data=form_data
+        )
+        # THEN the response should be successful
+        assert resp.status_code == 200
+        # And should download a PDF file
+        assert resp.mimetype == "application/pdf"
 
 
 def test_gene_edit(client, real_panel_database):

--- a/tests/server/blueprints/panels/test_panels_views.py
+++ b/tests/server/blueprints/panels/test_panels_views.py
@@ -127,7 +127,7 @@ def test_delete_panel(app, real_panel_database):
         assert panel_obj.get("hidden")
 
 
-def test_panels(app, institute_obj):
+def test_panels(app):
     # GIVEN an initialized app
     # GIVEN a valid user and institute
 


### PR DESCRIPTION
Fix #3847 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. GitHub actions should pass

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions
