### PR TITLE
Apply dark mode styling to multi selects rendered by select2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - All links in disease table on diagnosis page now open in a new tab
-- Dark mode settings applied to multidelects in institute settings
+- Dark mode settings applied to multiselects on institute settings
 
 ## [4.79.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - All links in disease table on diagnosis page now open in a new tab
+- Dark mode settings applied to multidelects in institute settings
 
 ## [4.79.1]
 ### Fixed

--- a/scout/server/blueprints/institutes/static/select2_darktheme.css
+++ b/scout/server/blueprints/institutes/static/select2_darktheme.css
@@ -1,0 +1,63 @@
+/* Select 2 Dark Theme */
+@media (prefers-color-scheme: dark) {
+
+    .select2-selection {
+        color: #b1b1b1;
+        background-color: #222 !important;
+        border: 1px solid #515151 !important;
+    }
+
+    .select2-dropdown {
+        color: #b1b1b1;
+        background-color: #222 !important;
+        border: 1px solid #515151 !important;
+    }
+
+    .select2-results__option {
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .select2-results__option:hover {
+        color: #dfe0e1;
+        background-color: #343a40;
+    }
+
+    .select2-selection__choice:has(> span:hover) {
+        opacity: 0.5;
+    }
+
+    .select2-selection__choice__remove:first-child {
+        background-color: transparent !important;
+        filter: brightness(70) saturate(0%);
+    }
+
+    .select2-selection__choice__remove:hover {
+        filter: invert(1)
+    }
+
+    .select2-results__option[aria-selected=true],
+    .select2-result__option,
+    .select2-selection__choice,
+    .select2-selection__choice__remove {
+        color: #fafafa !important;
+        background-color: #626262 !important;
+        border-color: #626262 !important;
+    }
+
+    /* This is a check mark displayed for selected options */
+    .select2-results__option[aria-selected=true]::after {
+        content: '';
+        display: block;
+        width: 0.5em;
+        height: 1em;
+        border-style: solid;
+        border-width: 0 0.26em 0.26em 0;
+        -webkit-transform-style: preserve-3d;
+        transform-style: preserve-3d;
+        -webkit-transform: rotate(45deg);
+        -ms-transform: rotate(45deg);
+        -o-transform: rotate(45deg);
+        transform: rotate(45deg);
+    }
+}

--- a/scout/server/blueprints/institutes/static/select2_darktheme.css
+++ b/scout/server/blueprints/institutes/static/select2_darktheme.css
@@ -1,14 +1,9 @@
-/* Select 2 Dark Theme */
+/* Dark Theme compatibility for select2 multiselects*/
 @media (prefers-color-scheme: dark) {
 
+    .select2-dropdown,
     .select2-selection {
-        color: #b1b1b1;
-        background-color: #222 !important;
-        border: 1px solid #515151 !important;
-    }
-
-    .select2-dropdown {
-        color: #b1b1b1;
+        color: #b1b1b1 !important;
         background-color: #222 !important;
         border: 1px solid #515151 !important;
     }
@@ -16,17 +11,21 @@
     .select2-results__option {
         display: flex;
         gap: 0.5rem;
+        color: #b1b1b1 !important;
+        background-color: #222 !important;
     }
 
-    .select2-results__option:hover {
-        color: #dfe0e1;
-        background-color: #343a40;
+    .select2-results__option:hover,
+    .select2-results__option[aria-selected=true]:hover {
+        color: #dfe0e1 !important;
+        background-color: #343a40 !important;
     }
 
     .select2-selection__choice:has(> span:hover) {
         opacity: 0.5;
     }
 
+    /* Filters adjusts color of svg used as remove-button for selected options */
     .select2-selection__choice__remove:first-child {
         background-color: transparent !important;
         filter: brightness(70) saturate(0%);
@@ -45,7 +44,7 @@
         border-color: #626262 !important;
     }
 
-    /* This is a check mark displayed for selected options */
+    /* This is a check mark displayed for the selected options */
     .select2-results__option[aria-selected=true]::after {
         content: '';
         display: block;

--- a/scout/server/blueprints/institutes/templates/overview/institute_settings.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_settings.html
@@ -11,6 +11,7 @@
   <link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet" integrity="sha512-nMNlpuaDPrqlEls3IX/Q56H36qvBASwb3ipuo3MxeWbsQB1881ox0cRv7UPTgBlriqoynt35KjEwgGUeUXIPnw==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/css/bootstrap-select.min.css" integrity="sha512-g2SduJKxa4Lbn3GW+Q7rNz+pKP9AWMR++Ta8fgwsZRCUsawjPvF/BxSMkGS61VsR9yinGoEgrHPGPn2mrj8+4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link href="https://cdn.jsdelivr.net/npm/select2-bootstrap-5-theme@1.2.0/dist/select2-bootstrap-5-theme.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('overview.static', filename='select2_darktheme.css') }}"/>
 {% endblock %}
 
 {% block top_nav %}
@@ -124,5 +125,4 @@
         });
     });
   </script>
-
 {% endblock %}


### PR DESCRIPTION
This PR adds custom css to make multi selects in institute settings have dark mode styles.

This closes #3985

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Navigate to institute settings and verify styling of select2 inputs have a reasonable appearance when used

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by TB
