### PR TITLE
Display MANE badges on gene pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - New SO terms: `sequence_variant` and `coding_transcript_variant`
 - More MEI specific annotation is shown on the variant page
 - Parse and save MANE transcripts info when updating genes in build 38
+- `Mane Select` and `Mane Plus Clinical` badges on Gene page, when available
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -255,6 +255,8 @@
             <a target="_blank" href={{ transcript.ensembl_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank"> {{ transcript.ensembl_transcript_id }}</a>
             /  {{ transcript.refseq_identifiers|join(', ') or '-' }}
             {% if transcript.is_primary %}<small>(primary)</small>{% endif %}
+            {% if transcript.mane_select %} <span class="badge badge-sm bg-dark">MANE Select</span> {% endif %}
+            {% if transcript.mane_plus_clinical %} <span class="badge badge-sm bg-dark">MANE Plus Clinical </span> {% endif %}
 		  <span class="float-end">{{ transcript['position'] }}</span>
         </li>
       {% endfor %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- On gene page, display MANE badges, if available


Example with PRDM16 gene:

<img width="1676" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/9b554bbe-02ee-479a-81e3-40fee4b5e280">

Example with ERCC& gene:

<img width="1669" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/9cc7c155-d3dc-4ec7-9a77-8d7199093d7b">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. `scout --demo download everything` (also without the api key)
2. `scout --demo update genes`
3. Visit the page of the genes mentioned in the PR description and make sure you see the MANE tags

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by
