### PR TITLE
Fix parsing of disease-associated HPO phenotypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - CaseS search regexp should not allow backslash
 - CaseS cohort tags can contain whitespace and still match
 - Remove diagnoses from cases even if OMIM term is not found in the database
+- Parsing of disease-associated HPO terms
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - CaseS search regexp should not allow backslash
 - CaseS cohort tags can contain whitespace and still match
 - Remove diagnoses from cases even if OMIM term is not found in the database
+<<<<<<< HEAD
 - Parsing of disease-associated HPO terms
+=======
+- Parsing of HPO terms associated to OMIM diagnoses
+>>>>>>> f915f1a13af58f772553ee7f4774e5c68d6290f6
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/scout/load/hpo.py
+++ b/scout/load/hpo.py
@@ -1,9 +1,10 @@
 import logging
 from datetime import datetime
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List, Optional
 
 from click import progressbar
 
+from scout.adapter import MongoAdapter
 from scout.build.disease import build_disease_term
 from scout.build.hpo import build_hpo_term
 from scout.models.phenotype_term import HpoTerm
@@ -65,6 +66,38 @@ def load_hpo(
     )
 
 
+def _set_hpo_terms_genes(
+    adapter: MongoAdapter, hpo_terms: dict, hpo_gene_lines: List[str], alias_genes: Dict[str, Dict]
+):
+    """Populate the 'genes' key of the HPO term dictionary."""
+
+    # Fetch the hpo gene information if no file
+    if not hpo_gene_lines:
+        hpo_gene_lines = fetch_hpo_to_genes_to_disease()
+
+    # Get a map with HGNC symbols to HGNC ids from scout
+    if not alias_genes:
+        alias_genes = adapter.genes_by_alias()
+
+    for hpo_id, hgnc_symbols in parse_hpo_to_genes(hpo_gene_lines).items():
+        if hpo_id not in hpo_terms:
+            continue
+
+        for hgnc_symbol in hgnc_symbols:
+            # Fetch gene info to get correct HGNC id
+            gene_info = alias_genes.get(hgnc_symbol)
+            if not gene_info:
+                continue
+
+            hgnc_id = gene_info["true"]
+            hpo_term = hpo_terms[hpo_id]
+
+            if not "genes" in hpo_term:
+                hpo_term["genes"] = set()
+
+            hpo_term["genes"].add(hgnc_id)
+
+
 def load_hpo_terms(
     adapter,
     hpo_lines=None,
@@ -92,40 +125,16 @@ def load_hpo_terms(
     for hpo_id, hpo_term in hpo_terms.items():
         HpoTerm(**hpo_term)  # Validate basic term using pydantic
 
-    # Fetch the hpo gene information if no file
-    if not hpo_gene_lines:
-        hpo_gene_lines = fetch_hpo_to_genes_to_disease()
-
-    # Get a map with HGNC symbols to HGNC ids from scout
-    if not alias_genes:
-        alias_genes = adapter.genes_by_alias()
-
-    for hpo_to_symbol in parse_hpo_to_genes(hpo_gene_lines):
-        hgnc_symbol = hpo_to_symbol["hgnc_symbol"]
-        hpo_id = hpo_to_symbol["hpo_id"]
-
-        # Fetch gene info to get correct hgnc id
-        gene_info = alias_genes.get(hgnc_symbol)
-        if not gene_info:
-            continue
-
-        hgnc_id = gene_info["true"]
-
-        if hpo_id not in hpo_terms:
-            continue
-
-        hpo_term = hpo_terms[hpo_id]
-
-        if not "genes" in hpo_term:
-            hpo_term["genes"] = set()
-
-        hpo_term["genes"].add(hgnc_id)
-
     if not hpo_terms:
         LOG.error("No HPO terms found. Aborting update without dropping HPO term collection.")
         return
 
+    _set_hpo_terms_genes(
+        adapter=adapter, hpo_terms=hpo_terms, hpo_gene_lines=hpo_gene_lines, alias_genes=alias_genes
+    )
+
     LOG.info("Dropping old HPO term collection")
+
     adapter.hpo_term_collection.delete_many({})
 
     start_time = datetime.now()
@@ -189,7 +198,7 @@ def load_disease_terms(
 
     if not hpo_disease_lines:
         hpo_disease_lines = fetch_hpo_to_genes_to_disease()
-    hpo_term_to_symbol = _get_hpo_term_to_symbol(hpo_disease_lines)
+    hpo_term_to_symbol = parse_hpo_to_genes(lines=hpo_disease_lines)
 
     if not hpo_annotation_lines:
         hpo_annotation_lines = fetch_hpo_disease_annotation()
@@ -222,32 +231,25 @@ def _parse_disease_term_info(
     disease_annotations: Dict[str, Any],
     disease_id: str,
     hpo_term_to_symbol: Dict[Any, set],
-) -> Dict:
+) -> Optional[Dict]:
     """
     Starting from the OMIM disease terms (genemap2), update with HPO terms from
-    HPO annotations, aadd in any missing diseases from hpo_anontations,
-    and
-    Args:
-        disease_annotations(dict(dict)): indexed by disease_id, from phenotype.hpoa
-        disease_terms(dict(dict)): indexed by HPO term number, from genemap2.txt
-        disease_number: current disease number
-        hpo_term_to_symbol(dict(set)):  dict, keyed on HPO term, with sets of gene symbols, from phenotype_to_genes.txt
-
-    Modifies:
-        disease_info(dict)
+    HPO annotations, add in any missing diseases from hpo_annotations.
     """
 
-    if disease_id in disease_annotations:
-        if "hpo_terms" in disease_info:
-            disease_info["hpo_terms"].update(disease_annotations[disease_id]["hpo_terms"])
+    if disease_id not in disease_annotations:
+        return
+
+    if "hpo_terms" in disease_info:
+        disease_info["hpo_terms"].update(disease_annotations[disease_id]["hpo_terms"])
+    else:
+        disease_info["hpo_terms"] = set(disease_annotations[disease_id]["hpo_terms"])
+
+    for hpo_term in disease_info["hpo_terms"]:
+        if hpo_term not in hpo_term_to_symbol:
+            continue
+
+        if disease_info.get("hgnc_symbols"):
+            disease_info["hgnc_symbols"].update(hpo_term_to_symbol[hpo_term])
         else:
-            disease_info["hpo_terms"] = set(disease_annotations[disease_id]["hpo_terms"])
-
-        for hpo_term in disease_info["hpo_terms"]:
-            if hpo_term not in hpo_term_to_symbol:
-                continue
-
-            if disease_info["hgnc_symbols"]:
-                disease_info["hgnc_symbols"].update(hpo_term_to_symbol[hpo_term])
-            else:
-                disease_info["hgnc_symbols"] = hpo_term_to_symbol[hpo_term]
+            disease_info["hgnc_symbols"] = hpo_term_to_symbol[hpo_term]

--- a/scout/load/hpo.py
+++ b/scout/load/hpo.py
@@ -159,7 +159,7 @@ def _get_hpo_term_to_symbol(hpo_disease_lines: Iterable[str]) -> Dict:
         if hpo_id not in hpo_term_to_symbol:
             hpo_term_to_symbol[hpo_id] = set([hpo_to_symbol["hgnc_symbol"]])
         else:
-            hpo_term_to_symbol[hpo_id].update(hpo_to_symbol["hgnc_symbol"])
+            hpo_term_to_symbol[hpo_id].add(hpo_to_symbol["hgnc_symbol"])
     return hpo_term_to_symbol
 
 

--- a/scout/parse/hpo_mappings.py
+++ b/scout/parse/hpo_mappings.py
@@ -1,11 +1,11 @@
 import logging
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 LOG = logging.getLogger(__name__)
 
 
-def parse_hpo_to_genes(lines):
-    """Parse the map from hpo term to hgnc symbol
+def parse_hpo_to_genes(lines) -> Dict[str, List[str]]:
+    """Parse the map from hpo term to HGNC symbols
 
     Args:
         lines(iterable(str)): example:
@@ -16,16 +16,23 @@ def parse_hpo_to_genes(lines):
         HP:0000002	Abnormality of body height	79633	FAT4		orphadata	ORPHA:314679
 
     Yields:
-        hpo_to_gene(dict): A dictionary with information on how a term map to a hgnc symbol
+        hpo_to_genes(dict): A dictionary with information on how an HPO term maps to HGNC symbols
     """
+    hpo_to_genes = {}
     for line in lines:
         if line.startswith("#") or len(line) < 5:
             continue
         line = line.rstrip().split("\t")
+
         hpo_id = line[0]
         hgnc_symbol = line[3]
 
-        yield {"hpo_id": hpo_id, "hgnc_symbol": hgnc_symbol}
+        if hpo_to_genes.get(hpo_id):
+            hpo_to_genes[hpo_id].append(hgnc_symbol)
+        else:
+            hpo_to_genes[hpo_id] = [hgnc_symbol]
+
+    return hpo_to_genes
 
 
 def parse_hpo_annotations(hpo_annotation_lines: Iterable[str]) -> Dict[str, Any]:

--- a/scout/parse/hpo_mappings.py
+++ b/scout/parse/hpo_mappings.py
@@ -68,8 +68,8 @@ def parse_hpo_annotations(hpo_annotation_lines: Iterable[str]) -> Dict[str, Any]
                 "hpo_terms": set(),
             }
 
-        if "hpo_term" in disease and disease["hpo_term"]:
-            diseases[disease_id]["hpo_terms"].add(disease["hpo_term"])
+        if "hpo_terms" in disease and disease["hpo_terms"]:
+            diseases[disease_id]["hpo_terms"].add(disease["hpo_terms"])
 
     return diseases
 

--- a/tests/parse/test_parse_hpo_mappings.py
+++ b/tests/parse/test_parse_hpo_mappings.py
@@ -8,9 +8,9 @@ def test_parse_hpo_to_genes(hpo_disease_handle):
     hpo_2_genes = parse_hpo_to_genes(hpo_disease_handle)
 
     # THEN the iterator returned should contain hpo_id and hgnc_symbol
-    for item in hpo_2_genes:
-        assert item["hpo_id"]
-        assert item["hgnc_symbol"]
+    for hpo_id, gene_list in hpo_2_genes.items():
+        assert hpo_id.startswith("HP:")
+        assert isinstance(gene_list, list)
 
 
 def test_parse_hpo_annotations(hpo_phenotype_annotation_handle):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- fix #4115 - Diagnoses with no associated HPO terms

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Run scout setup demo using main branch and this branch

**Expected outcome**:
- HPO should be present in OMIM terms loaded using this branch

**Review:**
- [ ] code approved by
- [x] tests executed by CR
