### PR TITLE
ACMG on report -  part two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Refactored code in cases blueprints and variant_events adapter (set diseases for partial causative variants) to use "disease" instead of "omim" to encompass also ORPHA terms
 - Refactored code in `scout/parse/omim.py` and `scout/parse/disease_terms.py` to use "disease" instead of "phenotype" to differentiate from HPO terms
 - Be more careful about checking access to variant on API access
+- Show also ACMG VUS on general report
 
 ## [4.78]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Refactored code in cases blueprints and variant_events adapter (set diseases for partial causative variants) to use "disease" instead of "omim" to encompass also ORPHA terms
 - Refactored code in `scout/parse/omim.py` and `scout/parse/disease_terms.py` to use "disease" instead of "phenotype" to differentiate from HPO terms
 - Be more careful about checking access to variant on API access
-- Show also ACMG VUS on general report
+- Show also ACMG VUS on general report (could be hidden if not pinned)
 
 ## [4.78]
 ### Added

--- a/scout/adapter/mongo/event.py
+++ b/scout/adapter/mongo/event.py
@@ -240,13 +240,13 @@ class EventHandler(CaseEventHandler, VariantEventHandler):
 
         return self.event_collection.find(query)
 
-    def case_events_by_verb(self, category, institute, case, verb):
+    def case_events_by_verb(self, category: str, institute: dict, case: dict, verb: str):
         """Return events with a specific verb for a case of an institute
         Args:
             category (str): "case" or "variant"
             institute (dict): an institute id
             case (dict): a case id
-            verb (dict): an event action verb, example: "dismiss_variant"
+            verb (str): an event action verb, example: "dismiss_variant"
 
         Returns:
             pymongo.Cursor: Query results

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -573,7 +573,9 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
                 continue
             if case_key == "partial_causatives":
                 var_obj["phenotypes"] = case_obj["partial_causatives"][var_id]
-            evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
+            evaluated_variants_by_type[eval_category].append(
+                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
+            )
 
     for var_obj in store.evaluated_variants(
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -589,15 +589,21 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
                 var_obj["phenotypes"] = case_obj["partial_causatives"][var_id]
             evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
 
-    # Collect all evaluated variants except causative, partial causative and suspected variants
-    for var_obj in store.evaluated_variants(
-        case_id=case_obj["_id"], institute_id=institute_obj["_id"]
-    ):
+    def _partition_var_by_type():
+        """We collect all evaluated variants except causative, partial causative and suspected variants,
+        then partition them according to event type.
+        Ensure variant actually has the corresponding key set, and that it is not just None.
+        """
         for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
             if variant_key in var_obj and var_obj["variant_key"] is not None:
                 evaluated_variants_by_type[eval_category].append(
                     _get_decorated_var(var_obj=var_obj)
                 )
+
+    for var_obj in store.evaluated_variants(
+        case_id=case_obj["_id"], institute_id=institute_obj["_id"]
+    ):
+        _partition_var_by_type(evaluated_variants_by_type, var_obj)
 
     data["variants"] = evaluated_variants_by_type
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -578,12 +578,12 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
     for var_obj in store.evaluated_variants(
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
-        _partition_var_by_type(evaluated_variants_by_type, var_obj)
+        _partition_var_by_type(evaluated_variants_by_type, var_obj, institute_obj, case_obj)
 
     data["variants"] = evaluated_variants_by_type
 
 
-def _get_decorated_var(var_obj: dict) -> dict:
+def _get_decorated_var(var_obj: dict, institute_obj: dict, case_obj: dict) -> dict:
     """Decorate a variant object for display using the variant controller"""
     return variant_decorator(
         store=store,
@@ -599,14 +599,18 @@ def _get_decorated_var(var_obj: dict) -> dict:
     )["variant"]
 
 
-def _partition_var_by_type(evaluated_variants_by_type: dict, var_obj: dict):
+def _partition_var_by_type(
+    evaluated_variants_by_type: dict, var_obj: dict, institute_obj: dict, case_obj: dict
+):
     """We collect all evaluated variants except causative, partial causative and suspected variants,
     then partition them according to event type.
     Ensure variant actually has the corresponding key set, and that it is not just None.
     """
     for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
         if variant_key in var_obj and var_obj["variant_key"] is not None:
-            evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
+            evaluated_variants_by_type[eval_category].append(
+                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
+            )
 
 
 def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -594,7 +594,7 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
         for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
-            if variant_key in var_obj:
+            if variant_key in var_obj and var_obj["variant_key"] is not None:
                 evaluated_variants_by_type[eval_category].append(
                     _get_decorated_var(var_obj=var_obj)
                 )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -563,20 +563,6 @@ def check_outdated_gene_panel(panel_obj, latest_panel):
 def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dict, data: dict):
     """Gather evaluated variants info to include in case report."""
 
-    def _get_decorated_var(var_obj: dict) -> dict:
-        return variant_decorator(
-            store=store,
-            variant_id=None,
-            institute_id=institute_obj["_id"],
-            case_name=case_obj["display_name"],
-            variant_obj=var_obj,
-            add_other=False,
-            get_overlapping=False,
-            variant_type=var_obj["category"],
-            institute_obj=institute_obj,
-            case_obj=case_obj,
-        )["variant"]
-
     evaluated_variants_by_type: Dict[str, list] = {vt: [] for vt in CASE_REPORT_VARIANT_TYPES}
 
     # Collect causative, partial causative and suspected variants
@@ -595,6 +581,22 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
         _partition_var_by_type(evaluated_variants_by_type, var_obj)
 
     data["variants"] = evaluated_variants_by_type
+
+
+def _get_decorated_var(var_obj: dict) -> dict:
+    """Decorate a variant object for display using the variant controller"""
+    return variant_decorator(
+        store=store,
+        variant_id=None,
+        institute_id=institute_obj["_id"],
+        case_name=case_obj["display_name"],
+        variant_obj=var_obj,
+        add_other=False,
+        get_overlapping=False,
+        variant_type=var_obj["category"],
+        institute_obj=institute_obj,
+        case_obj=case_obj,
+    )["variant"]
 
 
 def _partition_var_by_type(evaluated_variants_by_type: dict, var_obj: dict):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -580,7 +580,9 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
     for var_obj in store.evaluated_variants(
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
-        _partition_var_by_type(evaluated_variants_by_type, var_obj, institute_obj, case_obj)
+        _append_evaluated_variant_by_type(
+            evaluated_variants_by_type, var_obj, institute_obj, case_obj
+        )
 
     data["variants"] = evaluated_variants_by_type
 
@@ -601,11 +603,11 @@ def _get_decorated_var(var_obj: dict, institute_obj: dict, case_obj: dict) -> di
     )["variant"]
 
 
-def _partition_var_by_type(
+def _append_evaluated_variant_by_type(
     evaluated_variants_by_type: dict, var_obj: dict, institute_obj: dict, case_obj: dict
 ):
     """We collect all evaluated variants except causative, partial causative and suspected variants,
