### PR TITLE
Fix type of some RNA fusion variant keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed some extra characters from top of general report left over from FontAwsome fix
 - Do not save fusion variants-specific key/values in other types of variants
 - Alamut link for MT variants in build 38
-- Convert RNA fusions variants `tool_hits, fusion_score, exon_number_a, exon_number_b` keys from string to numbers
+- Convert RNA fusions variants `tool_hits` and `fusion_score` keys from string to numbers
 
 ## [4.74.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed some extra characters from top of general report left over from FontAwsome fix
 - Do not save fusion variants-specific key/values in other types of variants
 - Alamut link for MT variants in build 38
+- Convert RNA fusions variants `tool_hits, fusion_score, exon_number_a, exon_number_b` keys from string to numbers
 
 ## [4.74.1]
 ### Changed

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -440,9 +440,9 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
 
     parsed_variant["gene_a"] = call_safe(str, variant.INFO.get("GENEA", ""))
     parsed_variant["gene_b"] = call_safe(str, variant.INFO.get("GENEB", ""))
-    parsed_variant["tool_hits"] = call_safe(str, variant.INFO.get("TOOL_HITS", 0))
+    parsed_variant["tool_hits"] = call_safe(int, variant.INFO.get("TOOL_HITS", 0))
     parsed_variant["found_db"] = set_found_db(call_safe(str, variant.INFO.get("FOUND_DB")))
-    parsed_variant["fusion_score"] = call_safe(str, variant.INFO.get("SCORE", None))
+    parsed_variant["fusion_score"] = call_safe(float, variant.INFO.get("SCORE", None))
     parsed_variant["hgnc_id_a"] = call_safe(int, variant.INFO.get("HGNC_ID_A", 0))
     parsed_variant["hgnc_id_b"] = call_safe(int, variant.INFO.get("HGNC_ID_B", 0))
     parsed_variant["orientation"] = replace_nan(
@@ -458,10 +458,10 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
         str, replace_nan(variant.INFO.get("TRANSCRIPT_ID_B", ""))
     )
     parsed_variant["exon_number_a"] = call_safe(
-        str, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_A", "")))
+        int, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_A", "")))
     )
     parsed_variant["exon_number_b"] = call_safe(
-        str, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_B", "")))
+        int, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_B", "")))
     )
     parsed_variant["fusion_genes"] = [parsed_variant["gene_a"], parsed_variant["gene_b"]]
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -458,10 +458,10 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
         str, replace_nan(variant.INFO.get("TRANSCRIPT_ID_B", ""))
     )
     parsed_variant["exon_number_a"] = call_safe(
-        int, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_A", "")))
+        str, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_A", "")))
     )
     parsed_variant["exon_number_b"] = call_safe(
-        int, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_B", "")))
+        str, call_safe(int, replace_nan(variant.INFO.get("EXON_NUMBER_B", "")))
     )
     parsed_variant["fusion_genes"] = [parsed_variant["gene_a"], parsed_variant["gene_b"]]
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Converts RNA fusions variants `tool_hits, fusion_score` keys from string to numbers - Fix #4281 - 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
