### PR TITLE
Fix remove case from group if case has been already removed in another tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Case display name defaulting to case ID when `family_name` or `display_name` are missing from case upload config file
 - Expanded menu visible at screen sizes below 1000px now has background color
 - The image in ClinVar howto-modal is now responsive
+- Clicking on a case in case groups when case was already removed from group in another browser tab
 ### Changed
 - STRs visualization on case panel to emphasize abnormal repeat count and associated condition
 - Removed cytoband column from STRs variant view on case report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- Shortcut button for HPO panel MEI variants from case page
+- Export managed variants from CLI
+### Changed
+- STRs visualization on case panel to emphasize abnormal repeat count and associated condition
+- Removed cytoband column from STRs variant view on case report
+- More long integers formatted with thin spaces, and copy to clipboard buttons added
 ### Fixed
 - OMIM table is scrollable if higher than 700px
 - Pinned variants validation badge is now red for false positives.
@@ -12,13 +19,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Expanded menu visible at screen sizes below 1000px now has background color
 - The image in ClinVar howto-modal is now responsive
 - Clicking on a case in case groups when case was already removed from group in another browser tab
-### Changed
-- STRs visualization on case panel to emphasize abnormal repeat count and associated condition
-- Removed cytoband column from STRs variant view on case report
-- More long integers formatted with thin spaces, and copy to clipboard buttons added
-### Added
-- Shortcut button for HPO panel MEI variants from case page
-- Export managed variants from CLI
 
 ## [4.72.4]
 ### Changed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1071,8 +1071,10 @@ def remove_case_group(store, current_user, institute_id, case_name, case_group):
 
     current_group_ids = case_obj.get("group", [])
 
-    # STR OBJID mismatch?
-    current_group_ids.remove(ObjectId(case_group))
+    obj_id_group = ObjectId(case_group)
+    if obj_id_group not in current_group_ids:
+        return
+    current_group_ids.remove(obj_id_group)
     updated_case = store.update_case_group_ids(
         institute_obj, case_obj, user_obj, link, current_group_ids
     )

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -353,7 +353,7 @@
             <div class="col-12 ms-2">
               {% for grouped_case in case_group %}
                 <div class="badge bg-light">
-                  <a class="text-dark" href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}">{{ grouped_case.display_name }}</a>
+                  <a href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}">{{ grouped_case.display_name }}</a>
 
                   <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
                       <span class="fa fa-remove text-dark"></span></a>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -356,7 +356,7 @@
                   <a class="text-dark" href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}">{{ grouped_case.display_name }}</a>
 
                   <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
-                      <span class="fa fa-remove"></span></a>
+                      <span class="fa fa-remove text-black"></span></a>
 
                 </div>
               {% endfor %}

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -356,7 +356,7 @@
                   <a class="text-dark" href="{{ url_for('cases.case', institute_id=grouped_case.owner, case_name=grouped_case.display_name) }}">{{ grouped_case.display_name }}</a>
 
                   <a href="{{ url_for('cases.remove_case_group', institute_id=institute._id, case_name=grouped_case.display_name, case_group=group_id) }}" class="btn btn-link btn-sm">
-                      <span class="fa fa-remove text-black"></span></a>
+                      <span class="fa fa-remove text-dark"></span></a>
 
                 </div>
               {% endfor %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -614,7 +614,7 @@
               name="{{ button_name if button_name }}"
               value="{{ button_value if button_value }}"
               type="submit">
-        <i class="fa fa-remove"></i>
+        <i class="fa fa-remove text-dark""></i>
       </button>
     </div>
   </form>


### PR DESCRIPTION
Fix #4205 
Specifically:
-  "x" button to remove a case from a group sometimes is not visible, based on the clicked status:

<img width="394" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/ca779b0d-73f9-4798-b85c-15788d185a82">

- Fix remove the case from a group whenever it has been already removed in another browser tab (fix #4205 )


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, from demo case 643594, create a group and add cancer_case to this group. Go o another browser tab and open case 643594. Remove cancer_case from the group and go to the other tab. Try to remove cancer_case from the group also in the pther tab

**Expected outcome**:
- Main branch should crash
- This branch should just reload the case page

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
