### PR TITLE
Add button for displaying STR variants occurring in the dynamic HPO panel on case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Added tags for Sniffles and CNVpytor, two LRS SV callers
+- Button for displaying STR variants occurring in the dynamic HPO panel on case page
 ### Changed
 - In the diagnoses page genes associated with a disease are displayed using hgnc symbol instead of hgnc id
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Added tags for Sniffles and CNVpytor, two LRS SV callers
-- Button for displaying STR variants occurring in the dynamic HPO panel on case page
+- Button on case page for displaying STR variants occurring in the dynamic HPO panel
 ### Changed
 - In the diagnoses page genes associated with a disease are displayed using hgnc symbol instead of hgnc id
 - Refactor view route to allow navigation directly to unique variant document id, improve permissions check

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -180,7 +180,7 @@
                  Clinical HPO SNVs
               </a>
             {% endif %}
-            {% if case.vcf_files.vcf_sv %}
+            {% if case.has_svvariants %}
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('variants.sv_variants', institute_id=institute._id,
                                  case_name=case.display_name, variant_type='clinical',
@@ -188,7 +188,7 @@
                  Clinical HPO SVs
                </a>
             {% endif %}
-            {% if case.vcf_files.vcf_str %}
+            {% if case.has_strvariants %}
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.str_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
@@ -196,7 +196,7 @@
                Clinical HPO STRs
              </a>
             {% endif %}
-            {% if case.vcf_files.vcf_mei %}
+            {% if case.has_meivariants %}
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.mei_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -143,7 +143,7 @@
       </div>
 
       <div class="row mt-2"> <!-- Show variants in dynamic gene list -->
-        <div class="col">
+        <div class="row">
           <form action="{{ url_for('cases.update_clinical_filter_hpo', institute_id=institute._id, case_name=case.display_name)+'#hpo_clinical_filter' }}" method="POST">
             <div class="form-check form-switch">
               <input type="checkbox" class="form-check-input" id="hpo_clinical_filter" onChange="this.form.submit()" name="hpo_clinical_filter"{% if case.hpo_clinical_filter %}checked{% endif %}>
@@ -152,7 +152,7 @@
             </div>
           </form>
         </div>
-        <div class="col d-flex justify-content-end">
+        <div class="row">
           <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}
             <a class="btn btn-secondary btn-sm text-white"
@@ -179,6 +179,12 @@
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
                Clinical HPO SVs
+             </a>
+             <a class="btn btn-secondary btn-sm text-white"
+              href="{{ url_for('variants.str_variants', institute_id=institute._id,
+                               case_name=case.display_name, variant_type='clinical',
+                               gene_panels=['hpo']) }}">
+               Clinical HPO STRs
              </a>
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.mei_variants', institute_id=institute._id,

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -152,7 +152,7 @@
             </div>
           </form>
         </div>
-        <div class="row">
+        <div class="row mt-3">
           <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}
             <a class="btn btn-secondary btn-sm text-white"

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -159,7 +159,7 @@
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('variants.cancer_variants', institute_id=institute._id,
                                  case_name=case.display_name, variant_type='clinical',
-                                 gene_panels=['hpo']) }}">
+                                 gene_panels=['hpo']) }}" target="_blank" rel="noopener">
                  Clinical HPO SNVs
                </a>
             {% endif %}
@@ -167,7 +167,7 @@
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
                                  case_name=case.display_name, variant_type='clinical',
-                                 gene_panels=['hpo']) }}">
+                                 gene_panels=['hpo']) }}" target="_blank" rel="noopener">
                  Clinical HPO SVs
                </a>
             {% endif %}
@@ -176,7 +176,7 @@
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('variants.variants', institute_id=institute._id,
                                  case_name=case.display_name, variant_type='clinical',
-                                 gene_panels=['hpo']) }}">
+                                 gene_panels=['hpo']) }}" target="_blank" rel="noopener">
                  Clinical HPO SNVs
               </a>
             {% endif %}
@@ -184,7 +184,7 @@
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('variants.sv_variants', institute_id=institute._id,
                                  case_name=case.display_name, variant_type='clinical',
-                                 gene_panels=['hpo']) }}">
+                                 gene_panels=['hpo']) }}" target="_blank" rel="noopener">
                  Clinical HPO SVs
                </a>
             {% endif %}
@@ -192,7 +192,7 @@
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.str_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
+                               gene_panels=['hpo']) }}" target="_blank" rel="noopener" >
                Clinical HPO STRs
              </a>
             {% endif %}
