### PR TITLE
Fix case crashing when evaluating ClinVar vars among pinned not loaded variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - End coordinates for indels in ClinVar form
 - Diagnoses API search crashing with empty search string
 - Variant's overlapping panels should show overlapping of variant genes against the latest version of the panel
+- Case page crashing when case has both variants in a ClinVar submission and pinned not loaded variants
 
 ## [4.81]
 ### Added

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -334,7 +334,7 @@ def case(store, institute_obj, case_obj):
     clinvar_variants_not_in_suspects = [
         store.variant(variant_id) or variant_id
         for variant_id in case_obj["clinvar_variants"]
-        if variant_id not in [entry.get("_id") for entry in suspects]
+        if variant_id not in case_obj.get("suspects", [])
     ]
 
     case_obj["clinvar_variants_not_in_suspects"] = clinvar_variants_not_in_suspects

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -4,7 +4,7 @@ import itertools
 import json
 import logging
 import os
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Set
 
 import query_phenomizer
 import requests


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- FIx #4607 --> Case with variants in ClinVar and variants pinned but not loaded, like this --> https://scout-stage.scilifelab.se/cust000/F0006358-mip7

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test this [case](https://scout-stage.scilifelab.se/cust000/F0006358-mip7) with main branch and this branch
2. [Other cases](https://scout-stage.scilifelab.se/cust002/F0025588-0809) with all pinned variants present in the database should work with both branches

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
