### PR TITLE
Escape protein names in case general report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Documentation nav links for a few documents
 - Slightly extended the BioNano Genomics Access integration docs
 - Loading of SVs when VCF is missing the INFO.END field but has INFO.SVLEN field
+- Escape protein sequence name in case general report to render special characters correctly
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -254,7 +254,7 @@
 
         <!-- show transcript info only if it's canonical, disease-associated or primary (print max 5 primary transcripts) -->
       {% if transcript.refseq_identifiers and n_primary_txs.count <= 5 or transcript.is_canonical or transcript.is_disease_associated or transcript.is_primary %}
-        <li>{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name|safe or '')|truncate(20, True) }}
+        <li>{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name|url_decode or '')|truncate(20, True) }}
           {% if transcript.is_canonical %}
             <span class="badge rounded-pill bg-info text-white" title="canonical">C</span>
           {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -283,11 +283,11 @@
     {% set display_genes = [] %}
     {% for gene in variant.genes %}
       {% if gene.hgvs_identifier and gene.hgnc_symbol  %}
-        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
+        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier|truncate(20,True) }}
       {% elif gene.hgnc_symbol %}
           {{ "" if display_genes.append(gene.hgnc_symbol) }}
       {% elif gene.hgvs_identifier and gene.hgnc_id %}
-          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier) }}
+          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier|truncate(20,True) }}
       {% endif %}
     {% endfor %}
 

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -254,7 +254,7 @@
 
         <!-- show transcript info only if it's canonical, disease-associated or primary (print max 5 primary transcripts) -->
       {% if transcript.refseq_identifiers and n_primary_txs.count <= 5 or transcript.is_canonical or transcript.is_disease_associated or transcript.is_primary %}
-        <li>{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name or '')|truncate(20, True) }}
+        <li>{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name|safe or '')|truncate(20, True) }}
           {% if transcript.is_canonical %}
             <span class="badge rounded-pill bg-info text-white" title="canonical">C</span>
           {% endif %}
@@ -283,11 +283,11 @@
     {% set display_genes = [] %}
     {% for gene in variant.genes %}
       {% if gene.hgvs_identifier and gene.hgnc_symbol  %}
-        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
+        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier) }}
       {% elif gene.hgnc_symbol %}
           {{ "" if display_genes.append(gene.hgnc_symbol) }}
       {% elif gene.hgvs_identifier and gene.hgnc_id %}
-          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
+          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier) }}
       {% endif %}
     {% endfor %}
 

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -283,11 +283,11 @@
     {% set display_genes = [] %}
     {% for gene in variant.genes %}
       {% if gene.hgvs_identifier and gene.hgnc_symbol  %}
-        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier|truncate(20,True) }}
+        {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
       {% elif gene.hgnc_symbol %}
           {{ "" if display_genes.append(gene.hgnc_symbol) }}
       {% elif gene.hgvs_identifier and gene.hgnc_id %}
-          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier|truncate(20,True) }}
+          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
       {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
Fix #4104

Same case as in issue, after the fix:

<img width="346" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/f4de20da-9a19-4f67-a31f-ebfebd7fbc44">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR
