### PR TITLE
Fix #3970 - IGV locus search fix by giving reference id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed release versions for actions.
 - Freeze tornado below 6.3.0 for compatibility with livereload 2.6.3
 - Force update variants count on case re-upload
+- IGV locus search not working - add genome reference id
 ### Changed
 - FontAwesome integrity check fail (updated resource)
 - Removed ClinVar API validation buttons in favour of direct API submission

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -29,6 +29,7 @@ HG19CLINVAR_SVS_URL = (
 
 # Human genome reference genome build 37. Always displayed
 HUMAN_REFERENCE_37 = {
+    "id": "hg19",
     "fastaURL": HG19REF_URL,
     "indexURL": HG19REF_INDEX_URL,
     "cytobandURL": HG19CYTOBAND_URL,
@@ -36,6 +37,7 @@ HUMAN_REFERENCE_37 = {
 
 # Human genome reference genome build 38. Always displayed
 HUMAN_REFERENCE_38 = {
+    "id": "hg38",
     "fastaURL": HG38REF_URL,
     "indexURL": HG38REF_INDEX_URL,
     "cytobandURL": HG38CYTOBAND_URL,

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -41,6 +41,7 @@
                       showCenterGuide: false,
                     {% endif %}
                     reference: {
+                        id: "{{ reference_track.id }}",
                         fastaURL: "{{ reference_track.fastaURL }}",
                         indexURL: "{{ reference_track.indexURL }}",
                         cytobandURL: "{{ reference_track.cytobandURL }}"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fixes locus search by giving genome id to the IGV reference track. The added benefit is a display of the id on the browser, making it easier for the user to keep track with several windows and genomes open.

![Screenshot 2023-06-01 at 12 34 08](https://github.com/Clinical-Genomics/scout/assets/758570/0f4b4092-9199-4a2b-b1a5-e13e2788eac6)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
