### PR TITLE
reintroduce and slightly modify variant rankscore sort index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Buttons layout in HPO genes panel on case page
+- Added back old variant rankscore index with different key order to help loading on demo instance
 
 ## [4.80]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -671,7 +671,7 @@ class VariantHandler(VariantLoader):
         result = self.variant_collection.delete_many(query)
         LOG.info("{0} variants deleted".format(result.deleted_count))
 
-    def overlapping(self, variant_obj):
+    def overlapping(self, variant_obj, limit=30):
         """Return overlapping variants.
 
         Look at the genes that a variant overlaps to.
@@ -701,7 +701,7 @@ class VariantHandler(VariantLoader):
         }
         sort_key = [("rank_score", pymongo.DESCENDING)]
         # We collect the 30 most severe overlapping variants
-        variants = self.variant_collection.find(query).sort(sort_key).limit(30)
+        variants = self.variant_collection.find(query).sort(sort_key).limit(limit)
 
         return variants
 

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -63,6 +63,16 @@ INDEXES = {
         ),
         IndexModel(
             [
+                ("category", ASCENDING),
+                ("case_id", ASCENDING),
+                ("variant_type", ASCENDING),
+                ("variant_rank_score", ASCENDING),
+            ],
+            name="category_caseid_varianttype_rankscore",
+            background=True,
+        ),
+        IndexModel(
+            [
                 ("case_id", ASCENDING),
                 ("category", ASCENDING),
                 ("variant_type", ASCENDING),

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -66,7 +66,7 @@ INDEXES = {
                 ("category", ASCENDING),
                 ("case_id", ASCENDING),
                 ("variant_type", ASCENDING),
-                ("variant_rank_score", ASCENDING),
+                ("rank_score", ASCENDING),
             ],
             name="category_caseid_varianttype_rankscore",
             background=True,

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -1,8 +1,11 @@
+import logging
 import re
 
 from pymongo import ReturnDocument
 
 from scout.constants import CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
+
+LOG = logging.getLogger(__name__)
 
 
 def test_build_gene_variant_query(adapter, case_obj, test_hpo_terms, institute_obj):
@@ -848,7 +851,7 @@ def test_query_svs_by_coordinates(real_populated_database, sv_variant_objs, case
     assert list(results)[0] == updated_variant
 
 
-def test_get_overlapping_variant(real_variant_database, case_obj, variant_objs):
+def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, sv_variant_obj):
     """Test function that finds SVs overlapping to a given SNV"""
 
     ## GIVEN a database with snv variants
@@ -858,22 +861,34 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_objs):
     adapter.load_variants(
         case_obj, variant_type="clinical", category="sv", rank_threshold=-10, build="37"
     )
-    # GIVEN a SV variant from this database
-    sv_variant = adapter.variant_collection.find_one({"category": "sv"})
+    # GIVEN a SV variant in this database
+    sv_variant = adapter.variant_collection.find_one({"_id": sv_variant_obj["_id"]})
     assert sv_variant
     sv_variant_id = sv_variant["_id"]
 
-    # WITH a given gene from sv variant
-    gene_id = sv_variant["hgnc_ids"][0]
+    # WITH a given gene on the SV
+    gene_id = 17978
+    updated_sv_variant = adapter.variant_collection.find_one_and_update(
+        {"_id": sv_variant["_id"]},
+        {"$set": {"hgnc_ids": [gene_id]}},
+        return_document=ReturnDocument.AFTER,
+    )
 
-    # Retrieve a SNV variant occurring in the same gene:
-    snv_variant = adapter.variant_collection.find_one({"category": "snv"})
+    # Retrieve a SNV variant occurring in the same case:
+    snv_variant = adapter.variant_collection.find_one({"_id": variant_obj["_id"]})
+    assert snv_variant
+
     # And arbitrary set its hgnc_ids to gene_id
     updated_snv_variant = adapter.variant_collection.find_one_and_update(
-        {"_id": snv_variant["_id"]}, {"$set": {"hgnc_ids": [gene_id]}}
+        {"_id": snv_variant["_id"]},
+        {"$set": {"hgnc_ids": [gene_id]}},
+        return_document=ReturnDocument.AFTER,
     )
+
+    print("snv: {0} sv: {1}".format(updated_snv_variant, updated_sv_variant))
+
     # THEN the function that finds overlapping variants to the snv_variant
-    results = adapter.overlapping(updated_snv_variant)
+    results = adapter.overlapping(updated_snv_variant, limit=10000)
     for res in results:
         # SHOULD return SV variant
         assert res["category"] == "sv"
@@ -881,5 +896,6 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_objs):
 
     # The function should also work the other way around:
     # and return snv variants that overlaps with sv variants
-    results = list(adapter.overlapping(sv_variant))
-    assert updated_snv_variant in results
+    result_vars = list(adapter.overlapping(updated_sv_variant, limit=10000))
+    result_ids = [result_var["_id"] for result_var in result_vars]
+    assert updated_snv_variant["_id"] in result_ids

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -1,11 +1,8 @@
-import logging
 import re
 
 from pymongo import ReturnDocument
 
 from scout.constants import CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
-
-LOG = logging.getLogger(__name__)
 
 
 def test_build_gene_variant_query(adapter, case_obj, test_hpo_terms, institute_obj):
@@ -888,7 +885,7 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
     # THEN the function that finds overlapping variants to the snv_variant
     results = adapter.overlapping(updated_snv_variant, limit=10000)
     for res in results:
-        # SHOULD return SV variant
+        # SHOULD return the SV variant
         assert res["category"] == "sv"
         assert res["_id"] == sv_variant_id
 

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -885,8 +885,6 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
         return_document=ReturnDocument.AFTER,
     )
 
-    print("snv: {0} sv: {1}".format(updated_snv_variant, updated_sv_variant))
-
     # THEN the function that finds overlapping variants to the snv_variant
     results = adapter.overlapping(updated_snv_variant, limit=10000)
     for res in results:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix https://github.com/Clinical-Genomics/scout/issues/4533

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
