### PR TITLE
Remove unused parameter in server/blueprints/variant/controllers/observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Revel score, Revel rank score and SpliceAI values are also displayed in Causatives and Validated variants tables
 - Remove unused functions and tests
 - Analysis type and direct link from cases list for OGM cases
+- Removed unused `case_obj` parameter from server/blueprints/variant/controllers/observations function
 ### Fixed
 - Disease_term identifiers are now prefixed with the name of the coding system
 - Command line crashing with error when updating a user that doesn't exist

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -1,10 +1,10 @@
 import logging
 import os
+from typing import Dict, List
 
 import requests
 from flask import Markup, current_app, flash, url_for
 from flask_login import current_user
-from typing import Dict, List
 
 from scout.adapter import MongoAdapter
 from scout.constants import (
@@ -26,7 +26,7 @@ from scout.server.blueprints.variant.utils import (
     update_variant_case_panels,
 )
 from scout.server.blueprints.variants.utils import update_case_panels
-from scout.server.extensions import cloud_tracks, gens, LoqusDB
+from scout.server.extensions import LoqusDB, cloud_tracks, gens
 from scout.server.links import get_variant_links
 from scout.server.utils import (
     case_has_alignments,
@@ -412,18 +412,13 @@ def variant_rank_scores(store, case_obj, variant_obj):
     return rank_score_results
 
 
-def get_loqusdb_obs_cases(store: MongoAdapter, variant_obj: dict, category: str, obs_families:list =[]) -> List[dict]:
-    """Get a list of cases where variant observations occurred.
-    These are only the cases the user has access to.
-
-    Args:
-        store (scout.adapter.MongoAdapter)
-        variant_obj(scout.models.Variant) it's the variant the loqusdb stats are computer for
-        category(str)
-        obs_families(list). List of all cases in loqusdb where variant occurred
-
-    Returns:
-        obs_cases(list).
+def get_loqusdb_obs_cases(
+    store: MongoAdapter, variant_obj: dict, category: str, obs_families: list = []
+) -> List[dict]:
+    """Get a list of cases where variant observations occurred. These are only the cases the user has access to.
+    We need to add links to the variant in other cases where the variant has been observed.
+    First we need to make sure that the user has access to these cases. The user_institute_ids holds
+    information about what institutes the user has access to.
     """
     obs_cases = []
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -456,7 +456,7 @@ def get_loqusdb_obs_cases(store, variant_obj, category, obs_families=[]):
     return obs_cases
 
 
-def observations(store, loqusdb, case_obj, variant_obj):
+def observations(store, loqusdb, variant_obj):
     """Query observations for a variant.
 
     Check if variant_obj have been observed before ni the loqusdb instance.

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -4,6 +4,7 @@ import os
 import requests
 from flask import Markup, current_app, flash, url_for
 from flask_login import current_user
+from typing import Dict, List
 
 from scout.adapter import MongoAdapter
 from scout.constants import (
@@ -411,7 +412,7 @@ def variant_rank_scores(store, case_obj, variant_obj):
     return rank_score_results
 
 
-def get_loqusdb_obs_cases(store, variant_obj, category, obs_families=[]):
+def get_loqusdb_obs_cases(store: MongoAdapter, variant_obj: dict, category: str, obs_families:list =[]) -> List[dict]:
     """Get a list of cases where variant observations occurred.
     These are only the cases the user has access to.
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -459,7 +459,7 @@ def get_loqusdb_obs_cases(store, variant_obj, category, obs_families=[]):
 def observations(store, loqusdb, variant_obj):
     """Query observations for a variant.
 
-    Check if variant_obj have been observed before ni the loqusdb instance.
+    Check if variant_obj have been observed before in the loqusdb instance.
     If not return empty dictionary.
 
     We need to add links to the variant in other cases where the variant has been observed.

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -520,8 +520,6 @@ def observations(store, loqusdb, variant_obj):
             store, variant_obj, category, obs_data[loqus_id].get("families", [])
         )
 
-    flash(obs_data)
-
     return obs_data
 
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -5,6 +5,7 @@ import requests
 from flask import Markup, current_app, flash, url_for
 from flask_login import current_user
 
+from scout.adapter import MongoAdapter
 from scout.constants import (
     ACMG_COMPLETE_MAP,
     ACMG_CRITERIA,
@@ -24,7 +25,7 @@ from scout.server.blueprints.variant.utils import (
     update_variant_case_panels,
 )
 from scout.server.blueprints.variants.utils import update_case_panels
-from scout.server.extensions import cloud_tracks, gens
+from scout.server.extensions import cloud_tracks, gens, LoqusDB
 from scout.server.links import get_variant_links
 from scout.server.utils import (
     case_has_alignments,
@@ -456,27 +457,9 @@ def get_loqusdb_obs_cases(store, variant_obj, category, obs_families=[]):
     return obs_cases
 
 
-def observations(store, loqusdb, variant_obj):
-    """Query observations for a variant.
-
-    Check if variant_obj have been observed before in the loqusdb instance.
-    If not return empty dictionary.
-
-    We need to add links to the variant in other cases where the variant has been observed.
-    First we need to make sure that the user has access to these cases. The user_institute_ids holds
-    information about what institutes the user has access to.
-
-    Loop over the case ids from loqusdb and check if they exist in the scout instance.
-    Also make sure that we do not link to the observation that is the current variant.
-
-    Args:
-        store (scout.adapter.MongoAdapter)
-        loqusdb (scout.server.extensions.LoqusDB)
-        case_obj (scout.models.Case)
-        variant_obj (scout.models.Variant)
-
-    Returns:
-        obs_data(dict) with loqusdb id as key and observations stats as value
+def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Dict[str, dict]:
+    """Check if variant_obj have been observed before in the loqusdb instances available in the institute settings.
+       If not return empty dictionary.
     """
     obs_data = {}
     institute_id = variant_obj["institute"]

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -520,6 +520,8 @@ def observations(store, loqusdb, variant_obj):
             store, variant_obj, category, obs_data[loqus_id].get("families", [])
         )
 
+    flash(obs_data)
+
     return obs_data
 
 

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -158,7 +158,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for loqusid,obs in observations.items() %}
+          {% for loqusid, obs in observations.items() %}
               <tr>
                 <td>{{ loqusid }}</td>
                <td>{{ obs.observations|default('N/A') }}</td>

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -84,7 +84,7 @@ def cancer_variant(institute_id, case_name, variant_id):
 
     if current_app.config.get("LOQUSDB_SETTINGS"):
         LOG.debug("Fetching loqusdb information for %s", variant_id)
-        data["observations"] = observations(store, loqusdb, data["case"], data["variant"])
+        data["observations"] = observations(store, loqusdb, data["variant"])
 
     return data
 
@@ -105,7 +105,7 @@ def sv_variant(institute_id, case_name, variant_id):
 
     if current_app.config.get("LOQUSDB_SETTINGS"):
         LOG.debug("Fetching loqusdb information for %s", variant_id)
-        data["observations"] = observations(store, loqusdb, data["case"], data["variant"])
+        data["observations"] = observations(store, loqusdb, data["variant"])
 
     return data
 

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -58,7 +58,7 @@ def variant(institute_id, case_name, variant_id):
 
     if current_app.config.get("LOQUSDB_SETTINGS"):
         LOG.debug("Fetching loqusdb information for %s", variant_id)
-        data["observations"] = observations(store, loqusdb, data["case"], data["variant"])
+        data["observations"] = observations(store, loqusdb, data["variant"])
 
     return data
 

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -201,7 +201,7 @@ def test_observations_controller_non_existing(app, institute_obj, case_obj, loqu
     data = None
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
-        data = observations(store, loqusdb, case_obj, var_obj)
+        data = observations(store, loqusdb, var_obj)
 
     ## THEN assert that the number of cases is still returned
     assert data[loqus_id]["total"] == n_cases
@@ -244,7 +244,7 @@ def test_observations_controller_snv(app, institute_obj, loqusdburl):
     data = None
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
-        data = observations(store, loqusdb, case_obj, var_obj)
+        data = observations(store, loqusdb, var_obj)
 
     ## THEN loqus should return the occurrence from the first case
     assert case_obj["_id"] in data[loqus_id]["families"]
@@ -288,7 +288,7 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
     with app.test_client() as client:
         resp = client.get(url_for("auto_login"))
         # THEN the observation of the original case should be found
-        data = observations(store, loqusdb, case_obj, sv_variant_obj)
+        data = observations(store, loqusdb, sv_variant_obj)
 
     ## THEN loqus should return the occurrence from the first case
     assert case_obj["_id"] in data[loqus_id]["families"]

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -202,10 +202,10 @@ def test_observations_controller_non_existing(app, institute_obj, case_obj, loqu
         client.get(url_for("auto_login"))
         data = observations(store, loqusdb, var_obj)
 
-        ## THEN assert that the number of cases is still returned
-        assert data[loqus_id]["total"] == n_cases
-        ## THEN assert the cases variable is in data but it's an empty list
-        assert data[loqus_id]["cases"] == []
+    ## THEN assert that the number of cases is still returned
+    assert data[loqus_id]["total"] == n_cases
+    ## THEN assert the cases variable is in data but it's an empty list
+    assert data[loqus_id]["cases"] == []
 
 
 @responses.activate
@@ -244,10 +244,10 @@ def test_observations_controller_snv(app, institute_obj, loqusdburl):
         client.get(url_for("auto_login"))
         data = observations(store, loqusdb, var_obj)
 
-        ## THEN loqus should return the occurrence from the first case
-        assert case_obj["_id"] in data[loqus_id]["families"]
-        assert data[loqus_id]["cases"][0]["case"] == case_obj
-        assert data[loqus_id]["cases"][0]["variant"]["_id"] == var_obj["_id"]
+    ## THEN loqus should return the occurrence from the first case
+    assert case_obj["_id"] in data[loqus_id]["families"]
+    assert data[loqus_id]["cases"][0]["case"] == case_obj
+    assert data[loqus_id]["cases"][0]["variant"]["_id"] == var_obj["_id"]
 
 
 @responses.activate
@@ -288,10 +288,10 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
         # THEN the observation of the original case should be found
         data = observations(store, loqusdb, sv_variant_obj)
 
-        ## THEN loqus should return the occurrence from the first case
-        assert case_obj["_id"] in data[loqus_id]["families"]
-        assert data[loqus_id]["cases"][0]["case"] == case_obj
-        assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
+    ## THEN loqus should return the occurrence from the first case
+    assert case_obj["_id"] in data[loqus_id]["families"]
+    assert data[loqus_id]["cases"][0]["case"] == case_obj
+    assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
 
 
 def test_case_matching_causatives(app, real_variant_database):

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -198,15 +198,14 @@ def test_observations_controller_non_existing(app, institute_obj, case_obj, loqu
     ## WHEN updating the case_id for the variant
     var_obj["case_id"] = "internal_id2"
 
-    data = None
     with app.test_client() as client:
-        resp = client.get(url_for("auto_login"))
+        client.get(url_for("auto_login"))
         data = observations(store, loqusdb, var_obj)
 
-    ## THEN assert that the number of cases is still returned
-    assert data[loqus_id]["total"] == n_cases
-    ## THEN assert the cases variable is in data but it's an empty list
-    assert data[loqus_id]["cases"] == []
+        ## THEN assert that the number of cases is still returned
+        assert data[loqus_id]["total"] == n_cases
+        ## THEN assert the cases variable is in data but it's an empty list
+        assert data[loqus_id]["cases"] == []
 
 
 @responses.activate
@@ -241,15 +240,14 @@ def test_observations_controller_snv(app, institute_obj, loqusdburl):
     ## WHEN updating the case_id for the variant
     var_obj["case_id"] = "internal_id2"
 
-    data = None
     with app.test_client() as client:
-        resp = client.get(url_for("auto_login"))
+        client.get(url_for("auto_login"))
         data = observations(store, loqusdb, var_obj)
 
-    ## THEN loqus should return the occurrence from the first case
-    assert case_obj["_id"] in data[loqus_id]["families"]
-    assert data[loqus_id]["cases"][0]["case"] == case_obj
-    assert data[loqus_id]["cases"][0]["variant"]["_id"] == var_obj["_id"]
+        ## THEN loqus should return the occurrence from the first case
+        assert case_obj["_id"] in data[loqus_id]["families"]
+        assert data[loqus_id]["cases"][0]["case"] == case_obj
+        assert data[loqus_id]["cases"][0]["variant"]["_id"] == var_obj["_id"]
 
 
 @responses.activate
@@ -286,14 +284,14 @@ def test_observations_controller_sv(app, sv_variant_obj, institute_obj, loqusdbu
     sv_variant_obj["variant_id"] = "someOtherVarID"
 
     with app.test_client() as client:
-        resp = client.get(url_for("auto_login"))
+        client.get(url_for("auto_login"))
         # THEN the observation of the original case should be found
         data = observations(store, loqusdb, sv_variant_obj)
 
-    ## THEN loqus should return the occurrence from the first case
-    assert case_obj["_id"] in data[loqus_id]["families"]
-    assert data[loqus_id]["cases"][0]["case"] == case_obj
-    assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
+        ## THEN loqus should return the occurrence from the first case
+        assert case_obj["_id"] in data[loqus_id]["families"]
+        assert data[loqus_id]["cases"][0]["case"] == case_obj
+        assert data[loqus_id]["cases"][0]["variant"]["_id"] == sv_variant_obj["_id"]
 
 
 def test_case_matching_causatives(app, real_variant_database):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- The case_obj parameter is never used in the observations function, so this PR is removing it from there and whererever the function is invoked from

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
