### PR TITLE
Fix assigned name when id is different from email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Freeze tornado below 6.3.0 for compatibility with livereload 2.6.3
 - Force update variants count on case re-upload
 - IGV locus search not working - add genome reference id
+- Fixed the name of the assigned user when the internal user ID is different from the user email address
 ### Changed
 - FontAwesome integrity check fail (updated resource)
 - Removed ClinVar API validation buttons in favour of direct API submission

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -232,7 +232,7 @@ class CaseHandler(object):
                 "$and": [{"name": {"$regex": term, "$options": "i"}} for term in query_terms]
             }
             users = self.user_collection.find(user_query)
-            query["assignees"] = {"$in": [user["email"] for user in users]}
+            query["assignees"] = {"$in": [user["_id"] for user in users]}
 
         return order
 
@@ -299,7 +299,7 @@ class CaseHandler(object):
             yield_query(bool): If true, only return mongo query dict for use in
                                 compound querying.
             within_days(int): timespan (in days) for latest event on case
-            assignee(str): email of an assignee
+            assignee(str): id of an assignee
             verification_pending(bool): If search should be restricted to cases with verification_pending
             has_clinvar_submission(bool): If search should be limited to cases with a ClinVar submission
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -180,7 +180,9 @@ def case(store, institute_obj, case_obj):
         individual["phenotype_human"] = pheno_map.get(individual["phenotype"])
         case_obj["individual_ids"].append(individual["individual_id"])
 
-    case_obj["assignees"] = [store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])]
+    case_obj["assignees"] = [
+        store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])
+    ]
 
     # Provide basic info on alignment files availability for this case
     case_has_alignments(case_obj)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -180,7 +180,7 @@ def case(store, institute_obj, case_obj):
         individual["phenotype_human"] = pheno_map.get(individual["phenotype"])
         case_obj["individual_ids"].append(individual["individual_id"])
 
-    case_obj["assignees"] = [store.user(user_email) for user_email in case_obj.get("assignees", [])]
+    case_obj["assignees"] = [store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])]
 
     # Provide basic info on alignment files availability for this case
     case_has_alignments(case_obj)

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -558,7 +558,7 @@ def assign(institute_id, case_name, user_id=None, inactivate=False):
     if user_id:
         user_obj = store.user(user_id=user_id)
     else:
-        user_obj = store.user(current_user.email)
+        user_obj = store.user(email=current_user.email)
     if request.form.get("action") == "DELETE":
         store.unassign(institute_obj, case_obj, user_obj, link, inactivate)
     else:

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -556,7 +556,7 @@ def assign(institute_id, case_name, user_id=None, inactivate=False):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     link = url_for(".case", institute_id=institute_id, case_name=case_name)
     if user_id:
-        user_obj = store.user(user_id)
+        user_obj = store.user(user_id=user_id)
     else:
         user_obj = store.user(current_user.email)
     if request.form.get("action") == "DELETE":

--- a/tests/server/blueprints/cases/test_cases_templates.py
+++ b/tests/server/blueprints/cases/test_cases_templates.py
@@ -137,7 +137,7 @@ def test_sidebar_cnv_report(app, institute_obj, cancer_case_obj, user_obj):
 
 
 def test_sidebar_assign(app, institute_obj, case_obj, user_obj):
-    """Test the case sidebar macro items for a cancer case"""
+    """Test the case sidebar macro items for a case"""
     # GIVEN an initialized app
     with app.test_client() as client:
         # GIVEN that the user could be logged in


### PR DESCRIPTION
As @dnil got to see last week, our Scout instance did not show the assigned user correctly in the case view. This is what we had:

![image](https://github.com/Clinical-Genomics/scout/assets/2573608/68a431a6-2ec2-4078-847c-d89bbe1cf53c)

After digging around, it seemed to be due to the user ID not being the same as the user email. We are using LDAP for login, and would like to keep the ID separate from the email. This PR addresses this issue by making sure that the user ID is used when assigning a user to a case, and that the assigned users are fetched properly when the case is processed for viewing.

![image](https://github.com/Clinical-Genomics/scout/assets/2573608/ddc4ce5c-1830-4a61-a3e9-54f91b2ac135)

I noticed more places where emails are used like user IDs, but decided to only modify the bare minimum to solve this particular problem. Hopefully this doesn't introduce any issues elsewhere. Looking forward to your feedback!

**Review:**
- [ ] code approved by
- [ ] tests executed by
