### PR TITLE
Remove method that calls netlify to track browser versions

### DIFF
--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -623,7 +623,6 @@ class CaseHandler(object):
         ]
 
         try:
-
             for vcf_file in files:
                 # Check if file exists
                 if not case_obj["vcf_files"].get(vcf_file["file_name"]):
@@ -940,7 +939,6 @@ class CaseHandler(object):
 
         n_status_updated = 0
         for old_var in old_eval_variants:
-
             # search for the same variant in newly uploaded vars for this case
             display_name = old_var["display_name"]
 

--- a/scout/adapter/mongo/event.py
+++ b/scout/adapter/mongo/event.py
@@ -490,7 +490,6 @@ class EventHandler(CaseEventHandler, VariantEventHandler):
 
         # and create the same comment for the new variant
         for old_comment in comments_query:
-
             comment_user = self.user(old_comment["user_id"])
             if comment_user is None:
                 continue

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -68,7 +68,7 @@ class FilterHandler(object):
             institute_obj.get("display_name") + "-" + case_obj.get("display_name")
         )
 
-        for (element, value) in filter_obj.lists():
+        for element, value in filter_obj.lists():
             if value == [""]:
                 continue
             if element in ["save_filter", "filters", "csrf_token"]:

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -462,12 +462,10 @@ class VariantHandler(VariantLoader):
         causatives = []
 
         if case_id:
-
             case_obj = self.case_collection.find_one({"_id": case_id})
             causatives = [causative for causative in case_obj.get("causatives", [])]
 
         elif institute_id:
