### PR TITLE
Fix #4322 - ClinVar submitters cleared with unpriv saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue
 - Thaw crypography - current base image and library version allow Docker builds
+- Clinvar submitters would be cleared when unprivileged users saved institute settings page
+
 
 ## [4.75]
 ### Added

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -275,6 +275,19 @@ class PanelHandler:
 
         return self.panel_collection.find(query)
 
+    def gene_panels_dict(self, panel_names: List[str]) -> Dict[str, Dict]:
+        """
+        Return gene panel objects, by names list, as a dict keyed by panel name.
+        """
+        gene_panels = {}
+        for panel_name in panel_names:
+            panel_obj = self.gene_panel(panel_name)
+            if panel_obj is None:
+                continue
+            gene_panels[panel_name] = panel_obj["display_name"]
+
+        return gene_panels
+
     def hgnc_to_panels(self, hgnc_id):
         """Get a list of gene panel objects for a hgnc_id
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -359,11 +359,12 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
         sharing_institutes.append(inst)
 
     phenotype_groups = []
+    group_abbreviations = []
+
     for pheno_group in form.getlist("pheno_groups"):
         phenotype_groups.append(pheno_group.split(" ,")[0])
         group_abbreviations.append(pheno_group[pheno_group.find("( ") + 2 : pheno_group.find(" )")])
 
-    group_abbreviations = []
     if form.get("hpo_term") and form.get("pheno_abbrev"):
         phenotype_groups.append(form["hpo_term"].split(" |")[0])
         group_abbreviations.append(form["pheno_abbrev"])

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -341,14 +341,7 @@ def get_gene_panels(store: MongoAdapter, form: MultiDict, tag: str) -> Dict:
 
     tag as in the form e.g. "gene_panels" or "gene_panels_matching".
     """
-    gene_panels = {}
-    for panel_name in form.getlist(tag):
-        panel_obj = store.gene_panel(panel_name)
-        if panel_obj is None:
-            continue
-        gene_panels[panel_name] = panel_obj["display_name"]
-
-    return gene_panels
+    return store.get_panels_dict(panel_names=form.getlist(tag))
 
 
 def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: MultiDict) -> Dict:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -384,7 +384,7 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
         add_groups=False,
         sharing_institutes=sharing_institutes,
         cohorts=cohorts,
-        loqusdb_ids=get_locusdb_ids(form),
+        loqusdb_ids=get_loqusdb_ids(form),
         alamut_key=form.get("alamut_key"),
         alamut_institution=form.get("alamut_institution"),
         check_show_all_vars=form.get("check_show_all_vars"),

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -341,11 +341,14 @@ def get_gene_panels(store: MongoAdapter, form: MultiDict, tag: str) -> Dict:
 
     tag as in the form e.g. "gene_panels" or "gene_panels_matching".
     """
+    gene_panels = {}
     for panel_name in form.getlist(tag):
         panel_obj = store.gene_panel(panel_name)
         if panel_obj is None:
             continue
         gene_panels[panel_name] = panel_obj["display_name"]
+
+    return gene_panels
 
 
 def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: MultiDict) -> Dict:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 import datetime
 import logging
-import re
 from typing import Dict, List, Optional, Tuple
 
 from flask import Response, current_app, flash, url_for
 from flask_login import current_user
 from pymongo import ASCENDING, DESCENDING
 from pymongo.cursor import Cursor
-from werkzeug.datastructures import Headers
+from werkzeug.datastructures import Headers, MultiDict
 
 from scout.adapter.mongo.base import MongoAdapter
 from scout.constants import (
@@ -300,35 +299,52 @@ def populate_institute_form(form, institute_obj):
     return default_phenotypes
 
 
-def update_institute_settings(store, institute_obj, form):
-    """Update institute settings with data collected from institute form
-
-    Args:
-        score(adapter.MongoAdapter)
-        institute_id(str)
-        form(dict)
-
-    Returns:
-        updated_institute(dict)
-
+def get_sanger_recipients(form: MultiDict) -> List[str]:
+    """
+    Return list of Sanger recipients from form multiselect.
     """
     sanger_recipients = []
+    for email in form.getlist("sanger_emails"):
+        sanger_recipients.append(email.strip())
+
+    return sanger_recipients
+
+
+def get_clinvar_submitters(form: MultiDict) -> Optional[List[str]]:
+    """
+    Return list of ClinVar sumbitters from form multiselect.
+    This is not available on the form for unprivileged users, only admin.
+    """
+
     clinvar_submitters = None
