### PR TITLE
Use latest gene panel for panel overlap in variantS, variant view and case report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix condition dropdown and pre-selection on ClinVar form for cases with associated ORPHA diagnoses
 - Improved visibility of ClinVar form in dark mode
 - End coordinates for indels in ClinVar form
+- Variant's overlapping panels should show overlapping of variant genes against the latest version of the panel
 
 ## [4.81]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -443,6 +443,18 @@
 </div>
 {% endmacro %}
 
+{% macro overlapping_panels(variant) %}
+{% if variant.case_panels %}
+  {% if variant.case_panels|length <= 3 %}
+    {% for panel in variant.case_panels %}
+      <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" class="badge bg-secondary">{{ panel.panel_name }}</a><br>
+    {% endfor %}
+  {% else %}
+    {{ variant.case_panels|length }} panels
+  {% endif %}
+{% endif %}
+{% endmacro %}
+
 {% macro variant_content(variant, index) %}
   {% if variant.category == 'snv' %}
     {{ sn_variant_content(variant, index) }}
@@ -544,15 +556,7 @@
               {% endif %}
             </td>
             <td>
-              {% if variant.panels%}
-                {% if variant.panels|length <= 3 %}
-                  {% for panel_id in variant.panels %}
-                   <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" rel="noopener" target="_blank" class="badge bg-secondary">{{ panel_id }}</a><br>
-                  {% endfor %}
-                {% else %}
-                  {{ variant.panels|length }} panels
-                {% endif %}
-              {% endif %}
+              {{ overlapping_panels(variant) }}
             </td>
           </tr>
         </tbody>
@@ -965,15 +969,7 @@
             <td>-</td>
           {% endif %}
           <td>
-            {% if variant.panels %}
-              {% if variant.panels|length <= 3 %}
-                {% for panel_id in variant.panels %}
-                  <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" rel="noopener" target="_blank" class="badge bg-secondary">{{ panel_id }}</a><br>
-                {% endfor %}
-              {% else %}
-                {{ variant.panels|length }} panels
-              {% endif %}
-            {% endif %}
+            {{ overlapping_panels(variant) }}
           </td>
           <td>
             {% if variant.callers %}
@@ -1183,15 +1179,7 @@
             {% endif %}
           </td>
           <td>
-            {% if variant.panels %}
-              {% if variant.panels|length <= 3 %}
-                {% for panel_id in variant.panels %}
-                  <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" class="badge bg-secondary">{{ panel_id }}</a><br>
-                {% endfor %}
-              {% else %}
-                {{ variant.panels|length }} panels
-              {% endif %}
-            {% endif %}
+            {{ overlapping_panels(variant) }}
           </td>
         </tr>
       </tbody>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -447,7 +447,7 @@
 {% if variant.case_panels %}
   {% if variant.case_panels|length <= 3 %}
     {% for panel in variant.case_panels %}
-      <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" class="badge bg-secondary">{{ panel.panel_name }}</a><br>
+      <a style="text-decoration:none;" href="{{ url_for('panels.panel', panel_id=panel_id) }}" target="_blank" rel="noopener" class="badge bg-secondary">{{ panel.panel_name }}</a><br>
     {% endfor %}
   {% else %}
     {{ variant.case_panels|length }} panels

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -238,7 +238,7 @@ def variant(
     # The hierarchical call order is relevant: cases are used to populate variants
     update_variant_case_panels(case_obj, variant_obj)
 
-    associate_variant_genes_with_case_panels(store, variant_obj)
+    associate_variant_genes_with_case_panels(case_obj, variant_obj)
 
     # Provide basic info on alignment files availability for this case
     case_has_alignments(case_obj)

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional
 
 from scout.adapter import MongoAdapter
 from scout.constants import ACMG_COMPLETE_MAP, CALLERS, CLINSIG_MAP, SO_TERMS
-from scout.server.extensions import store
 from scout.server.links import add_gene_links, add_tx_links
 
 LOG = logging.getLogger(__name__)

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -3,8 +3,8 @@ from typing import Dict, List, Optional
 
 from scout.adapter import MongoAdapter
 from scout.constants import ACMG_COMPLETE_MAP, CALLERS, CLINSIG_MAP, SO_TERMS
-from scout.server.links import add_gene_links, add_tx_links
 from scout.server.extensions import store
+from scout.server.links import add_gene_links, add_tx_links
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/blueprints/variants/utils.py
+++ b/scout/server/blueprints/variants/utils.py
@@ -15,5 +15,6 @@ def update_case_panels(store: MongoAdapter, case_obj: dict):
         panel_name = panel_info["panel_name"]
         latest_panel = store.gene_panel(panel_name)
         panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
-        latest_panel["hgnc_ids"] = [gene["hgnc_id"] for gene in latest_panel.get("genes", [])]
-        case_obj["latest_panels"].append(latest_panel)
+        if latest_panel:
+            latest_panel["hgnc_ids"] = [gene["hgnc_id"] for gene in latest_panel.get("genes", [])]
+            case_obj["latest_panels"].append(latest_panel)

--- a/scout/server/blueprints/variants/utils.py
+++ b/scout/server/blueprints/variants/utils.py
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
+from scout.adapter import MongoAdapter
 
 
-def update_case_panels(store, case_obj):
+def update_case_panels(store: MongoAdapter, case_obj: dict):
     """Refresh case gene panels with info on if a panel was removed.
+    Also sets the key "latest_panels" for a case where the value is the latest version of the case panels
 
-    Also return these more populated panels for optional storage on the variant_obj.
     If you do not use the returned variants, but rely on the update, please remember
     to call this function before updating the variants.
-
-    store(adapter.MongoAdapter)
-    case_obj(dict)
-
-    Returns:
-        list(panel_info)
     """
+    case_obj["latest_panels"] = []
 
     for panel_info in case_obj.get("panels", []):
         panel_name = panel_info["panel_name"]
         latest_panel = store.gene_panel(panel_name)
         panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
-
-    return case_obj.get("panels", [])
+        latest_panel["hgnc_ids"] = [gene["hgnc_id"] for gene in latest_panel.get("genes", [])]
+        case_obj["latest_panels"].append(latest_panel)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #2733 -> Use latest gene panel for panel overlap in variantS, variant view and case report

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Use the same example as in the original issue -> https://github.com/Clinical-Genomics/scout/issues/2733#issuecomment-869855261

**Expected outcome**:
- Make sure variantS page, variant page and case report don't show panel1 as overlapping to the variant

**Review:**
- [x] code approved by DN
- [x] tests executed by CR

