### PR TITLE
Fix jinja2 filter rendering long integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Jinja filter that renders long integers
+
 ## [4.72]
 ### Added
 - A GitHub action that checks for broken internal links in docs pages

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -199,9 +199,10 @@ def register_filters(app):
     @app.template_filter()
     def human_longint(value: Union[int, str]) -> str:
         """Convert a long integers int or string representation into a human easily readable number."""
-        if value == "inf":
-            return value
-        return "{:,}".format(int(value)).replace(",", " ")
+        value = str(value)
+        if value.isnumeric():
+            return "{:,}".format(int(value)).replace(",", " ")
+        return value
 
     @app.template_filter()
     def human_decimal(number, ndigits=4):

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -1,4 +1,4 @@
-def test_app_human_longint_filter_inf(mock_app):
+def test_app_human_longint_filter_non_numeric_str(mock_app):
     """Test template filter human_longint when the provided string is 'inf'."""
     assert "human_longint" in mock_app.jinja_env.filters.keys()
     assert mock_app.jinja_env.filters["human_longint"]("inf") == "inf"


### PR DESCRIPTION
Fix #4140 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Show all demo case SVs (deselect OMIM auto panel)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
