### PR TITLE
Show user that created a ClinVar submission, when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Pydantic validation of image paths provided in case load config file
+- Info on the user which created a ClinVar submission, when available
 ### Changed
 - Revel score, Revel rank score and SpliceAI values are also displayed in Causatives and Validated variants tables
 - Remove unused functions and tests

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from bson import ObjectId
 from datetime import datetime
 
 import pymongo
@@ -12,26 +13,21 @@ LOG = logging.getLogger(__name__)
 class ClinVarHandler(object):
     """Class to handle clinvar submissions for the mongo adapter"""
 
-    def create_submission(self, institute_id):
-        """Create an open clinvar submission for an institute
-        Args:
-             institute_id(str): an institute ID
-
-        returns:
-             submission(obj): an open clinvar submission object
-        """
+    def create_submission(self, institute_id: str, user_id: str) -> ObjectId:
+        """Create an open ClinVar submission for an institute."""
 
         submission_obj = {
             "status": "open",
             "created_at": datetime.now(),
             "institute_id": institute_id,
+            "created_by": user_id,
         }
-        LOG.info("Creating a new clinvar submission institute %s", institute_id)
+        LOG.info("Creating a new ClinVar submission for institute %s", institute_id)
         result = self.clinvar_submission_collection.insert_one(submission_obj)
         return result.inserted_id
 
     def delete_submission(self, submission_id):
-        """Deletes a Clinvar submission object, along with all associated clinvar objects (variants and casedata)
+        """Deletes a ClinVar submission object, along with all associated objects (variants and casedata)
 
         Args:
             submission_id(str): the ID of the submission to be deleted
@@ -68,15 +64,9 @@ class ClinVarHandler(object):
         # return deleted_count, deleted_submissions
         return deleted_objects, deleted_submissions
 
-    def get_open_clinvar_submission(self, institute_id):
-        """Retrieve the database id of an open clinvar submission for an institute,
-        if none is available then create a new submission and return it
-
-        Args:
-             institute_id(str): an institute ID
-
-        Returns:
-             submission(obj) : an open clinvar submission object
+    def get_open_clinvar_submission(self, institute_id: str, user_id: str) -> dict:
+        """Retrieve the database id of an open ClinVar submission for an institute,
+        if none is available then creates a new submission dictionary and returns it.
         """
 
         LOG.info("Retrieving an open clinvar submission for institute %s", institute_id)
@@ -85,7 +75,7 @@ class ClinVarHandler(object):
 
         # If there is no open submission for this institute, create one
         if submission is None:
-            submission_id = self.create_submission(institute_id)
+            submission_id = self.create_submission(institute_id, user_id)
             submission = self.clinvar_submission_collection.find_one({"_id": submission_id})
 
         return submission
@@ -247,10 +237,12 @@ class ClinVarHandler(object):
         for result in results:
             submission = {}
             cases = {}
+            user: dict = self.user(user_id=result.get("created_by"))
             submission["_id"] = result.get("_id")
             submission["status"] = result.get("status")
             submission["institute_id"] = result.get("institute_id")
             submission["created_at"] = result.get("created_at")
+            submission["created_by"] = user["name"] if user else None
             submission["updated_at"] = result.get("updated_at")
 
             if "clinvar_subm_id" in result:

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
-from bson import ObjectId
 from datetime import datetime
 
 import pymongo
+from bson import ObjectId
 from bson.objectid import ObjectId
 from pymongo import ReturnDocument
 

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -48,7 +48,7 @@
   <div class="accordion-item">
     <h2 class="accordion-header" id="header-{{subm_obj._id}}">
       <a class="accordion-button collapsed {% if subm_obj.status=='open' %} link-primary {% elif subm_obj.status=='submitted' %} link-success {% else %} link-secondary {% endif%}" type="button" data-bs-toggle="collapse" data-bs-target="#flush-{{subm_obj._id}}" aria-expanded="false" aria-controls="flush-{{subm_obj._id}}" style="text-decoration: none;">
-        Submission&nbsp;<strong>{{subm_obj._id}} - ({{subm_obj.status|upper}})</strong>&nbsp;/&nbsp;Created:&nbsp;<strong>{{subm_obj.created_at.strftime('%Y-%m-%d')}}</strong>&nbsp;/&nbsp;Last updated:&nbsp;<strong>{{subm_obj.updated_at.strftime('%d-%m-%Y, %T')}}</strong>
+        Submission&nbsp;<strong>{{subm_obj._id}} - ({{subm_obj.status|upper}})</strong>&nbsp;/&nbsp;Created {% if subm_obj.created_by %}&nbsp;by&nbsp;<strong>{{subm_obj.created_by}}</strong>{% endif %}&nbsp;on&nbsp;<strong>{{subm_obj.created_at.strftime('%Y-%m-%d')}}</strong>&nbsp;/&nbsp;Last updated:&nbsp;<strong>{{subm_obj.updated_at.strftime('%d-%m-%Y, %T')}}</strong>
       </a>
     </h2>
     <div id="flush-{{subm_obj._id}}" class="accordion-collapse collapse" aria-labelledby="header-{{subm_obj._id}}" data-bs-parent="#accordionFlushSubmissions">

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -39,7 +39,7 @@ def clinvar_save(institute_id, case_name):
     casedata_list = controllers.parse_casedata_form_fields(request.form)  # a list of dictionaries
 
     # retrieve or create an open ClinVar submission:
-    subm = store.get_open_clinvar_submission(institute_id)
+    subm = store.get_open_clinvar_submission(institute_id, current_user._id)
     # save submission objects in submission:
     result = store.add_to_submission(subm["_id"], (variant_data, casedata_list))
     if result:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Partially fixing  #4326 

<img width="879" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/0bfebd5d-33ee-4ced-9529-f05e5d752a99">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by CR