-    sharing_institutes = []
+    if current_user.is_admin:
+        clinvar_submitters = []
+        for email in form.getlist("clinvar_emails"):
+            clinvar_submitters.append(email.strip())
+    return clinvar_submitters
+
+
+def get_loqusdb_ids(form: MultiDict) -> Optional[List[str]]:
+    """
+    Return loqusdb ids from the form multiselect.
+    This is not available on the form for unprivileged users, only admin.
+    """
+    if current_user.is_admin is False:
+        return None
+
+    return form.getlist("loqusdb_id")
+
+
+def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: MultiDict) -> Dict:
+    """Update institute settings with data collected from institute form."""
+
     phenotype_groups = []
     gene_panels = {}
     gene_panels_matching = {}
     group_abbreviations = []
     cohorts = []
 
-    for email in form.getlist("sanger_emails"):
-        sanger_recipients.append(email.strip())
-
-    if current_user.is_admin:
-        clinvar_submitters = []
-        for email in form.getlist("clinvar_emails"):
-            clinvar_submitters.append(email.strip())
-
+    sharing_institutes = []
     for inst in form.getlist("institutes"):
         sharing_institutes.append(inst)
 
@@ -355,13 +371,9 @@ def update_institute_settings(store, institute_obj, form):
     for cohort in form.getlist("cohorts"):
         cohorts.append(cohort.strip())
 
-    loqusdb_ids = form.getlist("loqusdb_id")
-    if current_user.is_admin is False:
-        loqusdb_ids = None
-
     updated_institute = store.update_institute(
         internal_id=institute_obj["_id"],
-        sanger_recipients=sanger_recipients,
+        sanger_recipients=get_sanger_recipients(form),
         coverage_cutoff=int(form.get("coverage_cutoff")),
         frequency_cutoff=float(form.get("frequency_cutoff")),
         display_name=form.get("display_name"),
@@ -372,12 +384,12 @@ def update_institute_settings(store, institute_obj, form):
         add_groups=False,
         sharing_institutes=sharing_institutes,
         cohorts=cohorts,
-        loqusdb_ids=loqusdb_ids,
+        loqusdb_ids=get_locusdb_ids(form),
         alamut_key=form.get("alamut_key"),
         alamut_institution=form.get("alamut_institution"),
         check_show_all_vars=form.get("check_show_all_vars"),
         clinvar_key=form.get("clinvar_key"),
-        clinvar_submitters=clinvar_submitters,
+        clinvar_submitters=get_clinvar_submitters(form),
     )
     return updated_institute
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -313,7 +313,7 @@ def update_institute_settings(store, institute_obj, form):
 
     """
     sanger_recipients = []
-    clinvar_submitters = []
+    clinvar_submitters = None
     sharing_institutes = []
     phenotype_groups = []
     gene_panels = {}
@@ -324,8 +324,10 @@ def update_institute_settings(store, institute_obj, form):
     for email in form.getlist("sanger_emails"):
         sanger_recipients.append(email.strip())
 
-    for email in form.getlist("clinvar_emails"):
-        clinvar_submitters.append(email.strip())
+    if current_user.is_admin:
+        clinvar_submitters = []
+        for email in form.getlist("clinvar_emails"):
+            clinvar_submitters.append(email.strip())
 
     for inst in form.getlist("institutes"):
         sharing_institutes.append(inst)

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -341,7 +341,7 @@ def get_gene_panels(store: MongoAdapter, form: MultiDict, tag: str) -> Dict:
 
     tag as in the form e.g. "gene_panels" or "gene_panels_matching".
     """
-    return store.get_panels_dict(panel_names=form.getlist(tag))
+    return store.gene_panels_dict(panel_names=form.getlist(tag))
 
 
 def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: MultiDict) -> Dict:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. add a clinvar api key and at least one user as submitter (e.g. as admin or in db) for an institute with an unprivileged user
2. as that unprivileged user, change something else on the institute settings page and save
3. note that the user is no longer a clinvar submitter and can no longer submit
4. apply patch, repeat process and note that the user is this time not removed from the submitter list

<img width="889" alt="Screenshot 2024-01-09 at 17 42 45" src="https://github.com/Clinical-Genomics/scout/assets/758570/eb5736c5-1e76-45c1-8d83-c7ffddce2085">

<img width="766" alt="Screenshot 2024-01-09 at 17 41 07" src="https://github.com/Clinical-Genomics/scout/assets/758570/048bfb87-2260-4ad7-96c0-d68b3602b803">

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
