### PR TITLE
Validate custom image paths when a case is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- command line crashing with error when updating a user that doesn't exist
+- Command line crashing with error when updating a user that doesn't exist
+- Thaw coloredlogs - 15.0.1 restores errorhandler issue
 
 ## [4.75]
 ### Added
@@ -32,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Convert RNA fusions variants `tool_hits` and `fusion_score` keys from string to numbers
 - Fix genotype reference and alternative sequencing depths defaulting to -1 when values are 0
 - DecimalFields were limited to two decimal places for several forms - lifting restrictions on AF, CADD etc.
+
 
 ## [4.74.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Pydantic validation of image paths provided in case load config file
 ### Fixed
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask-Markdown
 WTForms
 Flask-WTF
 Flask-Mail
-coloredlogs<=14.0
+coloredlogs
 query_phenomizer
 Flask-Babel>=3
 livereload

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -323,7 +323,6 @@ def set_custom_images(images: Optional[List[Image]]) -> Optional[List[Image]]:
         else:
             real_folder_images.append(image)  # append other non-repid images
 
-
     return real_folder_images
 
 

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -20,7 +20,7 @@ from scout.exceptions import PedigreeError
 from scout.utils.date import get_date
 
 LOG = logging.getLogger(__name__)
-
+REPID = "{REPID}"
 
 SAMPLES_FILE_PATH_CHECKS = [
     "bam_file",
@@ -280,7 +280,7 @@ class Image(BaseModel):
             raise TypeError(
                 f"Custom images should be of type: {', '.join(SUPPORTED_IMAGE_FORMATS)}"
             )
-        if "{REPID}" not in path and _is_string_path(path) is False:
+        if REPID not in path and _is_string_path(path) is False:
             raise ValueError(f"Image path '{path}' is not valid.")
         return path
 
@@ -308,15 +308,15 @@ def set_custom_images(images: Optional[List[Image]]) -> Optional[List[Image]]:
 
     real_folder_images: List[Image] = []
     for image in images:
-        if image.str_repid == "{REPID}":  # This will be more than one image in a folder
+        if image.str_repid == REPID:  # This will be more than one image in a folder
             for match in _glob_wildcard(path=image.path):
                 new_image: Dict = {
-                    "description": image.description.replace("{REPID}", match["repid"]),
+                    "description": image.description.replace(REPID, match["repid"]),
                     "height": image.height,
                     "format": None,
                     "path": str(match["path"]),
                     "str_repid": match["repid"],
-                    "title": image.title.replace("{REPID}", match["repid"]),
+                    "title": image.title.replace(REPID, match["repid"]),
                     "width": image.width,
                 }
                 real_folder_images.append(Image(**new_image))

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -273,13 +273,15 @@ class Image(BaseModel):
 
     @field_validator("path", mode="before")
     @classmethod
-    def check_image_format(cls, path: str) -> Optional[str]:
+    def check_image_path(cls, path: str) -> Optional[str]:
         """Make sure that the image is has standard format."""
         image_format: str = path.split(".")[-1]
         if image_format not in SUPPORTED_IMAGE_FORMATS:
             raise TypeError(
                 f"Custom images should be of type: {', '.join(SUPPORTED_IMAGE_FORMATS)}"
             )
+        if "{REPID}" not in path and _is_string_path(path) is False:
+            raise ValueError(f"Image path '{path}' is not valid.")
         return path
 
 
@@ -320,6 +322,7 @@ def set_custom_images(images: Optional[List[Image]]) -> Optional[List[Image]]:
                 real_folder_images.append(Image(**new_image))
         else:
             real_folder_images.append(image)  # append other non-repid images
+
 
     return real_folder_images
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4135. After a recent fix we are no longer storing images in the database, so the error occurring in the issue is no longer happening, but this PR introduces an additional check that the custom images provided in the config file have valid paths.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, alter the config file with a custom image path that is not valid and make sure that case load fails

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by TB
- [x] tests executed by TB
