### PR TITLE
Tentaive fix to server hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Jinja filter that renders long integers
+- Case cache when looking for causatives in other cases causing the server to hang
 
 ## [4.72]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -551,19 +551,13 @@ class VariantHandler(VariantLoader):
             }
         )
 
-        # Fetching all cases in one go faster that one by one through self.case:
-        target_cases = var_causative_events.clone().distinct("case")
-        required_case_fields = {"causatives": 1, "partial_causatives": 1, "_id": 1}
-        cases = self.case_collection.find({"_id": {"$in": target_cases}}, required_case_fields)
-        cases_cache = {case["_id"]: case for case in cases}
-
         positional_variant_ids = set()
         for var_event in var_causative_events:
             if var_event["case"] == case_obj["_id"]:
                 # exclude causatives from the same case
                 continue
 
-            other_case = cases_cache.get(var_event["case"])
+            other_case = self.case(var_event["case"])
             if other_case is None:
                 # Other variant belongs to a case that doesn't exist any more
                 continue


### PR DESCRIPTION
- Fix the fact that caseS and case page  aresucking up all memory
- Partially reverting #4100

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by GitHub actions
