### PR TITLE
Add option to search disease_terms in database to diagnosis page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update GitHub actions
 - Default loglevel up to INFO, making logs with default start easier to read
 - Add XTR region to PAR region definition
-- The diagnoses in the scout database can be searched in the diagnosis page
+- Diagnoses can be searched on diagnoses page without waiting for load first
 ### Fixed
 - Removed log info showing hgnc IDs used in variantS search
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update GitHub actions
 - Default loglevel up to INFO, making logs with default start easier to read
 - Add XTR region to PAR region definition
+- The diagnoses in the scout database can be searched in the diagnosis page
 ### Fixed
 - Removed log info showing hgnc IDs used in variantS search
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded

--- a/scout/adapter/mongo/disease_terms.py
+++ b/scout/adapter/mongo/disease_terms.py
@@ -117,6 +117,7 @@ class DiagnosisHandler(object):
         using filter_project. By default do not return disease-associated genes and HPO terms."""
         query = {}
         if source:
+            LOG.debug(f"Fetching all {source} diseases")
             query = {"source": source}
         else:
             LOG.info("Fetching all disease terms")

--- a/scout/adapter/mongo/disease_terms.py
+++ b/scout/adapter/mongo/disease_terms.py
@@ -15,7 +15,13 @@ DISEASE_FILTER_PROJECT = {"hpo_terms": 0, "genes": 0}
 class DiagnosisHandler(object):
     """Class for handling OMIM and disease-related database objects"""
 
-    def query_disease(self, query: str = None, source: str = None, limit: int = None) -> Iterable:
+    def query_disease(
+        self,
+        query: str = None,
+        source: str = None,
+        limit: int = None,
+        filter_project: Optional[dict] = DISEASE_FILTER_PROJECT,
+    ) -> Iterable:
         """Return all disease_terms
 
         If a query is sent it will try to match with regex on term or
@@ -44,7 +50,7 @@ class DiagnosisHandler(object):
         limit = limit or int(10e10)
 
         res = (
-            self.disease_term_collection.find(query_dict, DISEASE_FILTER_PROJECT)
+            self.disease_term_collection.find(query_dict, filter_project)
             .limit(limit)
             .sort("disease_nr", ASCENDING)
         )
@@ -104,35 +110,18 @@ class DiagnosisHandler(object):
 
     def disease_terms(
         self,
-        query: str = None,
         source: Optional[str] = None,
         filter_project: Optional[dict] = DISEASE_FILTER_PROJECT,
     ) -> list:
         """Return all disease terms optionally from only one source and filtered the returned key/values
         using filter_project. By default do not return disease-associated genes and HPO terms."""
-        query_dict = {}
-        if query:
-            query_dict = {
-                "$or": [
-                    {"disease_nr": {"$regex": query, "$options": "i"}},
-                    {"description": {"$regex": query, "$options": "i"}},
-                ]
-            }
-            # If source is specified, add this restriction to the query
-            if source:
-                query_dict = {
-                    "$and": [
-                        query_dict,
-                        {"source": source},
-                    ]
-                }
-        elif source:
-            LOG.debug(f"Fetching all {source} diseases")
-            query_dict = {"source": source}
+        query = {}
+        if source:
+            query = {"source": source}
         else:
             LOG.info("Fetching all disease terms")
 
