### PR TITLE
Audit filters specifics on case report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Expanded menu visible at screen sizes below 1000px now has background color
 - The image in ClinVar howto-modal is now responsive
 - Clicking on a case in case groups when case was already removed from group in another browser tab
+- Page crashing when saving filters for mei variants
 
 ## [4.72.4]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - STRs visualization on case panel to emphasize abnormal repeat count and associated condition
 - Removed cytoband column from STRs variant view on case report
 - More long integers formatted with thin spaces, and copy to clipboard buttons added
+- Details on variant type and category for audit filters on case general report
 ### Fixed
 - OMIM table is scrollable if higher than 700px on SV page
 - Pinned variants validation badge is now red for false positives.

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -2,19 +2,10 @@
 import logging
 
 from bson.objectid import ObjectId
+from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 from flask import url_for
 
 LOG = logging.getLogger(__name__)
-
-VARIANTS_TARGET_FROM_CATEGORY = {
-    "sv": "variants.sv_variants",
-    "cancer": "variants.cancer_variants",
-    "cancer_sv": "variants.cancer_sv_variants",
-    "mei": "variants.mei_variants",
-    "snv": "variants.variants",
-    "str": "variants.str_variants",
-    "fusion": "variants.fusion_variants",
-}
 
 
 class FilterHandler(object):
