### PR TITLE
Drastic but effective fix to case report crasing for pinned somatc cancer vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unrelease]
+### Fixed
+- Fix pinned somatic cancer variants causing case report page to crash
+
 ## [4.72.2]
 ### Changed
 - A gunicorn maxrequests parameter for Docker server image - default to 1200

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -341,9 +341,6 @@
   <div class="card-body">
     {% set duplicated_variants = [] %}
     {% if variants.suspects_detailed %}
-      {% if cancer %}
-        {{ somatic_variant_table(variants.suspects_detailed) }}
-      {% endif %}
       {% for pinned in variants.suspects_detailed|sort(attribute='variant_rank') %}
         {% if pinned['_id'] not in printed_vars %}
           {% do printed_vars.append(pinned['_id']) %}
@@ -1315,41 +1312,6 @@
     {% endfor %}
   </tbody>
 </table>
-{% endmacro %}
-
-{% macro somatic_variant_table(variants) %}
-  <div class="card" style="border-width: 5px; display: block;">
-    <div class="card-header">Summary table</div>
-    <div class="card-body">
-      <div class="row d-flex align-items-center">
-       <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent">
-        <thead>
-          <tr class="table-secondary">
-            <th>Gene Symbol</th>
-            <th>Transcript</th>
-            <th>HGVS c.</th>
-            <th>HGVS p.</th>
-            <th>Tumor VAF%</th>
-            <th>ACMG</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for acmg in ["P","LP", "VUS", "LB", "B", ] %}
-          {% for variant in variants|selectattr("acmg_classification.short", "equalto", acmg)|selectattr("first_rep_gene.hgnc_symbol", "defined")|sort(attribute='first_rep_gene.hgnc_symbol')%}
-            {{ variant_table_line(variant) }}
-          {% endfor %}
-        {% endfor %}
-        {% for variant in variants|selectattr("acmg_classification.short", "undefined")|selectattr("first_rep_gene.hgnc_symbol", "defined")|sort(attribute='first_rep_gene.hgnc_symbol') %}
-          {{ variant_table_line(variant) }}
-        {% endfor %}
-        {% for variant in variants|selectattr("first_rep_gene.hgnc_symbol", "undefined") %}
-          {{ alt_variant_line(variant) }}
-        {% endfor %}
-        </tbody>
-       </table>
-      </div>
-    </div>
-  </div>
 {% endmacro %}
 
 {% macro variant_table_line(variant) %}


### PR DESCRIPTION
This is a fix alternative to #4179. Fix #4172 

I don't see why the pinned variants should get a display table different than the other categories. For instance if you have a causative variant then it is shown using the standard variant macro, so why pinned vars have that dedicated `somatic_variant_table` macro? And if the macro is not used by categories other than pinned, perhaps is not that important and also pinned variants can be displayed as usual?

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
