### PR TITLE
Speed up variant page by projecting inheritance in disease terms query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not include genes fetched from HPO terms when loading diseases
 - Consider the renamed fields `Approved Symbol` -> `Approved Gene Symbol` and `Gene Symbols` -> `Gene/Locus And Other Related Symbols` when parsing OMIM terms from genemap2.txt file
 - Speed up case retrieval and lower memory use by projecting case queries
-- Speed up variant pages by projecting inheritance key in disease collection query
+- Speed up variant pages by projecting only the necessary key in disease collection query
 
 ## [4.72.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not include genes fetched from HPO terms when loading diseases
 - Consider the renamed fields `Approved Symbol` -> `Approved Gene Symbol` and `Gene Symbols` -> `Gene/Locus And Other Related Symbols` when parsing OMIM terms from genemap2.txt file
 - Speed up case retrieval and lower memory use by projecting case queries
+- Speed up variant pages by projecting inheritance key in disease collection query
 
 ## [4.72.1]
 ### Fixed

--- a/scout/adapter/mongo/omim.py
+++ b/scout/adapter/mongo/omim.py
@@ -100,7 +100,7 @@ class DiagnosisHandler(object):
         hgnc_id: Optional[int] = None,
         filter_project: Optional[dict] = DISEASE_FILTER_PROJECT,
     ) -> list:
-        """Return all disease terms for a gene HGNC ID. Optionally filter the returned key/values using filter_project."""
+        """Return all disease terms for a gene HGNC ID. It's not returning disease-associated HPO genes and HPO terms."""
         query = {}
         if hgnc_id:
             LOG.debug("Fetching all diseases for gene %s", hgnc_id)

--- a/scout/adapter/mongo/omim.py
+++ b/scout/adapter/mongo/omim.py
@@ -100,7 +100,7 @@ class DiagnosisHandler(object):
         hgnc_id: Optional[int] = None,
         filter_project: Optional[dict] = DISEASE_FILTER_PROJECT,
     ) -> list:
-        """Return all disease terms for a gene HGNC ID. It's not returning disease-associated HPO genes and HPO terms."""
+        """Return all disease terms for a gene HGNC ID. Optionally filter the returned key/values using filter_project. By default do not return disease-associated genes and HPO terms."""
         query = {}
         if hgnc_id:
             LOG.debug("Fetching all diseases for gene %s", hgnc_id)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -141,7 +141,9 @@ class VariantHandler(VariantLoader):
 
             variant_gene["common"] = hgnc_gene
             # Add the associated disease terms
-            variant_gene["disease_terms"] = self.disease_terms(hgnc_id)
+            variant_gene["disease_terms"] = self.disease_terms(
+                hgnc_id, filter_project={"inheritance": 1, "description": 1}
+            )
 
         return variant_obj
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -437,7 +437,7 @@ def case(store, institute_obj, case_obj):
 
 def _limit_genes_on_default_panels(default_genes: list, limit_genes: list) -> list:
     """Take two lists of genes, the default ones for the case and the limit list for the institute
-    and instersect them.
+    and intersect them.
 
     An empty set is interpreted permissively downstream. Hence we need a special rule if either input list
     is empty, but the other populated.

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -257,12 +257,11 @@ def add_gene_info(store, variant_obj, gene_panels=None, genome_build=None):
                 variant_obj["disease_associated_transcripts"].append(transcript_str)
 
             # Add the associated disease terms
-            disease_terms = store.disease_terms(hgnc_id)
-            variant_gene["disease_terms"] = disease_terms
+            disease_terms = store.disease_terms(hgnc_id, filter_project={"inheritance": 1})
 
             all_models = all_models.union(set(variant_gene["manual_inheritance"]))
             omim_models = set()
-            for disease_term in variant_gene.get("disease_terms", []):
+            for disease_term in disease_terms:
                 omim_models.update(disease_term.get("inheritance", []))
             variant_gene["omim_inheritance"] = list(omim_models)
 


### PR DESCRIPTION
- Speed up variant page by collecting only inheritance key/values from disease terms

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
