### PR TITLE
Add REVEL, REVEL rank and SpliceAI scores to causatives and validated pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- command line crashing with error when updating a user that doesn't exist
+- Command line crashing with error when updating a user that doesn't exist
+- Thaw coloredlogs - 15.0.1 restores errorhandler issue
 
 ## [4.75]
 ### Added
@@ -32,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Convert RNA fusions variants `tool_hits` and `fusion_score` keys from string to numbers
 - Fix genotype reference and alternative sequencing depths defaulting to -1 when values are 0
 - DecimalFields were limited to two decimal places for several forms - lifting restrictions on AF, CADD etc.
+
 
 ## [4.74.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing delete icons on phenomodels page
 - Missing cryptography lib error while running Scout container on an ARM processor
 - Round CADD values with many decimals on causatives and validated variants pages
+- Dark-mode visibility of some fields on causatives and validated variants pages
 
 ## [4.75]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue
+- Round CADD values with many decimals on causatives and validated variants pages
 
 ## [4.75]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Revel score, Revel rank score and SpliceAI values are also displayed in Causatives and Validated variants tables
 ### Fixed
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Markdown
 WTForms
 Flask-WTF
 Flask-Mail
-coloredlogs<=14.0
+coloredlogs
 query_phenomizer
 Flask-Babel>=3
 livereload

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -263,6 +263,11 @@ def register_filters(app):
         """Returns the elements that are common in 2 lists"""
         return list(set(list1) & set(list2))
 
+    @app.template_filter()
+    def list_remove_none(in_list:list) -> list:
+        """Returns a list after removing any None values from it."""
+        return [item for item in in_list if item is not None]
+
 
 def register_tests(app):
     @app.template_test("existing")

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -308,6 +308,9 @@
           <th>Callers</th>
           <th>CADD score</th>
           <th data-bs-toggle='tooltip' data-bs-container='body' title="score(model version)">Rank score</th>
+          <th>Revel score</th>
+          <th>Revel rank score</th>
+          <th>SpliceAI DS max</th>
           <th data-bs-toggle='tooltip' data-bs-container='body' title="ref/alt-GQ">Zygosity</th>
           <th>Inheritance</th>
           <th>ACMG</th>
@@ -388,14 +391,35 @@
               {% endif %}
             </td>
             <td><!-- Rank score -->
-              <a href="#"><span class="badge rounded-pill bg-secondary">
+              <span class="badge rounded-pill bg-secondary">
               {{ variant.rank_score }}
               {% if variant.category == 'sv' %}
                 (v. {{case.sv_rank_model_version or 'na'}})
               {% else %}
                 (v. {{case.rank_model_version or 'na'}})
               {% endif %}
-              </span></a>
+              </span>
+            </td>
+            <td><!-- REVEL score -->
+              {% if variant.revel %}
+              <span class="badge rounded-pill bg-secondary">
+                {{variant.revel}}
+              </span>
+              {% else %}
+               -
+              {% endif %}
+            </td>
+            <td><!-- REVEL rank score -->
+              {% if variant.revel_score %}
+              <span class="badge rounded-pill bg-secondary">
+                {{variant.revel_score}}
+              </span>
+              {% else %}
+               -
+              {% endif %}
+            </td>
+            <td><!-- SpliceAI -->
+            {{variant.spliceai_scores}}
             </td>
             <td><!-- Zygosity -->
               {%- for sample in variant.samples -%}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -382,7 +382,7 @@
             </td>
             <td><!-- CADD score -->
               {% if variant.cadd_score %}
