### PR TITLE
Balsamic frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Added Balsamic keys for SweGen and loqusdb local archive frequecies, SNV and SV
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
 - Howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -101,6 +101,14 @@ def build_variant(
         local_obs_old = int,
         local_obs_hom_old = int,
         local_obs_old_freq = float,
+        # cancer caller (balsamic) loqusdb frequencies
+        local_obs_cancer_germline_old=int, # germline counts
+        local_obs_cancer_germline_hom_old=int, # germline counts for homoz
+        local_obs_cancer_germline_old_freq=float, # germline frequency
+
+        local_obs_cancer_somatic_old=int,# somatic counts
+        local_obs_cancer_somatic_hom_old=int, # somatic counts for homoz
+        local_obs_cancer_somatic_old_freq=float, # somatic frequency
 
         # Predicted deleteriousness:
         cadd_score = float,

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -249,6 +249,22 @@ def build_variant(
     variant_obj["local_obs_old_desc"] = variant.get("local_obs_old_desc")
     variant_obj["local_obs_old_nr_cases"] = variant.get("local_obs_old_nr_cases")
 
+    # local observations from cancer pipeline
+    variant_obj["local_obs_cancer_germline_old"] = variant.get("local_obs_cancer_germline_old")
+    variant_obj["local_obs_cancer_somatic_old"] = variant.get("local_obs_cancer_somatic_old")
+    variant_obj["local_obs_cancer_germline_hom_old"] = variant.get(
+        "local_obs_cancer_germline_hom_old"
+    )
+    variant_obj["local_obs_cancer_somatic_hom_old"] = variant.get(
+        "local_obs_cancer_somatic_hom_old"
+    )
+    variant_obj["local_obs_cancer_germline_old_freq"] = variant.get(
+        "local_obs_cancer_germline_old_freq"
+    )
+    variant_obj["local_obs_cancer_somatic_old_freq"] = variant.get(
+        "local_obs_cancer_somatic_old_freq"
+    )
+
     ##### Add the severity predictors #####
     variant_obj["cadd_score"] = variant.get("cadd_score")
     variant_obj["revel_score"] = variant.get("revel_score")

--- a/scout/models/variant/variant.py
+++ b/scout/models/variant/variant.py
@@ -70,6 +70,12 @@ variant = dict(
     local_obs_old_desc=str,
     local_obs_old_nr_cases=int,
     local_obs_old_date=str,
+    local_obs_cancer_germline_old=int,
+    local_obs_cancer_germline_hom_old=int,
+    local_obs_cancer_germline_old_freq=float,
+    local_obs_cancer_somatic_old=int,
+    local_obs_cancer_somatic_hom_old=int,
+    local_obs_cancer_somatic_old_freq=float,
     # Predicted deleteriousness:
     cadd_score=float,
     clnsig=list,  # list of <clinsig>

--- a/scout/parse/variant/frequency.py
+++ b/scout/parse/variant/frequency.py
@@ -2,6 +2,8 @@ from typing import Dict
 
 import cyvcf2
 
+swegen_keys = ["swegen", "swegenAF", "SWEGENAF"]
+
 
 def parse_frequencies(variant, transcripts):
     """Add the frequencies to a variant
@@ -23,8 +25,6 @@ def parse_frequencies(variant, transcripts):
 
     exac_keys = ["EXACAF"]
     exac_max_keys = ["ExAC_MAX_AF", "EXAC_MAX_AF"]
-
-    swegen_keys = ["swegen", "swegenAF", "SWEGENAF"]
 
     # Gnomad have both snv and sv frequencies
     gnomad_keys = ["GNOMADAF", "GNOMAD_AF", "gnomad_svAF"]
@@ -98,7 +98,7 @@ def parse_sv_frequencies(variant: cyvcf2.Variant) -> Dict:
     ]
 
     clingen_ngi_keys = ["clingen_ngi", "clingen_ngiAF", "clingen_ngiOCC"]
-    swegen_keys = ["swegen", "swegenAF", "SWEGENAF"]
+
     decipher_keys = ["decipherAF", "decipher"]
     cg_keys = ["clinical_genomics_mipAF", "clinical_genomics_mipOCC"]
 

--- a/scout/parse/variant/frequency.py
+++ b/scout/parse/variant/frequency.py
@@ -24,6 +24,8 @@ def parse_frequencies(variant, transcripts):
     exac_keys = ["EXACAF"]
     exac_max_keys = ["ExAC_MAX_AF", "EXAC_MAX_AF"]
 
+    swegen_keys = ["swegen", "swegenAF", "SWEGENAF"]
+
     # Gnomad have both snv and sv frequencies
     gnomad_keys = ["GNOMADAF", "GNOMAD_AF", "gnomad_svAF"]
     gnomad_max_keys = ["GNOMADAF_popmax", "GNOMADAF_POPMAX", "GNOMADAF_MAX"]
@@ -31,6 +33,7 @@ def parse_frequencies(variant, transcripts):
     update_frequency_from_vcf(frequencies, variant, exac_keys, "exac")
     update_frequency_from_vcf(frequencies, variant, exac_max_keys, "exac_max")
     update_frequency_from_vcf(frequencies, variant, gnomad_keys, "gnomad")
+    update_frequency_from_vcf(frequencies, variant, swegen_keys, "swegen")
     update_frequency_from_vcf(frequencies, variant, gnomad_max_keys, "gnomad_max")
     update_frequency_from_vcf(frequencies, variant, thousand_genomes_keys, "thousand_g")
     update_frequency_from_vcf(frequencies, variant, thousand_genomes_max_keys, "thousand_g_max")
@@ -95,7 +98,7 @@ def parse_sv_frequencies(variant: cyvcf2.Variant) -> Dict:
     ]
 
     clingen_ngi_keys = ["clingen_ngi", "clingen_ngiAF", "clingen_ngiOCC"]
-    swegen_keys = ["swegen", "swegenAF"]
+    swegen_keys = ["swegen", "swegenAF", "SWEGENAF"]
     decipher_keys = ["decipherAF", "decipher"]
     cg_keys = ["clinical_genomics_mipAF", "clinical_genomics_mipOCC"]
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -179,7 +179,11 @@ def parse_variant(
     parsed_variant["frequencies"] = frequencies
 
     # SNVs contain INFO field Obs, SVs contain clinical_genomics_loqusObs
-    local_obs_old = variant.INFO.get("Obs") or variant.INFO.get("clinical_genomics_loqusObs")
+    local_obs_old = (
+        variant.INFO.get("Obs")
+        or variant.INFO.get("clinical_genomics_loqusObs")
+        or variant.INFO.get("clin_obs")
+    )
     if local_obs_old:
         parsed_variant["local_obs_old"] = int(local_obs_old)
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -191,9 +191,8 @@ def parse_variant(
     parsed_variant["local_obs_hom_old"] = call_safe(int, variant.INFO.get("Hom"))
 
     # SVs only
-    parsed_variant["local_obs_old_freq"] = call_safe(
-        float, variant.INFO.get("clinical_genomics_loqusFrq")
-    )
+    local_frq_old = variant.INFO.get("clinical_genomics_loqusFrq") or variant.INFO.get("Frq")
+    parsed_variant["local_obs_old_freq"] = call_safe(float, local_frq_old)
     set_local_archive_info(parsed_variant, local_archive_info)
 
     ###################### Add severity predictions ######################

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -178,6 +178,9 @@ def parse_variant(
 
     parsed_variant["frequencies"] = frequencies
 
+    # loqus archive frequencies
+
+    # RD germline, for MIP and Balsamic
     # SNVs contain INFO field Obs, SVs contain clinical_genomics_loqusObs
     local_obs_old = (
         variant.INFO.get("Obs")
@@ -194,6 +197,27 @@ def parse_variant(
     local_frq_old = variant.INFO.get("clinical_genomics_loqusFrq") or variant.INFO.get("Frq")
     parsed_variant["local_obs_old_freq"] = call_safe(float, local_frq_old)
     set_local_archive_info(parsed_variant, local_archive_info)
+
+    # Cancer (Balsamic) Germline and Somatic loqus archives
+    parsed_variant["local_obs_cancer_germline_old"] = call_safe(
+        int, variant.INFO.get("Cancer_Germline_Obs")
+    )
+    parsed_variant["local_obs_cancer_germline_hom_old"] = call_safe(
+        int, variant.INFO.get("Cancer_Germline_Hom")
+    )
+    parsed_variant["local_obs_cancer_germline_old_freq"] = call_safe(
+        float, variant.INFO.get("Cancer_Germline_Frq")
+    )
+
+    parsed_variant["local_obs_cancer_somatic_old"] = call_safe(
+        int, variant.INFO.get("Cancer_Somatic_Obs")
+    )
+    parsed_variant["local_obs_cancer_somatic_hom_old"] = call_safe(
+        int, variant.INFO.get("Cancer_Somatic_Hom")
+    )
+    parsed_variant["local_obs_cancer_somatic_old_freq"] = call_safe(
+        float, variant.INFO.get("Cancer_Somatic_Frq")
+    )
 
     ###################### Add severity predictions ######################
     parsed_variant["cadd_score"] = parse_cadd(variant, parsed_transcripts)

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -202,6 +202,7 @@
       <table class="table">
         <thead class="thead table-light">
           <tr>
+            <th scope="col">Archive</th>
             <th scope="col">Nr obs.</th>
             <th scope="col">Nr homo.</th>
             <th scope="col">Frequency</th>
@@ -209,10 +210,25 @@
         </thead>
         <tbody>
           <tr>
+            <td>RD</td>
             <td>{{ variant.local_obs_old|default('N/A') }}</td>
             <td>{{ variant.local_obs_hom_old|default('N/A') }}</td>
             <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% elif variant.local_obs_old_nr_cases and variant.local_obs_old %} {{ (variant.local_obs_old/variant.local_obs_old_nr_cases)|round(5) }} {% elif variant.local_obs_old_nr_cases %} 0 / {{variant.local_obs_old_nr_cases}} {% else %} N/A {% endif %}</td>
           </tr>
+          {% if variant.category == "cancer" %}
+            <tr>
+              <td>Cancer Germline</td>
+              <td>{{ variant.local_obs_cancer_germline_old|default('N/A') }}</td>
+              <td>{{ variant.local_obs_cancer_germline_hom_old|default('N/A') }}</td>
+              <td>{% if variant.local_obs_cancer_germline_old_freq %} {{variant.local_obs_cancer_germline_old_freq|round(6)}} {% elif variant.local_obs_cancer_germline_old_nr_cases and variant.local_obs_cancer_germline_old %} {{ (variant.local_obs_cancer_germline_old/variant.local_obs_cancer_germline_old_nr_cases)|round(5) }} {% elif variant.local_obs_cancer_germline_old_nr_cases %} 0 / {{variant.local_obs_cancer_germline_old_nr_cases}} {% else %} N/A {% endif %}</td>
+            </tr>
+            <tr>
+              <td>Cancer Somatic</td>
+              <td>{{ variant.local_obs_cancer_somatic_old|default('N/A') }}</td>
+              <td>{{ variant.local_obs_cancer_somatic_hom_old|default('N/A') }}</td>
+              <td>{% if variant.local_obs_cancer_somatic_old_freq %} {{variant.local_obs_cancer_somatic_old_freq|round(6)}} {% elif variant.local_obs_cancer_somatic_old_nr_cases and variant.local_obs_cancer_somatic_old %} {{ (variant.local_obs_cancer_somatic_old/variant.local_obs_cancer_somatic_old_nr_cases)|round(5) }} {% elif variant.local_obs_cancer_somatic_old_nr_cases %} 0 / {{variant.local_obs_cancer_somatic_old_nr_cases}} {% else %} N/A {% endif %}</td>
+            </tr>
+          {% endif %}
         </tbody>
       </table>
     </div>

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -389,6 +389,7 @@ def frequencies(variant_obj):
                 "display_name": "ExAC(max)",
                 "link": variant_obj.get("exac_link"),
             },
+            "swegen": {"display_name": "SweGen", "link": variant_obj.get("swegen_link")},
             "gnomad_mt_homoplasmic_frequency": {
                 "display_name": "GnomAD MT, homoplasmic",
                 "link": variant_obj.get("gnomad_link"),

--- a/tests/parse/test_frequency.py
+++ b/tests/parse/test_frequency.py
@@ -44,6 +44,7 @@ def test_parse_frequencies(cyvcf2_variant):
     # GIVEN a variant dict with a differenct frequencies
     variant.INFO["1000GAF"] = "0.01"
     variant.INFO["EXACAF"] = "0.001"
+    variant.INFO["SWEGENAF"] = "0.02"
 
     # WHEN frequencies are parsed
     frequencies = parse_frequencies(variant, [])
@@ -51,6 +52,7 @@ def test_parse_frequencies(cyvcf2_variant):
     # THEN the frequencies should be returned in a dictionary
     assert frequencies["thousand_g"] == float(variant.INFO["1000GAF"])
     assert frequencies["exac"] == float(variant.INFO["EXACAF"])
+    assert frequencies["swegen"] == float(variant.INFO["SWEGENAF"])
 
 
 def test_parse_sv_frequencies_clingen_benign(cyvcf2_variant):


### PR DESCRIPTION
This PR adds a functionality: archive loqus frequencies for Balsamic, plus reintroduction of Swegen frequencies since Balsamic has them. Balsamic cases will be annotated with three different loqus archives:
- RD (germline) - essentially same as RD, with slightly different key names
- Cancer Germline - loqus archive for Balsamic calls for normal samples
- Cancer Somatic - loqus archive for Balsamic calls for somatic samples

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by
