### PR TITLE
Directly redirect to chanjo2 when creating reports

### DIFF
--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -85,7 +85,7 @@ def phenomizer_diseases(hpo_ids, case_obj, p_value_treshold=1):
         flash("Could not establish a conection to Phenomizer", "danger")
 
 
-def chanjo2_coverage_report_contents(
+def chanjo2_coverage_report(
     institute_obj: dict, case_obj: dict, panel_name: str, panel_id: Optional[str], report_type: str
 ) -> Optional[str]:
     """Retrieve the HTML contents of the Chanjo2 coverage report/overview for a case."""
@@ -136,8 +136,7 @@ def chanjo2_coverage_report_contents(
     }
 
     report_url: str = "/".join([current_app.config.get("CHANJO2_URL"), report_type])
-    response = requests.post(report_url, json=report_query)
-    return response.text
+    requests.redirect(report_url, json=report_query, code=307)
 
 
 def coverage_report_contents(base_url, institute_obj, case_obj):

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -323,16 +323,13 @@ def chanjo2_coverage_report(institute_id: str, case_name: str, report_type: str)
         return redirect(request.referrer)
 
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
-    report_html_content: str = controllers.chanjo2_coverage_report_contents(
+    controllers.chanjo2_coverage_report(
         institute_obj=institute_obj,
         case_obj=case_obj,
         panel_name=request.args.get("panel_name"),
         panel_id=request.args.get("panel_id"),
         report_type=report_type,
     )
-    if report_html_content is None:
-        return redirect(request.referrer)
-    return report_html_content
 
 
 @cases_bp.route("/<institute_id>/<case_name>/mt_report", methods=["GET"])


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Tentative fix #4539 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
