### PR TITLE
 Harmonization of case report spacing for some lists and #panel_tabels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- In the case_report #panel-tables has a fixed width
+
 ## [4.81]
 ### Added
 - Tag for somatic SV IGH-DUX4 detection samtools script

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -174,27 +174,30 @@
 	          {% endif %}
 	        </td>
 	        <td class="ms-3 d-flex align-items-start flex-column" style="border-bottom:none;">
-            <strong>Associated phenotypes:</strong><br>
-  	          {% if case.phenotype_terms %}
-  	            <ul>
-  	              {% for pheno in case.phenotype_terms %}
-  	                <li>
-  	                {{pheno.feature}} - (<a style="text-decoration:none;" href="https://hpo.jax.org/app/browse/term/{{pheno.phenotype_id}}" target="_blank">{{pheno.phenotype_id}})</a>
-                    {% for feature_ind in pheno.individuals %} <!-- display eventual individual-level HPO terms -->
-                      {% for case_ind in case.individuals %}
-                        {% if feature_ind.individual_name == case_ind.display_name %}
-                          <span class="ms-1 {% if case_ind.phenotype == 2 %} text-danger {% endif %}">{{case_ind.display_name}}</span>
-                        {% endif %}
+              <strong>Associated phenotypes:</strong>
+  	            {% if case.phenotype_terms %}
+  	              <ul>
+  	                {% for pheno in case.phenotype_terms %}
+  	                  <li>
+  	                  {{pheno.feature}} - (<a style="text-decoration:none;" href="https://hpo.jax.org/app/browse/term/{{pheno.phenotype_id}}" target="_blank">{{pheno.phenotype_id}})</a>
+                      {% for feature_ind in pheno.individuals %} <!-- display eventual individual-level HPO terms -->
+                        {% for case_ind in case.individuals %}
+                          {% if feature_ind.individual_name == case_ind.display_name %}
+                            <span class="ms-1 {% if case_ind.phenotype == 2 %} text-danger {% endif %}">{{case_ind.display_name}}</span>
+                          {% endif %}
+                        {% endfor %}
                       {% endfor %}
-                    {% endfor %}
-  	                </li>
-  	              {% endfor %}
-  	            </ul>
-  	          {% else %}
-  	            No associated HPO terms.
-  	          {% endif %}
-              <br>
-              <strong>Associated diagnoses:</strong><br>
+  	                  </li>
+  	                {% endfor %}
+  	              </ul>
+  	            {% else %}
+                  <ul style="list-style-type: none; padding-left:0;">
+                    <li>
+  	                  No associated HPO terms.
+                    </li>
+                  </ul>
+  	            {% endif %}
+              <strong>Associated diagnoses:</strong>
               {% if case.diagnosis_phenotypes %}
                 <ul>
                   {% for dia in case.diagnosis_phenotypes %}
@@ -211,7 +214,11 @@
                   {% endfor %}
                 </ul>
               {% else %}
-                No associated diagnoses.
+                <ul style="list-style-type: none;padding-left:0;">
+                  <li>
+                    No associated diagnoses.
+                  </li>
+                </ul>
               {% endif %}
 	        </td>
 	      </tr>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -361,10 +361,10 @@
           {% do printed_vars.append(pinned['_id']) %}
           {% do pinned_not_causative_variants.append(pinned['_id']) %}
           {{ variant_content(pinned, loop.index) }}
+          <br>
         {% else %}
           {% do duplicated_variants.append(pinned['_id']) %}
         {% endif %}
-        <br>
       {% endfor %}
     {% else %}
       No pinned variants available for this case
