### PR TITLE
Added Decipher button to SNV/MEI and str variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- SNVs and Indels, MEI and str variants genes have links to Decipher
 ### Fixed
 -loqusdb table no longer has empty row below each loqusid
 

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -258,6 +258,9 @@
           {% if gene.pubmed_link %}
             <a href="{{ gene.pubmed_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">PubMed</a>
           {% endif %}
+          {% if gene.decipher_link %}
+            <a href="{{ gene.decipher_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Decipher</a>
+          {% endif %}
           <a href="http://tools.genes.toronto.edu/" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">SPANR</a>
           <a href="{{ gene.reactome_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Reactome</a>
           <a href="{{ gene.expression_atlas_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Expr. Atlas</a>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from flask import current_app
 
@@ -80,6 +80,13 @@ def add_gene_links(gene_obj, build=37):
     gene_obj["stripy_link"] = stripy_gene(hgnc_symbol)
     gene_obj["gnomad_str_link"] = gnomad_str_gene(hgnc_symbol)
     gene_obj["panelapp_link"] = panelapp_gene(hgnc_symbol)
+    gene_obj["decipher_link"] = decipher_gene(hgnc_symbol)
+
+
+def decipher_gene(hgnc_symbol: str) -> Optional[str]:
+    """Create link to Decipher gene."""
+    if hgnc_symbol:
+        return f"https://www.deciphergenomics.org/gene/{hgnc_symbol}/overview/clinical-info"
 
 
 def panelapp_gene(hgnc_symbol):


### PR DESCRIPTION
Partially fixing #4210 - just the Decipher link for now

<img width="373" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/0c24e65a-b9ae-4f3b-9c8f-dfa7f77d8d6a">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Go to any SNV/MEI/str variant page and make sure the link to Decipher exists and points to the right page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN, TB
- [x] tests executed by CR
