### PR TITLE
Fix #4119, Fix #4120 - only re escape for re search. Fix #3571 or at …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Slightly extended the BioNano Genomics Access integration docs
 - Loading of SVs when VCF is missing the INFO.END field but has INFO.SVLEN field
 - Escape protein sequence name (if available) in case general report to render special characters correctly
+-
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Slightly extended the BioNano Genomics Access integration docs
 - Loading of SVs when VCF is missing the INFO.END field but has INFO.SVLEN field
 - Escape protein sequence name (if available) in case general report to render special characters correctly
--
+- CaseS HPO term searches for multiple terms works independent of order
+- CaseS search regexp should not allow backslash
+- CaseS cohort tags can contain whitespace and still match
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -221,6 +221,8 @@ class CaseHandler(object):
         query_field = name_query.split(":")[0]  # example:status
         query_term = name_query[name_query.index(":") + 1 :].strip()
 
+        LOG.info("Name query: %s Field: %s term: %s", name_query, query_field, query_term)
+
         if query_field == "case" and query_term != "":
             self._set_case_name_query(query, query_term)
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -221,8 +221,6 @@ class CaseHandler(object):
         query_field = name_query.split(":")[0]  # example:status
         query_term = name_query[name_query.index(":") + 1 :].strip()
 
-        LOG.info("Name query: %s Field: %s term: %s", name_query, query_field, query_term)
-
         if query_field == "case" and query_term != "":
             self._set_case_name_query(query, query_term)
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -149,11 +149,11 @@ class CaseHandler(object):
     def _set_case_name_query(self, query: Dict[str, Any], query_term: str):
         """Set case query to reg exp search in case and individual display names for parts of the name query."""
 
-        escaped_query_term = re.escape(query_term)
+        case_name_regex = {"$regex": re.escape(query_term)}
         query["$or"] = [
-            {"display_name": {"$regex": escaped_query_term}},
-            {"individuals.display_name": {"$regex": escaped_query_term}},
-            {"_id": {"$regex": escaped_query_term}},
+            {"display_name": case_name_regex},
+            {"individuals.display_name": case_name_regex},
+            {"_id": case_name_regex},
         ]
 
     def _set_case_phenotype_query(self, query: Dict[str, Any], query_term: str):

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -424,7 +424,7 @@ def cases(store, request, institute_id):
         name_query = "".join(
             [
                 request.args.get("search_type"),
-                re.escape(request.args["search_term"].strip()),
+                request.args["search_term"].strip(),
             ]
         )
     data["name_query"] = name_query

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -30,7 +30,7 @@
       </div>
       <div class="col-3">
           <label class="control-label" for="search_term">Search cases</label>
-          <input class="form-control" id="search_term" name="search_term" value="{{form.search_term.data}}" placeholder="example:18201" type="text" pattern="[^<>?!=\\/]*" title="Characters ^<>?!=\/ are not allowed">
+          <input class="form-control" id="search_term" name="search_term" value="{{form.search_term.data}}" placeholder="example:18201" type="text" pattern="[^\\\<\>\?\!\=\/]*" title="Characters \<>?!=/ are not allowed">
       </div>
       <div class="col-1">
         {{ form.search(class="btn btn-primary form-control") }}

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -714,6 +714,22 @@ def test_get_cases_cohort(real_adapter, case_obj, user_obj):
     assert sum(1 for i in result) == 1
 
 
+def test_get_cases_cohort_with_space(real_adapter, case_obj, user_obj):
+    adapter = real_adapter
+    # GIVEN an empty database (no cases)
+    assert sum(1 for i in adapter.cases()) == 0
+
+    cohort_name = "cohort with spaceS"
+
+    case_obj["cohorts"] = [cohort_name]
+    adapter.case_collection.insert_one(case_obj)
+
+    # WHEN retreiving cases by a cohort name query
+    result = adapter.cases(name_query="cohort:{}".format(cohort_name))
+    # THEN we should get the case returned
+    assert sum(1 for i in result) == 1
+
+
 def test_get_cases_solved_since(real_adapter, case_obj, user_obj, institute_obj, variant_obj):
     adapter = real_adapter
     # GIVEN an empty database (no cases)

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -20,7 +20,7 @@ def test_add_cases(adapter, case_obj):
 
     ## THEN it should be populated with the new case
     result = adapter.cases()
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
     for case in result:
         assert case["owner"] == case_obj["owner"]
 
