### PR TITLE
Replace "omim" with "disease" in case page query search and related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded
 - Inheritance mode from ORPHA should not be confounded with the OMIM inheritance model
 - Decipher link URL changes
+- Refactored casepage to use "disease" instead of "omim" where orpha-terms are also handled
 
 
 ## [4.77]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Maintain Matchmaker Exchange and Beacon submission status when a case is re-uploaded
 - Inheritance mode from ORPHA should not be confounded with the OMIM inheritance model
 - Decipher link URL changes
-- Refactored casepage to use "disease" instead of "omim" where orpha-terms are also handled
+- Refactored code in cases blueprints to use "disease" instead of "omim" to encompass also ORPHA terms
 
 
 ## [4.77]

--- a/scout/adapter/mongo/case_events.py
+++ b/scout/adapter/mongo/case_events.py
@@ -542,7 +542,7 @@ class CaseEventHandler(object):
         user: dict,
         link: str,
         disease_id: str,
-        omim_inds: list = [],
+        affected_inds: list = [],
         remove: bool = False,
     ) -> Optional[dict]:
         """Add or remove a diagnose to a case and eventually case individuals."""
@@ -556,22 +556,22 @@ class CaseEventHandler(object):
                     continue
                 updated_diagnoses.append(case_dia)
         else:  # Add new diagnosis term to case diseases list
-            omim_obj = self.disease_term(disease_identifier=disease_id)
-            if omim_obj is None:
+            disease_obj = self.disease_term(disease_identifier=disease_id)
+            if disease_obj is None:
                 return
             updated_diagnoses = case_diagnoses
             new_dia = {
-                "disease_nr": omim_obj["disease_nr"],
+                "disease_nr": disease_obj["disease_nr"],
                 "disease_id": disease_id,
-                "description": omim_obj["description"],
+                "description": disease_obj["description"],
             }
-            if omim_inds:
+            if affected_inds:
                 new_dia["individuals"] = [
                     {
                         "individual_id": ind.split("|")[0],
                         "individual_name": ind.split("|")[1],
                     }
-                    for ind in omim_inds
+                    for ind in affected_inds
                 ]
             updated_diagnoses.append(new_dia)
 
@@ -591,7 +591,7 @@ class CaseEventHandler(object):
                 verb="update_diagnosis",
                 subject=case["display_name"],
                 content=disease_id,
-                individuals=[ind.split("|")[1] for ind in omim_inds],
+                individuals=[ind.split("|")[1] for ind in affected_inds],
             )
 
         return updated_case

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -655,8 +655,8 @@
           process(data)
         });
       }
-      function getOmimTerms(query, process) {
-        $.get("{{ url_for('cases.omimterms') }}", {query: query}, function(data) {
+      function getDiseaseTerms(query, process) {
+        $.get("{{ url_for('cases.diseaseterms') }}", {query: query}, function(data) {
           process(data)
         });
       }
@@ -684,9 +684,9 @@
         minLength: 3,
       });
 
-      $(".typeahead_omim").typeahead({
-        name: 'omim_term',
-        source: getOmimTerms,
+      $(".typeahead_disease").typeahead({
+        name: 'disease_term',
+        source: getDiseaseTerms,
         minLength: 3,
       });
 

--- a/scout/server/blueprints/cases/templates/cases/phenotype.html
+++ b/scout/server/blueprints/cases/templates/cases/phenotype.html
@@ -81,7 +81,7 @@
         <div class="col-1">
           {{ remove_form(url_for('cases.case_diagnosis', institute_id=institute._id,
                                 case_name=case.display_name, remove='yes'),
-                       hidden_input=('omim_term', diagnosis.disease_id)) }}
+                       hidden_input=('disease_term', diagnosis.disease_id)) }}
         </div>
       </div>
     {% endfor %}
@@ -91,7 +91,7 @@
   </div>
 {% endmacro %}
 
-<!-- This macro is used to display case individuals associated with an HPO phenotype or an OMIM disease -->
+<!-- This macro is used to display case individuals associated with an HPO phenotype or a disease -->
 {% macro feature_individuals(case, feature) %}
   {% for feature_ind in feature.individuals %}
     {% for case_ind in case.individuals %}
@@ -105,13 +105,13 @@
 
 {% macro diagnosis_form(case, institute) %}
   <form action="{{ url_for('cases.case_diagnosis', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
-    <div class="d-flex justify-content-around" id="omim_assign">
+    <div class="d-flex justify-content-between" id="disease_assign">
       <div>
-        <input name="omim_term" id="assign-omim-term" class="form-control typeahead_omim" data-provide="typeahead" autocomplete="off"
-            required placeholder="Search..." oninput="toggleClickableButtons('assign-omim-button', 'assign-omim-term');">
+        <input name="disease_term" id="assign-disease-term" class="form-control typeahead_disease align-self" data-provide="typeahead" autocomplete="off"
+            required placeholder="Search..." oninput="toggleClickableButtons('assign-disease-button', 'assign-disease-term');">
       </div>
       <div>
-        <select name="omim_inds" multiple class="selectpicker" data-style="btn-secondary">
+        <select name="affected_inds" multiple class="selectpicker" data-style="btn-secondary">
           {% for ind in case.individuals %}
             <option value="{{ind.individual_id}}|{{ind.display_name}}" {{"selected" if ind.phenotype==2 }}>
               {{ind.display_name}}
