### PR TITLE
Fix #4568 - add a STR details panel to the variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## Added
 - Tooltip for combined score in tables for compounds and overlapping vars
 - Option to filter variants by excluding genes listed in selected gene panels, files or provided as list
+- STR variant information card with database links, replacing empty frequency panel
 ### Changed
 - In the case_report #panel-tables has a fixed width
 - Updated IGV.js to 2.15.11

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -5,7 +5,7 @@
 {% from "variant/utils.html" import causative_button, genes_panel, modal_causative, overlapping_panel, pin_button, proteins_panel, transcripts_panel, custom_annotations %}
 {% from "variant/tx_overview.html" import disease_associated, transcripts_overview %}
 {% from "variant/gene_disease_relations.html" import autozygosity_panel, genemodels_panel, inheritance_panel, orpha_omim_phenotypes %}
-{% from "variant/variant_details.html" import frequencies, gtcall_panel, old_observations, observations_panel, severity_list, conservations, mappability %}
+{% from "variant/variant_details.html" import conservations, frequencies, gtcall_panel, mappability, observations_panel, old_observations, severity_list, str_db_card %}
 {% from "variant/components.html" import alignments, clinsig_table, compounds_panel, external_links, external_scripts, external_stylesheets, matching_variants, panel_classify, variant_scripts %}
 {% from "variant/sanger.html" import modal_cancel_sanger, modal_sanger, sanger_button %}
 {% from "variant/rank_score_results.html" import rankscore_panel %}
@@ -90,11 +90,15 @@
         {{ panel_summary() }}
       </div>
       <div class="col-lg-4">
-        {{ frequencies(variant) }}
-        {% if config['LOQUSDB_SETTINGS'] %}
-          {{ observations_panel(variant, observations, case) }}
+        {% if str %}
+          {{ str_db_card(variant) }}
+        {% else %}
+          {{ frequencies(variant) }}
+          {% if config['LOQUSDB_SETTINGS'] %}
+            {{ observations_panel(variant, observations, case) }}
+          {% endif %}
+          {{  old_observations(variant) }}
         {% endif %}
-        {{  old_observations(variant) }}
       </div>
     </div>
     <div class="row">
@@ -227,8 +231,8 @@
           <tr>
             <td>
               Position:
-	      <strong>{{ variant.chromosome }}:<span class="text-muted">{{ variant.position }}</span></strong>
-             <button type="button" class="fa fa-copy btn-xs js-tooltip js-copy" style="background-color: Transparent;outline:none; border: none;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-copy="{{ variant.chromosome }}:{{ variant.position }}" title="Copy to clipboard">
+	            <strong>{{ variant.chromosome }}:<span class="text-muted">{{ variant.position }}</span></strong>
+              <button type="button" class="fa fa-copy btn-xs js-tooltip js-copy" style="background-color: Transparent;outline:none; border: none;" data-bs-toggle="tooltip" data-bs-placement="bottom" data-copy="{{ variant.chromosome }}:{{ variant.position }}" title="Copy to clipboard">
               </button>
             </td>
             <td {% if not mei %}colspan="3"{% endif %}>
@@ -282,13 +286,12 @@
               </strong></span>
             </td>
           </tr>
-
         </tbody>
       </table>
       <table class="table table-bordered table-fixed table-sm">
         <tbody class="border-top">
           <tr>
-            <td>
+            <td {% if str %}colspan="2"{% endif %}>
               Matches OMIM inhert.
               {% if variant.is_matching_inheritance %}
                 <span class="badge bg-success float-end">Yes</span>
@@ -296,12 +299,14 @@
                 <div class="badge bg-warning float-end">No</div>
               {% endif %}
             </td>
-            <td>
-              Frequency
-              <div class="badge bg-{% if variant.frequency == 'common' %}danger{% elif variant.frequency == 'uncommon' %}warning{% else %}success{% endif %} float-end">
-                {{ variant.frequency }}
-              </div>
-            </td>
+            {% if not str %}
+              <td>
+                Frequency
+                <div class="badge bg-{% if variant.frequency == 'common' %}danger{% elif variant.frequency == 'uncommon' %}warning{% else %}success{% endif %} float-end">
+                  {{ variant.frequency }}
+                </div>
+              </td>
+            {% endif %}
           </tr>
         </tbody>
       </table>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -107,9 +107,9 @@
 
 {% macro str_db_card(variant) %}
   <div class="card panel-default">