@@ -200,7 +200,7 @@
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.mei_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
+                               gene_panels=['hpo']) }}" target="_blank" rel="noopener">
                Clinical HPO MEIs
              </a>
             {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -155,43 +155,55 @@
         <div class="row mt-3">
           <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}
-            <a class="btn btn-secondary btn-sm text-white"
-              href="{{ url_for('variants.cancer_variants', institute_id=institute._id,
-                               case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
-               Clinical HPO SNVs
-             </a>
-            <a class="btn btn-secondary btn-sm text-white"
-              href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
-                               case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
-               Clinical HPO SVs
-             </a>
+            {% if case.vcf_files.vcf_cancer %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('variants.cancer_variants', institute_id=institute._id,
+                                 case_name=case.display_name, variant_type='clinical',
+                                 gene_panels=['hpo']) }}">
+                 Clinical HPO SNVs
+               </a>
+            {% endif %}
+            {% if case.vcf_files.vcf_cancer_sv %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('variants.cancer_sv_variants', institute_id=institute._id,
+                                 case_name=case.display_name, variant_type='clinical',
+                                 gene_panels=['hpo']) }}">
+                 Clinical HPO SVs
+               </a>
+            {% endif %}
           {% else %}
-            <a class="btn btn-secondary btn-sm text-white"
-              href="{{ url_for('variants.variants', institute_id=institute._id,
-                               case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
-               Clinical HPO SNVs
-             </a>
-            <a class="btn btn-secondary btn-sm text-white"
-              href="{{ url_for('variants.sv_variants', institute_id=institute._id,
-                               case_name=case.display_name, variant_type='clinical',
-                               gene_panels=['hpo']) }}">
-               Clinical HPO SVs
-             </a>
+            {% if case.vcf_files.vcf_snv %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('variants.variants', institute_id=institute._id,
+                                 case_name=case.display_name, variant_type='clinical',
+                                 gene_panels=['hpo']) }}">
+                 Clinical HPO SNVs
+              </a>
+            {% endif %}
+            {% if case.vcf_files.vcf_sv %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('variants.sv_variants', institute_id=institute._id,
+                                 case_name=case.display_name, variant_type='clinical',
+                                 gene_panels=['hpo']) }}">
+                 Clinical HPO SVs
+               </a>
+            {% endif %}
+            {% if case.vcf_files.vcf_str %}
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.str_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
                Clinical HPO STRs
              </a>
+            {% endif %}
+            {% if case.vcf_files.vcf_mei %}
              <a class="btn btn-secondary btn-sm text-white"
               href="{{ url_for('variants.mei_variants', institute_id=institute._id,
                                case_name=case.display_name, variant_type='clinical',
                                gene_panels=['hpo']) }}">
                Clinical HPO MEIs
              </a>
+            {% endif %}
            {% endif %}
           </div>
         </div>

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -140,7 +140,13 @@ def variants(institute_id, case_name):
         return controllers.download_variants(store, case_obj, variants_query)
 
     data = controllers.variants(
-        store, institute_obj, case_obj, variants_query, result_size, page, query_form=form.data
+        store,
+        institute_obj,
+        case_obj,
+        variants_query,
+        result_size,
+        page,
+        query_form=form.data,
     )
 
     return dict(
@@ -195,6 +201,7 @@ def str_variants(institute_id, case_name):
         form.chrom.data = request.args.get("chrom", "")
 
     controllers.populate_force_show_unaffected_vars(institute_obj, form)
+    controllers.update_form_hgnc_symbols(store, case_obj, form)
 
     # populate filters dropdown
     available_filters = list(store.filters(institute_id, category))
@@ -459,7 +466,10 @@ def cancer_variants(institute_id, case_name):
             # Flash a message with errors
             for field, err_list in form.errors.items():
                 for err in err_list:
-                    flash(f"Content of field '{field}' does not have a valid format", "warning")
+                    flash(
+                        f"Content of field '{field}' does not have a valid format",
+                        "warning",
+                    )
             # And do not submit the form
             return redirect(
                 url_for(".cancer_variants", institute_id=institute_id, case_name=case_name)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4473 

Main branch:

<img width="691" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/996593db-5197-4a27-97c5-d5b75e1f6c92">


This branch:

<img width="699" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/81730457-2dca-49c1-8be3-1d71c6c57414">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
