### PR TITLE
Fix missing family name parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Fixed
 - OMIM table is scrollable if higher than 700px
+- Case display name defaulting to case ID when `family_name` or `display_name` are missing from case upload config file
 ### Changed
 - STRs visualization on case panel to emphasize abnormal repeat count and associated condition
 - Removed cytoband column from STRs variant view on case report

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -378,7 +378,6 @@ class CaseLoader(BaseModel):
     display_name: Optional[str] = Field(None, alias="family_name")
     exe_ver: Optional[str] = None
     family: Optional[str] = None
-    family_name: Optional[str] = None
     gene_fusion_report: Optional[str] = None
     gene_fusion_report_research: Optional[str] = None
     gene_panels: Optional[List[str]] = []
@@ -420,13 +419,6 @@ class CaseLoader(BaseModel):
     def set_case_id(cls, values) -> "CaseLoader":
         """Make sure case will have an _id."""
         values.update({"case_id": values.get("case_id", values.get("family"))})
-        return values
-
-    @model_validator(mode="before")
-    def set_display_name(cls, values) -> "CaseLoader":
-        """Set case's display name."""
-        if values.get("display_name") is None:
-            values.update({"display_name": values.get("family")})
         return values
 
     @model_validator(mode="before")

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -375,9 +375,10 @@ class CaseLoader(BaseModel):
     custom_images: Optional[Union[RawCustomImages, ParsedCustomImages]] = None
     default_panels: Optional[List[str]] = Field([], alias="default_gene_panels")
     delivery_report: Optional[str] = None
-    display_name: Optional[str] = Field(alias="family_name")
+    display_name: Optional[str] = Field(None, alias="family_name")
     exe_ver: Optional[str] = None
     family: Optional[str] = None
+    family_name: Optional[str] = None
     gene_fusion_report: Optional[str] = None
     gene_fusion_report_research: Optional[str] = None
     gene_panels: Optional[List[str]] = []
@@ -419,6 +420,13 @@ class CaseLoader(BaseModel):
     def set_case_id(cls, values) -> "CaseLoader":
         """Make sure case will have an _id."""
         values.update({"case_id": values.get("case_id", values.get("family"))})
+        return values
+
+    @model_validator(mode="before")
+    def set_display_name(cls, values) -> "CaseLoader":
+        """Set case's display name."""
+        if values.get("display_name") is None:
+            values.update({"display_name": values.get("family")})
         return values
 
     @model_validator(mode="before")

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -81,6 +81,7 @@ def test_parse_case_parsing(scout_config, param_name):
     (
         [
             ("case_id", "family"),
+            ("display_name", "family_name"),
             ("default_panels", "default_gene_panels"),
             ("peddy_ped_check", "peddy_check"),
             ("peddy_sex_check", "peddy_sex"),


### PR DESCRIPTION
Fix #4197 


**How to test**:
1. Locally. branch main, remove `family_name` from demo config file. Run `scout setup demo`
2. Switch to this branch and try again `scout setup demo`

**Expected outcome**:
1. Main branch should not load the case and display validation error
3. This branch should load the case with a display name equal to case id (internal_id)

**Review:**
- [x] code approved by ALKC
- [x] tests executed by CR
