### PR TITLE
Typehead diseases when query contains source substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to filter variants by excluding genes listed in selected gene panels, files or provided as list
 - STR variant information card with database links, replacing empty frequency panel
 - Display paging and number of HPO terms available in the database on Phenotypes page
+- Typeahead hints when searching for disease with substrings containing source ("OMIM:", "ORPHA:")
 ### Changed
 - In the case_report #panel-tables has a fixed width
 - Updated IGV.js to 2.15.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to filter variants by excluding genes listed in selected gene panels, files or provided as list
 - STR variant information card with database links, replacing empty frequency panel
 - Display paging and number of HPO terms available in the database on Phenotypes page
-- Typeahead hints when searching for disease with substrings containing source ("OMIM:", "ORPHA:")
+- On case page, typeahead hints when searching for a disease using substrings containing source ("OMIM:", "ORPHA:")
 ### Changed
 - In the case_report #panel-tables has a fixed width
 - Updated IGV.js to 2.15.11

--- a/scout/adapter/mongo/disease_terms.py
+++ b/scout/adapter/mongo/disease_terms.py
@@ -33,6 +33,7 @@ class DiagnosisHandler(object):
             query_dict = {
                 "$or": [
                     {"disease_nr": {"$regex": query, "$options": "i"}},
+                    {"disease_id": {"$regex": query, "$options": "i"}},
                     {"description": {"$regex": query, "$options": "i"}},
                 ]
             }

--- a/scout/adapter/mongo/disease_terms.py
+++ b/scout/adapter/mongo/disease_terms.py
@@ -10,6 +10,8 @@ from scout.exceptions import IntegrityError
 LOG = logging.getLogger(__name__)
 
 DISEASE_FILTER_PROJECT = {"hpo_terms": 0, "genes": 0}
+REGEX_OPTIONS = "$options"
+REGEX_IGNORECASE = "i"
 
 
 class DiagnosisHandler(object):
@@ -32,9 +34,9 @@ class DiagnosisHandler(object):
         if query:
             query_dict = {
                 "$or": [
-                    {"disease_nr": {"$regex": query, "$options": "i"}},
-                    {"disease_id": {"$regex": query, "$options": "i"}},
-                    {"description": {"$regex": query, "$options": "i"}},
+                    {"disease_nr": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
+                    {"disease_id": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
+                    {"description": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
                 ]
             }
             # If source is specified, add this restriction to the query

--- a/scout/adapter/mongo/disease_terms.py
+++ b/scout/adapter/mongo/disease_terms.py
@@ -10,6 +10,7 @@ from scout.exceptions import IntegrityError
 LOG = logging.getLogger(__name__)
 
 DISEASE_FILTER_PROJECT = {"hpo_terms": 0, "genes": 0}
+REGEX = "$regex"
 REGEX_OPTIONS = "$options"
 REGEX_IGNORECASE = "i"
 
@@ -34,9 +35,8 @@ class DiagnosisHandler(object):
         if query:
             query_dict = {
                 "$or": [
-                    {"disease_nr": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
-                    {"disease_id": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
-                    {"description": {"$regex": query, REGEX_OPTIONS: REGEX_IGNORECASE}},
+                    {"disease_id": {REGEX: query, REGEX_OPTIONS: REGEX_IGNORECASE}},
+                    {"description": {REGEX: query, REGEX_OPTIONS: REGEX_IGNORECASE}},
                 ]
             }
             # If source is specified, add this restriction to the query


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- fix #4588 

<img width="888" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/86497c1d-0d80-4602-9dbc-e28de7848b67">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