@@ -123,7 +123,7 @@ def test_get_cases(adapter, case_obj):
     ## WHEN retreiving an existing case from the database
     result = adapter.cases()
     ## THEN we should get the correct case
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_prioritized_cases(adapter, case_obj, institute_obj):
@@ -137,7 +137,7 @@ def test_get_prioritized_cases(adapter, case_obj, institute_obj):
     result = adapter.prioritized_cases(institute_id=institute_obj["_id"])
 
     # THEN one prioritized case is returned
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_search_active_case(real_adapter, case_obj, institute_obj, user_obj):
@@ -157,13 +157,13 @@ def test_search_active_case(real_adapter, case_obj, institute_obj, user_obj):
     name_query = "status:active"
     # THEN a case should be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
     # BUT WHEN querying for inactive cases
     name_query = "status:inactive"
     # THEN no case should be returned.
     inactive_cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in inactive_cases) == 0
+    assert sum(1 for _ in inactive_cases) == 0
 
 
 def test_get_research_case(real_adapter, case_obj, institute_obj):
@@ -182,7 +182,7 @@ def test_get_research_case(real_adapter, case_obj, institute_obj):
 
     # THEN searching for reasearch cases should return one case
     research_cases = adapter.cases(owner=case_obj["owner"], is_research=True)
-    assert sum(1 for i in research_cases) == 1
+    assert sum(1 for _ in research_cases) == 1
 
 
 def test_get_cases_no_synopsis(real_adapter, case_obj, institute_obj, user_obj):
@@ -192,14 +192,14 @@ def test_get_cases_no_synopsis(real_adapter, case_obj, institute_obj, user_obj):
 
     # Insert a case
     adapter.case_collection.insert_one(case_obj)
-    assert sum(1 for i in adapter.case_collection.find()) == 1
+    assert sum(1 for _ in adapter.case_collection.find()) == 1
 
     # WHEN providing an empty value for synopsis:
     assert case_obj["synopsis"] == ""
     name_query = "synopsis:"
     # Then case should be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
     # After adding synopsis to case
     link = "synopsislink"
@@ -217,14 +217,14 @@ def test_get_cases_no_synopsis(real_adapter, case_obj, institute_obj, user_obj):
     name_query = "synopsis:"
     # Then case should NOT be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 0
