### PR TITLE
Parse and save MANE transcripts info when updating genes in build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Case status labels can be added, giving more finegrained details on a solved status (provisional, diagnostic, carrier, UPD, SMN, ...)
 - More MEI specific annotation is shown on the variant page
-- Load and save Mane transcripts info when updating genes in build 38
+- Parse and save Mane transcripts info when updating genes in build 38
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Case status labels can be added, giving more finegrained details on a solved status (provisional, diagnostic, carrier, UPD, SMN, ...)
 - More MEI specific annotation is shown on the variant page
+- Load and save Mane transcripts info when updating genes in build 38
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Case status labels can be added, giving more finegrained details on a solved status (provisional, diagnostic, carrier, UPD, SMN, ...)
 - More MEI specific annotation is shown on the variant page
-- Parse and save Mane transcripts info when updating genes in build 38
+- Parse and save MANE transcripts info when updating genes in build 38
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/scout/build/genes/transcript.py
+++ b/scout/build/genes/transcript.py
@@ -31,6 +31,9 @@ def build_transcript(transcript_info, build="37"):
     refseq_id = transcript_info.get("refseq_id")
     refseq_identifiers = transcript_info.get("refseq_identifiers")
 
+    mane_select: Optional[str] = transcript_info.get("mane_select")
+    mane_plus_clinical: Optional[str] = transcript_info.get("mane_plus_clinical")
+
     try:
         chrom = transcript_info["chrom"]
     except KeyError:
@@ -67,6 +70,8 @@ def build_transcript(transcript_info, build="37"):
         refseq_id=refseq_id,
         refseq_identifiers=refseq_identifiers,
         build=build,
+        mane_select=mane_select,
+        mane_plus_clinical=mane_plus_clinical,
     )
     # Remove unnessesary keys
     for key in list(transcript_obj):

--- a/scout/build/genes/transcript.py
+++ b/scout/build/genes/transcript.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from scout.models.hgnc_map import HgncTranscript
 
 

--- a/scout/models/hgnc_map.py
+++ b/scout/models/hgnc_map.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from bson.objectid import ObjectId
+from typing import List, Optional
 
 
 class Exon(dict):
@@ -32,31 +32,21 @@ class Exon(dict):
 
 
 class HgncTranscript(dict):
-    """Transcript dictionary
-
-    "transcript_id": str, # ensembl id
-    "hgnc_id": int,
-    "chrom": str,
-    "start": int,
-    "end": int,
-    "is_primary": bool,
-    "refseq_id": str,
-    "refseq_identifiers": list,
-    "build": str, # Genome build
-    "length": int
-    """
+    """Model for a transcript dictionary"""
 
     def __init__(
         self,
-        transcript_id,
-        hgnc_id,
-        chrom,
-        start,
-        end,
-        is_primary=False,
-        refseq_id=None,
-        refseq_identifiers=None,
-        build="37",
+        transcript_id: str,
+        hgnc_id: int,
+        chrom: str,
+        start: int,
+        end: int,
+        is_primary: bool = False,
+        refseq_id: Optional[str] = None,
+        refseq_identifiers: List[str] = None,
+        build: str = "37",
+        mane_select: Optional[str] = None,
+        mane_plus_clinical: Optional[str] = None,
     ):
         super(HgncTranscript, self).__init__()
         self["ensembl_transcript_id"] = transcript_id
@@ -69,6 +59,11 @@ class HgncTranscript(dict):
         self["refseq_identifiers"] = refseq_identifiers
         self["build"] = build
         self["length"] = self["end"] - self["start"]
+        if build == "38":
+            if mane_select:
+                self["mane_select"] = mane_select
+            if mane_plus_clinical:
+                self["mane_plus_clinical"] = mane_plus_clinical
 
 
 class HgncGene(dict):

--- a/scout/parse/ensembl.py
+++ b/scout/parse/ensembl.py
@@ -1,5 +1,7 @@
 """Code for parsing ensembl information"""
+
 import logging
+from typing import Any, Dict, List
 
 LOG = logging.getLogger(__name__)
 
@@ -44,23 +46,19 @@ def parse_ensembl_line(line, header):
         update_exon_info(ensembl_info, word, value)
         update_utr_info(ensembl_info, word, value)
         update_refseq_info(ensembl_info, word, value)
+        update_mane_info(ensembl_info, word, value)
     return ensembl_info
 
 
-def parse_transcripts(transcript_lines):
+def parse_transcripts(transcript_lines: List[str]) -> Dict[str, dict]:
     """Parse and massage the transcript information
 
     There could be multiple lines with information about the same transcript.
     This is why it is necessary to parse the transcripts first and then return a dictionary
     where all information has been merged.
-
-    Args:
-        transcript_lines(): Iterable with strings
-
-    Returns:
-        parsed_transcripts(dict): Map from enstid -> transcript info
     """
     LOG.info("Parsing transcripts")
+
     transcripts = parse_ensembl_transcripts(transcript_lines)
 
     # Since there can be multiple lines with information about the same transcript
@@ -95,11 +93,16 @@ def parse_transcripts(transcript_lines):
         if tx.get("refseq_ncrna"):
             tx_info["nc_rna"].add(tx["refseq_ncrna"])
 
+        # Add Mane-related info
+        for mane in ["mane_select", "mane_plus_clinical"]:
+            if tx.get(mane):
+                tx_info[mane] = tx[mane]
+
     return parsed_transcripts
 
 
 def parse_ensembl_genes(lines):
-    """Parse lines with ensembl formated genes
+    """Parse lines with ensembl formatted genes
 
     This is designed to take a biomart dump with genes from ensembl.
     Mandatory columns are:
@@ -219,7 +222,7 @@ def parse_ensembl_exons(lines):
         yield exon
 
 