-    <div class="panel-heading">STR locus detals</div>
+    <div class="panel-heading">STR locus details</div>
     <div class="card-body">
-      <table class="table">
+      <table class="table" aria-label="STR locus details">
         <thead class="thead table-light">
             <tr>
               <th scope="col">Source</th>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -105,37 +105,88 @@
   </div>
 {% endmacro %}
 
+{% macro str_db_card(variant) %}
+  <div class="card panel-default">
+    <div class="panel-heading">STR locus detals</div>
+    <div class="card-body">
+      <table class="table">
+        <thead class="thead table-light">
+            <tr>
+              <th scope="col">Source</th>
+              <th scope="col">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr><td>Normal max</td><td>{{ variant.str_normal_max }}</td></tr>
+            <tr><td>Pathologic min</td><td>{{ variant.str_pathologic_min }}</td><tr>
+            {% set str_mc = variant.alternative|replace("STR", "")|replace("<", "")|replace(">", "")|int %}
+            {% if variant.str_status == 'full_mutation' %}
+              <tr class="bg-danger">
+            {% elif variant.str_status == 'pre_mutation' %}
+              <tr class="bg-warning">
+            {% else %}
+              <tr>
+	          {% endif %}
+              <td>Motif copies</td><td>{{ str_mc }} <span class="badge bg-secondary text-white">{{ variant.str_status }}</span></td>
+            </tr>
+            <tr><td colspan=2>&nbsp;</td></tr>
+            {% if variant.str_swegen_mean %}
+              <tr><td>SweGen Z-score</td><td>
+              {{ ((str_mc - variant.str_swegen_mean ) / variant.str_swegen_std) | round(2) }}
+              </td></tr>
+              <tr><td>SweGen mean</td><td>{{variant.str_swegen_mean|round(2)}}</td></tr>
+              <tr><td>SweGen std</td><td>{{variant.str_swegen_std|round(2)}}</td></tr>
+              <tr><td colspan=2>&nbsp;</td></tr>
+            {% endif %}
+            {% for gene in variant.genes %}
+              {% if gene.stripy_link %}
+                <tr><td>
+                  <a href="{{ gene.str_gnomad_link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">gnomAD</a>
+                </td><td>{{ gene.hgnc_symbol }}</td></tr>
+              {% endif %}
+              {% if gene.stripy_link %}
+                <tr><td>
+                  <a href="{{ gene.stripy_link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">STRipy</a>
+                </td><td>{{ gene.hgnc_symbol }}</td></tr>
+              {% endif %}
+            {% endfor %}
+          </tbody>
+        </table>
+    </div>
+  </div>
+{% endmacro %}
+
 {% macro frequencies(variant) %}
   <div class="card panel-default">
     <div class="panel-heading">Frequencies</div>
     <div class="card-body">
       <table class="table">
-        <thead class="thead table-light">
-          <tr>
-            <th scope="col">Source</th>
-            <th scope="col">Frequency</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for freq_name, value, link in variant.frequencies %}
-          <tr>
-            <td>
-              {% if link %}
-                <a href="{{ link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">{{ freq_name }}</a>
-              {% else %}
-                {{ freq_name }}
-              {% endif %}
-            </td>
-            <td>
-              {% if value %}
-                <span class="badge bg-secondary">{{ value|human_decimal }}</span>
-              {% else %}
-                -
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
+          <thead class="thead table-light">
+            <tr>
+              <th scope="col">Source</th>
+              <th scope="col">Frequency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for freq_name, value, link in variant.frequencies %}
+              <tr>
+                <td>
+                  {% if link %}
+                    <a href="{{ link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">{{ freq_name }}</a>
+                  {% else %}
+                    {{ freq_name }}
+                  {% endif %}
+                </td>
+                <td>
+                  {% if value %}
+                    <span class="badge bg-secondary">{{ value|human_decimal }}</span>
+                  {% else %}
+                    -
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
       </table>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug. Replaces blank (and partly faulty) frequencies card on the STR variant page with a card with locus details previously shown on the variantS page, plus lifting variant specific db links to the top of the page.

![Screenshot 2024-04-18 at 16 42 58](https://github.com/Clinical-Genomics/scout/assets/758570/2188d1bd-6f51-445f-acf4-906f3ba39af8)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
