### PR TITLE
Fix orpha phenomodels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Added tags for Sniffles and CNVpytor, two LRS SV callers
+- Phenomodels checkboxes can now include orpha terms
 ### Changed
 ### Fixed
 

--- a/scout/server/blueprints/phenomodels/controllers.py
+++ b/scout/server/blueprints/phenomodels/controllers.py
@@ -119,7 +119,7 @@ def _update_subpanel(subpanel_obj, supb_changes):
         all_terms = {}
         # loop over the terms to keep into the checboxes dict
         for child in children_list:
-            if child.startswith("OMIM" or "ORPHA"):
+            if child.startswith("OMIM") or child.startswith("ORPHA"):
                 new_checkboxes[child] = checkboxes[child]
                 continue
 

--- a/scout/server/blueprints/phenomodels/controllers.py
+++ b/scout/server/blueprints/phenomodels/controllers.py
@@ -128,7 +128,7 @@ def _update_subpanel(subpanel_obj, supb_changes):
             try:
                 node = Node(child, parent=root, description=term_obj["description"])
             except Exception:
-                flash(f"Term {child} could not be find in database")
+                flash(f"Term {child} could not be found in database")
                 continue
 
             all_terms[child] = term_obj

--- a/scout/server/blueprints/phenomodels/templates/phenomodel.html
+++ b/scout/server/blueprints/phenomodels/templates/phenomodel.html
@@ -98,6 +98,12 @@
         OMIM checkbox
       </label>
     </div>
+    <div class="form-check form-check-inline mb-3">
+      <input class="form-check-input" type="radio" name="checkType" id="checkTypeOrpha" value="orpha" onchange="showDiv('omimForm','hpoForm')">
+      <label class="form-check-label" for="orpha">
+        Orpha checkbox
+      </label>
+    </div>
     <!-- HPO checkbox add -->
     <form action="{{ url_for('phenomodels.checkbox_edit', institute_id=institute._id, model_id=phenomodel._id)}}" method="POST" id="hpoForm">
       {{ term_title("hpo") }}
@@ -122,7 +128,7 @@
       <input type="text" class="form-control" name="omim_custom_name" placeholder="Custom checkbox name (optional)">
     </div>
     <div class="col-3">
-      <button type="submit" name="add_omim" class="btn btn-secondary btn-sm">Add OMIM term</button>
+      <button type="submit" id="add_disease" name="add_omim" class="btn btn-secondary btn-sm">Add OMIM term</button>
     </div>
   </div>
 {% endmacro %}
@@ -306,70 +312,102 @@
 {{ super() }}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha512-HWlJyU4ut5HkEj0QsK/IxBCY55n5ZpskyjVlAoV9Z7XQwwkqXoYdCIC93/htL3Gu5H3R4an/S0h2NXfbZk3g7w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script type="text/javascript">
+function getCheckedSource() {
+    //Get checked source from document
+    return document.querySelector('#add_terms input:checked').value.toUpperCase()
+}
 
-  function showDiv(showElem, hideElem) {
+function replaceDiseaseSource() {
+    source = getCheckedSource()
+
+    if (source != "OMIM" && source != "ORPHA") { return }
+
+    //Update disease_form input placeholder to match source
+    let diseaseInput = document.querySelector('#omim_term')
+    let initialPlaceholder = diseaseInput.getAttribute("placeholder")
+    let newPlaceholder = initialPlaceholder.replace("OMIM", source).replace("ORPHA", source)
+    diseaseInput.setAttribute("placeholder", newPlaceholder)
+
+    //Update the submit buttontext to match source
+    let diseaseAddButton = document.querySelector('#add_disease')
+    let initialText = diseaseAddButton.innerText || diseaseAddButton.textContent
+    let newText = initialText.replace("OMIM", source).replace("ORPHA", source)
+    diseaseAddButton.innerText = newText
+}
+
+
+function showDiv(showElem, hideElem) {
+    console.log("ShowDiv ran with: " + showElem + " " + hideElem)
     // show div of interest
     var divElem = document.getElementById(showElem);
     divElem.style.display = "block";
     // hide the other div
     divElem = document.getElementById(hideElem);
     divElem.style.display = "none";
-  }
 
-  $(document).ready(function(){
+    //Only update the disease_form if visible
+    if (showElem = "omimForm") { replaceDiseaseSource() }
+}
+
+$(document).ready(function () {
     $('#omimForm').toggle();
-  });
+});
 
