### PR TITLE
Fix #4418 - report division-by-zero on depth 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Rename `Comment on clinical significance` to `Comment on classification` in ClinVar submissions exported files
 - Show matching partial causatives on variant page
 - Matching causatives shown on case page consisting only of variant matching the default panels of the case - bug introduced since scout v4.72 (Oct 18, 2023)
+- Missing somatic variant read depth leading to report division by zero
 
 ## [4.76]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1376,7 +1376,17 @@
     {{ (variant.first_rep_gene.hgvs_identifier or variant.display_name)|truncate(20, True) }}
   </td>
   <td>{{ (variant.first_rep_gene.hgvsp_identifier or '') |url_decode|truncate(30, True) }}</td>
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {% if sample.read_depth and sample.allele_depths[1] != -1 %}{{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
+  <td>
+    {% for sample in variant.samples %}
+      {% if sample.is_affected %}
+        {% if sample.read_depth and sample.allele_depths[1] != -1 %}
+          {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}
+        {% else %}
+          N/A
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  </td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>
@@ -1407,8 +1417,17 @@
     {{ variant.alternative|truncate(20, True) }}
   {% endif %}
   </td>
-
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %}{% if sample.read_depth and sample.allele_depths[1] != -1 %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
+  <td>
+    {% for sample in variant.samples %}
+      {% if sample.is_affected %}
+        {% if sample.read_depth and sample.allele_depths[1] != -1 %}
+          {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}
+        {% else %}
+          N/A
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+  </td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1376,7 +1376,7 @@
     {{ (variant.first_rep_gene.hgvs_identifier or variant.display_name)|truncate(20, True) }}
   </td>
   <td>{{ (variant.first_rep_gene.hgvsp_identifier or '') |url_decode|truncate(30, True) }}</td>
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {% if sample.read_depth  %}{{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
+  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {% if sample.read_depth and sample.allele_depths[1] != -1 %}{{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>
@@ -1408,7 +1408,7 @@
   {% endif %}
   </td>
 
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %}{% if sample.read_depth  %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
+  <td>{% for sample in variant.samples %}{% if sample.is_affected %}{% if sample.read_depth and sample.allele_depths[1] != -1 %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1376,7 +1376,7 @@
     {{ (variant.first_rep_gene.hgvs_identifier or variant.display_name)|truncate(20, True) }}
   </td>
   <td>{{ (variant.first_rep_gene.hgvsp_identifier or '') |url_decode|truncate(30, True) }}</td>
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% endif %} {% endfor %}</td>
+  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {% if sample.read_depth  %}{{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>
@@ -1408,7 +1408,7 @@
   {% endif %}
   </td>
 
-  <td>{% for sample in variant.samples %}{% if sample.is_affected %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% endif %} {% endfor %}</td>
+  <td>{% for sample in variant.samples %}{% if sample.is_affected %}{% if sample.read_depth  %} {{ (sample.allele_depths[1]/sample.read_depth*100)|round|int }}{% else %}N/A{% endif %}{% endif %} {% endfor %}</td>
   <td>
     {% if variant.acmg_classification %}
       <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
