### PR TITLE
Fix #4435 - add MEI element name to variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-###
+### Added
 - Case status labels can be added, giving more finegrained details on a solved status (provisional, diagnostic, carrier, UPD, SMN, ...)
+- More MEI specific annotation is shown on the variant page
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -231,7 +231,7 @@
              <button type="button" class="fa fa-copy btn-xs js-tooltip js-copy" style="background-color: Transparent;outline:none; border: none;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-copy="{{ variant.chromosome }}:{{ variant.position }}" title="Copy to clipboard">
               </button>
             </td>
-            <td colspan=3>
+            <td {% if not mei %}colspan="3"{% endif %}>
               Change:
               {% if variant.reference|length > 8 %}
                 <strong>{{ variant.reference[:1] }}..{{variant.reference[-1:]}}</strong>
@@ -246,8 +246,11 @@
               {% endif %}
               <button type="button" class="fa fa-copy btn-xs js-tooltip js-copy" style="background-color: Transparent;outline:none; border: none;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-copy="{{ variant.reference }}>{{ variant.alternative }}" title="Copy to clipboard">
               </button>
-
-	    </td>
+	          </td>
+            {% if mei %}
+              <td>{{ variant.sub_category|upper }}</td>
+              <td>{{ variant.mei_name|upper }}</td>
+            {% endif %}
           </tr>
           <tr>
             <td>
@@ -279,6 +282,7 @@
               </strong></span>
             </td>
           </tr>
+
         </tbody>
       </table>
       <table class="table table-bordered table-fixed table-sm">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Adds MEI subtype / element annotation to variant page. Looks like we already represent the other things we parse to some degree (frequency, GT/depth/clipping), and there is not much more in the file yet. I think we are good until @kristinebilgrav has more news for us, on e.g. https://github.com/kristinebilgrav/TELLR.

Display 
![Screenshot 2024-02-19 at 14 33 58](https://github.com/Clinical-Genomics/scout/assets/758570/482174a5-1935-4718-9b9c-3581a35627ec)

without breaking e.g. SNVs
![Screenshot 2024-02-19 at 14 34 13](https://github.com/Clinical-Genomics/scout/assets/758570/407e7023-a7b5-421d-beb8-277d3ab2a13d)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [ ] tests executed by
