### PR TITLE
Fixed missing cryptography lib error with Docker on ARM processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue
+- Missing cryptography lib error while running Scout container on an ARM processor
 
 ## [4.75]
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: '3'
 services:
 
   mongodb:
-    image: mongo:4.4.9
+    image: mongo:7
     container_name: mongodb
     networks:
       - scout-net
@@ -16,6 +16,7 @@ services:
 
   scout-cli:
     build: .
+    platform: linux/amd64
     container_name: scout-cli
     command: bash -c "
       scout --host mongodb setup demo"
@@ -30,6 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile-server
+    platform: linux/amd64
     expose:
       - '8000'
     ports:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug

If you try to run the dockerized version of scout as described in the instructions on an ARM processor you get the following error:

```
scout-cli          |   File "/venv/lib/python3.8/site-packages/authlib/jose/rfc7517/__init__.py", line 10, in <module>
scout-cli          |     from ._cryptography_key import load_pem_key
scout-cli          |   File "/venv/lib/python3.8/site-packages/authlib/jose/rfc7517/_cryptography_key.py", line 1, in <module>
scout-cli          |     from cryptography.x509 import load_pem_x509_certificate
scout-cli          |   File "/venv/lib/python3.8/site-packages/cryptography/x509/__init__.py", line 7, in <module>
scout-cli          |     from cryptography.x509 import certificate_transparency
scout-cli          |   File "/venv/lib/python3.8/site-packages/cryptography/x509/certificate_transparency.py", line 11, in <module>
scout-cli          |     from cryptography.hazmat.bindings._rust import x509 as rust_x509
scout-cli          | ImportError: /venv/lib/python3.8/site-packages/cryptography/hazmat/bindings/_rust.abi3.so: cannot open shared object file: No such file or directory
scout-scout-web-1 exited with code 3
scout-cli exited with code 1
```

This PR is fixing this error by forcing docker-compose to build the image and run it using the linux/amd64 platform


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by TB
- [x] tests executed by CR
