### PR TITLE
Add test and fixtures for RNA fusion case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - SNVs and Indels, MEI and str variants genes have links to Decipher
 - An `owner + case display name` index for cases database collection
+- Test and fixtures for RNA fusion case page
 ### Fixed
 - loqusdb table no longer has empty row below each loqusid
 - MatchMaker submission details page crashing because of change in date format returned by PatientMatcher

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,6 @@ from scout.build.user import build_user
 from scout.build.variant import build_variant
 from scout.demo import (
     cancer_load_path,
-    rnafusion_load_path,
     cancer_snv_path,
     cancer_sv_path,
     clinical_snv_path,
@@ -32,6 +31,7 @@ from scout.demo import (
     load_path,
     panel_path,
     ped_path,
+    rnafusion_load_path,
     vep_97_annotated_path,
     vep_104_annotated_path,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ from scout.build.user import build_user
 from scout.build.variant import build_variant
 from scout.demo import (
     cancer_load_path,
+    rnafusion_load_path,
     cancer_snv_path,
     cancer_sv_path,
     clinical_snv_path,
@@ -394,26 +395,23 @@ def ped_lines(request):
     ]
     return case_lines
 
-
 @pytest.fixture(scope="function")
-def case_lines(request, scout_config):
-    """Get the lines for a case"""
+def parsed_case(request, scout_config) -> dict:
+    """Get a WES parsed case."""
     case = parse_case_config(scout_config)
     return case
 
 
 @pytest.fixture(scope="function")
-def parsed_case(request, scout_config):
-    """Get the lines for a case"""
-    case = parse_case_config(scout_config)
-    return case
-
-
-@pytest.fixture(scope="function")
-def cancer_parsed_case(request, cancer_scout_config):
-    """Get the lines for a cancer case"""
+def cancer_parsed_case(request, cancer_scout_config) -> dict:
+    """Get a cancer panel parsed case."""
     case = parse_case_config(cancer_scout_config)
     return case
+
+@pytest.fixture(scope="function")
+def fusion_parsed_case(request, fusion_scout_config) -> dict:
+    """Get a parsed RNA fusion case."""
+    return parse_case_config(fusion_scout_config)
 
 
 @pytest.fixture(scope="function")
@@ -473,6 +471,15 @@ def case_obj(request, parsed_case):
     case["phenotype_terms"] = []  # do not assign any phenotype
     case["cohorts"] = []  # do not assign any cohort
 
+    return case
+
+
+@pytest.fixture(scope="function")
+def fusion_case_obj(request, fusion_parsed_case) -> dict:
+    """Returns a DNA fusion case."""
+    case: dict =  fusion_parsed_case
+    case["_id"] = fusion_parsed_case["case_id"]
+    case["status"] = "inactive"
     return case
 
 
@@ -1347,7 +1354,7 @@ def ped_file(request):
 
 
 @pytest.fixture(scope="function")
-def scout_config(request, config_file):
+def scout_config(request, config_file) -> dict:
     """Return a dictionary with scout configs"""
     print("")
     in_handle = get_file_handle(config_file)
@@ -1356,9 +1363,16 @@ def scout_config(request, config_file):
 
 
 @pytest.fixture(scope="function")
-def cancer_scout_config(request):
+def cancer_scout_config(request) -> dict:
     """Return a dictionary with cancer case scout configs"""
     in_handle = get_file_handle(cancer_load_path)
+    data = yaml.safe_load(in_handle)
+    return data
+
+@pytest.fixture(scope="function")
+def fusion_scout_config(request) -> dict:
+    """Return a dictionary with fusion case scout configs"""
+    in_handle = get_file_handle(rnafusion_load_path)
     data = yaml.safe_load(in_handle)
     return data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -482,6 +482,8 @@ def fusion_case_obj(request, fusion_parsed_case) -> dict:
     case: dict = fusion_parsed_case
     case["_id"] = fusion_parsed_case["case_id"]
     case["status"] = "inactive"
+    case["phenotype_terms"] = []  # do not assign any phenotype
+    case["cohorts"] = []  # do not assign any cohort
     return case
 
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -2,7 +2,7 @@
 import datetime
 
 from bson.objectid import ObjectId
-from flask import current_app, json, url_for
+from flask import json, url_for
 
 from scout.constants import CUSTOM_CASE_REPORTS
 from scout.server.blueprints.cases.views import parse_raw_gene_ids, parse_raw_gene_symbols
@@ -423,13 +423,16 @@ def test_case_sma(app, case_obj, institute_obj):
         assert resp.status_code == 200
 
 
-def test_case_fusion(app, fusion_case_obj, institute_obj):
+def test_case_fusion(app, adapter, fusion_case_obj, institute_obj):
     """Test the RNA fusion case page."""
 
     # GIVEN an initialized app
     with app.test_client() as client:
         # GIVEN a valid user, case and institute
         client.get(url_for("auto_login"))
+
+        # GIVEN a database containing a fusion case object
+        assert store.case_collection.insert_one(fusion_case_obj)
 
         # WHEN accessing the RNA fusion case
         resp = client.get(

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -422,6 +422,29 @@ def test_case_sma(app, case_obj, institute_obj):
         # THEN it should return a page
         assert resp.status_code == 200
 
+def test_case_fusion(app, fusion_case_obj, institute_obj):
+    """Test the RNA fusion case page."""
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+
+        # GIVEN a valid user, case and institute
+        client.get(url_for("auto_login"))
+
+        # WHEN accessing the RNA fusion case
+        resp = client.get(
+            url_for(
+                "cases.case",
+                institute_id=institute_obj["internal_id"],
+                case_name=fusion_case_obj["display_name"],
+            )
+        )
+
+        # THEN it should return a page
+        assert resp.status_code == 200
+
+
+
 
 def test_update_individual(app, user_obj, institute_obj, case_obj, mocker, mock_redirect):
     mocker.patch("scout.server.blueprints.cases.views.redirect", return_value=mock_redirect)


### PR DESCRIPTION
- Adds fixtures for RNA fusion case
- Adds a test for fusion case page

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by EC
- [x] tests executed by GitHub actions
