### PR TITLE
Remove of table data  (without header) for inheritance in case_report if cancer case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Buttons layout in HPO genes panel on case page
 - Added back old variant rankscore index with different key order to help loading on demo instance
+- Cancer case_report panel-table no longer contains inheritance information
 
 ## [4.80]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1031,17 +1031,19 @@
             -
           {% endif %}
           </td>
-          <td>
-            <span class="float-left">
-              {% if variant.genetic_models %}
-                {% for model in variant.genetic_models|sort %}
-                  <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
-                {% endfor %}
-              {% else %}
-                <span class="badge badge-warning">No models followed</span>
-              {% endif %}
-            </span>
-          </td>
+          {% if not cancer %}
+            <td>
+              <span class="float-left">
+                {% if variant.genetic_models %}
+                  {% for model in variant.genetic_models|sort %}
+                    <span class="badge badge-info" title="{{genetic_models[model]}}">{{ model }}</span>
+                  {% endfor %}
+                {% else %}
+                  <span class="badge badge-warning">No models followed</span>
+                {% endif %}
+              </span>
+            </td>
+          {% endif %}
           <td>
             {% if variant.acmg_classification %}
               <span class="badge badge-pill badge-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['code'] }}</span>


### PR DESCRIPTION
This PR fixes a bug.

This PR closes #4546 by adding the same condition for rendering table Data containing inheritance information as was already present for the corresponding header. This applies to a #panel-table, in the case_report for cancer cases 


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by TB
