### PR TITLE
Revert global styles and fix variant buttons style instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - loqusdb table no longer has empty row below each loqusid
 - MatchMaker submission details page crashing because of change in date format returned by PatientMatcher
-- Links displayed as buttons does not change color when visited
+- Variant external links buttons style does not change color when visited
 - Hide compounds with compounds follow filter for region or function would fail for variants in multiple genes
 
 ## [4.73]

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -247,53 +247,53 @@
         External links: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
       </div>
       <div class="panel-body">
-          <a href="{{ gene.ensembl_link }}" class="btn btn-secondary" rel="noopener" oreferrerpolicy="no-referrer" target="_blank">Ensembl</a>
-          <a href="{{ gene.hpa_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">HPA</a>
-          <a href="{{ gene.string_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">STRING</a>
-          <a href="{{ gene.genemania_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">GENEMANIA</a>
-          <a href="{{ variant.ucsc_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">UCSC</a>
+          <a href="{{ gene.ensembl_link }}" class="btn btn-secondary text-white" rel="noopener" oreferrerpolicy="no-referrer" target="_blank">Ensembl</a>
+          <a href="{{ gene.hpa_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">HPA</a>
+          <a href="{{ gene.string_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">STRING</a>
+          <a href="{{ gene.genemania_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">GENEMANIA</a>
+          <a href="{{ variant.ucsc_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">UCSC</a>
           {% if gene.entrez_link %}
-            <a href="{{ gene.entrez_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Entrez</a>
+            <a href="{{ gene.entrez_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Entrez</a>
           {% endif %}
           {% if gene.pubmed_link %}
-            <a href="{{ gene.pubmed_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">PubMed</a>
+            <a href="{{ gene.pubmed_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">PubMed</a>
           {% endif %}
           {% if gene.decipher_link %}
-            <a href="{{ gene.decipher_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Decipher</a>
+            <a href="{{ gene.decipher_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Decipher</a>
           {% endif %}
-          <a href="http://tools.genes.toronto.edu/" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">SPANR</a>
-          <a href="{{ gene.reactome_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Reactome</a>
-          <a href="{{ gene.expression_atlas_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Expr. Atlas</a>
-          <a href="{{ gene.clingen_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">ClinGen</a>
-          <a href="{{ gene.gencc_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">GenCC</a>
+          <a href="http://tools.genes.toronto.edu/" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">SPANR</a>
+          <a href="{{ gene.reactome_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Reactome</a>
+          <a href="{{ gene.expression_atlas_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Expr. Atlas</a>
+          <a href="{{ gene.clingen_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">ClinGen</a>
+          <a href="{{ gene.gencc_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">GenCC</a>
           {% if variant.alamut_link %}
-            <a href="{{ variant.alamut_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Alamut</a>
+            <a href="{{ variant.alamut_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Alamut</a>
           {% endif %}
-          <a href="{{ gene.ppaint_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">Protein Paint</a>
+          <a href="{{ gene.ppaint_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Protein Paint</a>
           {% if variant.is_mitochondrial %}
-            <a href="{{ variant.mitomap_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">MitoMap</a>
+            <a href="{{ variant.mitomap_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">MitoMap</a>
           {% endif %}
           {% if variant.hmtvar_variant_id %}
-            <a href="{{ variant.hmtvar_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">HmtVar</a>
+            <a href="{{ variant.hmtvar_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">HmtVar</a>
           {% endif %}
           {% if gene.tp53_link %}
-            <a href="{{ gene.tp53_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">MutanTP53</a>
+            <a href="{{ gene.tp53_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">MutanTP53</a>
           {% endif %}
           {% if gene.iarctp53_link %}
-            <a href="{{ gene.iarctp53_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">TP53 Database</a>
+            <a href="{{ gene.iarctp53_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">TP53 Database</a>
           {% endif %}
           {% if cancer %}
-            <a href="{{ gene.cbioportal_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">cBioPortal</a>
-            <a href="{{ gene.oncokb_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">OncoKB</a>
-            <a href="{{ gene.civic_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">CIViC</a>
-            <a href="{{ gene.ckb_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">CKB</a>
+            <a href="{{ gene.cbioportal_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">cBioPortal</a>
+            <a href="{{ gene.oncokb_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">OncoKB</a>
+            <a href="{{ gene.civic_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">CIViC</a>
+            <a href="{{ gene.ckb_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">CKB</a>
           {% endif %}
           {% if str %}
-            <a href="{{ gene.stripy_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">STRipy</a>
-            <a href="{{ gene.gnomad_str_link}}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">GnomAD STR</a>
+            <a href="{{ gene.stripy_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">STRipy</a>
+            <a href="{{ gene.gnomad_str_link}}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">GnomAD STR</a>
           {% endif %}
-          <a href="{{ gene.panelapp_link }}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">PanelApp</a>
-          <a href="{{ url_for('variant.marrvel_link', build=case.genome_build or '37', variant_id=variant._id)}}" class="btn btn-secondary" rel="noopener" referrerpolicy="no-referrer" target="_blank">MARRVEL</a>
+          <a href="{{ gene.panelapp_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">PanelApp</a>
+          <a href="{{ url_for('variant.marrvel_link', build=case.genome_build or '37', variant_id=variant._id)}}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">MARRVEL</a>
       </div>
     {% endfor %}
   </div>

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -32,12 +32,12 @@ table.dataTable {margin-bottom: 0}
 	 top: 50px;
 }
 
-a:visited : not(class^='btn')
-  color: var(--bs-purple);
+a:visited {
+	color: var(--bs-purple);
 }
 
-a:visited : not(class^='img')
-  color: var(--bs-purple);
+a.btn:visited {
+  color: inherit;
 }
 
 a.dropdown-item:visited {


### PR DESCRIPTION
When you open pages like the cases of an institute or the variantS from a case, you no longer see which ones were visited because the visited link color looks like the un-visited link.

This was caused by #4236, which was an attempt to fix an error introduced by #4217.

In this PR I am:
- Reverting global css styles as they were before #4217 (fix #4245)
- Fixing the style of the visited external links buttons on variant page instead

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
