### PR TITLE
Option to submit multigene SNVs as single genes to MME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Changed
+- Split multi-gene SNV variants into single genes when submitting to Matchmaker Exchange
 ### Fixed
 -loqusdb table no longer has empty row below each loqusid
 

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -73,12 +73,22 @@
                   <li class="list-group-item">
                     Select <u><b>max 3</b></u> variants/genes from the pinned variants list (only gene names can be shared for SVs)<br>
                     <div style="max-height:200px; overflow-y: scroll;"">
+                      {% set count = namespace(value=0) %}
                       {% for var in suspects %}
+                        {% set count.value = count.value + 1 %}
                         {% if var.category == "snv" %} <!-- Share either gene names or variant details for SNVs -->
-                          <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}">{{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
+                          <!-- Share multi-gene variant -->
+                          ~ Variant {{count.value}} ~ <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}">{{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
+
+                          {% if var.genes|length > 1 %}
+                            {% for gene in var.genes %}  <!-- Share single gene variants from a multi-gene variant -->
+                              ~ Variant {{count.value}} ~ <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}">{{ gene.hgnc_symbol or gene.hgnc_id}} - {{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
+                            {% endfor %}
+                          {% endif %}
+
                         {% elif var.category == "sv" %} <!-- Share only gene names from SVs -->
                           {% for gene in var.genes %}
-                            <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}"> {{gene.hgnc_symbol or gene.hgnc_id}} - {{ pretty_variant(var) }} <span class="badge bg-warning">SV</span><br>
+                            ~ Variant {{count.value}} ~  <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}"> {{gene.hgnc_symbol or gene.hgnc_id}} - {{ pretty_variant(var) }} <span class="badge bg-warning">SV</span><br>
                           {% endfor %}
                         {% endif %}
                       {% endfor %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -77,11 +77,12 @@
                       {% for var in suspects %}
                         {% set count.value = count.value + 1 %}
                         {% if var.category == "snv" %} <!-- Share either gene names or variant details for SNVs -->
-                          <!-- Share multi-gene variant -->
+
+                          <!-- Share variant it is, could be a multi-gene variant, resulting into multiple gene submission-->
                           ~ Variant {{count.value}} ~ <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}">{{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
 
-                          {% if var.genes|length > 1 %}
-                            {% for gene in var.genes %}  <!-- Share single gene variants from a multi-gene variant -->
+                          {% if var.genes|length > 1 %} <!-- Share single gene variants from a multi-gene variant -->
+                            {% for gene in var.genes %}
                               ~ Variant {{count.value}} ~ <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}">{{ gene.hgnc_symbol or gene.hgnc_id}} - {{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
                             {% endfor %}
                           {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4096

Option to either submit a multi-gene variant as it is (resulting in multi-gene submission) or submitting single genes from the multi-gene variant

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
