### PR TITLE
Fix removing the same ClinVar variant from 2 different tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing cryptography lib error while running Scout container on an ARM processor
 - Round CADD values with many decimals on causatives and validated variants pages
 - Dark-mode visibility of some fields on causatives and validated variants pages
+- Page crashing when user tries to remove the same variant from a ClinVar submission in different browser tabs
 
 ## [4.75]
 ### Added

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -383,7 +383,6 @@ class ClinVarHandler(object):
         #   remove reference to it in the submission object 'case_data' list field
         #   remove casedata object from ClinVar collection
 
-
         if object_type == "variant_data":
             # pull out a variant from submission object
             self.clinvar_submission_collection.find_one_and_update(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4327

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Create a ClinVar submission on the local scout containing one or more variants
2. Open 2 tabs on the ClinVar submission page and remove the same variant in both tabs

**Expected outcome**:
- Removing the variant from the second tab wiil cause main branch to crash while this branch should not be affected

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
