### PR TITLE
Stricter control over ClinVar condition IDs provided in ClinVar form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated IGV.js to 2.15.11
 - Fusion variants in case report now contain same info as on fusion variantS page
 - Block submission of somatic variants to ClinVar, until we don't introduce the changes needed to harmonise with their changed API
+- Make sure
 ### Fixed
 - Submit requests to Chanjo2 using HTML forms instead of JSON data
 - `Research somatic variants` link name on caseS page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated IGV.js to 2.15.11
 - Fusion variants in case report now contain same info as on fusion variantS page
 - Block submission of somatic variants to ClinVar, until we don't introduce the changes needed to harmonise with their changed API
-- Make sure
+- Additional control on the format of conditions provided in ClinVar form
 ### Fixed
 - Submit requests to Chanjo2 using HTML forms instead of JSON data
 - `Research somatic variants` link name on caseS page

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -368,6 +368,7 @@ var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
 
 // Validates fields for conditions associated to a variant
 function validateConditions(){
+
   if ($("#condition_tags option:selected").length == 0) {
     alert("Please provide at least one condition ID");
     return false;
@@ -383,7 +384,15 @@ function validateConditions(){
     return false;
   }
 
-  return true
+  var selectedConditionsValues = $('#condition_tags').val();
+  for (let i = 0; i < selectedConditionsValues.length; i++) {
+    if (isNaN(selectedConditionsValues[i])){
+      alert(`Condition ID "${selectedConditionsValues[i]}" has an invalid format.`);
+      return false;
+    }
+  }
+
+  return true;
 }
 
 var current_fs, next_fs, previous_fs; //fieldsets

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -384,9 +384,10 @@ function validateConditions(){
     return false;
   }
 
+  // Make sure that provided conditions are numbers, except when condition type is MeSH
   var selectedConditionsValues = $('#condition_tags').val();
   for (let i = 0; i < selectedConditionsValues.length; i++) {
-    if (isNaN(selectedConditionsValues[i])){
+    if (isNaN(selectedConditionsValues[i]) && $('#condition_type').val() != 'MeSH'){
       alert(`Condition ID "${selectedConditionsValues[i]}" has an invalid format.`);
       return false;
     }

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -240,11 +240,7 @@
 
                     <select class="form-control, btn-secondary" name="condition_type" id="condition_type">
                       {% for dbtype, _ in variant_data.var_form.condition_type.choices %}
-                        {% if dbtype == "OMIM" and variant_data.var_form.omim_terms.choices or dbtype == "HP" and variant_data.var_form.hpo_terms.choices or dbtype == "Orphanet" and variant_data.var_form.orpha_terms.choices %}
-                          <option value="{{dbtype}}" selected>{{dbtype}}</option>
-                        {% else %}
-                          <option value="{{dbtype}}">{{dbtype}}</option>
-                        {% endif %}
+                        <option value="{{dbtype}}">{{dbtype}}</option>
                       {% endfor %}
                     </select>
 
@@ -525,6 +521,18 @@ $('#condition_tags').select2({
   tokenSeparators: [','],
   allowClear: true,
 });
+
+// Set selected condition type on page load
+window.onload = function() {
+  const selectedCondId = document.getElementById('condition_type');
+  {% if variant_data.var_form.omim_terms.choices %}
+    selectedCondId.options.selectedIndex = 4;
+  {% elif variant_data.var_form.orpha_terms.choices %}
+    selectedCondId.options.selectedIndex = 5;
+  {% elif variant_data.var_form.hpo_terms.choices %}
+    selectedCondId.options.selectedIndex = 0;
+  {% endif %}
+};
 
 // reset and modify conditions field's placeholder when condition ID type changes
 $(function(){


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- fix #4581

**I've considered the suggestion to force users to only provided conditions already assigned to the case, but I like the idea that they can also use other ontologies outside OMIM and ORPHA**, so I've opted to do a string is number check, see code.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. try adding a bunch a nonsense as observed conditions when you add a variant to the ClinVar submission object

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR
