### PR TITLE
Fix #3893 - missing phenopacket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Speed up instituteS page loadiding by refactoring cases/institutes query
 - Clinical Filter for SVs includes `splice_polypyrimidine_tract_variant` as a severe consequence
 - Clinical Filter for SVs includes local variant frequency freeze ("old") for filtering, starting at 30 counts
+### Fixed
+- Warning instead of crashed page when attempting to retrieve a non-existent Phenopacket
 
 ## [4.66]
 ### Changed

--- a/scout/server/extensions/phenopacket_extension.py
+++ b/scout/server/extensions/phenopacket_extension.py
@@ -107,7 +107,10 @@ class PhenopacketAPI:
             LOG.warning(json_response["message"])
             return
 
-        json_content = json_response.get("content")[0]
+        json_content = json_response.get("content")
+        if not json_content:
+            return None
+        json_content = json_content[0]
 
         selected_json = {}
         valid_phenopacket_fields = [


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. attempt to import a phenopacket from a case page with a non existing hash. See a crash without patch, error flash with.
2. verify that an existing phenopacket can still be retrieved after patch.

**Expected outcome**:

Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR, DN
