### PR TITLE
Compound follow multi gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - loqusdb table no longer has empty row below each loqusid
 - MatchMaker submission details page crashing because of change in date format returned by PatientMatcher
 - Links displayed as buttons does not change color when visited
+- Hide compounds with compounds follow filter for region or function would fail for variants in multiple genes
 
 ## [4.73]
 ### Added

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -126,7 +126,7 @@ class VariantLoader(object):
             else:
                 variant_obj = self.variant_collection.find_one({"_id": compound["variant"]})
             if variant_obj:
-                # If the variant exosts we try to collect as much info as possible
+                # If the variant exists we try to collect as much info as possible
                 not_loaded = False
                 compound["rank_score"] = variant_obj["rank_score"]
                 compound["is_dismissed"] = len(variant_obj.get("dismiss_variant", [])) > 0

--- a/scout/build/variant/genotype.py
+++ b/scout/build/variant/genotype.py
@@ -29,7 +29,6 @@ def build_genotype(gt_call):
         so=gt_call["so"],
         ffpm=gt_call["ffpm"],
         split_read=gt_call["split_read"],
-
     )
 
     return gt_obj

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -695,6 +695,14 @@ def _compound_follow_filter_in_compound(compound, compound_var_obj, query_form):
                 compound["is_dismissed"] = True
                 return True
 
+            split_any_gene_items = [
+                possible_gene_item.split(":")[-1]
+                for possible_gene_item in compound_items
+                if ":" in possible_gene_item
+            ]
+            if split_any_gene_items:
+                compound_items = split_any_gene_items
+
             if set(compound_items).isdisjoint(set(query_form_items)):
                 compound["is_dismissed"] = True
                 return True
@@ -732,7 +740,6 @@ def _compound_follow_filter_clnsig(compound, compound_var_obj, query_form):
         str_re = re.compile("|".join(query_str_rank))
 
         compound_clnsig = compound_var_obj.get("clnsig")
-        LOG.debug("compound_var_obj %s", compound_var_obj)
         if compound_clnsig:
             for compound_clnsig_item in compound_clnsig:
                 clnsig_value = compound_clnsig_item.get("value")
@@ -847,7 +854,6 @@ def hide_compounds_query(store, variant_obj, query_form):
             if not compound_var_obj:
                 compound["is_dismissed"] = True
                 continue
-
             compound_follow_filter(compound, compound_var_obj, query_form)
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The issue with a compound variant in multiple genes was that when aggregating the region and function annotations, we add a gene name with a colon to them, so they do not directly work in the comparison. The set disjunct is not totally perfect, but now at least does what it was intended to do: variants will not be dismissed if any of the genes have a functional annotation or region annotation that match the filter.

See issue as well, but in debug terms, before:
<img width="1390" alt="Screenshot 2023-11-28 at 11 57 56" src="https://github.com/Clinical-Genomics/scout/assets/758570/571e6430-43be-4938-b2ce-0148e8b9d617">

And after:
<img width="1609" alt="Screenshot 2023-11-28 at 12 00 55" src="https://github.com/Clinical-Genomics/scout/assets/758570/fc6a30dc-52be-48eb-be28-07546322267d">

✅ The filter does not dismiss the compound:
<img width="1621" alt="Screenshot 2023-11-28 at 11 59 06" src="https://github.com/Clinical-Genomics/scout/assets/758570/d99fa90a-a2e2-47d9-a67c-4bfb879c1e21">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
