### PR TITLE
Fix #2786 - constrain variant_type on variantS view requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to Weasyprint installation howto in README file
 - Avoid filling up disk by creating a reduced VCF file for every variant that is visualized
 - Remove legacy incorrectly formatted CODEOWNERS file
+- Restrain variant_type requests to variantS views to "clinical" or "research"
 ### Changed
 - Remove function call that tracks users' browser version
 - Include three more splice variant SO terms in clinical filter severe SO terms

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -50,6 +50,9 @@ def variants(institute_id, case_name):
     variant_type = Markup.escape(
         request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
+    if variant_type not in ["clinical", "research"]:
+        variant_type = "clinical"
+
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
     if request.form.get("hpo_clinical_filter"):
@@ -159,6 +162,8 @@ def str_variants(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
 
     variant_type = Markup.escape(request.args.get("variant_type", "clinical"))
+    if variant_type not in ["clinical", "research"]:
+        variant_type = "clinical"
 
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
@@ -245,6 +250,8 @@ def sv_variants(institute_id, case_name):
     variant_type = Markup.escape(
         request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
+    if variant_type not in ["clinical", "research"]:
+        variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
     if request.form.get("hpo_clinical_filter"):
@@ -413,6 +420,8 @@ def cancer_variants(institute_id, case_name):
     variant_type = Markup.escape(
         request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
+    if variant_type not in ["clinical", "research"]:
+        variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
     user_obj = store.user(current_user.email)
@@ -517,6 +526,8 @@ def cancer_sv_variants(institute_id, case_name):
     variant_type = Markup.escape(
         request.args.get("variant_type", request.form.get("variant_type", "clinical"))
     )
+    if variant_type not in ["clinical", "research"]:
+        variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
     if request.form.get("hpo_clinical_filter"):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Before:
<img width="997" alt="Screenshot 2023-08-21 at 16 03 25" src="https://github.com/Clinical-Genomics/scout/assets/758570/2a8efe42-1a36-4945-b259-6a18939cd1f9">

After:
<img width="792" alt="Screenshot 2023-08-21 at 16 01 57" src="https://github.com/Clinical-Genomics/scout/assets/758570/2f569c76-29ed-43b5-9e8b-09088aa4dc90">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