@@ -388,10 +388,10 @@
         {% if variant['_id'] not in printed_vars %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
+          <br>
         {% else %}
           {% do duplicated_variants.append(variant['_id']) %}
         {% endif %}
-        <br>
       {% endfor %}
     {% else %}
       No ACMG-classified variants available for this case
@@ -415,10 +415,10 @@
         {% if variant['_id'] not in printed_vars %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
+          <br>
         {% else %}
           {% do duplicated_variants.append(variant['_id']) %}
         {% endif %}
-        <br>
       {% endfor %}
     {% endif %}
     {% if variants.tier_detailed %}
@@ -426,10 +426,10 @@
         {% if variant['_id'] not in printed_vars %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
+          <br>
         {% else %}
           {% do duplicated_variants.append(variant['_id']) %}
         {% endif %}
-        <br>
       {% endfor %}
     {% endif %}
     {% if not (variants.tagged_detailed or variants.tier_detailed) %}
@@ -474,10 +474,10 @@
           {% else %}
             {{ sv_variant_content(variant, loop.index) }}
           {% endif %}
+          <br>
         {% else %}
           {% do duplicated_variants.append(variant['_id']) %}
         {% endif %}
-        <br>
       {% endfor %}
     {% else %}
       No commented variants for this case

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -558,7 +558,7 @@
       </table>
       <table class="table table-sm">
         <tr>
-          <td style="width:55%;">
+          <td style="width:60%;">
             {{ genotype_table(variant) }}
           </td>
           <td style="width:3%"></td>
@@ -988,7 +988,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <td style="width:55%;">
+        <td style="width:60%;">
           {{genotype_table(variant)}}
         </td>
         <td style="width:3%"></td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -558,7 +558,7 @@
       </table>
       <table class="table table-sm">
         <tr>
-          <td style="width=45%">
+          <td style="width:45%;">
             {{ genotype_table(variant) }}
           </td>
           <td style="width:3%"></td>
@@ -770,8 +770,8 @@
           </thead>
           {% for variant in variants.dismissed_detailed|sort(attribute='variant_rank') %}
             <tr{% if loop.index0 % 2 %} class="light-grey" {% endif %}>
-              <td width="5%">#{{loop.index}}</td>
-              <td width="25%">
+              <td style="width:5%,">#{{loop.index}}</td>
+              <td style="width:25%;">
                 {% if variant.category == 'snv' %}
                   <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name[:30]}}</strong></a>
                 {% elif variant.category == 'cancer' %}
@@ -782,8 +782,8 @@
                   <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>rep. {{variant.str_repid}}</strong></a>
                 {% endif %}
               </td>
-              <td width="5%">{{variant.category|upper}}</td>
-              <td width="15%">
+              <td style="width:5%;">{{variant.category|upper}}</td>
+              <td style="width:15%;"
                 {{ dismissed_gene_list(variant) }}
               </td>
 
@@ -988,7 +988,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <td>
+        <td style="width:45%;">
           {{genotype_table(variant)}}
         </td>
         <td style="width:3%"></td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -558,7 +558,7 @@
       </table>
       <table class="table table-sm">
         <tr>
-          <td style="width:45%;">
+          <td style="width:55%;">
             {{ genotype_table(variant) }}
           </td>
           <td style="width:3%"></td>
@@ -988,7 +988,7 @@
     </table>
     <table id="panel-table" class="table table-sm" style="background-color: transparent">
       <tr>
-        <td style="width:45%;">
+        <td style="width:55%;">
           {{genotype_table(variant)}}
         </td>
         <td style="width:3%"></td>

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -268,7 +268,7 @@
 
         <!-- show transcript info only if it's canonical, disease-associated or primary (print max 5 primary transcripts) -->
       {% if transcript.refseq_identifiers and n_primary_txs.count <= 5 or transcript.is_canonical or transcript.is_disease_associated or transcript.is_primary %}
-        <li>{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name or '')|url_decode|truncate(20, True) }}
+        <li class="mb-1">{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name or '')|url_decode|truncate(20, True) }}
           {% if transcript.is_canonical %}
             <span class="badge rounded-pill bg-info text-white" title="canonical">C</span>
           {% endif %}


### PR DESCRIPTION
This PR adds some space between <li> in some tables as well as replaces some <td> width attributes (deprecated in html5) with corresponding inline styles. Some <br> have been moved as to not render twice for the last child in a card as well as for unifying the structure of variant_content for different variant types. The aim for the change was to unify the visual expression of the nested tables in the case_report cards and to improve readability.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Go to /case_report for some cases and verify the styling is coherent.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by TB
