### PR TITLE
Use IGV.js 2.15.8 - fix default ClinVar track color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Crash when attempting to export phenotype from a case that had never had phenotypes
 - Aesthetic fix to Causative and Pinned Variants on Case page
 - Structural inconsistency for ClinVar Blueprint templates
+- Updated igv.js to 2.15.8 to fix track default color bug
+
 
 ## [4.68]
 ### Added

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
@@ -1,5 +1,5 @@
 {% macro igv_script() %}
   <link rel="shortcut icon" href="//igv.org/web/img/favicon.ico">
   <!-- IGV JS-->
-  <script src="https://cdn.jsdelivr.net/npm/igv@2.15.6/dist/igv.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/igv@2.15.8/dist/igv.min.js"></script>
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fix #3949. Track color now as per the bigbed by default, thanks to the IGV.js team!

![Screenshot 2023-05-30 at 09 04 36](https://github.com/Clinical-Genomics/scout/assets/758570/88577093-e22e-40c5-b6c3-4600d3cdeee2)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
