### PR TITLE
Avoid chanjo2 queries when there are no genes available for stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Block submission of somatic variants to ClinVar, until we don't introduce the changes needed to harmonise with their changed API
 - Additional control on the format of conditions provided in ClinVar form
 - Errors while loading managed variants from file are now displayed on the Managed Variants page
+- Chanjo2 coverage button visible only when query will contain a list of HGNC gene IDs
 ### Fixed
 - Submit requests to Chanjo2 using HTML forms instead of JSON data
 - `Research somatic variants` link name on caseS page

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -86,7 +86,7 @@
     </div>
 
     <!-- If connected to a chanjo or chanjo2 instance, display coverage report -->
-    {% if case.chanjo2_coverage %}
+    {% if case.chanjo2_coverage and case.default_genes %}
       <div href="#" class="bg-dark list-group-item text-white">
         <div class="d-flex flex-row flex-fill bd-highlight">
           <span class="menu-collapsed">Coverage (chanjo2)</span>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -212,7 +212,7 @@
               </form>
             {% endif %}
 
-            {% if case.chanjo2_coverage %}
+            {% if case.chanjo2_coverage and case.dynamic_gene_list %}
               {{ chanjo2_report_form(institute, case, "HPO Panel", 'report', case.dynamic_gene_list|map(attribute='hgnc_id')|join(',')) }} <!--chanjo2 report-->
               {{ chanjo2_report_form(institute, case, "HPO Panel", 'overview', case.dynamic_gene_list|map(attribute='hgnc_id')|join(',')) }} <!--chanjo2 genes overview -->
             {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -212,7 +212,7 @@
               </form>
             {% endif %}
 
-            {% if case.chanjo2_coverage and case.dynamic_gene_list %}
+            {% if case.chanjo2_coverage %}
               {{ chanjo2_report_form(institute, case, "HPO Panel", 'report', case.dynamic_gene_list|map(attribute='hgnc_id')|join(',')) }} <!--chanjo2 report-->
               {{ chanjo2_report_form(institute, case, "HPO Panel", 'overview', case.dynamic_gene_list|map(attribute='hgnc_id')|join(',')) }} <!--chanjo2 genes overview -->
             {% endif %}

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -104,7 +104,7 @@
           </span>
         </li>
       {% endif %}
-      {% if case and case.chanjo2_coverage %}
+      {% if case and case.chanjo2_coverage and panel.genes %}
         <li class="list-group-item">
           <label for="coverage_report">Coverage report (chanjo2)</label>
           <span class="float-end">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4605 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
Deploy on a stage env and test on (testable on cg-vm1 with [safeguinea]():
- A case with no associated default panels

**Expected outcome**:
The link to chanjo2 should NOT be visible

**Review:**
- [x] code approved by Jakob37
- [x] tests executed by Jakob37, CR
