### PR TITLE
Allow ClinVar submissions with custom API keys and allow resetting submission ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Analysis type and direct link from cases list for OGM cases
 - Removed unused `case_obj` parameter from server/blueprints/variant/controllers/observations function
 - Possibility to reset ClinVar submission ID
-- Allow any user with ClinVar submission clearance to submit variants, even if no ClinVar submission key is saved in the institute settings
+- Allow any user with ClinVar submission clearance to submit variants, even if no ClinVar submission API key is saved in the institute settings
 ### Fixed
 - Disease_term identifiers are now prefixed with the name of the coding system
 - Command line crashing with error when updating a user that doesn't exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove unused functions and tests
 - Analysis type and direct link from cases list for OGM cases
 - Removed unused `case_obj` parameter from server/blueprints/variant/controllers/observations function
+- Possibility to reset ClinVar submission ID
+- Allow any user with ClinVar submission clearance to submit variants, even if no ClinVar submission key is saved in the institute settings
 ### Fixed
 - Disease_term identifiers are now prefixed with the name of the coding system
 - Command line crashing with error when updating a user that doesn't exist

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -329,9 +329,10 @@ def update_clinvar_submission_status(request_obj, institute_id, submission_id):
 
     if update_status in ["open", "closed", "submitted"]:  # open or close a submission
         store.update_clinvar_submission_status(institute_id, submission_id, update_status)
-    if update_status == "register_id":  # register an official clinvar submission ID
+    if update_status == "register_id":  # register an official ClinVar submission ID
+        clinvar_id: str = request_obj.form.get("clinvar_id").replace(" ","") or None
         store.update_clinvar_id(
-            clinvar_id=request_obj.form.get("clinvar_id"),
+            clinvar_id = clinvar_id if clinvar_id else None,
             submission_id=submission_id,
         )
     if update_status == "delete":  # delete a submission

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -87,7 +87,7 @@
             <tr>
               <form id="updateName_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
               <td style="width: 10%"><label for="clinvar_id">Submission ID</label></td>
-              <td style="width: 25%"> <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id }}" required></td>
+              <td style="width: 25%"> <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id or ""}}"></td>
               <td style="width: 20%"><button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button></td>
               </form>
               {% if subm_obj.status == 'open' and show_submit  %}

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -245,7 +245,7 @@
       </div>
       <div class="modal-body">
         <label for="apiKey">Submitter's <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/" target="_blank" rel="noopener">API key</a></label>
-        <input type="password" class="form-control" name="apiKey" id="apiKey" placeholder="64 alphanumeric characters" value="{{institute.clinvar_key}}" required>
+        <input type="password" class="form-control" name="apiKey" id="apiKey" placeholder="64 alphanumeric characters" value="{{institute.clinvar_key or ''}}" required>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -5,6 +5,8 @@ from tempfile import NamedTemporaryFile
 from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user
 
+from typing import List
+
 from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, CLNSIG_TERMS
 from scout.server.extensions import store
 from scout.server.utils import institute_and_case

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -1,11 +1,10 @@
 import csv
 import logging
 from tempfile import NamedTemporaryFile
+from typing import List
 
 from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user
-
-from typing import List
 
 from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, CLNSIG_TERMS
 from scout.server.extensions import store

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -54,13 +54,14 @@ def clinvar_submissions(institute_id):
     """Handle clinVar submission objects and files"""
 
     institute_obj = institute_and_case(store, institute_id)
-
+    institute_clinvar_submitters: List[str] = institute_obj.get("clinvar_submitters", [])
     data = {
         "submissions": store.clinvar_submissions(institute_id),
         "institute": institute_obj,
         "variant_header_fields": CLINVAR_HEADER,
         "casedata_header_fields": CASEDATA_HEADER,
-        "show_submit": current_user.email in institute_obj.get("clinvar_submitters", []),
+        "show_submit": current_user.email in institute_clinvar_submitters
+        or not institute_clinvar_submitters,
     }
     return render_template("clinvar/clinvar_submissions.html", **data)
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -60,8 +60,7 @@ def clinvar_submissions(institute_id):
         "institute": institute_obj,
         "variant_header_fields": CLINVAR_HEADER,
         "casedata_header_fields": CASEDATA_HEADER,
-        "show_submit": institute_obj.get("clinvar_key")
-        and current_user.email in institute_obj.get("clinvar_submitters", []),
+        "show_submit": current_user.email in institute_obj.get("clinvar_submitters", []),
     }
     return render_template("clinvar/clinvar_submissions.html", **data)
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -63,7 +63,7 @@
             <th>Start</th>
             <th>End</th>
             <th>Length</th>
-            <th>Pop Freq</th>
+            <th>Pop Freq - Gnomad</th>
             <th>Observed</th>
             <th>Gene(s)</th>
             <th>Region</th>

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -63,7 +63,7 @@
             <th>Start</th>
             <th>End</th>
             <th>Length</th>
-            <th>Pop Freq - Gnomad</th>
+            <th>Pop Freq</th>
             <th>Observed</th>
             <th>Gene(s)</th>
             <th>Region</th>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Allow users to submit using a custom ClinVar API ID if no key is saved for their institute (closes #4324)
- Allow to reset ClinVar submission ID to None (closes #4350)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. In the settings of one institute, add yourself as a ClinVar submitter and remove any ClinVar API key
2. Try to submit one or more variants from the ClinVar submissions page
3. Try to set/reset the submission ID. It should be possible to set it to None using this branch, while on main you have to provide a string like SUB1234567

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
