### PR TITLE
debug Alchy load and route...

### DIFF
--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -325,11 +325,15 @@ def configure_coverage(app):
     """Setup coverage related extensions."""
     # setup chanjo report
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = True if app.debug else False
+    LOG.debug("configure coverage")
+
     if chanjo_api:
         chanjo_api.init_app(app)
         configure_template_filters(app)
         # register chanjo report blueprint
+        LOG.debug("Current URL map is %s", current_app.url_map)
         app.register_blueprint(report_bp, url_prefix="/reports")
+        LOG.debug("Current URL map is %s", current_app.url_map)
 
     babel = Babel()
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -36,15 +36,16 @@ from .blueprints import (
 
 LOG = logging.getLogger(__name__)
 
-try:
-    from chanjo_report.server.app import configure_template_filters
-    from chanjo_report.server.blueprints import report_bp
-    from chanjo_report.server.extensions import api as chanjo_api
-except ImportError:
-    chanjo_api = None
-    report_bp = None
-    configure_template_filters = None
-    LOG.info("chanjo report not installed!")
+# try:
+from chanjo_report.server.app import configure_template_filters
+from chanjo_report.server.blueprints import report_bp
+from chanjo_report.server.extensions import api as chanjo_api
+
+# except ImportError:
+#    chanjo_api = None
+#    report_bp = None
+#    configure_template_filters = None
+#    LOG.info("chanjo report not installed!")
 
 
 def create_app(config_file=None, config=None):
@@ -331,9 +332,9 @@ def configure_coverage(app):
         chanjo_api.init_app(app)
         configure_template_filters(app)
         # register chanjo report blueprint
-        LOG.debug("Current URL map is %s", current_app.url_map)
+        LOG.debug("Current URL map is %s", app.url_map)
         app.register_blueprint(report_bp, url_prefix="/reports")
-        LOG.debug("Current URL map is %s", current_app.url_map)
+        LOG.debug("Current URL map is %s", app.url_map)
 
     babel = Babel()
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -104,6 +104,8 @@ def case(
 
     data = controllers.case(store, institute_obj, case_obj)
 
+    LOG.debug("Current URL map is %s", current_app.url_map)
+
     return dict(
         **data,
     )

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -39,7 +39,7 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # )
 
 # Chanjo database connection string - used by chanjo report to create coverage reports
-# SQLALCHEMY_DATABASE_URI = "mysql+pymysql://test_user:test_passwordw@127.0.0.1:3306/chanjo"
+SQLALCHEMY_DATABASE_URI = "mysql+pymysql://test_user:test_passwordw@127.0.0.1:3306/chanjo"
 
 # URL to an instance of Chanjo2, for generating coverage report
 # CHANJO2_URL = "http://chanjo2-stage.scilifelab.se"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
