### PR TITLE
Add option of downloading clinvar submission as .json

### DIFF
--- a/scout/server/blueprints/clinvar/static/clinvar_submissions.js
+++ b/scout/server/blueprints/clinvar/static/clinvar_submissions.js
@@ -1,0 +1,43 @@
+async function getJson(url) {
+    try {
+        const baseUrl = window.location.origin
+        console.log(`url: ${baseUrl}${url}`)
+        //Fetch data
+        const response = await fetch(`${baseUrl}${url}`)
+        if (!response.ok) {
+            throw new Error('Failed to fetch')
+        }
+        const jsonRes = await response.json()
+
+				let fileName=url.split("/").pop()
+
+        download(fileName, jsonRes)
+
+    } catch (error) {
+
+        if (error.toString().includes('Failed to fetch')) {
+            console.log(error)
+        }
+    }
+}
+
+function download(filename, object){
+    const json= JSON.stringify(object)
+    let downloadLink=document.createElement('a')
+    downloadLink.setAttribute('href','data:application/json;charset=utf-8,' + encodeURIComponent(json))
+    downloadLink.setAttribute('download', filename)
+    downloadLink.style.display='none'
+    document.body.appendChild(downloadLink)
+    downloadLink.click()
+    document.body.removeChild(downloadLink)
+}
+
+document.querySelector("#download_clinvar_json").addEventListener("click",(e)=>{
+
+getJson(e.target.value)
+
+})
+
+
+
+

--- a/scout/server/blueprints/clinvar/static/clinvar_submissions.js
+++ b/scout/server/blueprints/clinvar/static/clinvar_submissions.js
@@ -1,26 +1,24 @@
 async function getJson(url) {
     try {
+    //Get base url and fetch data
         const baseUrl = window.location.origin
-        console.log(`url: ${baseUrl}${url}`)
-        //Fetch data
         const response = await fetch(`${baseUrl}${url}`)
         if (!response.ok) {
             throw new Error('Failed to fetch')
         }
         const jsonRes = await response.json()
-
 				let fileName=url.split("/").pop()
 
+				//Create and download file
         download(fileName, jsonRes)
-
     } catch (error) {
-
         if (error.toString().includes('Failed to fetch')) {
             console.log(error)
         }
     }
 }
 
+//Function creates a file download from an Object
 function download(filename, object){
     const json= JSON.stringify(object)
     let downloadLink=document.createElement('a')
@@ -32,10 +30,9 @@ function download(filename, object){
     document.body.removeChild(downloadLink)
 }
 
+//Add eventlistener to button for json download of preClinVar response
 document.querySelector("#download_clinvar_json").addEventListener("click",(e)=>{
-
 getJson(e.target.value)
-
 })
 
 

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -60,11 +60,14 @@
               <li class="breadcrumb-item">
                 <!-- Download the Variant data CSV file -->
                 <a href="{{ url_for('clinvar.clinvar_download_csv', submission=subm_obj._id, csv_type='variant_data', clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
-                  Download variants file
+                  Download variants csv file
                 </a>
                 <a href=" {{ url_for('clinvar.clinvar_download_csv', submission=subm_obj._id, csv_type='case_data', clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
-                  Download casedata file
+                  Download casedata csv file
                 </a>
+                <button type="button" id="download_clinvar_json" value="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}"   class="btn btn-primary btn-xs text-white">
+                  Download submission json file
+                </button>
               </li>
               {% if subm_obj.status=='open'%}
                 <li class="breadcrumb-item"><button type="submit" name="update_submission" value="closed" class="btn btn-warning btn-xs">Close submission</button></li>
@@ -271,7 +274,7 @@
 
 {% block scripts %}
   {{ super() }}
-
+<script src="{{ url_for('clinvar.static', filename='clinvar_submissions.js') }}"></script>
   <script type="text/javascript">
 
   $(function () {
@@ -301,4 +304,5 @@
       });
   });
 </script>
+
 {% endblock %}

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -65,7 +65,7 @@
                 <a href=" {{ url_for('clinvar.clinvar_download_csv', submission=subm_obj._id, csv_type='case_data', clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
                   Download casedata csv file
                 </a>
-                <button type="button" id="download_clinvar_json" value="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}"   class="btn btn-primary btn-xs text-white">
+                <button type="button" id="download_clinvar_json" value="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white">
                   Download submission json file
                 </button>
               </li>

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -91,7 +91,7 @@ def clinvar_update_submission(institute_id, submission):
     return redirect(request.referrer)
 
 
-@clinvar_bp.route("/<submission>/download/<csv_type>/<clinvar_id>", methods=["GET"])
+@clinvar_bp.route("/<submission>/download/csv/<csv_type>/<clinvar_id>", methods=["GET"])
 def clinvar_download_csv(submission, csv_type, clinvar_id):
     """Download a csv (Variant file or CaseData file) for a clinVar submission"""
 
@@ -116,3 +116,12 @@ def clinvar_download_csv(submission, csv_type, clinvar_id):
         mimetype="text/csv",
         as_attachment=True,
     )
+
+
+@clinvar_bp.route("/<submission>/download/json/<clinvar_id>", methods=["GET"])
+def clinvar_download_json(submission, clinvar_id):
+    """Download a json for a clinVar submission"""
+
+    code, conversion_res = controllers.json_api_submission(submission_id=submission)
+
+    return conversion_res


### PR DESCRIPTION
This PR adds the option of downloading a ClinVar submission as a json file, in addition to the possibility of downloading  it as 2 .csv files.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Navigate to the ClinVar submission page, locate the new button for json download and download the file.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
