### PR TITLE
Update case document with path to mei variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - An `owner + case display name` index for cases database collection
 - Test and fixtures for RNA fusion case page
 - Load and display fusion variants from VCF files as the other variant types
+- Option to update case document with path to mei variants (clinical and research)
 ### Fixed
 - loqusdb table no longer has empty row below each loqusid
 - MatchMaker submission details page crashing because of change in date format returned by PatientMatcher

--- a/scout/commands/update/case.py
+++ b/scout/commands/update/case.py
@@ -1,9 +1,7 @@
 import logging
-from pprint import pprint as pp
 
 import click
 import pymongo
-from flask.cli import with_appcontext
 
 from scout.server.extensions import store
 
@@ -71,7 +69,6 @@ LOG = logging.getLogger(__name__)
     help="Remove all SVs and re upload from existing files",
 )
 @click.option("--rankscore-treshold", help="Set a new rank score treshold if desired")
-@click.option("--rankmodel-version", help="Update the rank model version")
 @click.option("--sv-rankmodel-version", help="Update the SV rank model version")
 @click.pass_context
 def case(
@@ -92,7 +89,6 @@ def case(
     vcf_mei_research,
     reupload_sv,
     rankscore_treshold,
-    rankmodel_version,
     sv_rankmodel_version,
 ):
     """

--- a/scout/commands/update/case.py
+++ b/scout/commands/update/case.py
@@ -56,6 +56,16 @@ LOG = logging.getLogger(__name__)
     help="path to research VCF with cancer structural variants to be added",
 )
 @click.option(
+    "--vcf-mei",
+    type=click.Path(exists=True),
+    help="path to clinical mei variants to be added",
+)
+@click.option(
+    "--vcf-mei-research",
+    type=click.Path(exists=True),
+    help="path to research mei variants to be added",
+)
+@click.option(
     "--reupload-sv",
     is_flag=True,
     help="Remove all SVs and re upload from existing files",
@@ -78,6 +88,8 @@ def case(
     vcf_sv_research,
     vcf_cancer_research,
     vcf_cancer_sv_research,
+    vcf_mei,
+    vcf_mei_research,
     reupload_sv,
     rankscore_treshold,
     rankmodel_version,
@@ -112,37 +124,22 @@ def case(
             case_obj["collaborators"].append(collaborator)
             LOG.info("Adding collaborator %s", collaborator)
 
-    if vcf:
-        LOG.info("Updating 'vcf_snv' to %s", vcf)
-        case_obj["vcf_files"]["vcf_snv"] = vcf
-        case_changed = True
-    if vcf_sv:
-        LOG.info("Updating 'vcf_sv' to %s", vcf_sv)
-        case_obj["vcf_files"]["vcf_sv"] = vcf_sv
-        case_changed = True
-    if vcf_cancer:
-        LOG.info("Updating 'vcf_cancer' to %s", vcf_cancer)
-        case_obj["vcf_files"]["vcf_cancer"] = vcf_cancer
-        case_changed = True
-    if vcf_cancer_sv:
-        LOG.info("Updating 'vcf_cancer_sv' to %s", vcf_cancer_sv)
-        case_obj["vcf_files"]["vcf_cancer_sv"] = vcf_cancer_sv
-        case_changed = True
-    if vcf_research:
-        LOG.info("Updating 'vcf_research' to %s", vcf_research)
-        case_obj["vcf_files"]["vcf_research"] = vcf_research
-        case_changed = True
-    if vcf_sv_research:
-        LOG.info("Updating 'vcf_sv_research' to %s", vcf_sv_research)
-        case_obj["vcf_files"]["vcf_sv_research"] = vcf_sv_research
-        case_changed = True
-    if vcf_cancer_research:
-        LOG.info("Updating 'vcf_cancer_research' to %s", vcf_cancer_research)
-        case_obj["vcf_files"]["vcf_cancer_research"] = vcf_cancer_research
-        case_changed = True
-    if vcf_cancer_sv_research:
-        LOG.info("Updating 'vcf_cancer_sv_research' to %s", vcf_cancer_sv_research)
-        case_obj["vcf_files"]["vcf_cancer_sv_research"] = vcf_cancer_sv_research
+    for key_name, key in [
+        ("vcf", vcf),
+        ("vcf_sv", vcf_sv),
+        ("vcf_cancer", vcf_cancer),
+        ("vcf_cancer_sv", vcf_cancer_sv),
+        ("vcf_research", vcf_research),
+        ("vcf_sv_research", vcf_sv_research),
+        ("vcf_cancer_research", vcf_cancer_research),
+        ("vcf_cancer_sv_research", vcf_cancer_sv_research),
+        ("vcf_mei", vcf_mei),
+        ("vcf_mei_research", vcf_mei_research),
+    ]:
+        if key is None:
+            continue
+        LOG.info(f"Updating '{key_name}' to {key}")
+        case_obj["vcf_files"][key_name] = key
         case_changed = True
 
     if case_changed:

--- a/scout/commands/update/case.py
+++ b/scout/commands/update/case.py
@@ -121,7 +121,7 @@ def case(
             LOG.info("Adding collaborator %s", collaborator)
 
     for key_name, key in [
-        ("vcf", vcf),
+        ("vcf_snv", vcf),
         ("vcf_sv", vcf_sv),
         ("vcf_cancer", vcf_cancer),
         ("vcf_cancer_sv", vcf_cancer_sv),

--- a/tests/commands/update/test_update_case_cmd.py
+++ b/tests/commands/update/test_update_case_cmd.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from scout.commands import cli
 import pytest
+
+from scout.commands import cli
 from scout.server.extensions import store
 
 

--- a/tests/commands/update/test_update_case_cmd.py
+++ b/tests/commands/update/test_update_case_cmd.py
@@ -86,7 +86,7 @@ def test_update_case_change_collaborator(mock_app, case_obj):
     ],
 )
 def test_update_case_vcf_path(mock_app, case_obj, vcf_key, custom_temp_file):
-    """Test the CLI function that updates the case document with paths to dofferent variant types."""
+    """Test the CLI function that updates the case document with paths to different variant types."""
 
     # GIVEN a new VCF variant path to save in case document
     vcf_path = str(custom_temp_file(".vcf.gz"))


### PR DESCRIPTION
Update case with path to mei and research mei variants
Fix #4229 


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
