### PR TITLE
Fix missing genes, links and functional anno for fusion variants in causatives and verified pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue
+- Empty cells for RNA fusion variants in Causatives and Verified variants pages
 
 ## [4.75]
 ### Added

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -329,7 +329,7 @@
               {% endif %}
             </td>
             <td><!-- Variant link -->
-              {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant",  "mei": "variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant"} %}
+              {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant",  "mei": "variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant", "fusion": "variant.variant"} %}
               {% for key, page in var_type_page.items() %}
                 {% if variant.category == key %}
                   <a target="_blank" rel="noopener noreferrer" href="{{ url_for(page,

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -1,4 +1,4 @@
-{% from "variants/components.html" import variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import variant_gene_symbols_cell, variant_funct_anno_cell, fusion_variant_gene_symbols_cell %}
 
 {% macro analysis_type(analysis_types) %}
   {% for analysis_type in analysis_types %}
@@ -321,7 +321,13 @@
           {% set case = variant["case_obj"] %}
           {% set analysis_types = [] %} <!-- this will be used later in Analysis type column -->
           <tr>
-            <td>{{ variant_gene_symbols_cell(variant) }}</td>
+            <td>
+              {% if variant.category == "fusion" %}
+                {{ fusion_variant_gene_symbols_cell(variant) }}
+              {% else %}
+                {{ variant_gene_symbols_cell(variant) }}
+              {% endif %}
+            </td>
             <td><!-- Variant link -->
               {% set var_type_page = {"snv":"variant.variant", "str":"variant.variant",  "mei": "variant.variant", "cancer":"variant.cancer_variant", "sv":"variant.sv_variant", "cancer_sv": "variant.sv_variant"} %}
               {% for key, page in var_type_page.items() %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -23,6 +23,25 @@
   </div>
 {% endmacro %}
 
+{% macro fusion_variant_gene_symbols_cell(variant) %}
+<div class="align-items-center">
+  {% if variant.genes %}
+    {% for gene in variant.genes %}
+       <a data-bs-toggle="tooltip" data-bs-html="true" title="
+         <div>
+              <strong>{{ gene.hgnc_symbol or gene.hgnc_id }}</strong>:  {{ gene.description }}
+         </div>"
+        href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
+        </a> <br>
+    {% endfor %}
+  {% else %}
+    {% for symbol in variant.fusion_genes %}
+      {{ symbol }} <br>
+    {% endfor %}
+  {% endif %}
+</div>
+{% endmacro %}
+
 {% macro variant_funct_anno_cell(variant) %}
   <div class="d-flex justify-content-between align-items-center">
     <div>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -45,19 +45,23 @@
 {% macro variant_funct_anno_cell(variant) %}
   <div class="d-flex justify-content-between align-items-center">
     <div>
-      {% if variant.functional_annotations|length >= 5 %}
-        <a class="mr-3" data-bs-toggle="collapse" href="#_functanno_{{variant._id}}" role="button" aria-expanded="false" aria-controls="_{{variant._id}}">{% if variant.missing_data %}[first 30 genes]{% else %}[...]{% endif %}</a>
-        <div class="collapse" id="_functanno_{{variant._id}}">
-          <span class="text-body">
-          {% for annotation in variant.functional_annotations|sort %}
-            {{ annotation }}<br>
-          {% endfor %}
-          </span>
-        </div>
+      {% if variant.category == "fusion" %}
+        {{ variant.frame_status|lower if variant.frame_status else "-" }}
       {% else %}
-        <div>
-          <span class="text-body">{{ variant.functional_annotations|sort|join(", ") }}</span>
-        </div>
+        {% if variant.functional_annotations|length >= 5 %}
+          <a class="mr-3" data-bs-toggle="collapse" href="#_functanno_{{variant._id}}" role="button" aria-expanded="false" aria-controls="_{{variant._id}}">{% if variant.missing_data %}[first 30 genes]{% else %}[...]{% endif %}</a>
+          <div class="collapse" id="_functanno_{{variant._id}}">
+            <span class="text-body">
+            {% for annotation in variant.functional_annotations|sort %}
+              {{ annotation|replace("_", " ") }}<br>
+            {% endfor %}
+            </span>
+          </div>
+        {% else %}
+          <div>
+            <span class="text-body">{{ variant.functional_annotations|sort|join(", ")|replace("_", " ") }}</span>
+          </div>
+        {% endif %}
       {% endif %}
     </div>
   </div>

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import fusion_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, observed_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell, variant_region_anno_cell, gene_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, fusion_variant_gene_symbols_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - Fusion variants
@@ -104,22 +104,7 @@ onsubmit="return validateForm()">
       {{ cell_rank(variant, institute, case, form, manual_rank_options) }}
     </td>
     <td>
-      <div class="align-items-center">
-        {% if variant.genes %}
-          {% for gene in variant.genes %}
-             <a data-bs-toggle="tooltip" data-bs-html="true" title="
-               <div>
-                    <strong>{{ gene.hgnc_symbol or gene.hgnc_id }}</strong>:  {{ gene.description }}
-               </div>"
-              href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
-              </a> <br>
-          {% endfor %}
-        {% else %}
-          {% for symbol in variant.fusion_genes %}
-            {{ symbol }} <br>
-          {% endfor %}
-        {% endif %}
-      </div>
+      {{ fusion_variant_gene_symbols_cell(variant) }}
     </td>
     <td><span data-bs-toggle="tooltip" data-bs-html="true" title="{% for name, caller in variant.callers %}{{ name }}: {{ caller }}<br>{% endfor %}">
       {{ variant.tool_hits|int }}</span></td>
@@ -151,7 +136,6 @@ onsubmit="return validateForm()">
     <td>{{ variant.orientation }}</td>
   </tr>
 {% endmacro %}
-
 
 {% block scripts %}
   {{ super() }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4313

Causatives page on main branch:

<img width="798" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/d0ccbad1-e549-435f-8230-f163876505e3">

<hr>

Causatives pages on this branch:

<img width="792" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/e9d1cab5-7750-430e-b86f-58b172e651c0">





<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
