### PR TITLE
Added tooltip for combined compound score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+## Added
+- Tooltip for combined score in compounds-table
 ### Changed
 - In the case_report #panel-tables has a fixed width
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ## Added
-- Tooltip for combined score in compounds-table
+- Tooltip for combined score in tables for compounds and overlapping vars
 ### Changed
 - In the case_report #panel-tables has a fixed width
 

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -241,7 +241,7 @@
   <div class="card panel-default">
     <div class="panel-heading">Compounds (top 20)</div>
     <div class="card-body">
-      {{ compounds_table(institute, case, variant.compounds[:20]) }}
+      {{ compounds_table(institute, case, variant.compounds[:20], is_popover=false) }}
     </div>
   </div>
 {% endmacro %}

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -131,7 +131,9 @@
               <th>Variant</th>
               <th>Gene</th>
 	            <th>Type</th>
-              <th>Combined score</th>
+              <th>Combined score
+                <span data-bs-toggle='tooltip' data-bs-title='Combined score is the sum of variants´s score and overlapping variant´s score'>?</span>
+              </th>
               <th>Rank score</th>
               <th>Length</th>
               <th>Region</th>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -110,12 +110,17 @@
 {% endmacro %}
 
 
-{% macro compounds_table(institute, case, compounds) %}
+{% macro compounds_table(institute, case, compounds, is_popover) %}
+  {% set is_popover = is_popover|default(false) %}
   <table class='table table-condensed table-bordered table-sm'>
     <thead class='thead table-light'>
       <tr>
         <th>Variant</th>
-        <th>Combined score</th>
+        <th>Combined score
+          {% if not is_popover %}
+            <span data-bs-toggle='tooltip' data-bs-title='Combined score is the sum of variants´s score and compound variant´s score'>?</span>
+        </th>
+          {% endif %}
         <th>Rank score</th>
         <th>Gene annotation</th>
         <th>Func. annotation</th>
@@ -131,6 +136,8 @@
           <td>
               {% if compound.not_loaded %}
                 {{ compound.display_name }} <small>(not loaded)</small>
+              {% elif is_popover %}
+                {{ compound.display_name }}
               {% else %}
                 <a href='{{ url_for("variant.variant",
                 institute_id=institute._id,

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -164,7 +164,7 @@
     {% if ns.show_compounds %}
       <a href="#" class="badge bg-primary text-white" data-bs-toggle="popover" data-bs-placement="left"
         data-bs-html="true" data-bs-trigger="hover click"
-        data-bs-content="{{ compounds_table(institute, case, variant.compounds[:20]) }}">Compounds</a>
+        data-bs-content="{{ compounds_table(institute, case, variant.compounds[:20], is_popover=true) }}">Compounds</a>
     {% endif %}
   {% endif %}
 


### PR DESCRIPTION
This PR adds a tooltip for the "combined score" header in the compounds table. For technical reasons the tooltip is conditionally rendered so it's not included when the table is itself displayed in a popover.

This PR closes #4560

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by TB