-                <span class="badge bg-secondary">{{ variant.cadd_score }}</span>
+                <span class="badge bg-secondary">{{ variant.cadd_score|round(2) }}</span>
               {% else %}
                 -
               {% endif %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -405,7 +405,7 @@
             <td>
               {% if score %}
                 <span class="badge rounded-pill bg-secondary">
-                  {{score}}
+                  {{score|round(2)}}
                 </span>
               {% else %}
                 -

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -310,7 +310,7 @@
           <th data-bs-toggle='tooltip' data-bs-container='body' title="score(model version)">Rank score</th>
           <th>Revel score</th>
           <th>Revel rank score</th>
-          <th>SpliceAI</th>
+          <th>SpliceAI DS max</th>
           <th data-bs-toggle='tooltip' data-bs-container='body' title="ref/alt-GQ">Zygosity</th>
           <th>Inheritance</th>
           <th>ACMG</th>
@@ -419,7 +419,7 @@
               {% endif %}
             </td>
             <td><!-- SpliceAI -->
-            {{variant.spliceai_scores|join(', ')}}
+            {{ variant.spliceai_scores|list_remove_none|join(', ') }}
             </td>
             <td><!-- Zygosity -->
               {%- for sample in variant.samples -%}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -405,7 +405,7 @@
             <td>
               {% if score %}
                 <span class="badge rounded-pill bg-secondary">
-                  {{variant.revel}}
+                  {{score}}
                 </span>
               {% else %}
                 -

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -400,26 +400,20 @@
               {% endif %}
               </span>
             </td>
-            <td><!-- REVEL score -->
-              {% if variant.revel %}
-              <span class="badge rounded-pill bg-secondary">
-                {{variant.revel}}
-              </span>
+            <!-- Revel scores -->
+            {% for score in [variant.revel, variant.revel_score] %}
+            <td>
+              {% if score %}
+                <span class="badge rounded-pill bg-secondary">
+                  {{variant.revel}}
+                </span>
               {% else %}
-               -
+                -
               {% endif %}
             </td>
-            <td><!-- REVEL rank score -->
-              {% if variant.revel_score %}
-              <span class="badge rounded-pill bg-secondary">
-                {{variant.revel_score}}
-              </span>
-              {% else %}
-               -
-              {% endif %}
-            </td>
+            {% endfor %}
             <td><!-- SpliceAI -->
-            {{ variant.spliceai_scores|list_remove_none|join(', ') }}
+            {{ variant.spliceai_scores|list_remove_none|join(', ') if variant.spliceai_scores else "-" }}
             </td>
             <td><!-- Zygosity -->
               {%- for sample in variant.samples -%}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -415,7 +415,9 @@
             </td>
             {% endfor %}
             <td><!-- SpliceAI -->
-            {{ variant.spliceai_scores|list_remove_none|join(', ') if variant.spliceai_scores else "-" }}
+              <span class="text-muted">
+              {{ variant.spliceai_scores|list_remove_none|join(', ') if variant.spliceai_scores else "-" }}
+              </span>
             </td>
             <td><!-- Zygosity -->
               {%- for sample in variant.samples -%}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -310,7 +310,7 @@
           <th data-bs-toggle='tooltip' data-bs-container='body' title="score(model version)">Rank score</th>
           <th>Revel score</th>
           <th>Revel rank score</th>
-          <th>SpliceAI DS max</th>
+          <th>SpliceAI</th>
           <th data-bs-toggle='tooltip' data-bs-container='body' title="ref/alt-GQ">Zygosity</th>
           <th>Inheritance</th>
           <th>ACMG</th>
@@ -419,7 +419,7 @@
               {% endif %}
             </td>
             <td><!-- SpliceAI -->
-            {{variant.spliceai_scores}}
+            {{variant.spliceai_scores|join(', ')}}
             </td>
             <td><!-- Zygosity -->
               {%- for sample in variant.samples -%}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -347,22 +347,22 @@
               </span>
             </td>
             <td><!-- HGVS[c] -->
+              <span class="text-muted">
               {% if variant.first_rep_gene and variant.first_rep_gene.hgvs_identifier %}
-                <span class="text-muted">
-                  {{variant.first_rep_gene.hgvs_identifier|truncate(15, True)}}
-                </span>
+                {{variant.first_rep_gene.hgvs_identifier|truncate(15, True)}}
               {% else %}
                 -
               {% endif %}
+              </span>
             </td>
             <td><!-- HGVS[p] -->
+              <span class="text-muted">
               {% if variant.first_rep_gene and variant.first_rep_gene.hgvsp_identifier %}
-                <span class="text-muted">
                   {{variant.first_rep_gene.hgvsp_identifier|truncate(15, True)}}
-                </span>
               {% else %}
                 -
               {% endif %}
+              </span>
             </td>
             <td><!-- Functional Annotation -->
               {{ variant_funct_anno_cell(variant) }}
@@ -384,11 +384,13 @@
               </span>
             </td>
             <td><!-- CADD score -->
+              <span class="badge bg-secondary">
               {% if variant.cadd_score %}
-                <span class="badge bg-secondary">{{ variant.cadd_score|round(2) }}</span>
+                {{ variant.cadd_score|round(2) }}
               {% else %}
                 -
               {% endif %}
+              </span>
             </td>
             <td><!-- Rank score -->
               <span class="badge rounded-pill bg-secondary">
@@ -403,13 +405,13 @@
             <!-- Revel scores -->
             {% for score in [variant.revel, variant.revel_score] %}
             <td>
+              <span class="badge rounded-pill bg-secondary">
               {% if score %}
-                <span class="badge rounded-pill bg-secondary">
-                  {{score|round(2)}}
-                </span>
+                {{score|round(2)}}
               {% else %}
                 -
               {% endif %}
+              </span>
             </td>
             {% endfor %}
             <td><!-- SpliceAI -->


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Add REVEL score, REVEL rank and SpliceAI scores to Causatives and Validated variants page (fix #4311)
- Round the CADD score to the second decimal number (fix #4314 ) on the same pages

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
