### PR TITLE
Fixes needed before implementing orpha codes

### DIFF
--- a/scout/adapter/mongo/omim.py
+++ b/scout/adapter/mongo/omim.py
@@ -48,7 +48,7 @@ class DiagnosisHandler(object):
         """Convert case OMIM diagnoses from a list of integers (OMIM number) to a list of OMIM terms dictionaries."""
         updated_diagnoses = []
         for disease_nr in case_obj.get("diagnosis_phenotypes", []):
-            disease_term = self.disease_term(disease_identifier=disease_nr)
+            disease_term = self.disease_term(disease_identifier=f"OMIM:{disease_nr}")
             if disease_term is None:
                 continue
             updated_diagnoses.append(
@@ -87,16 +87,11 @@ class DiagnosisHandler(object):
 
     def disease_term(
         self,
-        disease_identifier: Union[str, int],
+        disease_identifier: str,
         filter_project: Optional[dict] = DISEASE_FILTER_PROJECT,
     ) -> dict:
         """Return a disease term after filtering out associated genes and HPO terms (using filter project)."""
-        query = {}
-        try:
-            disease_identifier = int(disease_identifier)
-            query["disease_nr"] = disease_identifier
-        except ValueError:
-            query["_id"] = disease_identifier
+        query = {"disease_id": disease_identifier}
 
         return self.disease_term_collection.find_one(query, filter_project)
 

--- a/scout/server/blueprints/genes/controllers.py
+++ b/scout/server/blueprints/genes/controllers.py
@@ -65,8 +65,12 @@ def gene(store, hgnc_id):
                 )
                 add_tx_links(transcript, build, record["hgnc_symbol"])
 
-            for phenotype in record.get("phenotypes", []):
-                phenotype["omim_link"] = omim(phenotype.get("mim_number"))
+            record["disease_terms"] = store.disease_terms(hgnc_id=record["hgnc_id"])
+
+            for disease in record["disease_terms"]:
+                if disease["source"] == "OMIM":
+                    mim_number = disease["disease_nr"]
+                    disease["omim_link"] = omim(mim_number)
 
             if not res["record"]:
                 res["record"] = record

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -102,17 +102,22 @@
               </div>
         </div>
 
-        {% if record.phenotypes %}
+        {% if record.disease_terms %}
         <div class="col-md-4">
             <div class="panel panel-default">
               <div class="panel-heading">Phenotypes</div>
-
-            {% for phenotype in record.phenotypes %}
+            {% for disease in record.disease_terms %}
                 <li class="list-group-item">
-                    {{ phenotype.description }}
+                  {{ disease.description }}
+                  {% if disease.omim_link %}
                     <span class="float-end">
-                        <a target="_blank" href={{ record.omim_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank"> {{ phenotype.mim_number }}</a>
+                      <a target="_blank" href={{ disease.omim_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank"> {{ disease.disease_nr }}</a>
                     </span>
+                  {% else %}
+                    <span class="float-end">
+                      {{ disease.disease_nr }}
+                    </span>
+                  {% endif %}
                 </li>
             {% endfor %}
             </div>

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -14,21 +14,24 @@
           </thead>
           <tbody>
             {% for gene in variant.genes %}
-              {% if gene.common %}
-                {% for disease_term in gene.common.phenotypes %}
-                  <tr>
-                    <td>
-                        <a href="http://omim.org/entry/{{ gene.common.omim_id }}" target="_blank">
-                          {{ gene.common.hgnc_symbol }}
-                        </a>
-                    </td>
-                    <td>
-                      <a href="http://omim.org/entry/{{ disease_term.mim_number|replace('OMIM:', '') }}" target="_blank">
-                        {{ disease_term.description }}
-                      </a>
-                    </td>
-                    <td>{{ disease_term.inheritance_models|join(', ') }}</td>
-                  </tr>
+              {% if gene.common and gene.disease_terms %}
+                {% for disease_term in gene.disease_terms %}
+                  {% if disease_term._id|replace('OMIM:', '') !=disease_term._id %}
+                    <tr>
+                      <td>
+                          <a href="http://omim.org/entry/{{ gene.common.omim_id }}" target="_blank">
+                            {{ gene.common.hgnc_symbol }}
+                          </a>
+                      </td>
+                      <td>
+
+                          <a href="http://omim.org/entry/{{ disease_term._id|replace('OMIM:', '') }}" target="_blank">
+                            {{ disease_term.description }}
+                          </a>
+                      </td>
+                      <td>{{ disease_term.inheritance_models|join(', ') }}</td>
+                    </tr>
+                  {% endif %}
                 {% endfor %}
               {% endif %}
             {% endfor %}

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -29,7 +29,7 @@
                             {{ disease_term.description }}
                           </a>
                       </td>
-                      <td>{{ disease_term.inheritance_models|join(', ') }}</td>
+                      <td>{{ disease_term.inheritance|join(', ') }}</td>
                     </tr>
                   {% endif %}
                 {% endfor %}

--- a/tests/adapter/mongo/test_diagnosis_handler.py
+++ b/tests/adapter/mongo/test_diagnosis_handler.py
@@ -68,7 +68,7 @@ def test_fetch_disease_term_by_number(adapter, test_omim_term):
 
     adapter.load_disease_term(test_omim_term)
     ## WHEN fetching a disease term
-    res = adapter.disease_term(test_omim_term["disease_nr"])
+    res = adapter.disease_term(test_omim_term["disease_id"])
 
     ## THEN assert the correct term was fetched
     assert res["_id"] == test_omim_term["_id"]


### PR DESCRIPTION
This PR is a fix for #4306

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data
2. Make sure affected templates still display as before with OMIM terms and ORPHA terms are not present in OMIM tables but visible without link in joint tables.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
