### PR TITLE
Pagination and nr HPO terms on Phenotypes page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tooltip for combined score in tables for compounds and overlapping vars
 - Option to filter variants by excluding genes listed in selected gene panels, files or provided as list
 - STR variant information card with database links, replacing empty frequency panel
+- Display paging and number of HPO terms available in the database on Phenotypes page
 ### Changed
 - In the case_report #panel-tables has a fixed width
 - Updated IGV.js to 2.15.11

--- a/scout/server/blueprints/phenotypes/templates/phenotypes/hpo_terms.html
+++ b/scout/server/blueprints/phenotypes/templates/phenotypes/hpo_terms.html
@@ -21,7 +21,7 @@
   <div class="row mt-3">
     <div class="col-md-12">
       <div class="card">
-        <div class="card-header">HPO terms</div>
+        <div class="card-header">Number of HPO terms present in the database:{{phenotypes|length}}</div>
         <div class="card-body">
           {% if phenotypes|length == 0 %}
             The search didn't return any phenotype term
@@ -54,7 +54,8 @@
   <script type="text/javascript">
     $(document).ready(function() {
       $('#phenotypes_table').DataTable( {
-          paging: false,
+          paging: true,
+          pageLength: 50,
           dom: 'fBrtip',
           buttons: [
             {


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4558
- Adds pagination to the HPO terms, which otherwise takes forever to load

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy on stage and check that Phenotypes page works, displaying only 50 HPO terms at the time

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
