### PR TITLE
Genes for orpha disease_terms are now saved as int, matching the format for omim disease_terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Analysis type and direct link from cases list for OGM cases
 - Removed unused `case_obj` parameter from server/blueprints/variant/controllers/observations function
 ### Fixed
+- All disease_terms have their genes in number format when added to the scout database
 - Disease_term identifiers are now prefixed with the name of the coding system
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Possibility to reset ClinVar submission ID
 - Allow any user with ClinVar submission clearance to submit variants, even if no ClinVar submission API key is saved in the institute settings
 ### Fixed
-- All disease_terms have their genes in number format when added to the scout database
+- All disease_terms have gene HGNC ids as integers when added to the scout database
 - Disease_term identifiers are now prefixed with the name of the coding system
 - Command line crashing with error when updating a user that doesn't exist
 - Thaw coloredlogs - 15.0.1 restores errorhandler issue

--- a/scout/parse/orpha.py
+++ b/scout/parse/orpha.py
@@ -50,7 +50,7 @@ def get_orpha_to_genes_information(lines: List[str]) -> Dict[str, dict]:
 
                     if gene_source == "HGNC":
                         reference = external_reference.find("Reference").text
-                        disease["hgnc_ids"].add(reference)
+                        disease["hgnc_ids"].add(int(reference))
                         break
         orpha_diseases_found[disease_id] = disease
 

--- a/tests/parse/conftest.py
+++ b/tests/parse/conftest.py
@@ -45,12 +45,12 @@ TEST_OMIM_DISEASES = {
 TEST_ORPHA_DISEASES = {
     "ORPHA:585": {
         "description": "Multiple sulfatase deficiency",
-        "hgnc_ids": {"20376"},
+        "hgnc_ids": {20376},
         "hpo_terms": {"HP:0000238", "HP:0000252", "HP:0000256", "HP:0000280"},
     },
     "ORPHA:118": {
         "description": "Beta-mannosidosis",
-        "hgnc_ids": {"6831"},
+        "hgnc_ids": {6831},
         "hpo_terms": {
             "HP:0000365",
             "HP:0001249",

--- a/tests/parse/test_parse_disease_terms.py
+++ b/tests/parse/test_parse_disease_terms.py
@@ -101,7 +101,7 @@ def test_get_orpha_disease_terms(orpha_to_genes_lines, orpha_to_hpo_lines):
 
     # THEN assert disease with correct contents including both hpo and genes is included in return
     assert disease["description"] == "Multiple sulfatase deficiency"
-    assert disease["hgnc_ids"] == {"20376"}
+    assert disease["hgnc_ids"] == {20376}
     assert disease["hpo_terms"] == {"HP:0000238", "HP:0000252", "HP:0000256", "HP:0000280"}
 
 

--- a/tests/parse/test_parse_orpha.py
+++ b/tests/parse/test_parse_orpha.py
@@ -29,7 +29,7 @@ def test_get_orpha_to_genes_information(orpha_to_genes_lines: List[str]):
     # THEN assert disease with correct contents was included in the return
 
     assert disease["description"] == "Multiple sulfatase deficiency"
-    assert disease["hgnc_ids"] == {"20376"}
+    assert disease["hgnc_ids"] == {20376}
 
 
 def test_get_orpha_to_hpo_information(orpha_to_hpo_lines: List[str]):


### PR DESCRIPTION
This PR fixes a bug.
When adding disease_terms to the database terms extracted from orphadata files had the hgnc-id of linked genes saved as a string. Disease_terms extracted from omim files had the hgnc-id saved as a number. 

This PR converts the hgnc-id extracted from orphadata files to a number before saving it to a disease object

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by TB
