### PR TITLE
Revert Python to 3.8 in Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Case validation fails on loading when associated files (alignments, VCFs and reports) are not present on disk
 - Case validation fails on loading when custom images have format different then ["gif", "svg", "png", "jpg", "jpeg"]
 - Custom images keys `case` and `str` in case config yaml file are renamed to `case_images` and `srt_variants_images`
-- Upgrade python version from 3.8 to 3.11 in Docker images
 
 
 ## [4.71]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.11-venv:1.0 AS python-builder
+FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 
@@ -18,7 +18,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 #########
 # FINAL #
 #########
-FROM python:3.11-slim-bullseye
+FROM python:3.8-slim-bullseye
 
 LABEL about.home="https://github.com/Clinical-Genomics/scout"
 LABEL about.documentation="https://clinical-genomics.github.io/scout"

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.11-venv:1.0 AS python-builder
+FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir -r requirements.txt gunicorn
 #########
 # FINAL #
 #########
-FROM python:3.11-slim-bullseye
+FROM python:3.8-slim-bullseye
 
 LABEL about.home="https://github.com/Clinical-Genomics/scout"
 LABEL about.documentation="https://clinical-genomics.github.io/scout"


### PR DESCRIPTION
Fix #4101 -> Scout uses chanjo to handle coverage reports and chanjo depends on alchy, which doesn't support python 3.11, see [here](https://github.com/Clinical-Genomics/scout/issues/4101#issuecomment-1741051935)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy on cg-vm1 and go to a case page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
