### PR TITLE
unfreeze PyMongo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom images keys `case` and `str` in case config yaml file are renamed to `case_images` and `srt_variants_images`
 - Simplify and speed up case general report code
 - Speed up case retrieval in case_matching_causatives
+- Upgrade pymongo to version 4
 
 
 ## [4.71]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ Flask-Babel>=3
 livereload
 tornado<6.3
 python-dateutil
-pymongo>=3.7,<4.0
+pymongo
 pathlib
 pdfkit
 phenopackets

--- a/scout/adapter/mongo/base.py
+++ b/scout/adapter/mongo/base.py
@@ -83,7 +83,7 @@ class MongoAdapter(
     """Adapter for communication with a Mongo database."""
 
     def __init__(self, database=None):
-        if database:
+        if database is not None:
             self.setup(database)
 
     def init_app(self, app):

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -569,13 +569,17 @@ class VariantLoader(object):
         clinical_variant = "".join([variant_prefix, "_clinical"])
         research_variant = "".join([variant_prefix, "_research"])
 
-        var_causative_events_count = self.event_collection.find(
-            {
-                "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
-                "category": "variant",
-                "subject": {"$in": [clinical_variant, research_variant]},
-            }
-        ).count()
+        var_causative_events_count = len(
+            list(
+                self.event_collection.find(
+                    {
+                        "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
+                        "category": "variant",
+                        "subject": {"$in": [clinical_variant, research_variant]},
+                    }
+                )
+            )
+        )
         return var_causative_events_count > 0
 
     def _is_managed(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

https://github.com/Clinical-Genomics/scout/issues/4076

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
