### PR TITLE
More API pin fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dark mode settings applied to multiselects on institute settings
 ### Fixed
 - On variants page, search for variants in genes present only in build 38 returning no results
+- Pin/unpin with API was not able to make event links
 
 ## [4.79.1]
 ### Fixed

--- a/scout/server/blueprints/api/views.py
+++ b/scout/server/blueprints/api/views.py
@@ -67,6 +67,12 @@ def pin_variant(
 
     (institute_obj, case_obj, variant_obj) = _lookup_variant(variant_id, institute_id, case_name)
 
+    if not institute_id:
+        institute_id = variant_obj["institute"]
+
+    if not case_name:
+        case_name = case_obj.get("display_name")
+
     user_obj = store.user(current_user.email)
     link = url_for(
         "variant.variant",
@@ -87,6 +93,12 @@ def unpin_variant(
     """Un-pin an existing, pinned variant"""
 
     (institute_obj, case_obj, variant_obj) = _lookup_variant(variant_id, institute_id, case_name)
+
+    if not institute_id:
+        institute_id = variant_obj["institute"]
+
+    if not case_name:
+        case_name = case_obj.get("display_name")
 
     user_obj = store.user(current_user.email)
     link = url_for(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

✅ API call is now ok:

![Screenshot 2024-03-19 at 15 37 03](https://github.com/Clinical-Genomics/scout/assets/758570/104733f2-acef-4bdf-811b-3a6d688c6742)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
