### PR TITLE
Fix #4157 - add pin API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - More MEI specific annotation is shown on the variant page
 - Parse and save MANE transcripts info when updating genes in build 38
 - `Mane Select` and `Mane Plus Clinical` badges on Gene page, when available
+- ClinVar submission can now be downloaded as a json file
 - API endpoint to pin variant
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
@@ -33,7 +34,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Possibility to submit variants associated with Orphanet conditions to ClinVar
 - Option update path to .d4 files path for individuals of an existing case using the command line
 - More constraint information is displayed per gene in addition to pLi: missense and LoF OE, CI (inluding LOEUF) and Z-score.
-- ClinVar submission can now be downloaded as a json file
 ### Changed
 - Introduce validation in the ClinVar multistep form to make sure users provide at least one variant-associated condition
 - CLI scout update individual accepts subject_id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - New SO terms: `sequence_variant` and `coding_transcript_variant`
 - More MEI specific annotation is shown on the variant page
 - Parse and save MANE transcripts info when updating genes in build 38
+- API endpoint to pin variant
 ### Changed
 - In the ClinVar form, database and id of assertion criteria citation are now separate inputs
 - Customise institute settings to be able to display all cases with a certain status on cases page (admin users)

--- a/scout/server/blueprints/api/views.py
+++ b/scout/server/blueprints/api/views.py
@@ -1,5 +1,5 @@
 from bson import json_util
-from flask import Blueprint, Response, abort
+from flask import Blueprint, Response, abort, url_for
 from flask_login import current_user
 
 from scout.server.extensions import store

--- a/scout/server/blueprints/api/views.py
+++ b/scout/server/blueprints/api/views.py
@@ -19,6 +19,42 @@ def case(institute_id, case_name):
 @api_bp.route("/<institute_id>/<case_name>/<variant_id>")
 def variant(institute_id, case_name, variant_id):
     """Display a specific SNV variant."""
+    variant_obj = store.variant(variant_id)
+    return Response(json_util.dumps(variant_obj), mimetype="application/json")
+
+
+@api_bp.route("/<institute_id>/<case_name>/<variant_id>/pin")
+def pin_variant(institute_id, case_name, variant_id):
+    """Pin an existing variant"""
+
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     variant_obj = store.variant(variant_id)
+
+    user_obj = store.user(current_user.email)
+    link = url_for(
+        "variant.variant",
+        institute_id=institute_id,
+        case_name=case_name,
+        variant_id=variant_id,
+    )
+    store.pin_variant(institute_obj, case_obj, user_obj, link, variant_obj)
+
+    return Response(json_util.dumps(variant_obj), mimetype="application/json")
+
+
+@api_bp.route("/<institute_id>/<case_name>/<variant_id>/unpin")
+def unpin_variant(institute_id, case_name, variant_id):
+    """Un-pin an existing, pinned variant"""
+    institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
+    variant_obj = store.variant(variant_id)
+
+    user_obj = store.user(current_user.email)
+    link = url_for(
+        "variant.variant",
+        institute_id=institute_id,
+        case_name=case_name,
+        variant_id=variant_id,
+    )
+    store.unpin_variant(institute_obj, case_obj, user_obj, link, variant_obj)
+
     return Response(json_util.dumps(variant_obj), mimetype="application/json")

--- a/scout/server/blueprints/api/views.py
+++ b/scout/server/blueprints/api/views.py
@@ -1,5 +1,6 @@
 from bson import json_util
 from flask import Blueprint, Response, abort
+from flask_login import current_user
 
 from scout.server.extensions import store
 from scout.server.utils import institute_and_case

--- a/tests/server/blueprints/api/test_api_views.py
+++ b/tests/server/blueprints/api/test_api_views.py
@@ -45,3 +45,66 @@ def test_variant(app, case_obj, variant_obj):
         # THEN it should return a valid response
         assert resp.status_code == 200
         assert resp.json["_id"] == variant_id
+
+
+def test_pin(app, case_obj, variant_obj):
+    """Test the api endpoint that pins variants"""
+
+    case_name = case_obj["display_name"]
+    variant_id = variant_obj["_id"]
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+        # WHEN the API is invoked with the right params
+        resp = client.get(
+            url_for(
+                "api.pin_variant",
+                institute_id=case_obj["owner"],
+                case_name=case_name,
+                variant_id=variant_id,
+                link="pinned it",
+            )
+        )
+        # THEN it should return a valid response
+        assert resp.status_code == 200
+        assert resp.json["_id"] == variant_id
+
+
+def test_unpin(app, institute_obj, case_obj, variant_obj):
+    """Test the api endpoint that unpins variants"""
+
+    case_name = case_obj["display_name"]
+    variant_id = variant_obj["_id"]
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+
+        # GIVEN a pinned variant
+        resp = client.get(
+            url_for(
+                "api.pin_variant",
+                institute_id=case_obj["owner"],
+                case_name=case_name,
+                variant_id=variant_id,
+                link="pinned it for testing",
+            )
+        )
+        assert resp.status_code == 200
+
+        # WHEN the API is invoked with the right params
+        resp = client.get(
+            url_for(
+                "api.unpin_variant",
+                institute_id=case_obj["owner"],
+                case_name=case_name,
+                variant_id=variant_id,
+                link="unpinned it",
+            )
+        )
+        # THEN it should return a valid response
+        assert resp.status_code == 200
+        assert resp.json["_id"] == variant_id


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
