### PR TITLE
Fix show FSHD button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show case default panel on caseS page
 - CADD filter for Cancer Somatic SNV variantS - show score
 - SpliceAI-lookup link (BROAD, shows SpliceAI and Pangolin) from variant page
-- BioNano Access server API - check projects, samples and fetch FSHD reports.
+- BioNano Access server API - check projects, samples and fetch FSHD reports
 ### Fixed
 - Name of reference genome build for RNA for compatibility with IGV locus search change
 - Howto to run the Docker image on Mac computers in `admin-guide/containers/container-deploy.md`
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ProteinPaint gene link (small StJude API change)
 - Causative MEI variant link on causatives page
 - Bionano access api settings commented out by default in Scout demo config file.
+- Do not show FSHD button on freshly loaded cases without bionano_access individuals
 ### Changed
 - Remove function call that tracks users' browser version
 - Include three more splice variant SO terms in clinical filter severe SO terms

--- a/scout/commands/update/individual.py
+++ b/scout/commands/update/individual.py
@@ -80,11 +80,13 @@ def individual(case_id, ind, key, value):
                 abort=True,
             )
 
-    # perform the update
+    # perform the update. Note that the keys that dig into dictionaries may have a parent exist and be None.
     for ind_obj in case_obj["individuals"]:
         if ind_obj["display_name"] == ind:
             if "." in key:
                 key_parts = key.split(".")
+                if not ind_obj[key_parts[0]]:
+                    ind_obj[key_parts[0]] = {}
                 ind_obj[key_parts[0]][key_parts[1]] = value
                 continue
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -256,7 +256,7 @@
         {% if case.smn_tsv %}
           <a class="btn btn-dark btn-sm text-white" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">SMN CN</a>
         {% endif %}
-        {% if case.individuals|rejectattr('bionano_access', 'undefined')|list|length > 0 %}
+        {% if case.individuals|rejectattr('bionano_access', 'undefined')|rejectattr('bionano_access', 'none')|list|length > 0 %}
           <a class="btn btn-dark btn-sm text-white" href="{{ url_for('cases.bionano', institute_id=institute._id, case_name=case.display_name) }}">BioNano FSHD</a>
         {% endif %}
         {% if case.vcf_files.vcf_cancer %}


### PR DESCRIPTION
Hide the FSHD button also if an individual has a None `bionano_access` property. Only show if a value really exists. 

This also fixes the `scout update individual` command with dot notation, when the first key has inadvertently been set to None, rather than not exist or be the empty Dict.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
