### PR TITLE
Added responsiveness to ClinVar howto image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - OMIM table is scrollable if higher than 700px
 - Pinned variants validation badge is now red for false positives.
 - Case display name defaulting to case ID when `family_name` or `display_name` are missing from case upload config file
+- The image in ClinVar howto-modal is now responsive
 ### Changed
 - STRs visualization on case panel to emphasize abnormal repeat count and associated condition
 - Removed cytoband column from STRs variant view on case report

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_howto.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_howto.html
@@ -15,7 +15,7 @@
             Follow the instructions provided on the <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/" target="_blank" rel="noopener">API pages</a> to obtain a valid key for the service account.<br>
             Once you are satisfied with the content of your submission in Scout, you can submit your variants using the ClinVar API. If you obtained a submission ID from ClinVar (format: "SUB999999") and you want to use it for the submission, you can save it using the "Update ID manually" button:<br><br>
 
-              <img width="875" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/8289aae8-eb95-4f77-8abc-44c748f8406c"><br><br>
+              <img class="img-fluid" width="875" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/8289aae8-eb95-4f77-8abc-44c748f8406c"><br><br>
 
             Alternatively you can <strong>leave the Submission ID blank, so it will be retrieved directly from the ClinVar API once a successful submission has been processed.</strong>.
 


### PR DESCRIPTION
This PR prevents the img in ClinVar hoot-modal to overflow in smaller screens. 
fixes  #4199


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
