### PR TITLE
Fix displaying custom case images loaded with scout version <= 4.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove diagnoses from cases even if OMIM term is not found in the database
 - Parsing of disease-associated genes
 - Removed an annoying warning while updating database's disease terms
+- Displaying custom case images loaded with scout version <= 4.71
 ### Changed
 - Column width adjustment on caseS page
 - Use Python 3.11 in tests

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -378,7 +378,10 @@ def case(store, institute_obj, case_obj):
 
     if case_obj.get("custom_images"):
         # re-encode images as base64
-        case_obj["custom_images"] = case_obj["custom_images"].get("case_images", {})
+        case_obj["custom_images"] = case_obj["custom_images"].get(
+            "case_images", case_obj["custom_images"].get("case", {})
+        )
+        LOG.warning(case_obj["custom_images"])
         for img_section in case_obj["custom_images"].keys():
             for img in case_obj["custom_images"][img_section]:
                 img["data"] = b64encode(img["data"]).decode("utf-8")

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -381,7 +381,6 @@ def case(store, institute_obj, case_obj):
         case_obj["custom_images"] = case_obj["custom_images"].get(
             "case_images", case_obj["custom_images"].get("case", {})
         )
-        LOG.warning(case_obj["custom_images"])
         for img_section in case_obj["custom_images"].keys():
             for img in case_obj["custom_images"][img_section]:
                 img["data"] = b64encode(img["data"]).decode("utf-8")


### PR DESCRIPTION
The images loaded with scout <= 4.71 don't show up. For example on this case -> https://scout-stage.scilifelab.se/cust000/F0006358-mip7

- Check also this test on latest version:  https://github.com/Clinical-Genomics/scout/pull/4125#issuecomment-1768401950


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy this branch on cg-vm1 and make sure that the case above displays the "hello" image on case page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR
