### PR TITLE
Link to chanjo2 coverage report for genes of the HPO panel:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Support for .d4 files coverage using chanjo2 (Case page sidebar link) with test
 - Link for chanjo2 coverage report on gene panel page
+- Link for chanjo2 coverage report on Case pagem HPO dynamic gene list
 ### Changed
 - All links in disease table on diagnosis page now open in a new tab
 - Dark mode settings applied to multiselects on institute settings

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -92,6 +92,10 @@ def chanjo2_coverage_report_contents(
 
     if panel_id:
         hgnc_gene_ids: List[int] = store.panel_to_genes(panel_id=panel_id, gene_format="hgnc_id")
+    elif panel_name == "HPO Panel":
+        hgnc_gene_ids: List[int] = [
+            gene["hgnc_id"] for gene in case_obj.get("dynamic_gene_list", [])
+        ]
     else:
         hgnc_gene_ids: List[int] = _get_default_panel_genes(store, case_obj)
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -91,21 +91,6 @@
         {% endif %}
         )
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
-        {% if case.track != 'cancer' and config.SQLALCHEMY_DATABASE_URI and case.dynamic_gene_list|length > 0 %}
-          <span class="pull-right">
-            <a href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
-            <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-            </form>
-          </span>
-          <span class="pull-right">&nbsp;&nbsp;&nbsp;</span>
-          <span class="pull-right">
-            <a href="#" onclick="document.getElementById('hpo-overview-form').submit();">Coverage overview</a>
-            <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
-              <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
-            </form>
-          </span>
-        {% endif %}
       </h6>
     </div>
 
@@ -205,6 +190,28 @@
              </a>
             {% endif %}
            {% endif %}
+          </div>
+        </div>
+        <div class="row mt-3">
+          <div class="btn-group btn-group-sm">
+            {% if case.chanjo_coverage %}
+              <a class="btn btn-secondary btn-sm text-white" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
+              <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+              </form>
+
+               <a class="btn btn-secondary btn-sm text-white" href="#" onclick="document.getElementById('hpo-overview-form').submit();">Coverage overview</a>
+              <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
+                <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
+              </form>
+            {% endif %}
+            {% if case.chanjo_coverage %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('cases.chanjo2_coverage_report', institute_id=institute._id,
+                                 case_name=case.display_name, panel_name='HPO', panel_id='HPO'}}" target="_blank" rel="noopener">
+                  Coverage report (Chanjo2)
+               </a>
+            {% endif %}
           </div>
         </div>
       </div> <!-- End of Show variants in dynamic gene list -->

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -192,7 +192,7 @@
            {% endif %}
           </div>
         </div>
