### PR TITLE
Reroute case no institute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - In the diagnoses page genes associated with a disease are displayed using hgnc symbol instead of hgnc id
 - Refactor view route to allow navigation directly to unique variant document id, improve permissions check
+- Refactor view route to allow navigation directly to unique case id (in particular for gens)
 ### Fixed
 - Refactored code in cases blueprints and variant_events adapter (set diseases for partial causative variants) to use "disease" instead of "omim" to encompass also ORPHA terms
 - Refactored code in `scout/parse/omim.py` and `scout/parse/disease_terms.py` to use "disease" instead of "phenotype" to differentiate from HPO terms

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -74,7 +74,7 @@ def index():
 
 
 @cases_bp.route("/<institute_id>/<case_name>")
-@cases_bp.route("/case/<case_id>")
+@cases_bp.route("/case/case_id/<case_id>")
 @templated("cases/case.html")
 def case(
     case_name: Optional[str] = None,
@@ -92,10 +92,10 @@ def case(
             flash("Case could not be found: please provide a case ID.")
             return redirect(request.referrer)
 
-        case_obj = store.case(case_id=case_id, projection={"display_name": 1})
+        case_obj = store.case(case_id=case_id, projection={"display_name": 1, "owner": 1})
         if not case_obj:
             flash("Case {} does not exist in database!".format(case_id))
-            return redirect(request.referrer)
+            return abort(404)
 
         case_name = case_obj.get("display_name")
         institute_id = case_obj.get("owner")

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -80,7 +80,7 @@ def case(
     case_name: Optional[str] = None,
     institute_id: Optional[str] = None,
     case_id: Optional[str] = None,
-) -> dict:
+):
     """Display one case.
     Institute and display_name pairs uniquely specify a case.
     So do case_id, but we still call institute_and_case again to fetch institute

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -74,9 +74,32 @@ def index():
 
 
 @cases_bp.route("/<institute_id>/<case_name>")
+@cases_bp.route("/case/<case_id>")
 @templated("cases/case.html")
-def case(institute_id, case_name):
-    """Display one case."""
+def case(
+    case_name: Optional[str] = None,
+    institute_id: Optional[str] = None,
+    case_id: Optional[str] = None,
+):
+    """Display one case.
+    Institute and display_name pairs uniquely specify a case.
+    So do case_id, but we still call institute_and_case again to fetch institute
+    and reuse its user access verification.
+    """
+
+    if not institute_id:
+        if not case_id:
+            flash("Case could not be found: please provide a case ID.")
+            return redirect(request.referrer)
+
+        case_obj = store.case(case_id=case_id, projection={"display_name": 1})
+        if not case_obj:
+            flash("Case {} does not exist in database!".format(case_id))
+            return redirect(request.referrer)
+
+        case_name = case_obj.get("display_name")
+        institute_id = case_obj.get("owner")
+
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     if not case_obj:
         flash("Case {} does not exist in database!".format(case_name))

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -87,12 +87,9 @@ def case(
     and reuse its user access verification.
     """
 
-    if not institute_id:
-        if not case_id:
-            flash("Case could not be found: please provide a case ID.")
-            return redirect(request.referrer)
-
+    if case_id:
         case_obj = store.case(case_id=case_id, projection={"display_name": 1, "owner": 1})
+
         if not case_obj:
             flash("Case {} does not exist in database!".format(case_id))
             return abort(404)

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -80,7 +80,7 @@ def case(
     case_name: Optional[str] = None,
     institute_id: Optional[str] = None,
     case_id: Optional[str] = None,
-):
+) -> dict:
     """Display one case.
     Institute and display_name pairs uniquely specify a case.
     So do case_id, but we still call institute_and_case again to fetch institute

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -445,7 +445,7 @@ def test_case_sma(app, case_obj, institute_obj):
         assert resp.status_code == 200
 
 
-def test_case_fusion(app, adapter, fusion_case_obj, institute_obj):
+def test_case_fusion(app, fusion_case_obj, institute_obj):
     """Test the RNA fusion case page."""
 
     # GIVEN an initialized app

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -365,6 +365,25 @@ def test_case_custom_images(app, institute_obj, case_obj):
             assert bytes(f"{section_name}-accordion", "utf-8") in dta
 
 
+def test_case_by_id(app, case_obj):
+    """Test that custom images are being displayed"""
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        resp = client.get(url_for("auto_login"))
+
+        # WHEN case page is loaded
+        resp = client.get(
+            url_for(
+                "cases.case",
+                case_id=case_obj["_id"],
+            )
+        )
+
+        # THEN it should return a valid page
+        assert resp.status_code == 200
+
+
 def test_case_outdated_panel(app, institute_obj, case_obj):
     """Test case displaying an outdated panel warning badge"""
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -366,11 +366,12 @@ def test_case_custom_images(app, institute_obj, case_obj):
 
 
 def test_case_by_id(app, case_obj):
-    """Test that custom images are being displayed"""
+    """Test that cases can be retrieved using case_id only"""
     # GIVEN an initialized app
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
 
         # WHEN case page is loaded
         resp = client.get(
@@ -404,6 +405,7 @@ def test_case_outdated_panel(app, institute_obj, case_obj):
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
 
         # WHEN case page is loaded
         resp = client.get(

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -350,6 +350,7 @@ def test_case_custom_images(app, institute_obj, case_obj):
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
 
         # WHEN case page is loaded
         resp = client.get(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Adds a route to the case view for unique `case_id`. Intended for use with Gens specifically.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