-    then partition them according to event type.
+    then partition them in the evaluated variants dict according to event type.
     Ensure variant actually has the corresponding key set, and that it is not just None.
     """
     for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -594,7 +594,7 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
         for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
-            if var_obj.get(variant_key):
+            if variant_key in var_obj:
                 evaluated_variants_by_type[eval_category].append(
                     _get_decorated_var(var_obj=var_obj)
                 )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -589,7 +589,7 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
                 var_obj["phenotypes"] = case_obj["partial_causatives"][var_id]
             evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
 
-    def _partition_var_by_type():
+    def _partition_var_by_type(evaluated_variants_by_type: dict, var_obj: dict):
         """We collect all evaluated variants except causative, partial causative and suspected variants,
         then partition them according to event type.
         Ensure variant actually has the corresponding key set, and that it is not just None.

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -589,23 +589,22 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
                 var_obj["phenotypes"] = case_obj["partial_causatives"][var_id]
             evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
 
-    def _partition_var_by_type(evaluated_variants_by_type: dict, var_obj: dict):
-        """We collect all evaluated variants except causative, partial causative and suspected variants,
-        then partition them according to event type.
-        Ensure variant actually has the corresponding key set, and that it is not just None.
-        """
-        for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
-            if variant_key in var_obj and var_obj["variant_key"] is not None:
-                evaluated_variants_by_type[eval_category].append(
-                    _get_decorated_var(var_obj=var_obj)
-                )
-
     for var_obj in store.evaluated_variants(
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
         _partition_var_by_type(evaluated_variants_by_type, var_obj)
 
     data["variants"] = evaluated_variants_by_type
+
+
+def _partition_var_by_type(evaluated_variants_by_type: dict, var_obj: dict):
+    """We collect all evaluated variants except causative, partial causative and suspected variants,
+    then partition them according to event type.
+    Ensure variant actually has the corresponding key set, and that it is not just None.
+    """
+    for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
+        if variant_key in var_obj and var_obj["variant_key"] is not None:
+            evaluated_variants_by_type[eval_category].append(_get_decorated_var(var_obj=var_obj))
 
 
 def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -611,7 +611,7 @@ def _append_evaluated_variant_by_type(
     Ensure variant actually has the corresponding key set, and that it is not just None.
     """
     for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
-        if variant_key in var_obj and var_obj["variant_key"] is not None:
+        if variant_key in var_obj and var_obj[variant_key] is not None:
             evaluated_variants_by_type[eval_category].append(
                 _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
             )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Sorry, my bad - I managed to get a typo in there.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