-
             query = self.case_collection.aggregate(
                 [
                     {

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -76,7 +76,6 @@ class VariantLoader(object):
         requests = []
 
         for index, var_obj in enumerate(variants):
-
             operation = pymongo.UpdateOne(
                 {"_id": var_obj["_id"]}, {"$set": {"variant_rank": index + 1}}
             )

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -49,7 +49,6 @@ def get_app(ctx=None):
     cli_config = {}
     # if a .yaml config file was provided use its params to intiate the app
     if options.params.get("config"):
-
         with open(options.params["config"], "r") as in_handle:
             cli_config = yaml.load(in_handle, Loader=yaml.SafeLoader)
 

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -29,7 +29,6 @@ def export_variants(adapter, collaborator, document_id=None, case_id=None):
     variant_ids = adapter.get_causatives(institute_id=collaborator, case_id=case_id)
     ##TODO add check so that same variant is not included more than once
     for document_id in variant_ids:
-
         variant_obj = adapter.variant(document_id)
         chrom = variant_obj["chromosome"]
         # Convert chromosome to integer for sorting

--- a/scout/load/hpo.py
+++ b/scout/load/hpo.py
@@ -111,7 +111,6 @@ def load_hpo_terms(adapter, hpo_lines=None, hpo_gene_lines=None, alias_genes=Non
     nr_terms = len(hpo_terms)
     hpo_bulk = []
     with progressbar(hpo_terms.values(), label="Loading hpo terms", length=nr_terms) as bar:
-
         for hpo_info in bar:
             hpo_bulk.append(build_hpo_term(hpo_info))
 

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -122,7 +122,6 @@ def load_panel_app(adapter, panel_id=None, institute="cust000"):
     panel_ids = [panel_id]
 
     if not panel_id:
-
         LOG.info("Fetching all panel app panels")
         json_lines = fetch_resource(base_url.format("list_panels"), json=True)
 

--- a/scout/load/transcript.py
+++ b/scout/load/transcript.py
@@ -64,7 +64,6 @@ def load_transcripts(adapter, transcripts_lines=None, build="37", ensembl_genes=
         transcripts_dict.values(), label="Building transcripts", length=nr_transcripts
     ) as bar:
         for tx_data in bar:
-
             #################### Get the correct refseq identifier ####################
             # We need to decide one refseq identifier for each transcript, if there are any to
             # choose from. The algorithm is as follows:

--- a/scout/models/phenotype_term.py
+++ b/scout/models/phenotype_term.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+
 # Hpo terms represents data from the hpo web
 class HpoTerm(dict):
     """Represents a hpo term

--- a/scout/parse/clinvar.py
+++ b/scout/parse/clinvar.py
@@ -46,7 +46,6 @@ def get_objects_from_form(variant_ids, form_fields, object_type):
 
     # Loop over the form fields and collect the data:
     for variant_id in variant_ids:  # loop over the variants
-
         subm_obj = {}  # A new submission object for each
 
         # Don't included casedata for a variant unless specified by user
@@ -134,7 +133,6 @@ def clinvar_submission_header(submission_objs, csv_type):
                 key,
                 value,
             ) in clinvar_obj.items():  # loop over the keys and values of the clinvar objects
-
                 if (
                     not header_key in custom_header and header_key == key
                 ):  # add to custom header if missing and specified in submission object

--- a/scout/parse/ensembl.py
+++ b/scout/parse/ensembl.py
@@ -67,7 +67,6 @@ def parse_ensembl_line(line, header):
                 ensembl_info["exon_rank"] = int(value)
 
         if "utr" in word:
-
             if "start" in word:
                 if "5" in word:
                     ensembl_info["utr_5_start"] = int(value)
@@ -161,7 +160,6 @@ def parse_ensembl_genes(lines):
     LOG.info("Parsing ensembl genes from file")
     header = []
     for index, line in enumerate(lines):
-
         # File allways start with a header line
         if index == 0:
             header = line.rstrip().split("\t")
@@ -186,7 +184,6 @@ def parse_ensembl_transcripts(lines):
     header = []
     LOG.info("Parsing ensembl transcripts from file")
     for index, line in enumerate(lines):
-
         # File allways start with a header line
         if index == 0:
             header = line.rstrip().split("\t")
@@ -208,7 +205,6 @@ def parse_ensembl_exons(lines):
     """
     header = []
     for index, line in enumerate(lines):
-
         # File allways start with a header line
         if index == 0:
             header = line.rstrip().split("\t")

--- a/scout/parse/matchmaker.py
+++ b/scout/parse/matchmaker.py
@@ -168,7 +168,6 @@ def parse_matches(patient_id, match_objs):
     parsed_matches = []
 
     for match_obj in match_objs:
-
         # convert match date from millisecond to readable date
         milliseconds_date = match_obj["created"]["$date"]
         mdate = datetime.datetime.fromtimestamp(milliseconds_date / 1000.0)
@@ -208,7 +207,6 @@ def parse_matches(patient_id, match_objs):
                 for patient in res["patients"]:
                     LOG.info("Looping in else, patient:{}".format(patient["patient"]["id"]))
                     if patient["patient"]["id"] == patient_id:
-
                         score = patient["score"]
                         match_patient = {
                             "patient_id": m_patient["id"],

--- a/scout/parse/omim.py
+++ b/scout/parse/omim.py
@@ -86,7 +86,6 @@ def parse_genemap2_phenotypes(phenotype_entry, mim_number=None):
         inheritance_text = ",".join(splitted_info[i:])
         for term in MIM_INHERITANCE_TERMS:
             if term in inheritance_text:
-
                 inheritance.add(TERMS_MAPPER[term])
 
         parsed_phenotypes.append(

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -170,7 +170,7 @@ def register_filters(app):
         Return:
             str: humanized string of the decimal number
         """
-        min_number = 10 ** -ndigits
+        min_number = 10**-ndigits
         if isinstance(number, str):
             number = None
         if number is None:

--- a/scout/server/blueprints/genes/controllers.py
+++ b/scout/server/blueprints/genes/controllers.py
@@ -17,7 +17,6 @@ def gene(store, hgnc_id):
     for build in res["builds"]:
         record = store.hgnc_gene(hgnc_id, build=build)
         if record:
-
             record["position"] = "{this[chromosome]}:{this[start]}-{this[end]}".format(this=record)
             res["aliases"] = record["aliases"]
             res["hgnc_id"] = record["hgnc_id"]

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -96,7 +96,6 @@ def causatives(institute_id):
 @blueprint.route("/<institute_id>/filters", methods=["GET"])
 @templated("overview/filters.html")
 def filters(institute_id):
-
     form = request.form
 
     institute_obj = institute_and_case(store, institute_id)
@@ -108,7 +107,6 @@ def filters(institute_id):
 
 @blueprint.route("/<institute_id>/lock_filter/<filter_id>", methods=["POST"])
 def lock_filter(institute_id, filter_id):
-
     filter_lock = request.form.get("filter_lock", "False")
     LOG.debug(
         "Attempting to toggle lock %s for %s with status %s", filter_id, institute_id, filter_lock

--- a/scout/server/blueprints/managed_variants/views.py
+++ b/scout/server/blueprints/managed_variants/views.py
@@ -53,7 +53,6 @@ def upload_managed_variants():
 
 @managed_variants_bp.route("/managed_variant/<variant_id>/modify", methods=["POST"])
 def modify_managed_variant(variant_id):
-
     edit_form = ManagedVariantModifyForm(request.form)
 
     if not controllers.modify_managed_variant(store, variant_id, edit_form):

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -21,7 +21,7 @@
       </p>
     {% else %}
       {% if config.GOOGLE %}
-        <a class="btn btn-primary" onclick="sendBrowserInfo()" href="{{ url_for('login.login') }}" role="button">
+        <a class="btn btn-primary" href="{{ url_for('login.login') }}" role="button">
           Login with Google
         </a>
       {% elif config.LDAP_HOST %}
@@ -33,7 +33,7 @@
             <label>Password{{ form.password(class="form-control") }}</label>
           </div>
           <div class="col-4">
-            <button type="submit" class="btn btn-primary form-control text-white" onclick="sendBrowserInfo()">Login</button>
+            <button type="submit" class="btn btn-primary form-control text-white">Login</button>
           </div>
           {{ form.hidden_tag() }}
         </form>
@@ -44,7 +44,7 @@
               <input type="text" placeholder="email" class="form-control" name="email">
             </div>
             <div class="col-4">
-              <button type="submit" class="btn btn-primary form-control text-white" onclick="sendBrowserInfo()">Login</button>
+              <button type="submit" class="btn btn-primary form-control text-white">Login</button>
             </div>
           </div>
         </form>
@@ -80,32 +80,4 @@
     </div>
   </main>
 </div>
-{% endblock %}
-
-{% block scripts %}
-{{ super() }}
-  <script type="text/javascript">
-    const sendBrowserInfo = () => {
-      console.log('Calling Netlify')
-      if (window.location.hostname.includes('scilifelab.se')) {
-          fetch('https://user-stats.netlify.app/.netlify/functions/add-browser', {
-              method: 'POST',
-              headers: {
-                  'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                  agent: navigator.userAgent,
-                  screenWidth: window.screen.width,
-                  screenHeight: window.screen.height,
-                  env: window.location.hostname,
-                  date: new Date(),
-              }),
-          }).then((response) => {
-              console.log(response.json());
-          }).catch(() => {
-              console.error('Failed to submit browser info');
-          })
-      }
-        };
-  </script>
 {% endblock %}

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -109,7 +109,6 @@ def omim(omim_id):
 
 
 def ensembl(ensembl_id, build=37):
-
     link = "http://grch37.ensembl.org/Homo_sapiens/Gene/Summary?db=core;g={}"
     if build == 38:
         link = "http://ensembl.org/Homo_sapiens/Gene/Summary?db=core;g={}"
@@ -214,7 +213,6 @@ def vega(vega_id):
 
 
 def ucsc(ucsc_id):
-
     link = (
         "http://genome.cse.ucsc.edu/cgi-bin/hgGene?org=Human&hgg_chrom=none&hgg_type=knownGene"
         "&hgg_gene={}"
@@ -335,7 +333,6 @@ def varsome(build, refseq_id, protein_sequence_name):
 
 
 def iarctp53(hgnc_symbol):
-
     if hgnc_symbol != "TP53":
         return None
 

--- a/scripts/generate_test_data.py
+++ b/scripts/generate_test_data.py
@@ -64,7 +64,6 @@ def get_reduced_hpo_terms(hpo_terms):
     nr_kept = 0
 
     for line in hpo_lines:
-
         # When we encounter a new term we yield all lines of the previous term
         if line.startswith("[Term]"):
             nr_terms += 1
@@ -124,7 +123,6 @@ def generate_hgnc(genes):
 
     # Loop over all hgnc gene lines
     for i, line in enumerate(hgnc_gene_lines):
-
         line = line.rstrip()
         # Skip lines that are empty
         if not len(line) > 0:

--- a/scripts/update_variant_panels.py
+++ b/scripts/update_variant_panels.py
@@ -93,7 +93,6 @@ def update_panels(context, mongodb, username, password, authdb, host, port, logl
         )
 
         for variant_obj in variants:
-
             panel_names = set()
             for hgnc_id in variant_obj["hgnc_ids"]:
                 gene_panels = gene_to_panels.get(hgnc_id, set())

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -128,7 +128,6 @@ def test_get_research_case(real_adapter, case_obj, institute_obj):
 
 
 def test_get_cases_no_synopsis(real_adapter, case_obj, institute_obj, user_obj):
-
     adapter = real_adapter
     # GIVEN a real database with no cases
     assert adapter.case_collection.find_one() is None
@@ -418,7 +417,6 @@ def test_update_dynamic_gene_list(gene_database, case_obj):
 
 
 def test_update_dynamic_gene_list_with_bad_dict_entry(gene_database, case_obj):
-
     # GIVEN an populated gene database,
     adapter = gene_database
 
@@ -489,7 +487,6 @@ def test_archive_unarchive_case(adapter, case_obj, institute_obj, user_obj):
 
 
 def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj):
-
     # GIVEN an empty database (no cases)
     assert sum(1 for i in adapter.cases()) == 0
     adapter.case_collection.insert_one(case_obj)

--- a/tests/adapter/mongo/test_clinvar_handler.py
+++ b/tests/adapter/mongo/test_clinvar_handler.py
@@ -57,7 +57,6 @@ def get_test_submission_case(case_obj):
 
 
 def get_new_submission(adapter, institute_obj):
-
     # And a valid institute id
     institute_id = institute_obj["_id"]
     assert institute_id

--- a/tests/adapter/mongo/test_evaluated_variants.py
+++ b/tests/adapter/mongo/test_evaluated_variants.py
@@ -137,7 +137,6 @@ def test_get_ranked_and_comment_two(real_variant_database):
 def test_evaluated_variants(
     case_obj, institute_obj, user_obj, real_populated_database, variant_objs
 ):
-
     adapter = real_populated_database
     case_id = case_obj["_id"]
 

--- a/tests/adapter/mongo/test_event_handling.py
+++ b/tests/adapter/mongo/test_event_handling.py
@@ -58,7 +58,6 @@ def test_assign(adapter, institute_obj, case_obj, user_obj):
 
 
 def test_unassign(adapter, institute_obj, case_obj, user_obj):
-
     case_obj["status"] = "active"
 
     # GIVEN an adapter to a database with one case

--- a/tests/adapter/mongo/test_institute_handler.py
+++ b/tests/adapter/mongo/test_institute_handler.py
@@ -7,7 +7,6 @@ from scout.exceptions import IntegrityError
 
 
 def test_add_institute(adapter, institute_obj):
-
     ## GIVEN an adapter without any institutes
     assert sum(1 for i in adapter.institutes()) == 0
 
@@ -31,7 +30,6 @@ def test_add_institute(adapter, institute_obj):
 
 
 def test_add_institute_twice(adapter, institute_obj):
-
     ## GIVEN an adapter without any institutes
     assert sum(1 for i in adapter.institutes()) == 0
 
@@ -46,7 +44,6 @@ def test_add_institute_twice(adapter, institute_obj):
 
 
 def test_fetch_institute(adapter, institute_obj):
-
     ## GIVEN an adapter without any institutes
     assert sum(1 for i in adapter.institutes()) == 0
 
@@ -63,7 +60,6 @@ def test_fetch_institute(adapter, institute_obj):
 
 
 def test_fetch_non_existing_institute(adapter, institute_obj):
-
     ## GIVEN an adapter without any institutes
     assert sum(1 for i in adapter.institutes()) == 0
 

--- a/tests/adapter/mongo/test_panel_handler.py
+++ b/tests/adapter/mongo/test_panel_handler.py
@@ -58,7 +58,6 @@ def test_get_non_existing_panel(adapter, testpanel_obj):
 
 
 def test_get_panel_multiple_versions(adapter, testpanel_obj):
-
     ## GIVEN an adapter with multiple versions of same gene panel
     testpanel_obj["_id"] = 1
     adapter.panel_collection.insert_one(testpanel_obj)
@@ -95,7 +94,6 @@ def test_reset_pending(adapter, testpanel_obj, gene_obj):
 
 
 def test_add_pending(adapter, testpanel_obj, gene_obj):
-
     adapter.panel_collection.insert_one(testpanel_obj)
     adapter.hgnc_collection.insert_one(gene_obj)
     ## GIVEN a adapter with one gene panel and a gene
@@ -300,7 +298,6 @@ def test_apply_pending_add_two_genes(adapter, testpanel_obj):
 
 
 def test_apply_pending_edit_gene(adapter, testpanel_obj):
-
     ## GIVEN an adapter with a gene panel
     adapter.panel_collection.insert_one(testpanel_obj)
     panel_obj = adapter.panel_collection.find_one()

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -416,7 +416,6 @@ def test_build_clinsig_always(real_variant_database):
 
     # Make sure that variants are filtered as they should:
     for var in filtered_variants:
-
         gnomad_filter = False
         anno_filter = False
         clisig_filter = False

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -129,7 +129,6 @@ def test_get_sanger_unevaluated(
 
     # Order Sanger for both variants
     for variant in test_variants:
-
         # Assert tha variant has NO Sanger ordered
         assert variant.get("sanger_ordered") is None
 

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -41,7 +41,6 @@ def test_matching_tiered(adapter, institute_obj, cancer_case_obj, user_obj, canc
 
 
 def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -75,7 +74,6 @@ def test_mark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj)
 
 
 def test_unmark_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     ## GIVEN a adapter with a variant that is marked causative
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -113,7 +111,6 @@ def test_unmark_causative(adapter, institute_obj, case_obj, user_obj, variant_ob
 
 
 def test_mark_partial_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -150,7 +147,6 @@ def test_mark_partial_causative(adapter, institute_obj, case_obj, user_obj, vari
 
 
 def test_unmark_partial_causative(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -196,7 +192,6 @@ def test_unmark_partial_causative(adapter, institute_obj, case_obj, user_obj, va
 
 
 def test_order_verification(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a populated database with variants
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -235,7 +230,6 @@ def test_order_verification(adapter, institute_obj, case_obj, user_obj, variant_
 
 
 def test_cancel_verification(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a populated database with a variant that has sanger ordered
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -275,7 +269,6 @@ def test_cancel_verification(adapter, institute_obj, case_obj, user_obj, variant
 
 
 def test_dismiss_variant(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a variant db with at least one variant, and no events
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -313,7 +306,6 @@ def test_dismiss_variant(adapter, institute_obj, case_obj, user_obj, variant_obj
 
 
 def test_update_cancer_tier(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a variant db with at least one variant, and no events
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)
@@ -350,7 +342,6 @@ def test_update_cancer_tier(adapter, institute_obj, case_obj, user_obj, variant_
 
 
 def test_update_manual_rank(adapter, institute_obj, case_obj, user_obj, variant_obj):
-
     # GIVEN a variant db with at least one variant, and no events
     adapter.case_collection.insert_one(case_obj)
     adapter.institute_collection.insert_one(institute_obj)

--- a/tests/commands/load/test_load_report_cmd.py
+++ b/tests/commands/load/test_load_report_cmd.py
@@ -19,7 +19,6 @@ def test_load_gene_fusion_report_research(mock_app):
 
     # WHEN the update_gene_fusion command is executed provifing a new gene fusion research report
     with tempfile.NamedTemporaryFile(suffix=".pdf") as tf:
-
         research_gene_fusion_report_path = os.path.dirname(tf.name)
         result = runner.invoke(
             cli,
@@ -48,7 +47,6 @@ def test_load_gene_fusion_report_update(mock_app):
 
     # WHEN the update_gene_fusion command is executed provifing a new gene fusion report
     with tempfile.NamedTemporaryFile(suffix=".pdf") as tf:
-
         new_report_path = os.path.dirname(tf.name)
         result = runner.invoke(
             cli, ["load", "gene-fusion-report", case_id, new_report_path, "--update"]

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -7,7 +7,6 @@ from scout.commands import cli
 
 # Coherence check for cli
 def test_base_cmd():
-
     # Create a test CLI runner
     runner = CliRunner()
     assert runner

--- a/tests/commands/update/test_update_groups_cmd.py
+++ b/tests/commands/update/test_update_groups_cmd.py
@@ -53,7 +53,7 @@ def test_update_groups(mock_app, tmpdir):
     assert updated_institute["phenotype_groups"]["HP:0000003"]["abbr"] == "ABBR1"
 
     # create a mock phenotype group file
-    phenotype_group_text = u"""#comment line\nHP:0000331\tABBR2\n"""
+    phenotype_group_text = """#comment line\nHP:0000331\tABBR2\n"""
     p = tmpdir.mkdir("sub").join("pheno_groups.csv")
     p.write(phenotype_group_text)
     assert p.read() == phenotype_group_text

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,7 +424,6 @@ def cancer_case_obj(request, cancer_parsed_case):
 
 @pytest.fixture(scope="function")
 def case_obj(request, parsed_case):
-
     case = parsed_case
     case["_id"] = parsed_case["case_id"]
     case["owner"] = parsed_case["owner"]
@@ -468,7 +467,6 @@ def case_obj(request, parsed_case):
 #############################################################
 @pytest.fixture(scope="function")
 def clinvar_variant(request):
-
     variant = {
         "_id": "internal_id_4c7d5c70d955875504db72ef8e1abe77",
         "csv_type": "variant",
@@ -496,7 +494,6 @@ def clinvar_variant(request):
 
 @pytest.fixture(scope="function")
 def clinvar_casedata(request):
-
     casedata = {
         "_id": "internal_id_4c7d5c70d955875504db72ef8e1abe77_NA12882",
         "csv_type": "casedata",

--- a/tests/load/test_load_case.py
+++ b/tests/load/test_load_case.py
@@ -1,5 +1,4 @@
 def test_load_case(case_obj, adapter):
-
     ## GIVEN a database with no cases
     assert adapter.case_collection.find_one() is None
 
@@ -11,7 +10,6 @@ def test_load_case(case_obj, adapter):
 
 
 def test_load_case_rank_model_version(case_obj, adapter):
-
     ## GIVEN a database with no cases
     assert adapter.case_collection.find_one() is None
 

--- a/tests/load/test_load_report.py
+++ b/tests/load/test_load_report.py
@@ -5,7 +5,6 @@ from scout.load.report import load_cnv_report, load_coverage_qc_report, load_del
 
 
 def test_load_delivery_report_bad_case_id(adapter):
-
     ## GIVEN no cases in database
     assert adapter.case_collection.find_one() is None
 
@@ -19,7 +18,6 @@ def test_load_delivery_report_bad_case_id(adapter):
 
 
 def test_load_delivery_report_using_case_id_without_update_fail(adapter, case_obj):
-
     adapter.case_collection.insert_one(case_obj)
     ## GIVEN a case exist, with a delivery report
     case_obj = adapter.case_collection.find_one()
@@ -43,7 +41,6 @@ def test_load_delivery_report_using_case_id_without_update_fail(adapter, case_ob
 
 
 def test_load_delivery_report_using_case_id_with_update_success(adapter, case_obj):
-
     adapter.case_collection.insert_one(case_obj)
     ## GIVEN a case exist, with a delivery report
     case_obj = adapter.case_collection.find_one()
@@ -67,7 +64,6 @@ def test_load_delivery_report_using_case_id_with_update_success(adapter, case_ob
 
 
 def test_load_cnv_report_using_case_id_with_update_success(adapter, cancer_case_obj):
-
     adapter.case_collection.insert_one(cancer_case_obj)
     ## GIVEN a case exist, with a delivery report
     cancer_case_obj = adapter.case_collection.find_one()
@@ -91,7 +87,6 @@ def test_load_cnv_report_using_case_id_with_update_success(adapter, cancer_case_
 
 
 def test_load_coverage_qc_report_using_case_id_with_update_success(adapter, cancer_case_obj):
-
     adapter.case_collection.insert_one(cancer_case_obj)
     ## GIVEN a case exist, with a delivery report
     cancer_case_obj = adapter.case_collection.find_one()

--- a/tests/parse/test_parse_clnsig.py
+++ b/tests/parse/test_parse_clnsig.py
@@ -236,7 +236,6 @@ def test_is_pathogenic_no_annotation(cyvcf2_variant):
 
 
 def test_is_pathogenic_VEP97_conflicting(one_vep97_annotated_variant):
-
     ## WHEN checking if variants should be loaded
     pathogenic = is_pathogenic(one_vep97_annotated_variant)
 

--- a/tests/parse/test_parse_conservation.py
+++ b/tests/parse/test_parse_conservation.py
@@ -45,7 +45,6 @@ def test_parse_conservations(cyvcf2_variant):
 
 
 def test_parse_conservation_csq(transcript_info):
-
     ## GIVEN a trascript with multiple conservation annotations
     keys = ["gerp", "phast", "phylop"]
     csq_entry = """0&4.6|0.8|2.4,0&4.6|0.8|2.4"""

--- a/tests/parse/test_parse_exac_genes.py
+++ b/tests/parse/test_parse_exac_genes.py
@@ -12,7 +12,6 @@ def test_parse_exac_line(exac_handle):
 
 
 def test_parse_exac_genes(exac_handle):
-
     genes = parse_exac_genes(exac_handle)
 
     for gene in genes:

--- a/tests/parse/test_parse_genotype.py
+++ b/tests/parse/test_parse_genotype.py
@@ -44,7 +44,6 @@ def test_parse_genotypes(variants):
     case["individuals"] = [individuals[ind_id] for ind_id in individuals]
     ## WHEN parsing the variants genotypes
     for variant in variants:
-
         ## THEN assert genotypes are parsed correct
 
         genotypes = parse_genotypes(variant, case["individuals"], ind_positions)

--- a/tests/parse/test_parse_omim.py
+++ b/tests/parse/test_parse_omim.py
@@ -35,7 +35,6 @@ def test_parse_genemap2_phenotype_entry_single():
 
 
 def test_parse_genemap(genemap_lines):
-
     for res in parse_genemap2(genemap_lines):
         assert res["Chromosome"] == "chr1"
         assert res["mim_number"] == 615291

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -84,7 +84,6 @@ def test_set_cloud_public_tracks(app):
     build = "37"
 
     with app.test_client() as client:
-
         # GIVEN that the user could be logged in
         client.get(url_for("auto_login"))
 

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -26,7 +26,6 @@ def test_igv(app, user_obj, case_obj):
     # GIVEN an initialized app
     # GIVEN a valid user and institute
     with app.test_client() as client:
-
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200

--- a/tests/server/blueprints/cases/test_cases_utils.py
+++ b/tests/server/blueprints/cases/test_cases_utils.py
@@ -7,7 +7,6 @@ from scout.constants import SAMPLE_SOURCE
 def test_update_individuals_table(app, case_obj, institute_obj):
     # GIVEN an initialized app
     with app.test_client() as client:
-
         # WHEN collecting the individuals_table jinja macro
         macro = get_template_attribute("cases/individuals_table.html", "individuals_table")
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -74,7 +74,6 @@ def test_reanalysis(app, institute_obj, case_obj, mocker, mock_redirect):
 
     # WHEN the rerun is triggered using the reanalysis endpoint
     with app.test_client() as client:
-
         json_string = '[{"sample_id": "NA12882", "sex": 1, "phenotype": 2}]'
         data = {"sample_metadata": json_string}
 
@@ -161,7 +160,6 @@ def test_parse_raw_gene_ids(app):
 def test_update_cancer_case_sample(
     app, user_obj, institute_obj, cancer_case_obj, mocker, mock_redirect
 ):
-
     mocker.patch("scout.server.blueprints.cases.views.redirect", return_value=mock_redirect)
 
     # GIVEN an initialized app
@@ -310,7 +308,6 @@ def test_case_sma(app, case_obj, institute_obj):
 
 
 def test_update_individual(app, user_obj, institute_obj, case_obj, mocker, mock_redirect):
-
     mocker.patch("scout.server.blueprints.cases.views.redirect", return_value=mock_redirect)
     # GIVEN an initialized app
     # GIVEN a valid user and institute
@@ -321,7 +318,6 @@ def test_update_individual(app, user_obj, institute_obj, case_obj, mocker, mock_
     assert case_obj["individuals"][0]["tissue_type"] == "blood"
 
     with app.test_client() as client:
-
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200
@@ -360,7 +356,6 @@ def test_update_individual(app, user_obj, institute_obj, case_obj, mocker, mock_
 
 
 def test_case_synopsis(app, institute_obj, case_obj, mocker, mock_redirect):
-
     mocker.patch("scout.server.blueprints.cases.views.redirect", return_value=mock_redirect)
 
     # GIVEN an initialized app
@@ -699,7 +694,6 @@ def test_mt_report(app, institute_obj, case_obj):
 
 
 def test_status(app, institute_obj, case_obj, user_obj, mocker, mock_redirect):
-
     mocker.patch("scout.server.blueprints.cases.views.redirect", return_value=mock_redirect)
 
     # GIVEN an initialized app
@@ -749,7 +743,6 @@ def _test_delivery_report(client, institute_obj, case_obj, response_format):
 
 
 def test_html_delivery_report(app, institute_obj, case_obj, user_obj):
-
     # GIVEN an initialized app
     # GIVEN a valid user and institute
     with app.test_client() as client:
@@ -763,7 +756,6 @@ def test_html_delivery_report(app, institute_obj, case_obj, user_obj):
 
 
 def test_pdf_delivery_report(app, institute_obj, case_obj, user_obj):
-
     # GIVEN an initialized app
     # GIVEN a valid user and institute
     with app.test_client() as client:

--- a/tests/server/blueprints/dashboard/test_dashboard_controllers.py
+++ b/tests/server/blueprints/dashboard/test_dashboard_controllers.py
@@ -15,7 +15,6 @@ def test_institute_select_choices(user_obj, app):
 
     # GIVEN an app with a logged user
     with app.test_client() as client:
-
         resp = client.get(url_for("auto_login"))
 
         # WHEN returning the institute institute select choices

--- a/tests/server/blueprints/diagnoses/test_diagnoses_views.py
+++ b/tests/server/blueprints/diagnoses/test_diagnoses_views.py
@@ -13,7 +13,6 @@ def test_omim_diagnosis(app, test_omim_term):
 
     # GIVEN an initialized app
     with app.test_client() as client:
-
         # WHEN accessing the page of one OMIM diagnosis
         resp = client.get(url_for("diagnoses.omim_diagnosis", omim_nr=test_omim_term["disease_nr"]))
 

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -396,7 +396,6 @@ def test_institute_settings(app, user_obj, institute_obj):
     # GIVEN an initialized app
     # GIVEN a valid user and institute
     with app.test_client() as client:
-
         client.get(url_for("auto_login"))
 
         # WHEN accessing the cases page (GET method)
@@ -674,7 +673,6 @@ def test_causatives(app, user_obj, institute_obj, case_obj):
 
     # Call scout causatives view and check if the above causatives are displayed
     with app.test_client() as client:
-
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200

--- a/tests/server/blueprints/login/test_views.py
+++ b/tests/server/blueprints/login/test_views.py
@@ -49,7 +49,6 @@ def test_ldap_login(ldap_app, user_obj, monkeypatch):
 
     # GIVEN an initialized app with LDAP config params
     with ldap_app.test_client() as client:
-
         # When submitting LDAP username and password
         form_data = {"username": "test_user", "password": "test_password"}
         resp = client.post(url_for("login.login", **form_data))

--- a/tests/server/blueprints/phenotypes/test_phenotypes_controllers.py
+++ b/tests/server/blueprints/phenotypes/test_phenotypes_controllers.py
@@ -4,7 +4,6 @@ from scout.server.blueprints.phenotypes import controllers
 
 
 def test_hpo_terms(real_adapter, hpo_term):
-
     adapter = real_adapter
 
     ## GIVEN a adapter with one hpo term

--- a/tests/server/blueprints/phenotypes/test_phenotypes_views.py
+++ b/tests/server/blueprints/phenotypes/test_phenotypes_views.py
@@ -19,7 +19,6 @@ def test_phenotypes(app, institute_obj):
 
 
 def test_phenotypes_api(app, real_adapter, hpo_term):
-
     adapter = real_adapter
     # GIVEN a database with an HPO term
     adapter.load_hpo_term(hpo_term)
@@ -33,7 +32,6 @@ def test_phenotypes_api(app, real_adapter, hpo_term):
 
 
 def test_phenotypes_api(app, real_adapter, hpo_term):
-
     adapter = real_adapter
     # GIVEN a database with an HPO term
     adapter.load_hpo_term(hpo_term)

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -302,7 +302,6 @@ def test_variant_controller_with_compounds(app, institute_obj, case_obj):
 
 
 def test_variant_controller_with_clnsig(app, institute_obj, case_obj):
-
     ## GIVEN a populated database with a variant
     variant_obj = store.variant_collection.find_one({"clnsig": {"$exists": True}})
     assert variant_obj
@@ -336,7 +335,6 @@ def test_variant_controller_with_clnsig(app, institute_obj, case_obj):
 
 
 def test_variant_controller(app, institute_obj, case_obj, variant_obj):
-
     ## GIVEN a populated database with a variant
     category = "snv"
     with app.test_client() as client:

--- a/tests/server/blueprints/variant/test_variant_utils.py
+++ b/tests/server/blueprints/variant/test_variant_utils.py
@@ -15,10 +15,8 @@ from scout.server.blueprints.variant.utils import (
 
 
 def test_modal_causative(app, case_obj, institute_obj, variant_obj):
-
     # GIVEN an initialized app
     with app.test_client() as client:
-
         # WHILE collection a specific jinja macro
         macro = get_template_attribute("variant/utils.html", "modal_causative")
         # and passing to it the required parameters

--- a/tests/server/blueprints/variant/test_variant_views.py
+++ b/tests/server/blueprints/variant/test_variant_views.py
@@ -8,10 +8,8 @@ from scout.server.extensions import store
 
 
 def test_acmg(app):
-
     # GIVEN an initialized app
     with app.test_client() as client:
-
         # the acmg endpoint endpoint should return an acmg json file
         resp = client.get("/api/v1/acmg")
         assert resp.status_code == 200
@@ -41,7 +39,6 @@ def test_variant(app, institute_obj, case_obj, variant_obj):
 
 
 def test_cancer_variant(app, cancer_case_obj, cancer_variant_obj):
-
     # GIVEN a cancer case object with a variant saved in database
     assert store.case_collection.insert_one(cancer_case_obj)
     assert store.variant_collection.insert_one(cancer_variant_obj)
@@ -173,7 +170,6 @@ def test_edit_variants_comments(
 def test_variant_update_cancer_tier(
     app, case_obj, variant_obj, institute_obj, mocker, mock_redirect
 ):
-
     mocker.patch("scout.server.blueprints.variant.views.redirect", return_value=mock_redirect)
     # GIVEN an initialized app
     # GIVEN a valid user and institute

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -9,7 +9,6 @@ from scout.server.extensions import store
 
 
 def test_variants_clinical_filter(app, institute_obj, case_obj, mocker, mock_redirect):
-
     mocker.patch("scout.server.blueprints.variants.views.redirect", return_value=mock_redirect)
 
     # GIVEN a variant without clinVar annotations

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -129,6 +129,7 @@ def test_loqusdb_api_cases(loqus_api_app, monkeypatch):
     """Test fetching info on number of cases from loqusdb API"""
     nr_snvs = 15
     nr_svs = 12
+
     # GIVEN a mocked loqus API
     def mockapi(*args):
         return {"content": {"nr_cases_snvs": nr_snvs, "nr_cases_svs": nr_svs}, "status_code": 200}

--- a/tests/server/extensions/test_loqusdb_exe_extension.py
+++ b/tests/server/extensions/test_loqusdb_exe_extension.py
@@ -159,6 +159,7 @@ def test_loqusdb_exe_cases(loqus_exe_app, monkeypatch):
 
 def test_loqusdb_exe_cases_ValueError(loqus_exe_app, monkeypatch):
     """Test the case count function in loqus extension"""
+
     # GIVEN a return value from loqusdb which is not an int
     def mockcommand(*args):
         return "nonsense"
@@ -172,6 +173,7 @@ def test_loqusdb_exe_cases_ValueError(loqus_exe_app, monkeypatch):
 
 def test_loqusdb_exe_case_count_CalledProcessError(loqus_exe_app, monkeypatch):
     """Test the case count function in loqus extension that raises an exception"""
+
     # GIVEN replacing subprocess.check_output to raise CalledProcessError
     def mockcommand(*args):
         raise subprocess.CalledProcessError(123, "case_count")

--- a/tests/server/test_server_utils.py
+++ b/tests/server/test_server_utils.py
@@ -46,7 +46,6 @@ def test_find_index_bai():
     # bam_file.bai
     with tempfile.TemporaryDirectory() as tmpdirname:
         with tempfile.NamedTemporaryFile(dir=tmpdirname, suffix=".bai") as idx:
-
             bam_file = idx.name.replace(".bai", ".bam")
             # THEN the find_index function should return the correct index file
             index = find_index(bam_file)
@@ -61,7 +60,6 @@ def test_find_index_bam_bai():
     # bam_file.bam.bai
     with tempfile.TemporaryDirectory() as tmpdirname:
         with tempfile.NamedTemporaryFile(dir=tmpdirname, suffix="bam.bai") as idx:
-
             bam_file = idx.name.replace(".bai", "")
             # THEN the find_index function should return the correct index file
             index = find_index(bam_file)
@@ -75,7 +73,6 @@ def test_find_index_crai():
     # bam_file.crai
     with tempfile.TemporaryDirectory() as tmpdirname:
         with tempfile.NamedTemporaryFile(dir=tmpdirname, suffix=".crai") as idx:
-
             cram_file = idx.name.replace(".crai", ".cram")
             # THEN the find_index function should return the correct index file
             index = find_index(cram_file)
@@ -90,7 +87,6 @@ def test_find_index_cram_crai():
     # bam_file.cram.crai
     with tempfile.TemporaryDirectory() as tmpdirname:
         with tempfile.NamedTemporaryFile(dir=tmpdirname, suffix="cram.crai") as idx:
-
             cram_file = idx.name.replace(".crai", "")
             # THEN the find_index function should return the correct index file
             index = find_index(cram_file)

--- a/tests/update/test_update_panel.py
+++ b/tests/update/test_update_panel.py
@@ -115,6 +115,5 @@ def test_update_panel_version_multiple(adapter, case_obj, testpanel_obj):
     assert updated_panel_obj["version"] == new_panel_version
 
     for case_obj in adapter.case_collection.find():
-
         for panel in case_obj["panels"]:
             assert panel["version"] == new_panel_version


### PR DESCRIPTION
This PR removes the method that was used to call the Netlify function that tracks the browser version used.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
