### PR TITLE
Text claiming all pinned variants are represented in causatives is now only rendered if this is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Buttons layout in HPO genes panel on case page
 - Added back old variant rankscore index with different key order to help loading on demo instance
+- Case report pinned variants card now displays info text if all pinned variants are present in causatives
 
 ## [4.80]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -342,6 +342,7 @@
   </div>
   <div class="card-body">
     {% set duplicated_variants = [] %}
+    {% set pinned_not_causative_variants = [] %}
     {% if variants.suspects_detailed %}
       {% if cancer %}
         {{ somatic_variant_table(variants.suspects_detailed) }}
@@ -349,6 +350,7 @@
       {% for pinned in variants.suspects_detailed|sort(attribute='variant_rank') %}
         {% if pinned['_id'] not in printed_vars %}
           {% do printed_vars.append(pinned['_id']) %}
+          {% do pinned_not_causative_variants.append(pinned['_id']) %}
           {{ variant_content(pinned, loop.index) }}
         {% else %}
           {% do duplicated_variants.append(pinned['_id']) %}
@@ -358,7 +360,7 @@
     {% else %}
       No pinned variants available for this case
     {% endif %}
-    {% if variants.suspects_detailed and duplicated_variants|length == variants.suspects_detailed.suspects_detailed|length %}
+    {% if pinned_not_causative_variants|length == 0 %}
       All pinned variants are described among the causative variants
     {% endif %}
   </div>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -360,7 +360,7 @@
     {% else %}
       No pinned variants available for this case
     {% endif %}
-    {% if pinned_not_causative_variants|length == 0 %}
+    {% if variants.suspects_detailed and pinned_not_causative_variants|length == 0 %}
       All pinned variants are described among the causative variants
     {% endif %}
   </div>


### PR DESCRIPTION
This PR fixes a bug which caused the text "All pinned variants are described among the causative variants" to be displayed when this was not the case.

This PR closes #4547


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by TB
