### PR TITLE
Add a new 'Explanation for multiple conditions` field in ClinVar form when a variant has more that one condition ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - On variants page, search for variants in genes present only in build 38 returning no results
 - Pin/unpin with API was not able to make event links
+- A new field `Explanation for multiple conditions` is available in ClinVar for submitting variants with more than one associated condition
 
 ## [4.79.1]
 ### Fixed

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -35,6 +35,7 @@ from .clinvar import (
     COLLECTION_METHOD,
     CONDITION_PREFIX,
     GERMLINE_CLASSIF_TERMS,
+    MULTIPLE_CONDITION_EXPLANATION,
 )
 from .clnsig import CLINSIG_MAP, REV_CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
 from .disease_parsing import (

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -187,3 +187,5 @@ CONDITION_PREFIX = {
 }
 
 CLINVAR_ASSERTION_METHOD_CIT_DB_OPTIONS = {"DOI", "pmc", "PMID"}
+
+MULTIPLE_CONDITION_EXPLANATION = ["Novel disease", "Uncertain", "Co-occurring"]

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -30,6 +30,7 @@ CLINVAR_HEADER = {
     "condition_id_type": "Condition ID type",
     "condition_id_value": "Condition ID value",
     "condition_comment": "Condition comment",
+    "explanation_for_multiple_conditions": "Explanation for multiple conditions",
     "clinsig": "Germline classification",
     "clinsig_comment": "Comment on classification",
     "last_evaluated": "Date last evaluated",

--- a/scout/models/clinvar.py
+++ b/scout/models/clinvar.py
@@ -31,6 +31,7 @@ clinvar_variant = {
     "condition_id_type": str,  # enum: "HPO", "OMIM"
     "condition_id_value": str,  # example: HP:0001298;HP:0001250
     "condition_comment": str,
+    "explanation_for_multiple_conditions": str,
     "start": int,
     "stop": int,
     "ref": str,

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -245,6 +245,8 @@ def _set_conditions(clinvar_var: dict, form: ImmutableMultiDict):
     clinvar_var["condition_id_value"] = ";".join(
         [f"{condition_prefix}{condition_id}" for condition_id in form.getlist("conditions")]
     )
+    if bool(form.get("multiple_condition_explanation")):
+        clinvar_var["explanation_for_multiple_conditions"] = form["multiple_condition_explanation"]
 
 
 def parse_variant_form_fields(form):

--- a/scout/server/blueprints/clinvar/form.py
+++ b/scout/server/blueprints/clinvar/form.py
@@ -26,6 +26,7 @@ from scout.constants import (
     COLLECTION_METHOD,
     CONDITION_PREFIX,
     GERMLINE_CLASSIF_TERMS,
+    MULTIPLE_CONDITION_EXPLANATION,
 )
 
 LOG = logging.getLogger(__name__)
@@ -65,6 +66,10 @@ class ClinVarVariantForm(FlaskForm):
         "Condition ID type", choices=[(key, key) for key, value in CONDITION_PREFIX.items()]
     )
     conditions = SelectMultipleField("Condition ID value, without prefix")
+    multiple_condition_explanation = SelectField(
+        "Explanation for multiple conditions",
+        choices=[(item, item) for item in MULTIPLE_CONDITION_EXPLANATION],
+    )
 
     # Extra fields:
     assertion_method = StringField("Assertion method", default=ASSERTION_METHOD)

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -379,12 +379,12 @@ function validateConditions(){
 
   if ($("#condition_tags option:selected").length > 1 && $("#multiple_condition_explanation option:selected").text() === "-") {
     alert("When multiple condition IDs are provided then an option for "Explanation for multiple conditions" must be provided");
-    return false; //
+    return false;
   }
 
   if ($("#condition_tags option:selected").length == 1 && $("#multiple_condition_explanation option:selected").text() !== "-") {
     alert("Please deselect the selected option in "Explanation for multiple conditions" since only one condition ID was provided.");
-    return false; //
+    return false;
   }
 
   return true

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -269,7 +269,7 @@
                     <div class="mt-3">
                       {{variant_data.var_form.multiple_condition_explanation.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required if you provide more than one condition ID."><strong>?</strong></span>
                       <select name="multiple_condition_explanation" id="multiple_condition_explanation" class="form-control, btn-secondary">
-                        <option selected>-</option>
+                        <option selected value>-</option>
                         {% for choice, _ in variant_data.var_form.multiple_condition_explanation.choices %}
                           <option value="{{choice}}">{{choice}}</option>
                         {% endfor %}

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -378,12 +378,12 @@ function validateConditions(){
   }
 
   if ($("#condition_tags option:selected").length > 1 && $("#multiple_condition_explanation option:selected").text() === "-") {
-    alert("When multiple condition IDs are provided then an option for "Explanation for multiple conditions" must be provided");
+    alert("When multiple condition IDs are provided then an option for 'Explanation for multiple conditions' must be provided");
     return false;
   }
 
   if ($("#condition_tags option:selected").length == 1 && $("#multiple_condition_explanation option:selected").text() !== "-") {
-    alert("Please deselect the selected option in "Explanation for multiple conditions" since only one condition ID was provided.");
+    alert("Please deselect the selected option in 'Explanation for multiple conditions' since only one condition ID was provided.");
     return false;
   }
 

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -232,7 +232,7 @@
 
               <fieldset data-step="6">
                 <legend>Associated Conditions</legend>
-                <h3 class="fs-subtitle">The condition for which the variant is interpreted. Examples available at <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/spreadsheet/#condition" target="_blank" rel="noopener">ClinVar</a>"</h3>
+                <h3 class="fs-subtitle">The condition for which the variant is interpreted. Examples available at <a href="https://www.ncbi.nlm.nih.gov/clinvar/docs/spreadsheet/#condition" target="_blank" rel="noopener">ClinVar</a></h3>
 
                 <div class="row">
                   <div class="col-6" id="clinvar_condition_container">
@@ -249,7 +249,7 @@
                       {% endfor %}
                     </select>
                     <br><br>
-                    {{variant_data.var_form.conditions.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field. Include data from ONE DATABASE TYPE ONLY (i.e. only OMIM terms, only HPO terms etc)"><strong>*?</strong></span>
+                    {{variant_data.var_form.conditions.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field. Include data from ONE DATABASE TYPE ONLY (i.e. only OMIM terms, only HPO terms etc). If multiple conditions are submitted for a variant, this indicates that the variant was interpreted for the combination of conditions in the same individual(s).  i.e. this variant causes both condition A and condition B in the same individual. This scenario is most common for a new disease or syndrome that does not yet have a name and is described by several clinical features. If you want to indicate that the variant has been interpreted for more than one condition, please submit these as separate records."><strong>*?</strong></span>
                     <select class="select2" id="condition_tags" name="conditions" multiple="true" style="width:100%;">
                       {% if variant_data.var_form.omim_terms.choices %}
                         {% for term, _ in variant_data.var_form.omim_terms.choices %}
@@ -265,6 +265,18 @@
                         {% endfor %}
                       {% endif %}
                     </select>
+
+                    <div class="mt-3">
+                      {{variant_data.var_form.multiple_condition_explanation.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required if you provide more than one condition ID."><strong>?</strong></span>
+                      <select name="multiple_condition_explanation" id="multiple_condition_explanation" class="form-control, btn-secondary">
+                        <option selected>-</option>
+                        {% for choice, _ in variant_data.var_form.multiple_condition_explanation.choices %}
+                          <option value="{{choice}}">{{choice}}</option>
+                        {% endfor %}
+                      </select>
+                    </div>
+
+
                   </div>
                   <div class="col-6">
                     {{ variant_data.var_form.omim_terms.label(class="fw-bold, text-dark" )}}<br>
@@ -360,7 +372,22 @@ var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
 
 // Validates fields for conditions associated to a variant
 function validateConditions(){
-  return $("#condition_tags option:selected").length > 0;
+  if ($("#condition_tags option:selected").length == 0) {
+    alert("Please provide at least one condition ID");
+    return false;
+  }
+
+  if ($("#condition_tags option:selected").length > 1 && $("#multiple_condition_explanation option:selected").text() === "-") {
+    alert("When multiple condition IDs are provided then an option for "Explanation for multiple conditions" must be provided");
+    return false; //
+  }
+
+  if ($("#condition_tags option:selected").length == 1 && $("#multiple_condition_explanation option:selected").text() !== "-") {
+    alert("Please deselect the selected option in "Explanation for multiple conditions" since only one condition ID was provided.");
+    return false; //
+  }
+
+  return true
 }
 
 var current_fs, next_fs, previous_fs; //fieldsets
@@ -383,11 +410,9 @@ $(".next").click(function(){
   // check to see if the validator for the specific step we are on passed or not.
   if(validationPassed == false){
     // do not proceed
-    alert("Please fill in required field");
     animating = false;
     return;
   }
-
 
 	next_fs = $(this).parent().next();
 

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -54,7 +54,7 @@ def test_clinvar_submissions(app, institute_obj, case_obj, clinvar_form):
             data=clinvar_form,
         )
 
-        # THEN clinvar_submissions endpoint should return a valid page
+        # THEN clinVar_submissions endpoint should return a valid page
         resp = client.get(
             url_for(
                 "clinvar.clinvar_submissions",

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -607,6 +607,7 @@ def clinvar_form(request):
             "collection_method": ["clinical testing"] * 3,
             "condition_type": "HPO",
             "conditions": ["0001298", "0001250"],
+            "multiple_condition_explanation": "Novel disease",
         }
     )
     return data


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4373, see specifically the [last comment](https://github.com/Clinical-Genomics/scout/issues/4373#issuecomment-1918737418)

<img width="790" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/6429d1cd-43c5-49da-a9fd-240f67f78379">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Locally, pin a variant for demo case
2. Do the ClinVar submission and make sure that:
- When there are multiple conditions then the user MUST specify also the explanation why
- If there is only one condition the USER must not select any value in the explanation field (fist option "-")
3. When the submission is saved, the export CSV file for the variant contains the "Explanation for multiple conditions" - applicable if at least one variant has multiple conditions

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by TB
- [x] tests executed by CR