-        return list(self.disease_term_collection.find(query_dict, filter_project))
+        return list(self.disease_term_collection.find(query, filter_project))
 
     def disease_terms_by_gene(
         self,

--- a/scout/server/blueprints/diagnoses/controllers.py
+++ b/scout/server/blueprints/diagnoses/controllers.py
@@ -24,11 +24,8 @@ def disease_entry(store, disease_id) -> dict:
     return disease_obj
 
 
-def disease_terms(store: MongoAdapter, query: str, source: str):
-    """Retrieve disease terms, optionally queried by source or a text-match for the disease description.
-    Returns:
-        data(dict): dict with key "terms" set to an array of all disease terms
-    """
+def disease_terms(store: MongoAdapter, query: str, source: str) -> dict:
+    """Retrieve disease terms, optionally queried by source or a text-match for the disease description."""
 
     data = {"terms": store.disease_terms(query=query, source=source, filter_project=None)}
     return data

--- a/scout/server/blueprints/diagnoses/controllers.py
+++ b/scout/server/blueprints/diagnoses/controllers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from scout.adapter import MongoAdapter
 from scout.server.links import disease_link
 
 
@@ -23,13 +24,11 @@ def disease_entry(store, disease_id) -> dict:
     return disease_obj
 
 
-def disease_terms(store):
-    """Retrieve all disease terms.
-    Args:
-        store(adapter.MongoAdapter):  an adapter to the scout database
+def disease_terms(store: MongoAdapter, query: str, source: str):
+    """Retrieve disease terms, optionally queried by source or a text-match for the disease description.
     Returns:
         data(dict): dict with key "terms" set to an array of all disease terms
     """
 
-    data = {"terms": store.disease_terms(filter_project=None)}
+    data = {"terms": store.disease_terms(query=query, source=source, filter_project=None)}
     return data

--- a/scout/server/blueprints/diagnoses/controllers.py
+++ b/scout/server/blueprints/diagnoses/controllers.py
@@ -27,5 +27,5 @@ def disease_entry(store, disease_id) -> dict:
 def disease_terms(store: MongoAdapter, query: str, source: str) -> dict:
     """Retrieve disease terms, optionally queried by source or a text-match for the disease description."""
 
-    data = {"terms": store.disease_terms(query=query, source=source, filter_project=None)}
+    data = {"terms": list(store.query_disease(query=query, source=source, filter_project=None))}
     return data

--- a/scout/server/blueprints/diagnoses/controllers.py
+++ b/scout/server/blueprints/diagnoses/controllers.py
@@ -25,7 +25,7 @@ def disease_entry(store, disease_id) -> dict:
 
 
 def disease_terms(store: MongoAdapter, query: str, source: str) -> dict:
-    """Retrieve disease terms, optionally queried by source or a text-match for the disease description."""
+    """Retrieve disease terms, queried by source or a text-match for the disease description."""
 
     data = {"terms": list(store.query_disease(query=query, source=source, filter_project=None))}
     return data

--- a/scout/server/blueprints/diagnoses/static/diagnoses.js
+++ b/scout/server/blueprints/diagnoses/static/diagnoses.js
@@ -8,7 +8,7 @@ async function loadDiseases() {
            Loading matching diagnoses, this might take some time...
         </div>`);
 
-    //Get input value
+    //Get input value to use in query
     const query = document.querySelector("#search-disease-term").value
 
     const baseUrl = window.location.origin
@@ -144,7 +144,6 @@ function initialiseTable(data) {
     });
     document.querySelector("#diagnoses_table_wrapper > .dt-buttons").classList.add("mb-2")
 }
-
 
 function removePreviousTableIfPresent() {
     if ($.fn.dataTable.isDataTable('#diagnoses_table')) {$('#diagnoses_table').DataTable().destroy()}

--- a/scout/server/blueprints/diagnoses/static/diagnoses.js
+++ b/scout/server/blueprints/diagnoses/static/diagnoses.js
@@ -146,5 +146,5 @@ function initialiseTable(data) {
 }
 
 function removePreviousTableIfPresent() {
-    if ($.fn.dataTable.isDataTable('#diagnoses_table')) {$('#diagnoses_table').DataTable().destroy()}
+    if ($.fn.dataTable.isDataTable('#diagnoses_table')) {$('#diagnoses_table').DataTable().clear().destroy()}
 }

--- a/scout/server/blueprints/diagnoses/static/diagnoses.js
+++ b/scout/server/blueprints/diagnoses/static/diagnoses.js
@@ -1,23 +1,23 @@
 async function loadDiseases() {
-		//Remove load button
-    let button=document.getElementById("load-button")
-
-    button.remove()
-
     //Add spinner to show loading is in progress
     $('#load-container').html(
         `<div id="spinner-container" class="d-flex align-items-center">
             <div class="spinner-border text-primary m-3" role="status">
                 <span class="visually-hidden"></span>
             </div>
-           Loading all diagnoses, this might take some time...
+           Loading matching diagnoses, this might take some time...
         </div>`);
+
+    //Get input value
+    const query = document.querySelector("#search-disease-term").value
 
     const baseUrl = window.location.origin
 
+    //If it's not the first search, remove the previously generated table
+    removePreviousTableIfPresent()
     try {
         //Fetch data and generate table with results
-        const response = await fetch(`${baseUrl}/api/v1/diagnoses`)
+        const response = await fetch(`${baseUrl}/api/v1/diagnoses?query=${query}`)
         if (!response.ok) {
             throw new Error('Failed to fetch')
         }
@@ -29,8 +29,6 @@ async function loadDiseases() {
     } catch (error) {
 
         if (error.toString().includes('Failed to fetch')) {
-        		//Replace load button
-        		document.querySelector("#diagnoses-card").append(button)
             //Replace loading spinner with error message if loading fails
             displayErrorMsg("Diagnoses could not be loaded, please try again", "spinner-container")
         }
@@ -39,8 +37,8 @@ async function loadDiseases() {
 
 function generateDiseaseTable(data, id) {
     const table = document.getElementById(id)
-    const row = table.querySelector("#diagnosis-row")
-    const tbody = table.querySelector("tbody")
+    const row = document.querySelector("#diagnosis-row")
+    const tbody = table.querySelector(`#${id} tbody`)
 
     //Create a table row for each diagnosis and append to the table
     data.forEach(item => {
@@ -48,8 +46,7 @@ function generateDiseaseTable(data, id) {
         tbody.append(newRow)
     })
 
-    //Replace invisible content so diagnosis-table is displayed
-    row.remove()
+    //Remove spinner and show the table if hidden
     document.querySelector("#spinner-container").remove()
     table.removeAttribute("style")
 }
@@ -84,8 +81,7 @@ function generateDiseaseTableRow(disease, rowTemplate) {
             inheritanceContainerElement.append(newInheritance)
         });
     } else {
-
-        inheritanceContainerElement .textContent = "-"
+        inheritanceContainerElement.textContent = "-"
     }
 
     //Add Genes
@@ -96,14 +92,15 @@ function generateDiseaseTableRow(disease, rowTemplate) {
 
     return newNode
 }
+
 function displayErrorMsg(msg, id) {
     //Replace spinner with error message
     const spinnerContainer = document.querySelector(`#${id}`)
     spinnerContainer.textContent = msg
 }
 
-function addHpoOrGeneLinks(parentNode, target, data){
-let linkElement = parentNode.querySelector(`#${target}-link`)
+function addHpoOrGeneLinks(parentNode, target, data) {
+    let linkElement = parentNode.querySelector(`#${target}-link`)
     let containerElement = parentNode.querySelector(`#${target}-container`)
 
     if (data.length > 0) {
@@ -131,23 +128,24 @@ function getExternalLink(source, disease_nr) {
     return link
 }
 
-
 function initialiseTable(data) {
     //Diagnosis table is turned into a DataTable with copy-buttons, pagination and search bar
     $('#diagnoses_table').DataTable({
         data: data,
         paging: true,
-        dom: 'fBrtip',
+        dom: 'Brtip',
         buttons: [
             {
                 extend: 'excelHtml5',
-                title: 'omim_terms'
+                title: 'disease_term_search_result'
             },
             'copyHtml5'
         ]
     });
-    document.querySelector("#diagnoses_table_filter").classList.add("text-start")
-		document.querySelector("#diagnoses_table_wrapper > .dt-buttons").classList.add("m-2")
+    document.querySelector("#diagnoses_table_wrapper > .dt-buttons").classList.add("mb-2")
 }
 
 
+function removePreviousTableIfPresent() {
+    if ($.fn.dataTable.isDataTable('#diagnoses_table')) {$('#diagnoses_table').DataTable().destroy()}
+}

--- a/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
+++ b/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
@@ -82,7 +82,7 @@
   </div>
   <table id="super_secret_table_template" style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0; padding: 0; white-space: nowrap; clip-path: inset(100%); clip: rect(0 0 0 0); overflow: hidden;">
   <tr id="diagnosis-row">
-    <td><a id="external-link" href="http://omim.org/entry/" target="_blank" rel=noopener ></a>
+    <td><a id="external-link" href="http://omim.org/entry/" target="_blank" rel=noopener ></a></td>
     <td><a id="internal-link" href="{{ url_for('diagnoses.diagnosis',disease_id='')}}"><span class="fa fa-link"></span></a></td>
     <td><span id="description" class="text-body"></span></td>
     <td id="inheritance-container"><!-- inheritance-->

--- a/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
+++ b/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
@@ -55,7 +55,16 @@
       <div class="card">
         <div class="card-header"> Diagnoses in database</div>
         <div id="diagnoses-card" class="card-body">
-          <div id="load-container"><button id="load-button" class="btn btn-primary my-2" onClick="loadDiseases()">Load all diseases from database</button></div>
+          <div class="d-flex align-items-center">
+            <div >
+              <input name=search-disease-term" id="search-disease-term" class="form-control typeahead_diseases" data-provide="typeahead_diseases" autocomplete="off" required placeholder="Search...">
+            </div>
+            <div class="mx-4">
+              <button id="load-button" class="btn btn-primary my-2" onClick="loadDiseases()">Search diseases</button>
+            </div>
+          </div>
+          <div id="load-container" class="d-flex align-items-center">
+          </div>
           <table id="diagnoses_table" class="table table-sm" style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0; padding: 0; white-space: nowrap; clip-path: inset(100%); clip: rect(0 0 0 0); overflow: hidden;" aria-label="Table containing all diagnoses in the scout database">
               <thead class="table-light thead">
                 <th>Diagnosis code</th>
@@ -66,30 +75,32 @@
                 <th>Associated HPO terms</th>
               </thead>
               <tbody>
-                <tr id="diagnosis-row">
-                  <td><a id="external-link" href="http://omim.org/entry/" target="_blank" rel=noopener ></a>
-                  <td><a id="internal-link" href="{{ url_for('diagnoses.diagnosis',disease_id='')}}"><span class="fa fa-link"></span></a></td>
-                  <td><span id="description" class="text-body"></span></td>
-                  <td id="inheritance-container"><!-- inheritance-->
-                      <span id="inheritance" class="badge bg-info m-1"></span>
-                  </td><!--end of inheritance-->
-                  <td id="gene-container">
-                    <span class="text-body">
-                      <a id="gene-link" class="badge link-primary m-1 fw-normal" href="{{ url_for('genes.gene', hgnc_id='0') }}" target="_blank" rel="noopener" ></a>
-                    </span>
-                  </td>
-                  <td id="hpo-container">
-                    <span class="text-body">
-                      <a id="hpo-link" class="badge bg-secondary text-white m-1" href="https://hpo.jax.org/app/browse/term/{{term}}" target="_blank" rel="noopener" ></a>
-                    </span>
-                  </td>
-                </tr>
               </tbody>
             </table>
         </div><!--end of card body-->
       </div><!--end of card-->
     </div>
   </div>
+  <table id="super_secret_table_template" style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0; padding: 0; white-space: nowrap; clip-path: inset(100%); clip: rect(0 0 0 0); overflow: hidden;">
+  <tr id="diagnosis-row">
+    <td><a id="external-link" href="http://omim.org/entry/" target="_blank" rel=noopener ></a>
+    <td><a id="internal-link" href="{{ url_for('diagnoses.diagnosis',disease_id='')}}"><span class="fa fa-link"></span></a></td>
+    <td><span id="description" class="text-body"></span></td>
+    <td id="inheritance-container"><!-- inheritance-->
+      <span id="inheritance" class="badge bg-info m-1"></span>
+    </td><!--end of inheritance-->
+    <td id="gene-container">
+      <span class="text-body">
+        <a id="gene-link" class="badge link-primary m-1 fw-normal" href="{{ url_for('genes.gene', hgnc_id='0') }}" target="_blank" rel="noopener" ></a>
+      </span>
+    </td>
+    <td id="hpo-container">
+      <span class="text-body">
+        <a id="hpo-link" class="badge bg-secondary text-white m-1" href="https://hpo.jax.org/app/browse/term/{{term}}" target="_blank" rel="noopener" ></a>
+      </span>
+    </td>
+  </tr>
+  </table>
 </div>
 {% endblock %}
 

--- a/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
+++ b/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
@@ -56,7 +56,7 @@
         <div id="diagnoses-card" class="card-body">
           <div class="d-flex align-items-center">
             <div >
-              <input name=search-disease-term" id="search-disease-term" class="form-control typeahead_diseases" data-provide="typeahead_diseases" autocomplete="off" required placeholder="Search...">
+              <input name=search-disease-term" id="search-disease-term" class="form-control" onkeydown="if (event.key == 'Enter'){loadDiseases()}" placeholder="Search...">
             </div>
             <div class="mx-4">
               <button id="load-button" class="btn btn-primary my-2" onClick="loadDiseases()">Search diseases</button>

--- a/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
+++ b/scout/server/blueprints/diagnoses/templates/diagnoses/diagnoses.html
@@ -50,7 +50,6 @@
         </div><!--end of card body-->
       </div><!--end of card-->
     </div>
-
     <div class="col-lg-9">
       <div class="card">
         <div class="card-header"> Diagnoses in database</div>

--- a/scout/server/blueprints/diagnoses/views.py
+++ b/scout/server/blueprints/diagnoses/views.py
@@ -35,7 +35,7 @@ def count_diagnoses():
 @omim_bp.route("/api/v1/diagnoses")
 @public_endpoint
 def api_diagnoses():
-    """Return JSON data about OMIM diseases in the database."""
+    """Return JSON data about diseases in the database."""
     query = request.args.get("query") or None
     source = request.args.get("source") or None
     data = controllers.disease_terms(store, query=query, source=source)

--- a/scout/server/blueprints/diagnoses/views.py
+++ b/scout/server/blueprints/diagnoses/views.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, request
 
 from scout.server.extensions import store
 from scout.server.utils import public_endpoint, templated
@@ -36,6 +36,7 @@ def count_diagnoses():
 @public_endpoint
 def api_diagnoses():
     """Return JSON data about OMIM diseases in the database."""
-
-    data = controllers.disease_terms(store)
+    query = request.args.get("query") or None
+    source = request.args.get("source") or None
+    data = controllers.disease_terms(store, query=query, source=source)
     return jsonify(data)

--- a/scout/server/blueprints/diagnoses/views.py
+++ b/scout/server/blueprints/diagnoses/views.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from flask import Blueprint, jsonify, request
 
 from scout.server.extensions import store
@@ -36,7 +38,7 @@ def count_diagnoses():
 @public_endpoint
 def api_diagnoses():
     """Return JSON data about diseases in the database."""
-    query = request.args.get("query") or None
-    source = request.args.get("source") or None
-    data = controllers.disease_terms(store, query=query, source=source)
+    query: Union[str, None] = request.args.get("query") or None
+    source: Union[str, None] = request.args.get("source") or None
+    data: dict = controllers.disease_terms(store, query=query, source=source)
     return jsonify(data)


### PR DESCRIPTION
This PR adds the option of searching the disease_terms in the database instead of loading all diseases. 
This is a fix for #4427

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Navigate to the diagnoses page
2. Explore the functioning of the diagnoses table

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by TB/CR
