### PR TITLE
Fix ugly causatives panel on Case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## unreleased
 ### Fixed
 - Crash when attempting to export phenotype from a case that had never had phenotypes
+- Aesthetic fix to Causative Variants panel on Case page for case without causatives
 
 ## [4.68]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## unreleased
 ### Fixed
 - Crash when attempting to export phenotype from a case that had never had phenotypes
-- Aesthetic fix to Causative Variants panel on Case page for case without causatives
+- Aesthetic fix to Causative and Pinned Variants on Case page
 
 ## [4.68]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -348,8 +348,8 @@
   {% set already_displayed_variant_ids = [] %}
   <div class="card mt-3">
      <div data-bs-toggle='tooltip' title="Displays all variants that have been marked causative for this case">
-      <div class="d-flex justify-content-around align-items-center">
-        <h6><span class="fa fa-medkit mt-2"></span>
+      <div class="d-flex align-items-between align-items-center">
+        <h6><span class="fa fa-medkit ms-3 mt-2"></span>
           {% if case.track == 'cancer' %}
             Clinically significant
           {% else %}
@@ -398,7 +398,7 @@
           <div class="list-group-item list-group-item-action">
             {% if variant._id %}
               {% do already_displayed_variant_ids.append(variant._id) %}
-              <div class="row align-items-between align-items-center">
+              <div class="d-flex align-items-between align-items-center">
                 <div class="col">
                   <i class="fa fa-check-circle-o"></i>
                   {% if variant.category == "snv" %}
@@ -508,8 +508,8 @@
 
 {% macro suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) %}
   <div class="card mt-3">
-    <div class="d-flex justify-content-around align-items-center" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
-      <h6><span class="fa fa-map-pin mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
+    <div class="d-flex align-items-between align-items-center" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
+      <h6><span class="fa fa-map-pin ms-3 mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
       </h6>
       {% if not suspects|length %}
         <span class="text-muted mt-2">

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -357,7 +357,7 @@
           {% endif %}
         </h6>
         {% if not case.causatives|length and not case.partial_causatives|length %}
-        <span class="text-muted mt-2">
+        <span class="text-muted ms-3 mt-2">
           <h6>No causative variants</h6>
         </span>
         {% endif %}
@@ -512,7 +512,7 @@
       <h6><span class="fa fa-map-pin ms-3 mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
       </h6>
       {% if not suspects|length %}
-        <span class="text-muted mt-2">
+        <span class="text-muted ms-3 mt-2">
           <h6>No pinned variants</h6>
         </span>
       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -347,17 +347,19 @@
 {% macro causatives_list(causatives, partial_causatives, evaluated_variants, institute, case, manual_rank_options, cancer_tier_options) %}
   {% set already_displayed_variant_ids = [] %}
   <div class="card mt-3">
-    <div data-bs-toggle='tooltip' title="Displays all variants that have been marked causative for this case">
-      <div class="d-flex justify-content-between">
-        <h6><span class="fa fa-medkit ms-3 mt-2"></span>
-        {% if case.track == 'cancer' %}
-          Clinically significant
-        {% else %}
-          Causative variants ({{causatives|length + partial_causatives|length}})
-        {% endif %}
+     <div data-bs-toggle='tooltip' title="Displays all variants that have been marked causative for this case">
+      <div class="d-flex justify-content-around align-items-center">
+        <h6><span class="fa fa-medkit mt-2"></span>
+          {% if case.track == 'cancer' %}
+            Clinically significant
+          {% else %}
+            Causative variants ({{causatives|length + partial_causatives|length}})
+          {% endif %}
         </h6>
         {% if not case.causatives|length and not case.partial_causatives|length %}
-          <span class="text-muted me-3 mt-2">No causative variants</span>
+        <span class="text-muted mt-2">
+          <h6>No causative variants</h6>
+        </span>
         {% endif %}
       </div>
     </div>
@@ -506,11 +508,13 @@
 
 {% macro suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) %}
   <div class="card mt-3">
-    <div class="d-flex justify-content-between" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
-      <h6><span class="fa fa-map-pin ms-3 mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
+    <div class="d-flex justify-content-around align-items-center" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
+      <h6><span class="fa fa-map-pin mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
       </h6>
       {% if not suspects|length %}
-        <span class="text-muted me-3 mt-2">No pinned variants</span>
+        <span class="text-muted mt-2">
+          <h6>No pinned variants</h6>
+        </span>
       {% endif %}
     </div>
     <div style="max-height:300px; overflow-y: scroll;">

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -357,7 +357,7 @@
         {% endif %}
         </h6>
         {% if not case.causatives|length and not case.partial_causatives|length %}
-          <span class="text-muted me-3 mt-2">No variants marked causative</span>
+          <span class="text-muted me-3 mt-2">No causative variants</span>
         {% endif %}
       </div>
     </div>

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -348,7 +348,7 @@
   {% set already_displayed_variant_ids = [] %}
   <div class="card mt-3">
      <div data-bs-toggle='tooltip' title="Displays all variants that have been marked causative for this case">
-      <div class="d-flex align-items-between align-items-center">
+      <div class="d-flex align-items-center">
         <h6><span class="fa fa-medkit ms-3 mt-2"></span>
           {% if case.track == 'cancer' %}
             Clinically significant
@@ -398,7 +398,7 @@
           <div class="list-group-item list-group-item-action">
             {% if variant._id %}
               {% do already_displayed_variant_ids.append(variant._id) %}
-              <div class="d-flex align-items-between align-items-center">
+              <div class="d-flex align-items-center">
                 <div class="col">
                   <i class="fa fa-check-circle-o"></i>
                   {% if variant.category == "snv" %}
@@ -471,7 +471,7 @@
                 {% if variant._id not in already_displayed_variant_ids %}
                   {% do already_displayed_variant_ids.append(variant._id) %}
                   <li class="list-group-item list-group-item-action">
-                    <div class="row align-items-between align-items-center">
+                    <div class="d-flex align-items-center">
                       <div class="col">
                         {{ pretty_link_variant(variant, case) }}
                         {{ variant_validation_badge(variant) }}
@@ -508,7 +508,7 @@
 
 {% macro suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) %}
   <div class="card mt-3">
-    <div class="d-flex align-items-between align-items-center" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
+    <div class="d-flex align-items-center" data-bs-toggle='tooltip' title="Displays all variants that has been pinned for this case">
       <h6><span class="fa fa-map-pin ms-3 mt-2"></span>&nbsp;Pinned variants ({{suspects|length}})
       </h6>
       {% if not suspects|length %}
@@ -524,7 +524,7 @@
           {% if variant._id %}
             <div class="row">
               <div class="col">
-                <div class="row align-items-between">
+                <div class="row">
                   <div class="col">
                     {{ pretty_link_variant(variant, case)}}
                     {{ clinical_assessments_badge(variant) }}


### PR DESCRIPTION
Fix #3953

Without causatives or pinned:

<img width="1207" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/7e9efe5b-d897-4512-827c-47817a007ca2">


With Causatives and pinned:

<img width="1214" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/822df9ee-020b-4594-898e-ddcb3f6492a6">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