+    assert sum(1 for _ in cases) == 0
 
     # but if a term contained in case synopsis is provided in name query:
     name_query = "synopsis:seizures"
 
     # Then updated case should be returned
     cases = adapter.cases(collaborator=updated_case["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
 
 def test_get_cases_no_HPO(adapter, case_obj):
@@ -236,13 +236,13 @@ def test_get_cases_no_HPO(adapter, case_obj):
     name_query = "exact_pheno:"
     # Then case should be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
     # WHEN providing an empty value for phenotype group:
     name_query = "pheno_group:"
     # Then case should be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
     # Add phenotype group and HPO term to case object:
     adapter.case_collection.find_one_and_update(
@@ -258,13 +258,13 @@ def test_get_cases_no_HPO(adapter, case_obj):
     name_query = "exact_pheno:"
     # Then case should NOT be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 0
+    assert sum(1 for _ in cases) == 0
 
     # WHEN providing an empty value for phenotype group:
     name_query = "pheno_group:"
     # Then case should NOT be returned
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
-    assert sum(1 for i in cases) == 0
+    assert sum(1 for _ in cases) == 0
 
 
 def test_cases_no_diagnosis(adapter, case_obj, omim_term):
@@ -278,7 +278,7 @@ def test_cases_no_diagnosis(adapter, case_obj, omim_term):
     name_query = "exact_dia:"
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
     # THEN a case should be returned
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
 
 def test_get_cases_no_assignees(real_adapter, case_obj):
@@ -289,7 +289,7 @@ def test_get_cases_no_assignees(real_adapter, case_obj):
     # WHEN retreiving an existing case from the database
     result = adapter.cases(name_query="user:john")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 0
+    assert sum(1 for _ in result) == 0
 
 
 def test_get_cases_display_name(real_adapter, case_obj):
@@ -306,7 +306,7 @@ def test_get_cases_display_name(real_adapter, case_obj):
     # WHEN retreiving cases by partial display name
     result = adapter.cases(name_query="case:643")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_existing_individual(real_adapter, case_obj):
@@ -317,7 +317,7 @@ def test_get_cases_existing_individual(real_adapter, case_obj):
     # WHEN retreiving cases by partial individual name
     result = adapter.cases(name_query="case:NA1288")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_assignees(real_adapter, case_obj, user_obj):
@@ -334,7 +334,7 @@ def test_get_cases_assignees(real_adapter, case_obj, user_obj):
     # WHEN retreiving cases by partial individual name
     result = adapter.cases(name_query="user:john")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_non_existing_assignee(real_adapter, case_obj, user_obj):
@@ -351,7 +351,7 @@ def test_get_cases_non_existing_assignee(real_adapter, case_obj, user_obj):
     # WHEN retreiving cases by partial individual name
     result = adapter.cases(name_query="user:damien")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 0
+    assert sum(1 for _ in result) == 0
 
 
 def test_get_cases_causatives(adapter, case_obj):
@@ -366,7 +366,7 @@ def test_get_cases_causatives(adapter, case_obj):
     # WHEN retreiving cases that have causatives
     result = adapter.cases(has_causatives=True)
     # THEN we should find one case
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_causatives_no_causatives(adapter, case_obj):
@@ -379,7 +379,7 @@ def test_get_cases_causatives_no_causatives(adapter, case_obj):
     # WHEN retreiving all cases that have causatives
     result = adapter.cases(has_causatives=True)
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 0
+    assert sum(1 for _ in result) == 0
 
 
 def test_get_cases_empty_causatives(adapter, case_obj):
@@ -394,7 +394,7 @@ def test_get_cases_empty_causatives(adapter, case_obj):
     # WHEN retreiving all cases that have causatives
     result = adapter.cases(has_causatives=True)
     # THEN we should not find any cases
-    assert sum(1 for i in result) == 0
+    assert sum(1 for _ in result) == 0
 
 
 def test_get_cases_non_existing_display_name(real_adapter, case_obj):
@@ -405,7 +405,7 @@ def test_get_cases_non_existing_display_name(real_adapter, case_obj):
     # WHEN retreiving cases by partial display name
     result = adapter.cases(name_query="case:hello")
     # THEN we should get the correct case
-    assert sum(1 for i in result) == 0
+    assert sum(1 for _ in result) == 0
 
 
 def test_get_non_existing_case(adapter, case_obj):
@@ -428,7 +428,7 @@ def test_delete_case_by_id(adapter, case_obj):
     # WHEN deleting a case from the database using case _id
     result = adapter.delete_case(case_id=case_obj["_id"])
     # THEN there should be no cases left in the database
-    assert sum(1 for i in adapter.cases()) == 0
+    assert sum(1 for _ in adapter.cases()) == 0
 
 
 def test_delete_case_by_display_name(adapter, case_obj):
@@ -441,7 +441,7 @@ def test_delete_case_by_display_name(adapter, case_obj):
         institute_id=case_obj["owner"], display_name=case_obj["display_name"]
     )
     # THEN there should be no cases left in the database
-    assert sum(1 for i in adapter.cases()) == 0
+    assert sum(1 for _ in adapter.cases()) == 0
 
 
 def test_update_case_collaborators(adapter, case_obj):
@@ -560,9 +560,9 @@ def test_archive_unarchive_case(adapter, case_obj, institute_obj, user_obj):
 
 def test_update_case_rerun_status(adapter, case_obj, institute_obj, user_obj):
     # GIVEN an empty database (no cases)
-    assert sum(1 for i in adapter.cases()) == 0
+    assert sum(1 for _ in adapter.cases()) == 0
     adapter.case_collection.insert_one(case_obj)
-    assert sum(1 for i in adapter.cases()) == 1
+    assert sum(1 for _ in adapter.cases()) == 1
 
     res = adapter.case(case_obj["_id"])
     assert res["status"] == "inactive"
@@ -613,14 +613,14 @@ def test_cases_by_diagnosis(adapter, case_obj, omim_term):
     # WHEN querying for cases with the given OMIM term
     cases = adapter.cases(collaborator=case_obj["owner"], name_query=name_query)
     # THEN a case should be returned
-    assert sum(1 for i in cases) == 1
+    assert sum(1 for _ in cases) == 1
 
 
 def test_cases_by_phenotype(hpo_database, test_hpo_terms, case_obj):
     adapter = hpo_database
 
     # Make sure database contains HPO terms
-    assert sum(1 for i in adapter.hpo_terms())
+    assert sum(1 for _ in adapter.hpo_terms())
 
     # update test case using test HPO terms
     case_obj["phenotype_terms"] = test_hpo_terms
@@ -631,7 +631,7 @@ def test_cases_by_phenotype(hpo_database, test_hpo_terms, case_obj):
     )
     # insert case into database
     adapter.case_collection.insert_one(case_obj)
-    assert sum(1 for i in adapter.case_collection.find()) == 1
+    assert sum(1 for _ in adapter.case_collection.find()) == 1
 
     # Add another case with slightly different phenotype
     case_2 = copy.deepcopy(case_obj)
@@ -640,7 +640,7 @@ def test_cases_by_phenotype(hpo_database, test_hpo_terms, case_obj):
 
     # insert this case in database:
     adapter.case_collection.insert_one(case_2)
-    assert sum(1 for i in adapter.case_collection.find()) == 2
+    assert sum(1 for _ in adapter.case_collection.find()) == 2
 
     # Add another case with phenotype very different from case_obj
     case_3 = copy.deepcopy(case_obj)
@@ -651,7 +651,7 @@ def test_cases_by_phenotype(hpo_database, test_hpo_terms, case_obj):
 
     # insert this case in database:
     adapter.case_collection.insert_one(case_3)
-    assert sum(1 for i in adapter.case_collection.find()) == 3
+    assert sum(1 for _ in adapter.case_collection.find()) == 3
 
     hpo_query_terms = [term["phenotype_id"] for term in test_hpo_terms]
     similar_cases = adapter.cases_by_phenotype(hpo_query_terms, case_obj["owner"], case_obj["_id"])
@@ -667,7 +667,7 @@ def test_get_cases_by_phenotype_name_query(hpo_database, test_hpo_terms, case_ob
     adapter = hpo_database
 
     # Make sure database contains HPO terms
-    assert sum(1 for i in adapter.hpo_terms())
+    assert sum(1 for _ in adapter.hpo_terms())
 
     # Give the case HPO terms
     case_obj["phenotype_terms"] = test_hpo_terms
@@ -679,7 +679,7 @@ def test_get_cases_by_phenotype_name_query(hpo_database, test_hpo_terms, case_ob
 
     # Insert a case into the db
     adapter.case_collection.insert_one(case_obj)
-    assert sum(1 for i in adapter.case_collection.find()) == 1
+    assert sum(1 for _ in adapter.case_collection.find()) == 1
 
     # WHEN querying for a case with one of the test phenotype ids
     name_query = f"exact_pheno:{test_hpo_terms[0]['phenotype_id']}"
@@ -689,7 +689,7 @@ def test_get_cases_by_phenotype_name_query(hpo_database, test_hpo_terms, case_ob
     assert len(cases) == 1
 
     # WHEN repeating the same query with a term not on the case included,
-    name_query = f"exact_pheno:HP:0000532"
+    name_query = "exact_pheno:HP:0000532"
 
     # THEN no case should be returned
     cases = list(adapter.cases(collaborator=case_obj["owner"], name_query=name_query))
@@ -707,7 +707,7 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
     adapter = hpo_database
 
     # Make sure database contains HPO terms
-    assert sum(1 for i in adapter.hpo_terms())
+    assert sum(1 for _ in adapter.hpo_terms())
 
     # Give the case HPO terms
     case_obj["phenotype_terms"] = test_hpo_terms
@@ -719,7 +719,7 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
 
     # Insert a case into the db
     adapter.case_collection.insert_one(case_obj)
-    assert sum(1 for i in adapter.case_collection.find()) == 1
+    assert sum(1 for _ in adapter.case_collection.find()) == 1
 
     # Add another case with slightly different phenotype:
 
@@ -729,7 +729,7 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
 
     # insert this case in database:
     adapter.case_collection.insert_one(case_2)
-    assert sum(1 for i in adapter.case_collection.find()) == 2
+    assert sum(1 for _ in adapter.case_collection.find()) == 2
 
     # WHEN querying for a similar case
     name_query = f"similar_case:{case_obj['display_name']}"
@@ -741,7 +741,7 @@ def test_get_similar_cases_by_name_query(hpo_database, test_hpo_terms, case_obj)
 def test_get_cases_cohort(real_adapter, case_obj, user_obj):
     adapter = real_adapter
     # GIVEN an empty database (no cases)
-    assert sum(1 for i in adapter.cases()) == 0
+    assert sum(1 for _ in adapter.cases()) == 0
 
     cohort_name = "cohort"
 
@@ -751,13 +751,13 @@ def test_get_cases_cohort(real_adapter, case_obj, user_obj):
     # WHEN retreiving cases by a cohort name query
     result = adapter.cases(name_query="cohort:{}".format(cohort_name))
     # THEN we should get the case returned
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_cohort_with_space(real_adapter, case_obj, user_obj):
     adapter = real_adapter
     # GIVEN an empty database (no cases)
-    assert sum(1 for i in adapter.cases()) == 0
+    assert sum(1 for _ in adapter.cases()) == 0
 
     cohort_name = "cohort with spaceS"
 
@@ -767,7 +767,7 @@ def test_get_cases_cohort_with_space(real_adapter, case_obj, user_obj):
     # WHEN retreiving cases by a cohort name query
     result = adapter.cases(name_query="cohort:{}".format(cohort_name))
     # THEN we should get the case returned
-    assert sum(1 for i in result) == 1
+    assert sum(1 for _ in result) == 1
 
 
 def test_get_cases_solved_since(real_adapter, case_obj, user_obj, institute_obj, variant_obj):
@@ -1074,7 +1074,7 @@ def test_keep_variant_comments_after_reupload(
         content="Hello, globally",
         comment_level="global",
     )
-    assert sum(1 for i in adapter.event_collection.find()) == 2
+    assert sum(1 for _ in adapter.event_collection.find()) == 2
 
     # WHEN the variant is re-uploaded
     adapter.variant_collection.delete_one(old_variant)
@@ -1093,4 +1093,4 @@ def test_keep_variant_comments_after_reupload(
     assert updated_new_vars["is_commented"] == [new_variant["_id"]]
 
     # and 2 new comments should be created in the database
-    assert sum(1 for i in adapter.event_collection.find()) == 4
+    assert sum(1 for _ in adapter.event_collection.find()) == 4


### PR DESCRIPTION
…least harden against it. It may not be deriving from direct input into the caseS search box.

This PR adds a functionality or fixes a bug.

Testing details here: 
Fix #4119 
Fix #4120 
 Briefly, try HPO terms in swapped order, and cohort tags with spaces.

Before:
<img width="1010" alt="Screenshot 2023-10-12 at 11 41 50" src="https://github.com/Clinical-Genomics/scout/assets/758570/0a8d124d-c914-4977-b747-9a1126370935">

<img width="836" alt="Screenshot 2023-10-12 at 09 34 12" src="https://github.com/Clinical-Genomics/scout/assets/758570/881ef1b9-9ef2-4d19-86b8-f0be1856d97a">

<img width="1060" alt="Screenshot 2023-10-12 at 11 47 18" src="https://github.com/Clinical-Genomics/scout/assets/758570/f57d0e22-d30e-4bca-a665-fc30a8ae05e5">

<img width="978" alt="Screenshot 2023-10-12 at 11 46 07" src="https://github.com/Clinical-Genomics/scout/assets/758570/94dc987d-e8e6-42cb-881d-7fa671e502e1">


After:
<img width="997" alt="Screenshot 2023-10-12 at 11 58 29" src="https://github.com/Clinical-Genomics/scout/assets/758570/d5554175-f570-47d7-b3b5-486e199c903f">

<img width="931" alt="Screenshot 2023-10-12 at 11 57 45" src="https://github.com/Clinical-Genomics/scout/assets/758570/a39b92e7-cf39-487f-8e05-73c8b133acc9">

<img width="936" alt="Screenshot 2023-10-12 at 11 55 09" src="https://github.com/Clinical-Genomics/scout/assets/758570/903c9a35-f3c0-4ea2-a114-eb82c53e012a">

For #3571, note that `\` is now disallowed in search field, in contrast to current main.

Before:
<img width="857" alt="Screenshot 2023-10-12 at 11 41 26" src="https://github.com/Clinical-Genomics/scout/assets/758570/d53f083d-7c01-41f0-ae8d-93dad7308334">

After:
<img width="356" alt="Screenshot 2023-10-12 at 11 27 14" src="https://github.com/Clinical-Genomics/scout/assets/758570/aa1b49c9-cff6-48bb-b41b-767a40306778">


I suspect some linter may have issues with the handling of direct user input. As per my reading, we are safe (the input appears as strings in different subqueries and should not have the opportunity to break out of them without causing error), but let's see. Some of the query categories could be made safer by only allowing existing values, but then we need to track that..

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
