### PR TITLE
Fix #4190 - GnomAD web service defaults to hg38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Changed
 - Automatic test mongod version increased to v7
+### Fixed
+- GnomAD now defaults to hg38 - change build 37 links accordingly
+
 
 ## [4.72.3]
 ### Fixed
 - Somatic general case report small variant table can crash with unclassified variants
-
 
 ## [4.72.2]
 ### Changed

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -585,9 +585,6 @@ def gnomad_sv_link(variant_obj, build=37):
     MT SVs are not available for 38 yet.
     """
 
-    if variant_obj["chromosome"] in ["M", "MT"] and build == 38:
-        return "https://gnomad.broadinstitute.org/"
-
     url_template = (
         "https://gnomad.broadinstitute.org/region/{this[chromosome]}-{this[position]}"
     ).format(this=variant_obj)
@@ -597,7 +594,7 @@ def gnomad_sv_link(variant_obj, build=37):
     else:
         url_template += f"-{variant_obj['position']}"
 
-    if build == 37:
+    if build == 37 or variant_obj["chromosome"] in ["M", "MT"]:
         url_template += "?dataset=gnomad_sv_r2_1"
         return url_template
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -556,6 +556,10 @@ def gnomad_link(variant_obj, build=37):
         "{this[position]}-{this[reference]}-{this[alternative]}"
     ).format(this=variant_obj)
 
+    if build == 37:
+        url_template += "?dataset=gnomad_r2_1"
+        return url_template
+
     if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
         url_template += "?dataset=gnomad_r3"
 
@@ -575,13 +579,13 @@ def spliceai_link(variant_obj, build=37):
 def gnomad_sv_link(variant_obj, build=37):
     """Compose link to gnomAD website for a structural variant.
 
-    GnomAD SVs are not yet public for hg38 or MT as 2023-02-01.
-
     Since we do not track the GnomAD variant ID we link to the region view instead.
     For balanced variants, we pick the region for the start position (the var is available in both).
+
+    MT SVs are not available for 38 yet.
     """
 
-    if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
+    if variant_obj["chromosome"] in ["M", "MT"] and build == 38:
         return "https://gnomad.broadinstitute.org/"
 
     url_template = (
@@ -593,7 +597,8 @@ def gnomad_sv_link(variant_obj, build=37):
     else:
         url_template += f"-{variant_obj['position']}"
 
-    url_template += "?dataset=gnomad_sv_r2_1"
+    if build == 37:
+        url_template += "?dataset=gnomad_sv_r2_1"
 
     return url_template
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -599,6 +599,9 @@ def gnomad_sv_link(variant_obj, build=37):
 
     if build == 37:
         url_template += "?dataset=gnomad_sv_r2_1"
+        return url_template
+
+    url_template += "?dataset=gnomad_sv_r4"
 
     return url_template
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

GnomAD links broken for build 37.

<img width="1395" alt="Screenshot 2023-11-02 at 10 23 37" src="https://github.com/Clinical-Genomics/scout/assets/758570/c5f63f57-da1f-4738-93b7-141b79fed153">
leding to the now default nomad grch38:
![Screenshot 2023-11-03 at 09 20 12](https://github.com/Clinical-Genomics/scout/assets/758570/4bc9b3c1-bf45-4f52-8f01-d47a6e5b39a8)


✅ with patch
<img width="1332" alt="Screenshot 2023-11-02 at 10 22 54" src="https://github.com/Clinical-Genomics/scout/assets/758570/b4fc2fd4-e221-4f6f-a8bf-023ef989f784">
goes back to trusty bad old grch37.
![Screenshot 2023-11-03 at 09 22 44](https://github.com/Clinical-Genomics/scout/assets/758570/6c4d2bff-4c7d-4119-921b-e8b127511d77)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. click links to gnomAD from different category variant pages

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
