### PR TITLE
Replace schug dependency with requests to schug web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - CLI scout update individual accepts subject_id
 - Update ClinVar inheritance models to reflect changes in ClinVar submission API
 - Handle variant-associated condition ID format in background when creating ClinVar submissions
-- Replace the code that downloads Ensembl genes, transcripts and exons with the Schug library
+- Replace the code that downloads Ensembl genes, transcripts and exons with the Schug web app
 ### Fixed
 - Text input of associated condition in ClinVar form now aligns to the left
 - Alignment of contents in the case report has been updated
@@ -23,7 +23,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Associate OMIM and/or ORPHA diagnoses with partial causatives
 - Visualization of partial causatives' diagnoses on case page: style and links
 - Revert style of pinned variants window on the case page
-
 
 ## [4.76]
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ click
 cryptography
 defusedxml
 svglib
-schug
 cairosvg
 importlib_resources
 

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -14,6 +14,7 @@ SCHUG_RESOURCE_URL: Dict[str, str] = {
     "exons": "/exons/ensembl_exons/?build=",
 }
 
+
 class EnsemblBiomartHandler:
     """A class that handles Ensembl genes, transcripts and exons downloads via schug-web."""
 

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterator
 import requests
 
 LOG = logging.getLogger(__name__)
-SCHUG_BASE = "https://schug-stage.scilifelab.se"
+SCHUG_BASE = "https://schug.scilifelab.se"
 
 BUILDS: Dict[str, str] = {"37": "GRCh37", "38": "GRCh38"}
 

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -27,7 +27,7 @@ class EnsemblBiomartHandler:
         return response.iter_lines(decode_unicode=True)
 
     def stream_resource(self, interval_type: str) -> Iterator[str]:
-        """Use schug web to fetche genes, transcripts or exons from a remote Ensembl biomart in the right genome build and save them to file."""
+        """Use schug web to fetch genes, transcripts or exons from a remote Ensembl biomart in the right genome build and save them to file."""
 
         def yield_resource_lines(iterable) -> str:
             """Removes the last element from an iterator."""

--- a/tests/commands/download/test_download_ensembl_cmd.py
+++ b/tests/commands/download/test_download_ensembl_cmd.py
@@ -31,7 +31,7 @@ def test_print_ensembl_genes(mocker, genes37_handle):
 
     # GIVEN a patched call to schug
     # GIVEN a patched response from Ensembl Biomart, via schug
-    mocker.patch.object(EnsemblBiomartHandler, "biomart_get", return_value=genes37_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=genes37_handle)
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -51,7 +51,7 @@ def test_print_ensembl_transcripts(mocker, transcripts_handle):
     """Test print ensembl transcripts function."""
 
     # GIVEN a patched call to schug
-    mocker.patch.object(EnsemblBiomartHandler, "biomart_get", return_value=transcripts_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=transcripts_handle)
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -71,7 +71,7 @@ def test_print_ensembl_exons(mocker, exons_handle):
     """Test print ensembl exons function."""
 
     # GIVEN a patched call to schug
-    mocker.patch.object(EnsemblBiomartHandler, "biomart_get", return_value=exons_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=exons_handle)
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()

--- a/tests/utils/test_ensembl_biomart_cients.py
+++ b/tests/utils/test_ensembl_biomart_cients.py
@@ -1,32 +1,31 @@
 from typing import Iterator
 
 import pytest
-from schug.demo import (
-    EXONS_37_FILE_PATH,
-    EXONS_38_FILE_PATH,
-    GENES_37_FILE_PATH,
-    GENES_38_FILE_PATH,
-    TRANSCRIPTS_37_FILE_PATH,
-    TRANSCRIPTS_38_FILE_PATH,
-)
-from schug.models.common import Build
 
+from scout.demo.resources import (
+    exons37_reduced_path,
+    exons38_reduced_path,
+    genes37_reduced_path,
+    genes38_reduced_path,
+    transcripts37_reduced_path,
+    transcripts38_reduced_path,
+)
 from scout.utils.ensembl_biomart_clients import EnsemblBiomartHandler
 from scout.utils.handle import get_file_handle
 
 SCHUG_BUILD_GENES_PATHS = [
-    (Build.build_37, GENES_37_FILE_PATH),
-    (Build.build_38, GENES_38_FILE_PATH),
+    ("37", genes37_reduced_path),
+    ("38", genes38_reduced_path),
 ]
 
 SCHUG_BUILD_TRANSCRIPTS_PATHS = [
-    (Build.build_37, TRANSCRIPTS_37_FILE_PATH),
-    (Build.build_38, TRANSCRIPTS_38_FILE_PATH),
+    ("37", transcripts37_reduced_path),
+    ("38", transcripts38_reduced_path),
 ]
 
 SCHUG_BUILD_EXONS_PATHS = [
-    (Build.build_37, EXONS_37_FILE_PATH),
-    (Build.build_38, EXONS_38_FILE_PATH),
+    ("37", exons37_reduced_path),
+    ("38", exons38_reduced_path),
 ]
 
 
@@ -39,7 +38,7 @@ def test_stream_resource_genes(build, path, mocker):
 
     # GIVEN a patched response from Ensembl Biomart, via schug
     mocker.patch.object(
-        EnsemblBiomartHandler, "biomart_get", return_value=get_file_handle(str(path))
+        EnsemblBiomartHandler, "stream_get", return_value=get_file_handle(str(path))
     )
 
     # THEN it should stream the gene resource when stream_resource in invoked
@@ -57,7 +56,7 @@ def test_stream_resource_transcripts(build, path, mocker):
 
     # GIVEN a patched response from Ensembl Biomart, via schug
     mocker.patch.object(
-        EnsemblBiomartHandler, "biomart_get", return_value=get_file_handle(str(path))
+        EnsemblBiomartHandler, "stream_get", return_value=get_file_handle(str(path))
     )
 
     # THEN it should stream the gene resource when stream_resource in invoked
@@ -75,7 +74,7 @@ def test_stream_resource_exons(build, path, mocker):
 
     # GIVEN a patched response from Ensembl Biomart, via schug
     mocker.patch.object(
-        EnsemblBiomartHandler, "biomart_get", return_value=get_file_handle(str(path))
+        EnsemblBiomartHandler, "stream_get", return_value=get_file_handle(str(path))
     )
 
     # THEN it should stream the gene resource when stream_resource in invoked


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4403 - Do not install schug which has a lib conflict with chanjo-report

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Download genes, transcript and exons locally by running the following command: scout --demo download ensembl --exons
2. Relax because it takes a while, especially the exons
3. Compare downloaded files with those downloaded previously (main branch or latest release branch)

**Expected outcome**:
- [x] Downloaded files should be the same as those downloaded with the latest release

**Review:**
- [x] code approved by TB
- [x] tests executed by CR / TB
