### PR TITLE
Fix archived local obs not visible on cancer variantS page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Submenu icons missing from collapsible actionbar
 - The collapsible actionbar had some non-collapsing overly long entries
 - Cancer observations for SVs not appearing in the variant details view
+- Archived local observations not visible on cancer variantS page
 
 ## [4.75]
 ### Added

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -182,7 +182,12 @@
   <div data-bs-toggle="tooltip" data-bs-placement="right" data-bs-html="true" title="
     <div class='text-start'>
       <div>
-        <strong>Local (arch.)</strong>: {{ variant.local_obs_old or 0 }} obs.
+        <strong>Local (arch.)</strong>:
+        {% if variant.category in ['snv', 'sv'] %}
+          {{ variant.local_obs_old or 0 }}
+        {% elif variant.category in ['cancer', 'cancer_sv'] %}
+          germline:{{ variant.local_obs_cancer_germline_old or 0}}, somatic:{{variant.local_obs_cancer_somatic_old or 0}}
+        {% endif %} obs.
       </div>
       {% if variant.mitomap_associated_diseases %}
         <strong>MITOMAP</strong>: {{ variant.mitomap_associated_diseases }}<br>
@@ -224,7 +229,7 @@
   {% if variant.clingen_cgh_pathogenic %}
     <span class="badge bg-secondary">CGH Pathogenic</span><br>
   {% endif %}
-  {% if variant.local_obs_old %}
+  {% if variant.local_obs_old or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old %}
     <span class="badge bg-secondary">Local</span>
     <br>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -186,7 +186,7 @@
         {% if variant.category in ['snv', 'sv'] %}
           {{ variant.local_obs_old or 0 }}
         {% elif variant.category in ['cancer', 'cancer_sv'] %}
-          germline:{{ variant.local_obs_cancer_germline_old or 0}}, somatic:{{variant.local_obs_cancer_somatic_old or 0}}
+          germline:{{ variant.local_obs_cancer_germline_old or 0}}, somatic:{{variant.local_obs_cancer_somatic_old or 0}}, rare-disease: {{ variant.local_obs_old or 0}},
         {% endif %} obs.
       </div>
       {% if variant.mitomap_associated_diseases %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Partially fixing #4342 - second checkbox

Main branch:

<img width="1425" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/884cc57f-929f-437c-ba52-eac083675244">

<hr>

This branch:

<img width="1435" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/1eb1cbef-1282-4d9e-a499-d6a84cc1a645">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
