### PR TITLE
Fix editing non-existing comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Speed up instituteS page loadiding by refactoring cases/institutes query
 - Clinical Filter for SVs includes `splice_polypyrimidine_tract_variant` as a severe consequence
 - Clinical Filter for SVs includes local variant frequency freeze ("old") for filtering, starting at 30 counts
+### Fixed
+- Page crashing when a user tries to edit a comment that was removed
 
 ## [4.66]
 ### Changed

--- a/scout/adapter/mongo/event.py
+++ b/scout/adapter/mongo/event.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pymongo
 from bson import ObjectId
+from flask import flash
 
 from scout.constants import DATE_DAY_FORMATTER
 
@@ -513,6 +514,9 @@ class EventHandler(CaseEventHandler, VariantEventHandler):
                 }
             },
         )
+        if not updated_comment:
+            flash("Comment could not be edited because it is no longer available.", "warning")
+            return
         # create an event to register that user has updated a comment
         current_time = datetime.now()
         event = dict(


### PR DESCRIPTION
Fix #3899 . The problem happens when a user has two tabs open on the same case/variant. If they remove the comment in a tab and then they try to edit the comment in the other tab, then the page crashes.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, try to remove and then edit a comment (on 2 different tabs) on both case and variant page

**Expected outcome**:
- Main branch should crash
- This  branch should just display error

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