@@ -119,8 +119,8 @@
           {% endfor %}
         </select>
       </div>
-      <div>
-        <button class="ms-3 btn no-hover btn-secondary form-control" type="submit" id="assign-omim-button">Assign Diagnosis</button>
+      <div style="margin-right:1rem;">
+        <button class="btn no-hover btn-secondary form-control" type="submit" id="assign-disease-button">Assign Diagnosis</button>
       </div>
     </div>
   </form>

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -330,19 +330,19 @@ def case_diagnosis(institute_id, case_name):
     user_obj = store.user(current_user.email)
     link = url_for(".case", institute_id=institute_id, case_name=case_name)
 
-    omim_id = request.form["omim_term"].split("|")[0]
-    omim_inds = request.form.getlist("omim_inds")  # Individual-level phenotypes
+    disease_id = request.form["disease_term"].split("|")[0]
+    affected_inds = request.form.getlist("affected_inds")  # Individual-level phenotypes
 
     store.diagnose(
         institute=institute_obj,
         case=case_obj,
         user=user_obj,
         link=link,
-        disease_id=omim_id.strip(),
-        omim_inds=omim_inds,
+        disease_id=disease_id.strip(),
+        affected_inds=affected_inds,
         remove=True if request.args.get("remove") == "yes" else False,
     )
-    return redirect("#".join([link, "omim_assign"]))
+    return redirect("#".join([link, "disease_assign"]))
 
 
 @cases_bp.route("/<institute_id>/<case_name>/phenotypes", methods=["POST"])
@@ -630,8 +630,8 @@ def hpoterms():
     return jsonify(json_terms)
 
 
-@cases_bp.route("/api/v1/omim-terms")
-def omimterms():
+@cases_bp.route("/api/v1/disease-terms")
+def diseaseterms():
     query = request.args.get("query")
     source = request.args.get("source") or None
     if query is None:

--- a/scout/server/blueprints/phenomodels/templates/phenomodel.html
+++ b/scout/server/blueprints/phenomodels/templates/phenomodel.html
@@ -345,7 +345,7 @@
   }
 
   function getOmimTerms(query, process) {
-    $.get("{{ url_for('cases.omimterms') }}", {query: query, source:"OMIM"}, function(data) {
+    $.get("{{ url_for('cases.diseaseterms') }}", {query: query, source:"OMIM"}, function(data) {
       process(data)
     });
   }

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -898,7 +898,7 @@ def test_caselist(app, case_obj):
         assert case_obj["display_name"] in str(resp.data)
 
 
-def test_omimterms(app, test_omim_database_term):
+def test_diseaseterms(app, test_omim_database_term):
     """Test The API which returns all OMIM terms when queried from case page"""
 
     # GIVEN a database containing at least one OMIM term
@@ -912,7 +912,7 @@ def test_omimterms(app, test_omim_database_term):
         assert resp.status_code == 200
 
         # WHEN the API is invoked with a query string containing part of the OMIM term description
-        resp = client.get(url_for("cases.omimterms", query="5-oxo"))
+        resp = client.get(url_for("cases.diseaseterms", query="5-oxo"))
         # THEN it should return a valid response
         assert resp.status_code == 200
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -761,9 +761,9 @@ def test_case_diagnosis(
         # GIVEN that the user could be logged in
         client.get(url_for("auto_login"))
 
-        req_data = {"omim_term": disease_id}
+        req_data = {"disease_term": disease_id}
 
-        # WHEN updating an OMIM diagnosis for a case
+        # WHEN updating a diagnosis for a case
         resp = client.post(
             url_for(
                 "cases.case_diagnosis",
@@ -781,7 +781,7 @@ def test_case_diagnosis(
         assert store.event_collection.find_one()
 
         # WHEN using the same endpoint to remove the diagnosis
-        req_data = {"omim_term": disease_id}
+        req_data = {"disease_term": disease_id}
         resp = client.post(
             url_for(
                 "cases.case_diagnosis",
@@ -899,7 +899,7 @@ def test_caselist(app, case_obj):
 
 
 def test_diseaseterms(app, test_omim_database_term):
-    """Test The API which returns all OMIM terms when queried from case page"""
+    """Test The API which returns all disease terms when queried from case page"""
 
     # GIVEN a database containing at least one OMIM term
     store.disease_term_collection.insert_one(test_omim_database_term)
@@ -911,12 +911,12 @@ def test_diseaseterms(app, test_omim_database_term):
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200
 
-        # WHEN the API is invoked with a query string containing part of the OMIM term description
+        # WHEN the API is invoked with a query string containing part of the disease term description
         resp = client.get(url_for("cases.diseaseterms", query="5-oxo"))
         # THEN it should return a valid response
         assert resp.status_code == 200
 
-        # containing the OMIM term
+        # containing the disease term
         assert test_omim_database_term["_id"] in str(resp.data)
         assert resp.mimetype == "application/json"
 


### PR DESCRIPTION
This PR replaces several instances in the case page where "omim" was used in ids, function names and variable names which also handles orpha terms. This is a fix for #4428.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. The workflow for adding and removing diagnosis for individuals in a case in scout should still be functional.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by TB
