### PR TITLE
Fix #4396 - reset default loglevel to INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-###
+### Added
 - Case status labels can be added, giving more finegrained details on a solved status (provisional, diagnostic, carrier, UPD, SMN, ...)
+- New SO terms: `sequence_variant` and `coding_transcript_variant`
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)
@@ -16,8 +17,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed log info showing hgnc IDs used in variantS search
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded
 
-### Added
-- New SO terms: `sequence_variant` and `coding_transcript_variant`
 
 ## [4.77]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)
+- Default loglevel up to WARNING, making logs with default start easier to read
 ### Fixed
 - Removed log info showing hgnc IDs used in variantS search
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -100,7 +100,7 @@ def get_app(ctx=None):
 )
 @click.option(
     "--loglevel",
-    default="DEBUG",
+    default="WARNING",
     type=click.Choice(LOG_LEVELS),
     help="Set the level of log output.",
     show_default=True,

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -100,7 +100,7 @@ def get_app(ctx=None):
 )
 @click.option(
     "--loglevel",
-    default="WARNING",
+    default="INFO",
     type=click.Choice(LOG_LEVELS),
     help="Set the level of log output.",
     show_default=True,

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -14,8 +14,8 @@ def test_base_cmd():
     # test the CLI base, no arguments provided
     result = runner.invoke(cli)
     assert result.exit_code == 0
-    # debug message should be printed
-    assert "Debug logging enabled." in result.output
+    # Info level should be LOG:ed by default
+    assert "Running scout version" in result.output
 
     # test the cli with a different loglevel that DEBUG
     result = runner.invoke(cli, ["--loglevel", "WARNING"])


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

This
![Screenshot 2024-02-19 at 15 10 05](https://github.com/Clinical-Genomics/scout/assets/758570/bd542efa-320d-4c54-95aa-8912452ba779)
instead of 
![Screenshot 2024-02-19 at 15 03 17](https://github.com/Clinical-Genomics/scout/assets/758570/5e5af4c8-6727-4dc0-9a6d-070dbe388029)
.

Perhaps clearer if we pick a command that does no INFO logging:
Before:
![Screenshot 2024-02-19 at 15 02 50](https://github.com/Clinical-Genomics/scout/assets/758570/1094deac-c868-4750-982f-a4905d7efe28)
After:
![Screenshot 2024-02-19 at 15 02 57](https://github.com/Clinical-Genomics/scout/assets/758570/82f09476-4818-4df6-9ee2-1d60861cc56b)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