-def update_gene_info(ensembl_info, word, value):
+def update_gene_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
     """Extract gene info from Ensembl formatted line"""
     if "gene" in word:
         if "id" in word:
@@ -231,7 +234,7 @@ def update_gene_info(ensembl_info, word, value):
     return ensembl_info
 
 
-def update_transcript_info(ensembl_info, word, value):
+def update_transcript_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
     """Extract transcript info from Ensembl formatted line"""
     if "transcript" in word:
         if "id" in word:
@@ -243,7 +246,7 @@ def update_transcript_info(ensembl_info, word, value):
     return ensembl_info
 
 
-def update_exon_info(ensembl_info, word, value):
+def update_exon_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
     """Extract exon info from Ensembl formatted line"""
     if "exon" in word:
         if "start" in word:
@@ -257,7 +260,7 @@ def update_exon_info(ensembl_info, word, value):
     return ensembl_info
 
 
-def update_utr_info(ensembl_info, word, value):
+def update_utr_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
     """Extract UTR info from Ensembl formatted line"""
     if "utr" in word:
         if "start" in word:
@@ -273,7 +276,7 @@ def update_utr_info(ensembl_info, word, value):
     return ensembl_info
 
 
-def update_refseq_info(ensembl_info, word, value):
+def update_refseq_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
     """Extract RefSeq info from Ensembl formatted line"""
     if "refseq" in word:
         if "mrna" in word:
@@ -284,4 +287,13 @@ def update_refseq_info(ensembl_info, word, value):
 
         if "ncrna" in word:
             ensembl_info["refseq_ncrna"] = value
+    return ensembl_info
+
+
+def update_mane_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
+    """Extract Mane Plus Clinical and Mane Select info from an Ensembl formatted line."""
+    if "mane select" in word:
+        ensembl_info["mane_select"] = value
+    if "mane plus clinical" in word:
+        ensembl_info["mane_plus_clinical"] = value
     return ensembl_info

--- a/scout/parse/ensembl.py
+++ b/scout/parse/ensembl.py
@@ -93,7 +93,7 @@ def parse_transcripts(transcript_lines: List[str]) -> Dict[str, dict]:
         if tx.get("refseq_ncrna"):
             tx_info["nc_rna"].add(tx["refseq_ncrna"])
 
-        # Add Mane-related info
+        # Add MANE-related info
         for mane in ["mane_select", "mane_plus_clinical"]:
             if tx.get(mane):
                 tx_info[mane] = tx[mane]
@@ -291,7 +291,7 @@ def update_refseq_info(ensembl_info: Dict[str, Any], word: str, value: str) -> D
 
 
 def update_mane_info(ensembl_info: Dict[str, Any], word: str, value: str) -> Dict[str, Any]:
-    """Extract Mane Plus Clinical and Mane Select info from an Ensembl formatted line."""
+    """Extract MANE Plus Clinical and MANE Select info from an Ensembl formatted line."""
     if "mane select" in word:
         ensembl_info["mane_select"] = value
     if "mane plus clinical" in word:

--- a/scout/parse/hgnc.py
+++ b/scout/parse/hgnc.py
@@ -1,5 +1,4 @@
 import logging
-from pprint import pprint as pp
 
 logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,8 @@ def unparsed_transcript(request):
         refseq_mrna_pred="",
         refseq_ncrna="",
         start=1167629,
+        mane_select="NM_022114.4",
+        mane_plus_clinical="NM_001160331.2",
     )
     return unparsed_transcript
 

--- a/tests/parse/test_parse_ensembl_transcripts.py
+++ b/tests/parse/test_parse_ensembl_transcripts.py
@@ -13,9 +13,11 @@ def test_parse_ensembl_line(unparsed_transcript):
         "RefSeq mRNA ID",
         "RefSeq mRNA predicted ID",
         "RefSeq ncRNA ID",
+        "RefSeq match transcript (MANE Select)",
+        "RefSeq match transcript(MANE Plus Clinical)",
     ]
 
-    transcript_line = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}".format(
+    transcript_line = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}\t{8}\t{9}".format(
         unparsed_transcript["chrom"],
         unparsed_transcript["ens_gene_id"],
         unparsed_transcript["ens_transcript_id"],
@@ -24,6 +26,8 @@ def test_parse_ensembl_line(unparsed_transcript):
         unparsed_transcript["refseq_mrna"],
         unparsed_transcript["refseq_mrna_pred"],
         unparsed_transcript["refseq_ncrna"],
+        unparsed_transcript["mane_select"],
+        unparsed_transcript["mane_plus_clinical"],
     )
 
     ## WHEN parsing the transcript line
@@ -36,6 +40,8 @@ def test_parse_ensembl_line(unparsed_transcript):
     assert parsed_transcript["transcript_start"] == unparsed_transcript["start"]
     assert parsed_transcript["transcript_end"] == unparsed_transcript["end"]
     assert parsed_transcript["refseq_mrna"] == unparsed_transcript["refseq_mrna"]
+    assert parsed_transcript["mane_select"] == unparsed_transcript["mane_select"]
+    assert parsed_transcript["mane_plus_clinical"] == unparsed_transcript["mane_plus_clinical"]
     assert "refseq_mrna_predicted" not in parsed_transcript
     assert "refseq_ncrna" not in parsed_transcript
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- This will make the MANE info available for old variants more up-to-date, since it's collected from latest gene/transcripts records in the database
- Would also help to achieve #4431
- We could use this info instead of relying on VEP annotations when parsing variants

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, download the ensembl files containing genes and transcript info
2. Run scout --demo update genes -f <path to downloaded files>

**Expected outcome**:
- Transcripts with MANE Select and MANE Plus Clinical should be loaded in the database

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
