### PR TITLE
Fix #3110 - move score out of quality column somatic variantS and Fix…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Include three more splice variant SO terms in clinical filter severe SO terms
 - Drop old HPO term collection only after parsing of new one completes
 - Move score to own column on Cancer Somatic SNV variantS page
+-
 ## [4.70]
 ### Added
 - Download a list of Gene Variants (max 500) resulting from SNVs and Indels search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show annotated observations on SV variantS view, also for cancer somatic SVs
 - Revel filter for variantS
 - Show case default panel on caseS page
+- CADD filter for Cancer Somatic SNV variantS - show score
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
 - Howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`
@@ -21,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove function call that tracks users' browser version
 - Include three more splice variant SO terms in clinical filter severe SO terms
 - Drop old HPO term collection only after parsing of new one completes
-
+- Move score to own column on Cancer Somatic SNV variantS page
 ## [4.70]
 ### Added
 - Download a list of Gene Variants (max 500) resulting from SNVs and Indels search

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -105,7 +105,7 @@ class VariantFiltersForm(FlaskForm):
     clinsig = NonValidatingSelectMultipleField("ClinVar CLINSIG", choices=CLINSIG_OPTIONS)
 
     gnomad_frequency = BetterDecimalField("gnomadAF", places=2, validators=[validators.Optional()])
-    local_obs = IntegerField("Local obs. (archive)")
+    local_obs = IntegerField("Local obs. (archive)", validators=[validators.Optional()])
 
     filters = NonValidatingSelectField(choices=[], validators=[validators.Optional()])
     filter_display_name = StringField(default="")

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -55,9 +55,11 @@
               <th style="width:2%"></th>
               <th title="Gene">Gene</th>
               <th title="Variant" style="width:12%">HGVS[c/p]</th>
-              <th title="Assessments including variant tier">Assessment</th>
-              <th title="Rank score and quality markers">Quality</th>
-              <th title="Genomic coordinate" style="width:10%">Chr pos</th>
+              <th title="Assessments including variant tier" style="width:8%">Assessment</th>
+              <th title="Quality markers" style="width:6%">Qual</th>
+              <th title="Scores for Rank and CADD" style="width:4%">Rank</th>
+              <th title="CADD score" style="width:4%">CADD</th>
+              <th title="Genomic coordinate" style="width:8%">Chr pos</th>
               <th title="Population frequency">Pop Freq</th>
               <th title="Observed" style="width:7%">Observed</th>
               <th title="Variant type">Type</th>
@@ -108,7 +110,9 @@
               {{ causative_badge(variant, case) }}
               {{ other_tiered_variants(variant) }}
             </td>
-            <td>{{ score_cell(variant) }}</td>
+            <td>{{ quality_cell(variant) }}</td>
+            <td>{{ rank_cell(variant) }}</td>
+            <td>{{ cadd_cell(variant) }}</td>
             <td>{{ position_cell(variant) }}</td>
             <td class="text-end">{{ frequency_cell_general(variant) }}</td>
             <td>{{ observed_cell_general(variant) }}</td>
@@ -141,8 +145,7 @@
   {% endif %}
 {% endmacro %}
 
-
-{% macro score_cell(variant) %}
+{% macro rank_cell(variant) %}
   {% if variant.rank_score is defined %}
     {% if variant.rank_score <= 4 %}
       {% set label_class = 'secondary' %}
@@ -157,7 +160,24 @@
     {% endif %}
     <div class="badge bg-{{ label_class }}" data-bs-toggle="tooltip" data-bs-placement="top" title="Rank score">{{ variant.rank_score }}</div>
   {% endif %}
+{% endmacro %}
 
+{% macro cadd_cell(variant) %}
+  {% if variant.cadd_score %}
+    {% if variant.cadd_score <= 10 %}
+      {% set label_class = 'secondary' %}
+    {% elif variant.cadd_score <= 20 %}
+      {% set label_class = 'primary' %}
+    {% elif variant.cadd_score <= 25 %}
+      {% set label_class = 'warning' %}
+    {% elif variant.cadd_score > 29 %}
+      {% set label_class = 'danger' %}
+    {% endif %}
+    <div class="badge bg-{{ label_class }}" data-bs-toggle="tooltip" data-bs-placement="top" title="CADD score">{{ variant.cadd_score|round }}</div>
+  {% endif %}
+{% endmacro %}
+
+{% macro quality_cell(variant) %}
   {% for filter in variant.filters %}
     <div data-bs-toggle="tooltip" data-bs-placement="top" title="{{ filter.description }}" class="badge bg-{{ filter.label_class }}">{{ filter.label }}</div>
   {% endfor %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -57,8 +57,8 @@
               <th title="Variant" style="width:12%">HGVS[c/p]</th>
               <th title="Assessments including variant tier" style="width:8%">Assessment</th>
               <th title="Quality markers" style="width:6%">Qual</th>
-              <th title="Scores for Rank and CADD" style="width:4%">Rank</th>
-              <th title="CADD score" style="width:4%">CADD</th>
+              <th title="Rank scores" style="width:4%">Rank</th>
+              <th title="CADD scores" style="width:4%">CADD</th>
               <th title="Genomic coordinate" style="width:8%">Chr pos</th>
               <th title="Population frequency">Pop Freq</th>
               <th title="Observed" style="width:7%">Observed</th>


### PR DESCRIPTION
… #4049 - CADD scores for cancer SNVs

This PR adds a functionality or fixes a bug.

CADD scores are already supported, including filtering. Added a CADD display column for the cancer somatic SNV variantS. Also broke the rank score out of the quality cell when touching that part of the page.

![Screenshot 2023-08-21 at 16 53 25](https://github.com/Clinical-Genomics/scout/assets/758570/96ad531a-50ea-415f-a3f1-d2ccf2893082)

![Screenshot 2023-08-21 at 16 53 44](https://github.com/Clinical-Genomics/scout/assets/758570/26d62338-2baa-44e1-8c8a-b7a8d8326dfe)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
