### PR TITLE
Fix #4058 - add SpliceAI link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Revel filter for variantS
 - Show case default panel on caseS page
 - CADD filter for Cancer Somatic SNV variantS - show score
+- SpliceAI-lookup link (BROAD, shows SpliceAI and Pangolin) from variant page
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
 - Howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -288,7 +288,7 @@
           <span class="float-end">{{ variant.spidex_human }}</span>
         </li>
         <li class="list-group-item">
-          SpliceAI (<a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">Lookup</a>) <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>
+          <a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>
           <span class="float-end control-label" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
               title="<strong>
                 {% for entry in variant.spliceai_scores %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -288,7 +288,7 @@
           <span class="float-end">{{ variant.spidex_human }}</span>
         </li>
         <li class="list-group-item">
-          <a href="https://doi.org/10.1016/j.cell.2018.12.015" target="_blank">SpliceAI</a> (<a href="{{ variant.spliceai_link }}">Lookup</a>) <a href="https://github.com/Illumina/SpliceAI" target="_blank">DS max</a>
+          SpliceAI (<a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">Lookup</a>) <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>
           <span class="float-end control-label" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
               title="<strong>
                 {% for entry in variant.spliceai_scores %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -288,7 +288,7 @@
           <span class="float-end">{{ variant.spidex_human }}</span>
         </li>
         <li class="list-group-item">
-          <a href="https://doi.org/10.1016/j.cell.2018.12.015" target="_blank">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank">DS max</a>
+          <a href="https://doi.org/10.1016/j.cell.2018.12.015" target="_blank">SpliceAI</a> (<a href="{{ variant.spliceai_link }}">Lookup</a>) <a href="https://github.com/Illumina/SpliceAI" target="_blank">DS max</a>
           <span class="float-end control-label" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
               title="<strong>
                 {% for entry in variant.spliceai_scores %}

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -466,7 +466,7 @@ def get_variant_links(institute_obj, variant_obj, build=None):
         mitomap_link=mitomap_link(variant_obj),
         hmtvar_link=hmtvar_link(variant_obj),
         spidex_human=spidex_human(variant_obj),
-        spliceai_link=spliceai_link(variant_obj),
+        spliceai_link=spliceai_link(variant_obj, build),
         str_source_link=str_source_link(variant_obj),
         snp_links=snp_links(variant_obj),
     )

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -466,6 +466,7 @@ def get_variant_links(institute_obj, variant_obj, build=None):
         mitomap_link=mitomap_link(variant_obj),
         hmtvar_link=hmtvar_link(variant_obj),
         spidex_human=spidex_human(variant_obj),
+        spliceai_link=spliceai_link(variant_obj),
         str_source_link=str_source_link(variant_obj),
         snp_links=snp_links(variant_obj),
     )
@@ -557,6 +558,16 @@ def gnomad_link(variant_obj, build=37):
 
     if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
         url_template += "?dataset=gnomad_r3"
+
+    return url_template
+
+
+def spliceai_link(variant_obj, build=37):
+    """Compopse a link to BROADs SpliceAI Lookup for a somewhat live view of SpliceAI and Pangolin scores."""
+    url_template = (
+        "https://spliceailookup.broadinstitute.org/#variant={this[chromosome]}-"
+        "{this[position]}-{this[reference]}-{this[alternative]}&hg={build}&distance=500&mask=1"
+    ).format(this=variant_obj, build=build)
 
     return url_template
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Adds a link that in particular @47KW wanted. Aside from colouring the values, I think it will be useful for 1) compute on slightly larger indels 2) includes pangolin scores.

Links from here:
![Screenshot 2023-08-28 at 15 04 31](https://github.com/Clinical-Genomics/scout/assets/758570/d98553ce-f1f3-4bb7-82f4-dc913fb9a80f)

to here:
![Screenshot 2023-08-28 at 15 06 07](https://github.com/Clinical-Genomics/scout/assets/758570/2ac17623-463e-40cc-be92-74fd861c4acf)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