-        {% if case.chanjo_coverage or case.chanjo2_coverage %}
+        {% if case.chanjo_coverage or case.chanjo2_coverage and case.dynamic_gene_list|length > 0 %}
         <div class="row mt-1">
           <div class="btn-group btn-group-sm">
             {% if case.chanjo_coverage %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -196,12 +196,14 @@
         <div class="row mt-1">
           <div class="btn-group btn-group-sm">
             {% if case.chanjo_coverage %}
-              <a class="btn btn-secondary btn-sm text-white" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
+              <button onClick="document.getElementById('hpo-report-form').submit();">Coverage report</button>
+              <a href="#section" onClick="document.getElementById('hpo-report-form').submit();" />
               <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
               </form>
 
-               <a class="btn btn-secondary btn-sm text-white" href="#" onclick="document.getElementById('hpo-overview-form').submit();">Coverage overview</a>
+              <button onClick="document.getElementById('hpo-overview-form').submit();">Coverage overview</button>
+              <a href="#section" onClick="document.getElementById('hpo-overview-form').submit();" />
               <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
               </form>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -205,11 +205,11 @@
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
               </form>
             {% endif %}
-            
+
             {% if case.chanjo_coverage %}
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('cases.chanjo2_coverage_report', institute_id=institute._id,
-                                 case_name=case.display_name, panel_name='HPO', panel_id='HPO'}}" target="_blank" rel="noopener">
+                                 case_name=case.display_name, panel_name='HPO Panel'}}" target="_blank" rel="noopener">
                   Coverage report (Chanjo2)
                </a>
             {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -196,13 +196,13 @@
         <div class="row mt-1">
           <div class="btn-group btn-group-sm">
             {% if case.chanjo_coverage %}
-              <button onClick="document.getElementById('hpo-report-form').submit();">Coverage report</button>
+              <button class="btn btn-secondary btn-sm text-white" onClick="document.getElementById('hpo-report-form').submit();">Coverage report</button>
               <a href="#section" onClick="document.getElementById('hpo-report-form').submit();" />
               <form id="hpo-report-form" action="{{ url_for('report.report', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
               </form>
 
-              <button onClick="document.getElementById('hpo-overview-form').submit();">Coverage overview</button>
+              <button class="btn btn-secondary btn-sm text-white" onClick="document.getElementById('hpo-overview-form').submit();">Coverage overview</button>
               <a href="#section" onClick="document.getElementById('hpo-overview-form').submit();" />
               <form id="hpo-overview-form" action="{{ url_for('report.genes', sample_id=case.individuals|map(attribute='individual_id')|list, panel_name="HPO panel", level=institute.coverage_cutoff) }}" method="POST" target="_blank">
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -205,6 +205,7 @@
                 <input type="hidden" name="gene_ids" value="{{ case.dynamic_gene_list|map(attribute='hgnc_id')|join(',') }}">
               </form>
             {% endif %}
+            
             {% if case.chanjo_coverage %}
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('cases.chanjo2_coverage_report', institute_id=institute._id,

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -192,7 +192,8 @@
            {% endif %}
           </div>
         </div>
-        <div class="row mt-3">
+        {% if case.chanjo_coverage or case.chanjo2_coverage %}
+        <div class="row mt-1">
           <div class="btn-group btn-group-sm">
             {% if case.chanjo_coverage %}
               <a class="btn btn-secondary btn-sm text-white" href="#" onclick="document.getElementById('hpo-report-form').submit();">Coverage report</a>
@@ -206,20 +207,21 @@
               </form>
             {% endif %}
 
-            {% if case.chanjo_coverage %}
+            {% if case.chanjo2_coverage %}
               <a class="btn btn-secondary btn-sm text-white"
                 href="{{ url_for('cases.chanjo2_coverage_report', institute_id=institute._id,
-                                 case_name=case.display_name, panel_name='HPO Panel'}}" target="_blank" rel="noopener">
+                                 case_name=case.display_name, panel_name='HPO Panel') }}" target="_blank" rel="noopener">
                   Coverage report (Chanjo2)
                </a>
             {% endif %}
           </div>
         </div>
+        {% endif %} <!-- End of if case.chanjo_coverage or case.chanjo2_coverage -->
       </div> <!-- End of Show variants in dynamic gene list -->
 
-      <div class="btn-group d-flex justify-content-center mt-2"> <!-- Download genes in HPO gene panel -->
-        <a class="btn btn-sm btn-primary mt-1 text-white" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>
-        <a class="btn btn-sm btn-primary mt-1 text-white" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel</a>
+      <div class="btn-group d-flex justify-content-center mt-1"> <!-- Download genes in HPO gene panel -->
+        <a class="btn btn-sm btn-primary text-white" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="clinical") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Clinical HPO gene panel</a>
+        <a class="btn btn-sm btn-primary text-white" href="{{ url_for('cases.download_hpo_genes', institute_id=institute._id, case_name=case.display_name, category="research") }}" download><span class="fa fa-download text-white" aria-hidden="true"></span>&nbsp;&nbsp;Research HPO gene panel</a>
       </div>
 
     {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Link to chanjo2 coverage report for genes of the HPO panel. Other partial fix for #4000 

### Main branch:

<img width="948" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/7ffa11b0-a51b-4bcd-8976-b1fb3746858c">

<hr>

### This branch:

<img width="945" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/b88c8394-37e1-4217-80e8-1ee39ca3d4c2">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test at CG**:
1. Deploy on cg-vm1.
2. Go to [a case with d4 files](https://scout-stage.scilifelab.se/cust000/F0006358-mip7)
3. Click on the new buttons and make sure they create reports

**How to test at elsewhere**:
1. Deploy
2. Go to a case with samples having d4 files
3. Assign an HPO phenotype to the case and then click on "Create HPO Panel"

<img width="729" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/8e8f00aa-7ae1-4ff1-a2a9-5ca01570b664">

4. Click on the chanjo2 report button and make sure it's populated


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by Jakob37
- [x] tests executed by Jakob37, CR
