### PR TITLE
Fix #4152 - dont split large numbers, use thin space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Case cache when looking for causatives in other cases causing the server to hang
 ### Changed
 - STR export limit increased to 500, as for other variants
+- Prevent long number wrapping and use thin spaces for separation, as per standards from SI, NIST, IUPAC, BIPM.
 
 ## [4.72]
 ### Added

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -201,7 +201,7 @@ def register_filters(app):
         """Convert a long integers int or string representation into a human easily readable number."""
         value = str(value)
         if value.isnumeric():
-            return "{:,}".format(int(value)).replace(",", " ")
+            return "{:,}".format(int(value)).replace(",", "&thinsp;")
         return value
 
     @app.template_filter()

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -108,9 +108,9 @@
       {{ variant.sub_category|upper }}</span>
     </td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
-    <td class="col-2">{{ variant.position|human_longint }}</td>
-    <td class="col-2">{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint }}</td>
-    <td class="col-2">{{ '-' if variant.length == 100000000000 else variant.length|human_longint }}</td>
+    <td class="col-2"><span style="white-space: nowrap;">{{ variant.position|human_longint|safe }}</span></td>
+    <td class="col-2"><span style="white-space: nowrap;">{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint|safe }}</span></td>
+    <td class="col-2"><span style="white-space: nowrap;">{{ '-' if variant.length == 100000000000 else variant.length|human_longint|safe }}</span></td>
     <td>
       {% if variant.gnomad_frequency %}
         {{ variant.gnomad_frequency|human_decimal }}

--- a/scout/server/blueprints/variants/templates/variants/mei-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/mei-variants.html
@@ -60,9 +60,9 @@ onsubmit="return validateForm()">
               <th>Rank</th>
               <th>Score</th>
               <th>Type</th>
-              <th>Element</th>
+              <th style="width:18%">Element</th>
               <th>Chr</th>
-              <th>Start loc</th>
+              <th style="width:9%">Start loc</th>
               <th>Frequency</th>
               <th>Gene(s)</th>
               <th>Region</th>
@@ -104,7 +104,7 @@ onsubmit="return validateForm()">
     <td>{{ variant.sub_category|upper }}</td>
     <td>{{ variant.mei_name }}</td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
-    <td class="col-2">{{ variant.position|human_longint }}</td>
+    <td class="col-2"><span style="white-space: nowrap;">{{ variant.position|human_longint|safe }}</span></td>
     <td>
       {{ frequency_cell_general(variant) }}
     </td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -103,14 +103,15 @@
                 {% endfor %}
             </td>
             <td class="text-end">{{ variant.chromosome }}</td>
-            <td class="text-end">
-              {{ variant.position|human_longint }}
+            <td class="text-end"><span style="white-space: nowrap;">
+              {{ variant.position|human_longint|safe }}</span>
               {{ reviewer_button(case,variant,case_groups,institute._id) }}
               {% if case.bam_files %}
                 <a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}" rel="noopener" target="_blank">IGV viewer</a>
               {% else %}
                 <button title="BAM file(s) missing" class="btn btn-secondary btn-sm" disabled>IGV viewer</button>
               {% endif %}
+
             </td>
         </tr>
         {% else %}

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -106,9 +106,9 @@ onsubmit="return validateForm()">
     <td><span data-bs-toggle="tooltip" data-bs-html="true" title="{% for name, caller in variant.callers %}{{ name }}: {{ caller }}<br>{% endfor %}">
       {{ variant.sub_category|upper }}</span></td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
-    <td>{{ variant.position|human_longint }}</td>
-    <td>{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint }}</td>
-    <td class="text-end">{{ '-' if variant.length == 100000000000 else variant.length|human_longint}}</td>
+    <td><span style="white-space: nowrap;">{{ variant.position|human_longint|safe }}</span></td>
+<td><span style="white-space: nowrap;">{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint|safe }}</span></td>
+    <td class="text-end"><span style="white-space: nowrap;">{{ '-' if variant.length == 100000000000 else variant.length|human_longint|safe}}</span></td>
     <td>
       {{ frequency_cell_general(variant) }}
     </td>

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -7,10 +7,10 @@ def test_app_human_longint_filter_non_numeric_str(mock_app):
 def test_app_human_longint_filter_str(mock_app):
     """Test template filter human_longint when the provided string represents a long number."""
     assert "human_longint" in mock_app.jinja_env.filters.keys()
-    assert mock_app.jinja_env.filters["human_longint"]("100000") == "100 000"
+    assert mock_app.jinja_env.filters["human_longint"]("100000") == "100&thinsp;000"
 
 
 def test_app_human_longint_filter_number(mock_app):
     """Test template filter human_longint with a long integer."""
     assert "human_longint" in mock_app.jinja_env.filters.keys()
-    assert mock_app.jinja_env.filters["human_longint"](100000) == "100 000"
+    assert mock_app.jinja_env.filters["human_longint"](100000) == "100&thinsp;000"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The spacing delimiter is now slightly thinner, and all `human_longint`s are wrapped in a non-ws-wrapping style `<span>`.
![Screenshot 2023-10-23 at 10 25 05](https://github.com/Clinical-Genomics/scout/assets/758570/de915700-f64c-4b45-8b2a-d77b4d0d7083)

I guess due to the safe filter, needed for html rendering of the thin space, it is recognised as a long number at least on my OS, and browser reaction is much like to a phone number. Copying is also kind of ok, though it will include spaces so still break some connectivity - but we ideally also don't want users to copy-paste, right. 😬 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
