### PR TITLE
Fix prettylink MEI - fix #3974

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Huge list of genes in case report for megabases-long structural variants.
 - Fix displaying institutes without associated cases on institutes page
 - Fix default panel selection on SVs in cancer case report
-
+- Pin links to MEI variants should end up on MEI not SV variant view
+- Load also matching MEI variants on forced region load
+- Allow excluding MEI from case variant deletion
 
 ## [4.66]
 ### Changed

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -825,7 +825,7 @@ class VariantHandler(VariantLoader):
             variant_file(str): string path to a VCF file on disk
         """
         variant_file = None
-        for var_type in ["snv", "sv", "str", "cancer"]:
+        for var_type in ["snv", "sv", "str", "cancer", "mei"]:
             if category != var_type:
                 continue
             if variant_type == "clinical":

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -23,7 +23,7 @@ DELETE_VARIANTS_HEADER = [
     "Removed variants",
 ]
 CASE_STATUS = ["solved", "archived", "active", "inactive", "ignored", "prioritized"]
-VARIANT_CATEGORIES = ["snv", "sv", "cancer", "cancer_sv", "str"]
+VARIANT_CATEGORIES = ["mei", "snv", "sv", "cancer", "cancer_sv", "str"]
 
 
 @click.command("variants", short_help="Delete variants for one or more cases")

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -304,7 +304,7 @@
 {% macro pretty_link_variant(variant, case) %}
 {# Returns human readable links to the corresponding variant page #}
 
-  {% if variant.category in ("str", "snv", "cancer") %}
+  {% if variant.category in ("mei", "str", "snv", "cancer") %}
     {% if variant.category == "cancer" %}
     <a href="{{ url_for('variant.cancer_variant',
                    institute_id=variant.institute,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Click here:
<img width="439" alt="Screenshot 2023-06-02 at 10 00 40" src="https://github.com/Clinical-Genomics/scout/assets/758570/acff4dc5-b94f-494d-ae03-3a8cc76b452f">

Before:
<img width="773" alt="Screenshot 2023-06-02 at 09 44 35" src="https://github.com/Clinical-Genomics/scout/assets/758570/a156ae93-c348-46ba-9c23-d3c37a989998">

After:
<img width="1160" alt="Screenshot 2023-06-02 at 09 58 04" src="https://github.com/Clinical-Genomics/scout/assets/758570/0bb6d47b-e311-4f58-98ec-71c595cb165c">

Also fixed a couple of minor missing MEI variant types (variant deletion +`keep` option, region load). Region load in particular has basically no effect right now as we dont rank MEI yet. 



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
