### PR TITLE
Enhance log output when VEP transcript variant frequency parsing fails 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update ClinVar inheritance models to reflect changes in ClinVar submission API
 - Handle variant-associated condition ID format in background when creating ClinVar submissions
 - Replace the code that downloads Ensembl genes, transcripts and exons with the Schug web app
+- Add more info to error log when transcript variant frequency parsing fails.
 ### Fixed
 - Text input of associated condition in ClinVar form now aligns to the left
 - Alignment of contents in the case report has been updated

--- a/scout/parse/variant/transcript.py
+++ b/scout/parse/variant/transcript.py
@@ -346,5 +346,12 @@ def set_variant_frequencies(transcript, entry):
             transcript["gnomad_max"] = max(gnomad_freqs)
 
     except Exception as err:
-        LOG.warning("Failed to parse variant frequencies")
-        LOG.warning("Only splitted and normalised VEP v90+ is supported")
+        LOG.error(
+            "Encountered error when parsing variant frequencies for transcript %s: Failed to parse %s (%s)",
+            transcript.get("transcript_id"),
+            key,
+            str(err),
+        )
+        LOG.debug("Exception details", exc_info=True)
+        LOG.debug("Current entry: %s", entry)
+        LOG.warning("Only splitted and normalised VEP v90+ frequencies are supported")


### PR DESCRIPTION
This update adds more info to the warning/error logs that are triggered when parsing of VEP AF annotation fails
The update also adds more technical info in debug log.

closes #4406 

Example when reloading the demo cancer case:

```
2024-02-08 12:36:52 7581ebac56e7 scout.parse.variant.transcript[1286] ERROR Encountered error when parsing variant frequencies for transcript NM_001126114.2: Failed to parse AMR_AF (could not convert string to float: 'deleterious(0)')                                              
2024-02-08 12:36:52 7581ebac56e7 scout.parse.variant.transcript[1286] DEBUG Exception details                                                                                                                                                                                           
Traceback (most recent call last):                                                                                                                                                                                                                                                      
  File "/home/worker/app/scout/parse/variant/transcript.py", line 340, in set_variant_frequencies                                                                                                                                                                                       
    thousandg_freqs.append(float(value))                                                                                                                                                                                                                                                
ValueError: could not convert string to float: 'deleterious(0)'                                                                                                                                                                                                                         
2024-02-08 12:36:52 7581ebac56e7 scout.parse.variant.transcript[1286] DEBUG Current entry: {'ALLELE': 'A', 'CONSEQUENCE': 'missense_variant', 'IMPACT': 'MODERATE', 'SYMBOL': 'TP53', 'GENE': '7157', 'FEATURE_TYPE': 'Transcript', 'FEATURE': 'NM_001126114.2', 'BIOTYPE': 'protein_cod
ing', 'EXON': '7/12', 'INTRON': '', 'HGVSC': 'NM_001126114.2:c.722C>T', 'HGVSP': 'NP_001119586.1:p.Ser241Phe', 'CDNA_POSITION': '924', 'CDS_POSITION': '722', 'PROTEIN_POSITION': '241', 'AMINO_ACIDS': 'S/F', 'CODONS': 'tCc/tTc', 'EXISTING_VARIATION': 'rs28934573&CM1212186&CM920673
&COSV52661688&COSV52662386&COSV52713934&COSV52760886', 'DISTANCE': '', 'STRAND': '-1', 'FLAGS': '', 'VARIANT_CLASS': 'SNV', 'SYMBOL_SOURCE': 'EntrezGene', 'HGNC_ID': '11998', 'CANONICAL': '', 'TSL': '', 'APPRIS': '', 'CCDS': '', 'ENSP': '', 'SWISSPROT': 'NP_001119586.1', 'TREMBL'
: '', 'UNIPARC': '', 'GENE_PHENO': '', 'SIFT': 'rseq_mrna_match', 'POLYPHEN': 'RefSeq', 'DOMAINS': '', 'MIRNA': 'G', 'HGVS_OFFSET': 'G', 'AF': '', 'AFR_AF': '', 'AMR_AF': 'deleterious(0)', 'EAS_AF': 'probably_damaging(1)', 'EUR_AF': '', 'SAS_AF': '', 'AA_AF': '', 'EA_AF': '', 'GN
OMAD_AF': '', 'GNOMAD_AFR_AF': '', 'GNOMAD_AMR_AF': '', 'GNOMAD_ASJ_AF': '', 'GNOMAD_EAS_AF': '', 'GNOMAD_FIN_AF': '', 'GNOMAD_NFE_AF': '', 'GNOMAD_OTH_AF': '3.977e-06', 'GNOMAD_SAS_AF': '0', 'MAX_AF': '0', 'MAX_AF_POPS': '0', 'FREQS': '0', 'CLIN_SIG': '0', 'SOMATIC': '8.791e-06'
, 'PHENO': '0', 'PUBMED': '0', 'MOTIF_NAME': '8.791e-06', 'MOTIF_POS': 'gnomAD_NFE', 'HIGH_INF_POS': 'likely_pathogenic&pathogenic', 'MOTIF_SCORE_CHANGE': '0&0&0&1&1&1&1', 'MES-NCSS_DOWNSTREAM_ACCEPTOR': '1&1&1&1&1&1&1', 'MES-NCSS_DOWNSTREAM_DONOR': '26619011&21264207&25105660&15
65143&8401536&16312222', 'MES-NCSS_UPSTREAM_ACCEPTOR': '', 'MES-NCSS_UPSTREAM_DONOR': '', 'MES-SWA_ACCEPTOR_ALT': '', 'MES-SWA_ACCEPTOR_DIFF': '', 'MES-SWA_ACCEPTOR_REF': '', 'MES-SWA_ACCEPTOR_REF_COMP': 'COSV52661688&COSV52661688&COSV52661688&COSV52661688&COSV52661688&COSV526616
88', 'MES-SWA_DONOR_ALT': 'c.722C>T&c.722C>T&c.722C>T&c.722C>T&c.722C>T&c.722C>T', 'MES-SWA_DONOR_DIFF': 'TP53_ENST00000420246&TP53_ENST00000455263&TP53_ENST00000413465&TP53_ENST00000445888&TP53_ENST00000359597&TP53', 'MES-SWA_DONOR_REF': '-&-&-&-&-&-', 'MES-SWA_DONOR_REF_COMP': 
'176&176&176&176&176&176', 'MAXENTSCAN_ALT': 'p.S241F&p.S241F&p.S241F&p.S241F&p.S241F&p.S241F'}                                                                                                                                                                                         
2024-02-08 12:36:52 7581ebac56e7 scout.parse.variant.transcript[1286] WARNING Only splitted and normalised VEP v90+ frequencies are supported                                                                                                                                           
```

I hope that's not too much info printed to the logs. (At least the verbose stuff is confined to the debug loggers). Lemme know if it is and I'll change it.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Start a demo instance with this branch
2. Remove the cancer_case and re-add it
```
docker exec scout-scout-web-1 scout delete case -d cancer_case -i cust000
docker exec scout-scout-web-1 scout load case scout/demo/cancer.load_config.yaml 
```
3. Confirm that the log output displays more details about the parsing failures

**Expected outcome**:

Error log should display what went wrong and in what transcript/VEP key

Debug log should display exception and full `entry` content

**Review:**
- [ ] code approved by
- [ ] tests executed by
