### PR TITLE
Fix show matching partial causatives on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Revert style of pinned variants window on the case page
 - Rename `Clinical significanc` to `Germline classification` in ClinVar submissions exported files
 - Rename `Comment on clinical significance` to `Comment on classification` in ClinVar submissions exported files
+- Show matching partial causatives on variant page
 
 ## [4.76]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -22,7 +22,6 @@ CASE_CAUSATIVES_PROJECTION = {"causatives": 1, "partial_causatives": 1}
 
 
 class VariantHandler(VariantLoader):
-
     """Methods to handle variants in the mongo adapter"""
 
     def add_gene_info(self, variant_obj, gene_panels=None, build=None):
@@ -595,7 +594,7 @@ class VariantHandler(VariantLoader):
 
         var_causative_events = self.event_collection.find(
             {
-                "verb": "mark_causative",
+                "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
                 "subject": {"$in": [clinical_variant, research_variant]},
                 "category": "variant",
             }


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
-  Fix #4321

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
