### PR TITLE
Fix search for variants in genes present only in build 38 returning no results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - All links in disease table on diagnosis page now open in a new tab
 - Dark mode settings applied to multiselects on institute settings
+### Fixed
+- On variants page, search for variants in genes present only in build 38 returning no results
 
 ## [4.79.1]
 ### Fixed

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -131,7 +131,7 @@ def variants(institute_id, case_name):
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     variants_query = store.variants(
@@ -220,7 +220,7 @@ def str_variants(institute_id, case_name):
 
     controllers.activate_case(store, institute_obj, case_obj, current_user)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     query = form.data
@@ -303,7 +303,7 @@ def sv_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -397,7 +397,7 @@ def mei_variants(institute_id, case_name):
     # populate available panel choices
     form.gene_panels.choices = controllers.gene_panel_choices(store, institute_obj, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -507,7 +507,7 @@ def cancer_variants(institute_id, case_name):
 
     form.gene_panels.choices = controllers.gene_panel_choices(store, institute_obj, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -587,7 +587,7 @@ def cancer_sv_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -672,7 +672,7 @@ def fusion_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -308,7 +308,9 @@ def sv_variants(institute_id, case_name):
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
+    variants_query = store.variants(
+        case_obj["_id"], category=category, query=form.data, build=genome_build
+    )
 
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -1,4 +1,5 @@
 """Views for the variants"""
+
 import io
 import logging
 
@@ -122,7 +123,6 @@ def variants(institute_id, case_name):
             return redirect(request.referrer)
 
         hgnc_symbols_set = set(form.hgnc_symbols.data)
-        LOG.debug("Symbols prior to upload: {0}".format(hgnc_symbols_set))
         new_hgnc_symbols = controllers.upload_panel(store, institute_id, case_name, stream)
         hgnc_symbols_set.update(new_hgnc_symbols)
         form.hgnc_symbols.data = hgnc_symbols_set
@@ -131,9 +131,12 @@ def variants(institute_id, case_name):
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    cytobands = store.cytoband_by_chrom(genome_build)
 
-    variants_query = store.variants(case_obj["_id"], query=form.data, category=category)
+    variants_query = store.variants(
+        case_obj["_id"], query=form.data, category=category, build=genome_build
+    )
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 
     if request.form.get("export"):
@@ -217,12 +220,15 @@ def str_variants(institute_id, case_name):
 
     controllers.activate_case(store, institute_obj, case_obj, current_user)
 
-    cytobands = store.cytoband_by_chrom(case_obj.get("genome_build"))
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
+    cytobands = store.cytoband_by_chrom(genome_build)
 
     query = form.data
     query["variant_type"] = variant_type
 
-    variants_query = store.variants(case_obj["_id"], category=category, query=query).sort(
+    variants_query = store.variants(
+        case_obj["_id"], category=category, query=query, build=genome_build
+    ).sort(
         [
             ("str_repid", pymongo.ASCENDING),
             ("chromosome", pymongo.ASCENDING),
@@ -297,7 +303,7 @@ def sv_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -389,12 +395,14 @@ def mei_variants(institute_id, case_name):
     # populate available panel choices
     form.gene_panels.choices = controllers.gene_panel_choices(store, institute_obj, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
+    variants_query = store.variants(
+        case_obj["_id"], category=category, query=form.data, build=genome_build
+    )
 
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 
@@ -496,7 +504,8 @@ def cancer_variants(institute_id, case_name):
     controllers.populate_chrom_choices(form, case_obj)
 
     form.gene_panels.choices = controllers.gene_panel_choices(store, institute_obj, case_obj)
-    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
+
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
@@ -576,12 +585,14 @@ def cancer_sv_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38" if "38" in str(case_obj.get("genome_build")) else "37"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
+    variants_query = store.variants(
+        case_obj["_id"], category=category, query=form.data, build=genome_build
+    )
 
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 
@@ -659,12 +670,14 @@ def fusion_variants(institute_id, case_name):
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)
 
-    genome_build = "38"
+    genome_build = "38" if "38" in str(case_obj.get("genome_build", "38")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
     controllers.update_form_hgnc_symbols(store, case_obj, form)
 
-    variants_query = store.variants(case_obj["_id"], category=category, query=form.data)
+    variants_query = store.variants(
+        case_obj["_id"], category=category, query=form.data, build=genome_build
+    )
 
     result_size = store.count_variants(case_obj["_id"], form.data, None, category)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4506, it's a bug present for all variant types, no just the fusion ones

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On a local demo instance of Scout, load all genes (both 37 and 38)
1. Go to fusion variants page of the demo RNA case
1. Pick a variant in a gene present in scout, for instance the first one:
<img width="334" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/9c2483ca-73f7-4452-ad9f-747034f3130f">

4. EML4 gene is present for both builds, so remove the document for build 37.
5. On main branch, replicate the issue in #4506 
6. Switch to this branch and make sure the variant in gene EML4 is found using search filters 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
