### PR TITLE
Panel-table on case-page initially renders default panel in first row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Dark mode settings applied to multiselects on institute settings
 - Comments on case and variant pages can be viewed by expanding an accordion
 - On case page information on pinned variants and variants submitted to ClinVar are displayed in the same table
+- On case page default panels are now found at the top of the table, and it can be sorted by this trait
 ### Fixed
 - On variants page, search for variants in genes present only in build 38 returning no results
 - Pin/unpin with API was not able to make event links

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -398,7 +398,7 @@ def case(store, institute_obj, case_obj):
 
     # Sort panels alphabetically on display name
     case_obj["panels"] = sorted(
-        case_obj.get("panels", []), key=lambda d: (d["display_name"], -d.get("is_default", False))
+        case_obj.get("panels", []), key=lambda d: (-d.get("is_default", False), d["display_name"])
     )
     LOG.info(case_obj["panels"])
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -396,12 +396,6 @@ def case(store, institute_obj, case_obj):
 
     case_obj["default_genes"] = _get_default_panel_genes(store, case_obj)
 
-    # Sort panels alphabetically on display name
-    case_obj["panels"] = sorted(
-        case_obj.get("panels", []), key=lambda d: (-d.get("is_default", False), d["display_name"])
-    )
-    LOG.info(case_obj["panels"])
-
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []
     ):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -397,7 +397,10 @@ def case(store, institute_obj, case_obj):
     case_obj["default_genes"] = _get_default_panel_genes(store, case_obj)
 
     # Sort panels alphabetically on display name
-    case_obj["panels"] = sorted(case_obj.get("panels", []), key=lambda d: d["display_name"])
+    case_obj["panels"] = sorted(
+        case_obj.get("panels", []), key=lambda d: (d["display_name"], -d["is_default"])
+    )
+    LOG.info(case_obj["panels"])
 
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -398,7 +398,7 @@ def case(store, institute_obj, case_obj):
 
     # Sort panels alphabetically on display name
     case_obj["panels"] = sorted(
-        case_obj.get("panels", []), key=lambda d: (d["display_name"], -d["is_default"])
+        case_obj.get("panels", []), key=lambda d: (d["display_name"], -d.get("is_default", False))
     )
     LOG.info(case_obj["panels"])
 

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -601,6 +601,7 @@
       paging: false,
       searching: false,
       ordering: true,
+      order:[[1, 'desc'],[0, 'asc']],
       info: false
     });
   {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -7,6 +7,7 @@
         <thead class="table-light thead">
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by gene panel name"></i></th>
+            <th><i class="fas fa-bars float-end mx-4" data-bs-toggle="tooltip" title="Sort by default panel"></i></th>
             <th>Version <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel version"></i></th>
             <th>Genes <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by number of genes"></i></th>
           </tr>
@@ -21,6 +22,8 @@
                     <span class="badge bg-danger">Removed</span>
                   {% endif %}
                 </a>
+              </td>
+              <td >
                 {% if panel.is_default %}
                   <span class="badge bg-dark float-end">Default</span>
                 {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -7,7 +7,7 @@
         <thead class="table-light thead">
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by gene panel name"></i></th>
-            <th><i class="fas fa-bars float-end mx-4" data-bs-toggle="tooltip" title="Sort by default panel"></i></th>
+            <th >Default <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by default panel"></i></th>
             <th>Version <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel version"></i></th>
             <th>Genes <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by number of genes"></i></th>
           </tr>
@@ -25,7 +25,7 @@
               </td>
               <td >
                 {% if panel.is_default %}
-                  <span class="badge bg-dark float-end">Default</span>
+                  <span class="badge bg-dark">Default</span>
                 {% endif %}
               </td>
               <td>{{ panel.version }} <small class="text">({{ panel.updated_at.date() }})</small></td>


### PR DESCRIPTION
This PR adds a functionality by replacing the default order of panels in the panel-table on case-page. This PR contains changes to render the panels in the table with the default panel in the first row of the table, followed by all other panels for the case in alphabetical order. 

In addition the option to sort the table depending on if the panel is the default or not has been added.

This PR closes  #4526

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by TB
