### PR TITLE
Logs for obs_cases

### DIFF
--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -745,7 +745,8 @@ class CaseHandler(object):
                 )
             query["owner"] = institute_id
             query["display_name"] = display_name
-
+        # TODO: Remove log
+        LOG.warning(f"In adapter.case the query became: {query}")
         return self.case_collection.find_one(filter=query, projection=projection)
 
     def delete_case(self, case_id=None, institute_id=None, display_name=None):

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -513,7 +513,7 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
 
         if not obs_data[loqus_id]:  # data is an empty dictionary
             # Collect count of variants in variant's case
-            # obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
+            obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
             if obs_data[loqus_id].get("total"):
                 LOG.warning("obs_data[loqus_id] contained 'total', 'observations was set to 0")
                 obs_data[loqus_id]["observations"] = 0

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -515,6 +515,7 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
             # Collect count of variants in variant's case
             # obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
             if obs_data[loqus_id].get("total"):
+                LOG.warning("obs_data[loqus_id] contained 'total', 'observations was set to 0")
                 obs_data[loqus_id]["observations"] = 0
             continue
         LOG.warning(

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -432,6 +432,8 @@ def get_loqusdb_obs_cases(
     obs_cases = []
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])
     for i, case_id in enumerate(obs_families):
+        # TODO: Remove log
+        LOG.warning(f"The case_id: {case_id} and the variant_obj['case_id'] will be compared")
         if len(obs_cases) == 10:
             break
         if case_id == variant_obj["case_id"]:
@@ -505,10 +507,16 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
             if obs_data[loqus_id].get("total"):
                 obs_data[loqus_id]["observations"] = 0
             continue
+        LOG.warning(
+            f"The variant_obj case_id: {variant_obj['case_id'] } and the families in loqous response: {obs_data[loqus_id]['families']}"
+        )
 
         # collect cases where observations occurred
         obs_data[loqus_id]["cases"] = get_loqusdb_obs_cases(
             store, variant_obj, category, obs_data[loqus_id].get("families", [])
+        )
+        LOG.warning(
+            f"The number of cases in the obs_data[loqus_id][cases] was : {len(obs_data[loqus_id]['cases'] )}"
         )
 
     return obs_data

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -432,16 +432,25 @@ def get_loqusdb_obs_cases(
     obs_cases = []
     user_institutes_ids = set([inst["_id"] for inst in user_institutes(store, current_user)])
     for i, case_id in enumerate(obs_families):
+        LOG.warning(f"Running round {i} of enumerate obs_families")
         # TODO: Remove log
-        LOG.warning(f"The case_id: {case_id} and the variant_obj['case_id'] will be compared")
+        LOG.warning(
+            f"The case_id: {case_id} and the variant_obj['case_id']: {variant_obj['case_id']} will be compared"
+        )
         if len(obs_cases) == 10:
+            LOG.warning("Obs_cases was longer than 10 and et_loqusdb_obs_cases ended in break")
             break
+        LOG.warning(
+            f"The case_id: {case_id} and the variant_obj[case_id]: {variant_obj['case_id']} was compared"
+        )
         if case_id == variant_obj["case_id"]:
+            LOG.warning("They matched, continuing")
             continue
         # other case might belong to same institute, collaborators or other institutes
         other_case = store.case(case_id)
         if not other_case:
             # Case could have been removed
+            LOG.warning("The case was not found in the scout database")
             LOG.debug("Case %s could not be found in database", case_id)
             continue
         other_institutes = set([other_case.get("owner")])
@@ -449,6 +458,7 @@ def get_loqusdb_obs_cases(
 
         if user_institutes_ids.isdisjoint(other_institutes):
             # If the user does not have access to the information we skip it. Admins allowed by user_institutes.
+            LOG.warning("The case was found but NOT appended to cases due to access ")
             continue
 
         other_variant = store.variant(
@@ -458,7 +468,7 @@ def get_loqusdb_obs_cases(
         # IF variant is SV variant, look for variants with different sub_category occurring at the same coordinates
         if other_variant is None and category == "sv":
             other_variant = store.overlapping_sv_variant(other_case["_id"], variant_obj)
-
+        LOG.warning("The case was appended to obs_cases")
         obs_cases.append(dict(case=other_case, variant=other_variant))
 
     return obs_cases
@@ -503,7 +513,7 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
 
         if not obs_data[loqus_id]:  # data is an empty dictionary
             # Collect count of variants in variant's case
-            obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
+            # obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
             if obs_data[loqus_id].get("total"):
                 obs_data[loqus_id]["observations"] = 0
             continue

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -508,7 +508,7 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
                 obs_data[loqus_id]["observations"] = 0
             continue
         LOG.warning(
-            f"The variant_obj case_id: {variant_obj['case_id'] } and the families in loqous response: {obs_data[loqus_id]['families']}"
+            f"The variant_obj case_id: {variant_obj['case_id'] } and the loqous response: {obs_data[loqus_id]}"
         )
 
         # collect cases where observations occurred


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
