### PR TITLE
Unfreeze coloredlogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix genotype reference and alternative sequencing depths defaulting to -1 when values are 0
 - DecimalFields were limited to two decimal places for several forms - lifting restrictions on AF, CADD etc.
 
+
 ## [4.74.1]
 ### Changed
 - Parse and save into database also OMIM terms not associated to genes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- command line crashing with error when updating a user that doesn't exist
+- Command line crashing with error when updating a user that doesn't exist
+- Thaw coloredlogs - 15.0.1 restores errorhandler issue
 
 ## [4.75]
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Markdown
 WTForms
 Flask-WTF
 Flask-Mail
-coloredlogs<=14.0
+coloredlogs
 query_phenomizer
 Flask-Babel>=3
 livereload


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

See https://github.com/Clinical-Genomics/scout/issues/2252 for some background.


Looks all good after upgrading to 15.0.1:
```
(scout39n) ➜  scout git:(main) ✗ pip install -U -r requirements.txt
...
Requirement already satisfied: coloredlogs in /usr/local/miniconda3/envs/scout39n/lib/python3.9/site-packages (from -r requirements.txt (line 11)) (14.0)
Collecting coloredlogs
  Using cached coloredlogs-15.0.1-py2.py3-none-any.whl (46 kB)
...
(scout39n) ➜  scout git:(main) ✗ pytest tests/commands/download/test_download_ensembl_cmd.py
=============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0 -- /usr/local/miniconda3/envs/scout39n/bin/python
cachedir: .pytest_cache
rootdir: /Users/dannil/sandbox/scout, configfile: pytest.ini
plugins: mock-3.7.0, test-groups-1.0.3, cov-3.0.0, flask-1.2.0
collected 5 items

tests/commands/download/test_download_ensembl_cmd.py::test_download_ensembl_cmd PASSED                                                                                                                                                      [ 20%]
tests/commands/download/test_download_ensembl_cmd.py::test_print_ensembl_genes PASSED                                                                                                                                                       [ 40%]
tests/commands/download/test_download_ensembl_cmd.py::test_print_ensembl_transcripts PASSED                                                                                                                                                 [ 60%]
tests/commands/download/test_download_ensembl_cmd.py::test_print_ensembl_exons PASSED                                                                                                                                                       [ 80%]
tests/commands/download/test_download_ensembl_cmd.py::test_print_ensembl_unknown_resource PASSED                                                                                                                                            [100%]
```

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. automated test should pass, in particular Ensembl dl test

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub Actions / pytest
