### PR TITLE
Clearer STRs on case general report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Changed
-- STRs visualization in case panel to emphasize abnormal repeat count and predicted outcome
+- STRs visualization on case panel to emphasize abnormal repeat count and associated condition
 - Removed cytoband column from STRs variant view on case report
 ### Added
 - Shortcut button for HPO panel MEI variants from case page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 
 ## [Unreleased]
+### Changed
+- STRs visualization in case panel to emphasize abnormal repeat count and predicted outcome
 ### Added
 - Shortcut button for HPO panel MEI variants from case page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Changed
 - STRs visualization in case panel to emphasize abnormal repeat count and predicted outcome
+- Removed cytoband column from STRs variant view on case report
 ### Added
 - Shortcut button for HPO panel MEI variants from case page
 

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1123,15 +1123,22 @@
         <tr class="table-secondary">
           <th>Variant type</th>
           <th>Estimated size</th>
+          <th>Reference size</th>
           <th>Coordinates</th>
-          <th>Cytoband</th>
           <th>Gene panels</th>
         </tr>
       </thead>
       <tbody>
-        <tr>
+        {% if variant.str_status == 'full_mutation' %}
+          <tr class="table-danger">
+        {% elif variant.str_status == 'pre_mutation' %}
+          <tr class="bg-warning">
+        {% else %}
+          <tr>
+        {% endif %}
           <td><span class="badge badge-info">{{variant.category | upper}}</span></td>
           <td>{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>
+          <td>{{ variant.str_ref }}</td>
           <td>
             {% if variant.chromosome == variant.end_chrom %}
               chr{{variant.chromosome}}:{{variant.position}}-{{variant.end}}
@@ -1139,11 +1146,6 @@
               chr{{variant.chromosome}}:{{variant.position}}/chr{{variant.end_chrom or variant.chromosome}}:{{variant.end}}
             {% endif %}
           </td>
-          {% if variant.cytoband_start and variant.cytoband_end %}
-            <td>{{variant.cytoband_start}}-{{variant.cytoband_end}}</td>
-          {% else %}
-            <td>-</td>
-          {% endif %}
           <td>
             {% if variant.panels %}
               {% if variant.panels|length <= 3 %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1249,7 +1249,7 @@
           </td>
           <td>
             {% if variant.str_source.display %}
-              <a href="{{variant.str_source_link}}" target="_blank" rel=”noopener">{{ variant.str_source.display }}</a>
+              <a href="{{variant.str_source_link}}" target="_blank" rel="noopener noreferrer">{{ variant.str_source.display }}</a>
             {% else %}
               "-"
             {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1129,12 +1129,12 @@
         </tr>
       </thead>
       <tbody>
-        {% if variant.str_status == 'full_mutation' %}
+        {% if not variant.str_status or variant.str_status == 'normal' %}
+          <tr>
+        {% elif variant.str_status == 'full_mutation' %}
           <tr class="table-danger">
         {% elif variant.str_status == 'pre_mutation' %}
           <tr class="bg-warning">
-        {% else %}
-          <tr>
         {% endif %}
           <td><span class="badge badge-info">{{variant.category | upper}}</span></td>
           <td>{{ variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "") }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1233,19 +1233,27 @@
       <thead>
         <tr class="table-secondary">
           <th>Disease</th>
+          <th>Inheritance model</th>
           <th>Source</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           {% if variant.str_disease %}
-            <td>{{ variant.str_disease }} ({{ variant.str_inheritance_mode }})</td>
-          {% endif %}
-          {% if variant.str_source is defined %}
-            <td>{{ variant.str_source.display }}</td>
+            <td>{{ variant.str_disease }}</td>
           {% else %}
             <td>-</td>
           {% endif %}
+          <td>
+            {{ variant.str_inheritance_mode if variant.str_inheritance_mode else "-" }}
+          </td>
+          <td>
+            {% if variant.str_source.display %}
+              <a href="{{variant.str_source_link}}" target="_blank" rel=”noopener">{{ variant.str_source.display }}</a>
+            {% else %}
+              "-"
+            {% endif %}
+          </td>
           </tr>
       </tbody>
     </table>


### PR DESCRIPTION
Fix #4176 

- Removed cytoband
- Added link to literature
- Added ref repats count
- Added a color to better classify STR (full mutation, pre-mutation, normal)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