-  $('#hpoHasTitle').change(function() {
-    if($(this).prop("checked")){
-      $("#hpoTermTitle").removeAttr('disabled');
+$('#hpoHasTitle').change(function () {
+    console.log("hpoHasTitle changed")
+    if ($(this).prop("checked")) {
+        $("#hpoTermTitle").removeAttr('disabled');
     }
-    else{
-      $("#hpoTermTitle").prop("disabled", true);
+    else {
+        $("#hpoTermTitle").prop("disabled", true);
     }
-  });
+});
 
-  $('#omimHasTitle').change(function() {
-    if($(this).prop("checked")){
-      $("#omimTermTitle").removeAttr('disabled');
+$('#omimHasTitle').change(function () {
+    console.log("omimHasTitle changed")
+    if ($(this).prop("checked")) {
+        $("#omimTermTitle").removeAttr('disabled');
     }
-    else{
-      $("#omimTermTitle").prop("disabled", true);
+    else {
+        $("#omimTermTitle").prop("disabled", true);
     }
-  });
+});
 
-  function getHpoTerms(query, process) {
-    $.get("{{ url_for('cases.hpoterms') }}", {query: query}, function(data) {
-      process(data)
+function getHpoTerms(query, process) {
+    console.log("Running hpo query")
+    $.get("{{ url_for('cases.hpoterms') }}", { query: query }, function (data) {
+        process(data)
     });
-  }
+}
 
-  function getOmimTerms(query, process) {
-    $.get("{{ url_for('cases.diseaseterms') }}", {query: query, source:"OMIM"}, function(data) {
-      process(data)
+function getOmimTerms(query, process) {
+    //Filter the query by the checkbox value
+    const source = getCheckedSource()
+    $.get("{{ url_for('cases.diseaseterms') }}", { query: query, source: source }, function (data) {
+        process(data)
     });
-  }
+}
 
-  function toggleDiv(divName){
+function toggleDiv(divName) {
     var div = document.getElementById(divName);
     if (div.style.display === "none") {
-      div.style.display = "block";
+        div.style.display = "block";
     } else {
-      div.style.display = "none";
+        div.style.display = "none";
     }
-  }
+}
 
-  $(".typeahead_hpo").typeahead({
+$(".typeahead_hpo").typeahead({
     name: 'hpo_term',
     source: getHpoTerms,
     minLength: 3,
-  });
+});
 
-  $(".typeahead_omim").typeahead({
+$(".typeahead_omim").typeahead({
     name: 'omim_term',
     source: getOmimTerms,
     minLength: 3,
-  });
+});
 
 </script>
 {% endblock %}

--- a/scout/server/blueprints/phenomodels/templates/phenomodel.html
+++ b/scout/server/blueprints/phenomodels/templates/phenomodel.html
@@ -87,19 +87,19 @@
   <!--div containing form elements to add HPO terms or custom checkbox fields-->
   <div class="mt-3 ms-3" id="add_terms" style="display:none;">
     <div class="form-check form-check-inline mb-3">
-      <input class="form-check-input" type="radio" name="checkType" id="checkTypeHpo" value="hpo" checked onchange="showDiv('hpoForm','omimForm')">
+      <input class="form-check-input" type="radio" name="checkType" id="checkTypeHpo" value="hpo" checked onchange="showDiv('hpoForm','diseaseForm')">
       <label class="form-check-label" for="hpo">
         HPO checkbox
       </label>
     </div>
     <div class="form-check form-check-inline mb-3">
-      <input class="form-check-input" type="radio" name="checkType" id="checkTypeOmim" value="omim" onchange="showDiv('omimForm','hpoForm')">
+      <input class="form-check-input" type="radio" name="checkType" id="checkTypeOmim" value="omim" onchange="showDiv('diseaseForm','hpoForm')">
       <label class="form-check-label" for="omim">
         OMIM checkbox
       </label>
     </div>
     <div class="form-check form-check-inline mb-3">
-      <input class="form-check-input" type="radio" name="checkType" id="checkTypeOrpha" value="orpha" onchange="showDiv('omimForm','hpoForm')">
+      <input class="form-check-input" type="radio" name="checkType" id="checkTypeOrpha" value="orpha" onchange="showDiv('diseaseForm','hpoForm')">
       <label class="form-check-label" for="orpha">
         Orpha checkbox
       </label>
@@ -109,26 +109,26 @@
       {{ term_title("hpo") }}
       {{ hpo_checkbox_macro() }}
     </form>
-    <!-- OMIM checkbox add-->
-    <form action="{{ url_for('phenomodels.checkbox_edit', institute_id=institute._id, model_id=phenomodel._id)}}" method="POST" id="omimForm">
-      {{ term_title("omim") }}
-      {{ omim_checkbox_macro() }}
+    <!-- Disease checkbox add-->
+    <form action="{{ url_for('phenomodels.checkbox_edit', institute_id=institute._id, model_id=phenomodel._id)}}" method="POST" id="diseaseForm" style="display:none">
+      {{ term_title("disease") }}
+      {{ disease_checkbox_macro() }}
     </form>
   </div>
 </div>
 <!--End of code for adding a subpanel-->
 {% endmacro %}
 
-{% macro omim_checkbox_macro() %}
+{% macro disease_checkbox_macro() %}
   <div class="row d-flex align-items-center">
     <div class="col-4">
-      <input type="text" class="typeahead_omim form-control" name="omim_term" id="omim_term" data-provide="typeahead" autocomplete="off" placeholder="Search OMIM term..">
+      <input type="text" class="typeahead_disease form-control" name="disease_term" id="disease_term" data-provide="typeahead" autocomplete="off" placeholder="Search OMIM term..">
     </div>
     <div class="col-5">
-      <input type="text" class="form-control" name="omim_custom_name" placeholder="Custom checkbox name (optional)">
+      <input type="text" class="form-control" name="disease_custom_name" placeholder="Custom checkbox name (optional)">
     </div>
     <div class="col-3">
-      <button type="submit" id="add_disease" name="add_omim" class="btn btn-secondary btn-sm">Add OMIM term</button>
+      <button type="submit" id="add_disease" name="add_disease" class="btn btn-secondary btn-sm">Add OMIM term</button>
     </div>
   </div>
 {% endmacro %}
@@ -323,12 +323,12 @@ function replaceDiseaseSource() {
     if (source != "OMIM" && source != "ORPHA") { return }
 
     //Update disease_form input placeholder to match source
-    let diseaseInput = document.querySelector('#omim_term')
+    let diseaseInput = document.querySelector('#disease_term')
     let initialPlaceholder = diseaseInput.getAttribute("placeholder")
     let newPlaceholder = initialPlaceholder.replace("OMIM", source).replace("ORPHA", source)
     diseaseInput.setAttribute("placeholder", newPlaceholder)
 
-    //Update the submit buttontext to match source
+    //Update the submit button text to match source
     let diseaseAddButton = document.querySelector('#add_disease')
     let initialText = diseaseAddButton.innerText || diseaseAddButton.textContent
     let newText = initialText.replace("OMIM", source).replace("ORPHA", source)
@@ -345,13 +345,8 @@ function showDiv(showElem, hideElem) {
     divElem = document.getElementById(hideElem);
     divElem.style.display = "none";
 
-    //Only update the disease_form if visible
-    if (showElem = "omimForm") { replaceDiseaseSource() }
+    replaceDiseaseSource()
 }
-
-$(document).ready(function () {
-    $('#omimForm').toggle();
-});
 
 $('#hpoHasTitle').change(function () {
     console.log("hpoHasTitle changed")
@@ -363,13 +358,12 @@ $('#hpoHasTitle').change(function () {
     }
 });
 
-$('#omimHasTitle').change(function () {
-    console.log("omimHasTitle changed")
+$('#diseaseHasTitle').change(function () {
     if ($(this).prop("checked")) {
-        $("#omimTermTitle").removeAttr('disabled');
+        $("#diseaseTermTitle").removeAttr('disabled');
     }
     else {
-        $("#omimTermTitle").prop("disabled", true);
+        $("#diseaseTermTitle").prop("disabled", true);
     }
 });
 
@@ -380,7 +374,7 @@ function getHpoTerms(query, process) {
     });
 }
 
-function getOmimTerms(query, process) {
+function getDiseaseTerms(query, process) {
     //Filter the query by the checkbox value
     const source = getCheckedSource()
     $.get("{{ url_for('cases.diseaseterms') }}", { query: query, source: source }, function (data) {
@@ -403,9 +397,9 @@ $(".typeahead_hpo").typeahead({
     minLength: 3,
 });
 
-$(".typeahead_omim").typeahead({
-    name: 'omim_term',
-    source: getOmimTerms,
+$(".typeahead_disease").typeahead({
+    name: 'disease_term',
+    source: getDiseaseTerms,
     minLength: 3,
 });
 

--- a/scout/server/blueprints/phenomodels/templates/phenomodel.html
+++ b/scout/server/blueprints/phenomodels/templates/phenomodel.html
@@ -318,7 +318,7 @@ function getCheckedSource() {
 }
 
 function replaceDiseaseSource() {
-    source = getCheckedSource()
+    let source = getCheckedSource()
 
     if (source != "OMIM" && source != "ORPHA") { return }
 


### PR DESCRIPTION
This PR adds the possibility to include orpha disease checkboxes to phenomodels. A radio button for selecting orpha_terms have been added to the phenomodels page. The form and functions previously in place for omim checkboxes have been renamed omim-> diseases and adapted to handle both orpha and omim terms.

This PR closes  #2159

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Navigate to phenomodels page and verify hop and disease checkboxes can be added and removed from the phenomodels.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by TB
