### PR TITLE
Fix admin docs to run docker scout on Mac - Arm processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
+- Command howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`
 
 ## [4.70]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
-- Command howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`
+- Howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`
 
 ## [4.70]
 ### Added

--- a/docs/admin-guide/containers/container-deploy.md
+++ b/docs/admin-guide/containers/container-deploy.md
@@ -23,7 +23,7 @@ Where `--tag <name>:<tag>` will name and optional tag the Docker Image.
 
 The container with the docker image contains only the app installation files and its required libraries. In order to work, the container must interact with a MongoDB database. This database could be either launched as another Docker image or could run as a mongod instance on your computer or on a remote server.
 
-	
+
 
 ## Running a Scout web app using a Docker image
 
@@ -35,11 +35,11 @@ docker run --net=host --rm --expose 5000 -p 5000:5000 clinicalgenomics/scout sco
 
 From a Mac machine the same command would be slightly different (the reason is described [here](https://docs.docker.com/desktop/mac/networking/)):
 ```
-docker run --rm --expose 5000 -p 5000:5000 clinicalgenomics/scout scout --host docker.for.mac.localhost -db scout-demo  serve --host 0.0.0.0
+docker run --platform=linux/amd64 --rm --expose 5000 -p 5000:5000 clinicalgenomics/scout scout --host docker.for.mac.localhost -db scout-demo  serve --host 0.0.0.0
 ```
 
 ### Anatomy of Run Command
-The basic structure of the run command is: 
+The basic structure of the run command is:
 ```
 docker run <image> <command>
 ```
@@ -93,7 +93,7 @@ services:
 ```
 
 ### Miscellaneous Tips
-	
+
 * View all installed images together with onfo and names: `docker image -a`
 * View all containers: `docker container ls -a`
 * Stop a running image: `docker stop <container name>`


### PR DESCRIPTION
Out docs state that to run a dockerized version of scout on Mac you should use the following command:

`docker run --rm --expose 5000 -p 5000:5000 clinicalgenomics/scout scout --host docker.for.mac.localhost -db scout-demo  serve --host 0.0.0.0`

But the image is compiled under linux and using a recent version of Docker the command fails with the error:

```
WARNING: image with reference clinicalgenomics/scout was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64
docker: Error response from daemon: image with reference clinicalgenomics/scout was found but does not match the specified platform: wanted linux/arm64, actual: linux/amd64.
```

<img width="1248" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/890f78b0-668c-481a-a2b4-8c5feaa16772">


This is a simple fix to the docs so it's running again on Mac (arm) computers:

<img width="1276" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/7f1312fa-4497-4d35-9f3f-8cb35807368b">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