@@ -127,7 +118,6 @@ class FilterHandler(object):
              Returns:
                  filter_obj(ReturnDocument)
         """
-        filter_obj = None
         LOG.debug("Retrieve filter {}".format(filter_id))
         filter_obj = self.filter_collection.find_one({"_id": ObjectId(filter_id)})
         if filter_obj is None:
@@ -138,7 +128,7 @@ class FilterHandler(object):
             target = VARIANTS_TARGET_FROM_CATEGORY.get(category)
 
             case_name = case_obj.get("display_name")
-            link = url_for(target, case_name=case_name, **filter_obj)
+            link = url_for(target, case_name=case_name, institute_id=institute_obj.get("_id"))
 
         subject = filter_obj["display_name"]
 

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -138,7 +138,7 @@ class FilterHandler(object):
             target = VARIANTS_TARGET_FROM_CATEGORY.get(category)
 
             case_name = case_obj.get("display_name")
-            link = url_for(target, case_name=case_name, institute_id=institute_obj.get("_id"))
+            link = url_for(target, case_name=case_name, **filter_obj)
 
         subject = filter_obj["display_name"]
 

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -2,8 +2,9 @@
 import logging
 
 from bson.objectid import ObjectId
-from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 from flask import url_for
+
+from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -11,6 +11,7 @@ VARIANTS_TARGET_FROM_CATEGORY = {
     "sv": "variants.sv_variants",
     "cancer": "variants.cancer_variants",
     "cancer_sv": "variants.cancer_sv_variants",
+    "mei": "variants.mei_variants",
     "snv": "variants.variants",
     "str": "variants.str_variants",
     "fusion": "variants.fusion_variants",

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -4,7 +4,7 @@ import logging
 from bson.objectid import ObjectId
 from flask import url_for
 
-from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
+from scout.constants import VARIANTS_TARGET_FROM_CATEGORY
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 
-import pymongo
 from bson.objectid import ObjectId
 from flask import url_for
 

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -81,6 +81,7 @@ from .variant_tags import (
     VARIANT_CALL,
     VARIANT_FILTERS,
     VARIANT_GENOTYPES,
+    VARIANTS_TARGET_FROM_CATEGORY,
 )
 from .variants_export import (
     CANCER_EXPORT_HEADER,

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -510,3 +510,13 @@ MOSAICISM_OPTIONS = {
         "evidence": ["allele_count"],
     },
 }
+
+VARIANTS_TARGET_FROM_CATEGORY = {
+    "sv": "variants.sv_variants",
+    "cancer": "variants.cancer_variants",
+    "cancer_sv": "variants.cancer_sv_variants",
+    "mei": "variants.mei_variants",
+    "snv": "variants.variants",
+    "str": "variants.str_variants",
+    "fusion": "variants.fusion_variants",
+}

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -2,7 +2,8 @@
 import logging
 import os
 from datetime import timedelta
-from typing import Union, Dict
+from typing import Dict, Union
+from urllib.parse import parse_qsl, unquote, urlsplit
 
 import coloredlogs
 from flask import Flask, current_app, redirect, request, url_for
@@ -31,9 +32,6 @@ from .blueprints import (
     variant,
     variants,
 )
-
-from urllib.parse import unquote, urlsplit, parse_qsl
-
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -2,7 +2,7 @@
 import logging
 import os
 from datetime import timedelta
-from typing import Union
+from typing import Union, Dict
 
 import coloredlogs
 from flask import Flask, current_app, redirect, request, url_for
@@ -32,10 +32,8 @@ from .blueprints import (
     variants,
 )
 
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib2 import unquote
+from urllib.parse import unquote, urlsplit, parse_qsl
+
 
 LOG = logging.getLogger(__name__)
 
@@ -241,6 +239,11 @@ def register_filters(app):
     def url_decode(string):
         """Decode a string with encoded hex values."""
         return unquote(string)
+
+    @app.template_filter()
+    def url_args(url: str) -> Dict[str, str]:
+        """Return all arguments and values present in a string URL."""
+        return dict(parse_qsl(urlsplit(url).query))
 
     @app.template_filter()
     def cosmic_prefix(cosmicId):

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -261,9 +261,11 @@
                 </tr>
               </thead>
               <tbody>
+                 {% set audit_query = namespace() %}
                  {% for audit in audits %}
+                  {% set audit_query = audit.link|url_args %}
                   <tr>
-                    <td><strong>{{ audit.subject }}</strong> was marked checked by {{ audit.user_name }} on {{audit.created_at.strftime('%Y-%m-%d')}}.</td>
+                    <td><strong>{{ audit.subject }} (category:{{ audit_query.category if audit_query.category else "NA"}}, type:{{audit_query.variant_type if audit_query.variant_type else "NA"}})</strong> was marked checked by {{ audit.user_name }} on {{audit.created_at.strftime('%Y-%m-%d')}}.</td>
                   </tr>
                  {%  endfor %}
               </tbody>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -265,7 +265,7 @@
                  {% for audit in audits %}
                   {% set audit_query = audit.link|url_args %}
                   <tr>
-                    <td><strong>{{ audit.subject }} (category:{{ audit_query.category if audit_query.category else "NA"}}, type:{{audit_query.variant_type if audit_query.variant_type else "NA"}})</strong> was marked checked by {{ audit.user_name }} on {{audit.created_at.strftime('%Y-%m-%d')}}.</td>
+                    <td><strong>{{ audit.subject }} ({{audit_query.variant_type if audit_query.variant_type else "type unavailable -"}} {{ audit_query.category if audit_query.category else "category unavailable"}})</strong> was marked checked by {{ audit.user_name }} on {{audit.created_at.strftime('%Y-%m-%d')}}.</td>
                   </tr>
                  {%  endfor %}
               </tbody>

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -26,8 +26,8 @@ from scout.constants import (
     MOSAICISM_OPTIONS,
     SPIDEX_HUMAN,
     VARIANT_FILTERS,
+    VARIANTS_TARGET_FROM_CATEGORY,
 )
-from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 from scout.constants.variants_export import CANCER_EXPORT_HEADER, EXPORT_HEADER
 from scout.server.blueprints.variant.utils import (
     callers,

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1510,7 +1510,6 @@ def persistent_filter_actions(
 
     if bool(request_form.get("audit_filter")):
         filter_id = request_form.get("filters")
-        LOG.error(request_form)
         audit_for = dict(
             category=category, variant_type=request_form.get("variant_type", "clinical")
         )

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -42,6 +42,7 @@ from scout.server.utils import (
     institute_and_case,
     user_institutes,
 )
+from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 
 from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, FusionFiltersForm, SvFiltersForm
 from .utils import update_case_panels
@@ -1509,7 +1510,24 @@ def persistent_filter_actions(
 
     if bool(request_form.get("audit_filter")):
         filter_id = request_form.get("filters")
-        filter_obj = store.audit_filter(filter_id, institute_obj, case_obj, user_obj, category)
+        LOG.error(request_form)
+        audit_for = dict(
+            category=category, variant_type=request_form.get("variant_type", "clinical")
+        )
+        link: str = url_for(
+            VARIANTS_TARGET_FROM_CATEGORY.get(category),
+            case_name=case_obj.get("display_name"),
+            institute_id=institute_obj.get("_id"),
+            **audit_for,
+        )
+        filter_obj = store.audit_filter(
+            filter_id=filter_id,
+            institute_obj=institute_obj,
+            case_obj=case_obj,
+            user_obj=user_obj,
+            category=category,
+            link=link,
+        )
         if filter_obj is not None:
             filter_obj = store.retrieve_filter(filter_id)
             form = FiltersFormClass(MultiDict(filter_obj))

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -27,6 +27,7 @@ from scout.constants import (
     SPIDEX_HUMAN,
     VARIANT_FILTERS,
 )
+from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 from scout.constants.variants_export import CANCER_EXPORT_HEADER, EXPORT_HEADER
 from scout.server.blueprints.variant.utils import (
     callers,
@@ -42,7 +43,6 @@ from scout.server.utils import (
     institute_and_case,
     user_institutes,
 )
-from scout.constants.variant_tags import VARIANTS_TARGET_FROM_CATEGORY
 
 from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, FusionFiltersForm, SvFiltersForm
 from .utils import update_case_panels

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -14,3 +14,15 @@ def test_app_human_longint_filter_number(mock_app):
     """Test template filter human_longint with a long integer."""
     assert "human_longint" in mock_app.jinja_env.filters.keys()
     assert mock_app.jinja_env.filters["human_longint"](100000) == "100&thinsp;000"
+
+
+def test_app_url_args_filter(mock_app):
+    """Test the template filter with a URL to parse."""
+    # GIVEN a URL as it would be saved in events collection
+    url = "/cust000/643594/sv/variants?category=sv&display_name=SVs_clinical&page=1&variant_type=clinical&gene_panels=panel1&_id=65645ef376be6591e1f72cf3"
+
+    # THEN url_args filter should parse and return the link query arguments as a dictionary:
+    parsed_url: dict = mock_app.jinja_env.filters["url_args"](url)
+    assert isinstance(parsed_url, dict)
+    assert parsed_url["category"]
+    assert parsed_url["variant_type"]


### PR DESCRIPTION
Attempt at adding info on variants category and type for audited filters on case report (fix #4219):

<img width="732" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/366d4ea1-95ae-43bf-967b-e6d79a71fdc0">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
