### PR TITLE
Parse and show RNA fusion found_db key/values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hovertip to gene panel names with associated genes in variant view, when variant covers more than one gene
 - Tests for panel to genes
 - Download of Orphadata en_product6 and en_product4 from CLI
-- Parse and display fusion variants
+- Parse and save `database_found` key/values for RNA fusion variants
 ### Changed
 - Allow use of projections when retrieving gene panels
 - Do not save custom images as binary data into case and variant database documents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hovertip to gene panel names with associated genes in variant view, when variant covers more than one gene
 - Tests for panel to genes
 - Download of Orphadata en_product6 and en_product4 from CLI
+- Parse and display fusion variants
 ### Changed
 - Allow use of projections when retrieving gene panels
 - Do not save custom images as binary data into case and variant database documents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cases are activated by viewing FSHD and SMA reports
 ### Fixed
 - Removed some extra characters from top of general report left over from FontAwsome fix
+- Do not save fusion variants-specific key/values in other types of variants
 
 ## [4.74.1]
 ### Changed

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -210,12 +210,12 @@ def build_variant(
     variant_obj["mei_polarity"] = variant.get("mei_polarity")
 
     ## Fusion variant specific
-    FUSION_KEYS = ["tool_hits", "fusion_score", "orientation", "frame_status", "fusion_genes"]
-    for key in FUSION_KEYS:
-        variant_obj[key] = variant.get(key)
-
     if variant_obj["category"] == "fusion":
         variant_obj["rank_score"] = variant_obj.get("fusion_score")
+
+        FUSION_KEYS = ["tool_hits", "fusion_score", "orientation", "frame_status", "fusion_genes", "found_db"]
+        for key in FUSION_KEYS:
+            variant_obj[key] = variant.get(key)
 
     ### Mitochondria Specific
     variant_obj["mitomap_associated_diseases"] = variant.get("mitomap_associated_diseases")

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -433,15 +433,15 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
         else:
             return value
 
+    def set_found_db(found_db_info: Optional[str]) -> Optional[List[str]]:
+        """Set the found_db value according to the value found in the VCF."""
+        if found_db_info not in [None, "[]", ""]:
+            return found_db_info.split(",")
+
     parsed_variant["gene_a"] = call_safe(str, variant.INFO.get("GENEA", ""))
     parsed_variant["gene_b"] = call_safe(str, variant.INFO.get("GENEB", ""))
     parsed_variant["tool_hits"] = call_safe(str, variant.INFO.get("TOOL_HITS", 0))
-    parsed_variant["found_db"] = call_safe(str, variant.INFO.get("FOUND_DB"))
-    parsed_variant["found_db"] = (
-        parsed_variant["found_db"].split(",")
-        if parsed_variant["found_db"] not in (None, "[]", "")
-        else None
-    )
+    parsed_variant["found_db"] = set_found_db(call_safe(str, variant.INFO.get("FOUND_DB")))
     parsed_variant["fusion_score"] = call_safe(str, variant.INFO.get("SCORE", None))
     parsed_variant["hgnc_id_a"] = call_safe(int, variant.INFO.get("HGNC_ID_A", 0))
     parsed_variant["hgnc_id_b"] = call_safe(int, variant.INFO.get("HGNC_ID_B", 0))

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -436,6 +436,12 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
     parsed_variant["gene_a"] = call_safe(str, variant.INFO.get("GENEA", ""))
     parsed_variant["gene_b"] = call_safe(str, variant.INFO.get("GENEB", ""))
     parsed_variant["tool_hits"] = call_safe(str, variant.INFO.get("TOOL_HITS", 0))
+    parsed_variant["found_db"] = call_safe(str, variant.INFO.get("FOUND_DB"))
+    parsed_variant["found_db"] = (
+        parsed_variant["found_db"].split(",")
+        if parsed_variant["found_db"] not in (None, "[]", "")
+        else None
+    )
     parsed_variant["fusion_score"] = call_safe(str, variant.INFO.get("SCORE", None))
     parsed_variant["hgnc_id_a"] = call_safe(int, variant.INFO.get("HGNC_ID_A", 0))
     parsed_variant["hgnc_id_b"] = call_safe(int, variant.INFO.get("HGNC_ID_B", 0))

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -59,7 +59,8 @@ onsubmit="return validateForm()">
             <th style="width:3%"></th>
             <th style="width:4%" title="Beta version. Currently testing">Rank (beta)</th>
             <th style="width:6%" title="Genes">Fusion Genes</th>
-            <th style="width:4%" title="Number of callers detecting a given event">Callers</th>
+            <th style="width:4%" title="Number of callers detecting a given event">Nr. callers</th>
+            <th style="width:4%" title="Database hits">Database hits</th>
             <th style="width:4%" title="Beta version. Currently testing">Score (beta)</th>
             <th style="width:6%" title="Number of paired-ends that support the event">Junction Reads</th>
             <th style="width:6%" title="Number of split reads that support the event">Split Reads</th>
@@ -122,6 +123,7 @@ onsubmit="return validateForm()">
     </td>
     <td><span data-bs-toggle="tooltip" data-bs-html="true" title="{% for name, caller in variant.callers %}{{ name }}: {{ caller }}<br>{% endfor %}">
       {{ variant.tool_hits|int }}</span></td>
+    <td>{{variant.found_db|join(", ") if variant.found_db else "-"}}</td>
     <td class="text-end">{{ variant.fusion_score|float|round(3) }}</td>
     <td>{{ variant.samples[0].read_depth }}</td>
     <td>{{ variant.samples[0].split_read }}</td>

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -60,7 +60,7 @@ onsubmit="return validateForm()">
             <th style="width:4%" title="Beta version. Currently testing">Rank (beta)</th>
             <th style="width:6%" title="Genes">Fusion Genes</th>
             <th style="width:4%" title="Number of callers detecting a given event">Nr. callers</th>
-            <th style="width:4%" title="Database hits">Database hits</th>
+            <th style="width:4%" title="Observed database matches">Observed</th>
             <th style="width:4%" title="Beta version. Currently testing">Score (beta)</th>
             <th style="width:6%" title="Number of paired-ends that support the event">Junction Reads</th>
             <th style="width:6%" title="Number of split reads that support the event">Split Reads</th>

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -59,7 +59,7 @@ onsubmit="return validateForm()">
             <th style="width:3%"></th>
             <th style="width:4%" title="Beta version. Currently testing">Rank (beta)</th>
             <th style="width:6%" title="Genes">Fusion Genes</th>
-            <th style="width:4%" title="Number of callers detecting a given event">Nr. callers</th>
+            <th style="width:4%" title="Number of callers detecting a given event">Callers</th>
             <th style="width:4%" title="Observed database matches">Observed</th>
             <th style="width:4%" title="Beta version. Currently testing">Score (beta)</th>
             <th style="width:6%" title="Number of paired-ends that support the event">Junction Reads</th>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4271
- Do not save fusion variants-specific key/values in other types of variants

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Run scout setup demo locally and make sure that the new parsed value is shown on fusion variants page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
