### PR TITLE
Fix removing of None key/values before saving parsed variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Removed some extra characters from top of general report left over from FontAwsome fix
 - Do not save fusion variants-specific key/values in other types of variants
+- Alamut link for MT variants in build 38
 
 ## [4.74.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Download of Orphadata en_product6 and en_product4 from CLI
 - Parse and save `database_found` key/values for RNA fusion variants
 - Added fusion_score, ffpm, split_reads, junction_reads and fusion_caller to the list of filters on RNA fusion variants page
+- Renamed the get_mei_info to set_mei_info function to be consistent with the other functions
+- Fixed removing None key/values from parsed variants
 ### Changed
 - Allow use of projections when retrieving gene panels
 - Do not save custom images as binary data into case and variant database documents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Retrieve and display case and variant custom images using image's saved path
 - Cases are activated by viewing FSHD and SMA reports
 - Split multi-gene SNV variants into single genes when submitting to Matchmaker Exchange
-- Avoid category-specific info being saved in all variant types upon loading
 ### Fixed
 - Removed some extra characters from top of general report left over from FontAwsome fix
 - Do not save fusion variants-specific key/values in other types of variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Download of Orphadata en_product6 and en_product4 from CLI
 - Parse and save `database_found` key/values for RNA fusion variants
 - Added fusion_score, ffpm, split_reads, junction_reads and fusion_caller to the list of filters on RNA fusion variants page
-- Renamed the `get_mei_info` to `set_mei_info` function to be consistent with the other functions
+- Renamed the function `get_mei_info` to `set_mei_info` to be consistent with the other functions
 - Fixed removing None key/values from parsed variants
 ### Changed
 - Allow use of projections when retrieving gene panels

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -153,7 +153,7 @@ def parse_variant(
     parsed_variant["str_swegen_std"] = call_safe(float, variant.INFO.get("SweGenStd"))
 
     # Add MEI info
-    get_mei_info(variant, parsed_variant)
+    set_mei_info(variant, parsed_variant)
 
     # Add Fusion info
     set_fusion_info(variant, parsed_variant)
@@ -294,7 +294,7 @@ def get_variant_alternative(variant, category):
         return "."
 
 
-def get_mei_info(variant: Variant, parsed_variant: Dict[str, Any]):
+def set_mei_info(variant: Variant, parsed_variant: Dict[str, Any]):
     """
     ################# Add MEI info ##################
     """

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -751,29 +751,32 @@ def alamut_link(
     Returns:
         url_template(str): link to Alamut browser
     """
-    build = build or 37
-    build_str = ""
-    if build == 38:
-        build_str = "(GRCh38)"
 
     if current_app.config.get("HIDE_ALAMUT_LINK"):
         return False
 
     url_template = (
-        "http://localhost:10000/{search_verb}?{alamut_key_arg}{alamut_inst_arg}request={this[chromosome]}{build_str}:"
+        "http://localhost:10000/{search_verb}?{alamut_key_arg}{alamut_inst_arg}request={chromosome}{build_str}:"
         "{this[position]}{this[reference]}>{this[alternative]}"
     )
     alamut_key = institute_obj.get("alamut_key")
     alamut_institution = institute_obj.get("alamut_institution")
-    # Alamut Visual Plus API has a different search verb
     search_verb = "search" if alamut_key else "show"
     alamut_key_arg = f"apikey={alamut_key}&" if alamut_key else ""
     alamut_inst_arg = f"institution={alamut_institution}&" if alamut_institution else ""
+    chromosome = variant_obj.get("chromosome")
+
+    build = build or 37
+    build_str = ""
+    if build == 38:
+        build_str = "(GRCh38)"
+        chromosome = chromosome.replace("M", "MT")
 
     return url_template.format(
         search_verb=search_verb,
         alamut_key_arg=alamut_key_arg,
         alamut_inst_arg=alamut_inst_arg,
+        chromosome=chromosome,
         this=variant_obj,
         build_str=build_str,
     )

--- a/scout/utils/convert.py
+++ b/scout/utils/convert.py
@@ -76,6 +76,8 @@ def call_safe(fun, unknown_var):
     Args: unknown_var: Object
           fun: Function
     Returns: Object"""
+    if unknown_var is None:
+        return None
     try:
         return fun(unknown_var)
     except ValueError:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fixes #4288 
- Renamed the `get_mei_info` to `set_mei_info` function to be consistent with the other functions

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locallly, run `scout setup demo` and make sure that any non-str variant doesn't contain the "None" values shown in #4288 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
