### PR TITLE
Non confirmed sex warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 # [4.82.1]
 ### Added
-- Warning icon in case pages for individuals where `confirmed_sex` is false
+- Warning icon in case pages for individuals where `confirmed_sex` is false 
 ### Fixed
 - Revert the installation of flask-ldapconn to use the version available on PyPI to be able to push new scout releases to PyPI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
-### Added
+### Fixed
 - Warning icon in case pages for individuals where `confirmed_sex` is false 
 
 ## [4.82.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-# [4.82.1]
+## [Unreleased]
 ### Added
 - Warning icon in case pages for individuals where `confirmed_sex` is false 
+
+## [4.82.1]
 ### Fixed
 - Revert the installation of flask-ldapconn to use the version available on PyPI to be able to push new scout releases to PyPI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 # [4.82.1]
+### Added
+- Warning icon in case pages for individuals where `confirmed_sex` is false
 ### Fixed
 - Revert the installation of flask-ldapconn to use the version available on PyPI to be able to push new scout releases to PyPI
 

--- a/scout/server/blueprints/cases/templates/cases/case_bionano.html
+++ b/scout/server/blueprints/cases/templates/cases/case_bionano.html
@@ -1,5 +1,6 @@
 {% extends "cases/case_tabular_view.html" %}
 {% from "utils.html" import comments_panel, activity_panel %}
+{% from "cases/utils.html" import sex_table_cell_content %}
 
 {% block title %}
   {{ super() }}
@@ -96,20 +97,7 @@
                   {% if loop.index == 1 %}
                     <td> {{ ind.display_name }}</td>
                     <td style="font-weight: bold;">
-                    {% if ind.sex_human in ['female','male'] %}
-                      {% if ind.sex_human == 'female' %}
-                        F
-                      {% elif ind.sex_human == 'male' %}
-                        M
-                      {% else %}
-                        {{ind.sex_human}}
-                      {% endif %}
-                    {% endif %}
-                    {% if ind.confirmed_sex %}
-                      <i class="fa fa-check"></i>
-                    {% else %}
-                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
-                    {% endif %}
+                      {% from "cases/utils.html" import sex_table_cell_content %}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>
                   {% else %}
@@ -132,20 +120,7 @@
               <tr class="bg-secondary text-white">
                 <td> {{ ind.display_name }}</td>
                     <td style="font-weight: bold;">
-                    {% if ind.sex_human in ['female','male'] %}
-                      {% if ind.sex_human == 'female' %}
-                        F
-                      {% elif ind.sex_human == 'male' %}
-                        M
-                      {% else %}
-                        {{ind.sex_human}}
-                      {% endif %}
-                    {% endif %}
-                    {% if ind.confirmed_sex %}
-                      <i class="fa fa-check"></i>
-                    {% else %}
-                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
-                    {% endif %}
+                      {% from "cases/utils.html" import sex_table_cell_content %}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>
                   <td colspan="4">N/A</td>

--- a/scout/server/blueprints/cases/templates/cases/case_bionano.html
+++ b/scout/server/blueprints/cases/templates/cases/case_bionano.html
@@ -108,7 +108,7 @@
                     {% if ind.confirmed_sex %}
                       <i class="fa fa-check"></i>
                     {% else %}
-                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
+                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
                     {% endif %}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_bionano.html
+++ b/scout/server/blueprints/cases/templates/cases/case_bionano.html
@@ -97,7 +97,7 @@
                   {% if loop.index == 1 %}
                     <td> {{ ind.display_name }}</td>
                     <td style="font-weight: bold;">
-                      {% from "cases/utils.html" import sex_table_cell_content %}
+                      {{ sex_table_cell_content(ind) }}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>
                   {% else %}
@@ -120,7 +120,7 @@
               <tr class="bg-secondary text-white">
                 <td> {{ ind.display_name }}</td>
                     <td style="font-weight: bold;">
-                      {% from "cases/utils.html" import sex_table_cell_content %}
+                      {{ sex_table_cell_content(ind) }}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>
                   <td colspan="4">N/A</td>

--- a/scout/server/blueprints/cases/templates/cases/case_bionano.html
+++ b/scout/server/blueprints/cases/templates/cases/case_bionano.html
@@ -107,6 +107,8 @@
                     {% endif %}
                     {% if ind.confirmed_sex %}
                       <i class="fa fa-check"></i>
+                    {% else %}
+                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
                     {% endif %}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>
@@ -141,6 +143,8 @@
                     {% endif %}
                     {% if ind.confirmed_sex %}
                       <i class="fa fa-check"></i>
+                    {% else %}
+                      <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
                     {% endif %}
                     </td>
                     <td>{{ ind.phenotype_human }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -116,7 +116,7 @@
 	              {% for ind in case.individuals %}
 	                <tr {% if ind.phenotype == 2 %} class="table-danger" {% endif %}>
 	                  <td>{{ ind.display_name }}</td>
-	                  <td>
+	                  <td bgcolor="red">
                       {% if ind.sex == '2' %}
                         F
                       {% elif ind.sex == '1' %}
@@ -124,9 +124,11 @@
                       {% else %}
                         n.a.
                       {% endif %}
-	                    {% if ind.confirmed_sex %}
-	                      <span class="badge rounded-pill py-1 bg-secondary">V</span>
-	                    {% endif %}
+                      {% if ind.confirmed_sex %}
+                        <i class="fa fa-check"></i>
+                      {% else %}
+                        <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
+                      {% endif %}
 	                  </td>
 	                  <td>
 	                  {% if ind.phenotype==2 %} <!--for later use-->

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -125,7 +125,7 @@
                         n.a.
                       {% endif %}
                       {% if ind.confirmed_sex %}
-                        <i class="fa fa-check"></i>
+                        <span class="badge rounded-pill py-1 bg-secondary">V</span>
                       {% else %}
                         <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
                       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -116,7 +116,7 @@
 	              {% for ind in case.individuals %}
 	                <tr {% if ind.phenotype == 2 %} class="table-danger" {% endif %}>
 	                  <td>{{ ind.display_name }}</td>
-	                  <td bgcolor="red">
+	                  <td>
                       {% if ind.sex == '2' %}
                         F
                       {% elif ind.sex == '1' %}
@@ -127,7 +127,7 @@
                       {% if ind.confirmed_sex %}
                         <i class="fa fa-check"></i>
                       {% else %}
-                        <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
+                        <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
                       {% endif %}
 	                  </td>
 	                  <td>

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -1,7 +1,6 @@
 {% extends "cases/case_tabular_view.html" %}
 {% from "utils.html" import comments_panel, activity_panel %}
 {% from "cases/utils.html" import individuals_table, sex_table_cell_content %}
-{% from "cases/utils.html" import sex_table_cell_content %}
 
 {% block title %}
   {{ super() }}

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -101,7 +101,7 @@
                 {% endif %}>
               <td>{{ ind.display_name }}</td>
               <td style="font-weight: bold;">
-                {% from "cases/utils.html" import sex_table_cell_content %}
+                {{ sex_table_cell_content(ind) }}
               </td>
               <td>{{ ind.phenotype_human }}</td>
               <td>{{ ind.is_sma }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -1,6 +1,7 @@
 {% extends "cases/case_tabular_view.html" %}
 {% from "utils.html" import comments_panel, activity_panel %}
 {% from "cases/utils.html" import individuals_table %}
+{% from "cases/utils.html" import sex_table_cell_content %}
 
 {% block title %}
   {{ super() }}
@@ -100,20 +101,7 @@
                 {% endif %}>
               <td>{{ ind.display_name }}</td>
               <td style="font-weight: bold;">
-                {% if ind.sex_human in ['female','male'] %}
-                  {% if ind.sex_human == 'female' %}
-                    F
-                  {% elif ind.sex_human == 'male' %}
-                    M
-                  {% else %}
-                    {{ind.sex_human}}
-                  {% endif %}
-                {% endif %}
-                {% if ind.confirmed_sex %}
-                  <i class="fa fa-check"></i>
-                {% else %}
-                  <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
-                {% endif %}
+                {% from "cases/utils.html" import sex_table_cell_content %}
               </td>
               <td>{{ ind.phenotype_human }}</td>
               <td>{{ ind.is_sma }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -101,16 +101,18 @@
               <td>{{ ind.display_name }}</td>
               <td style="font-weight: bold;">
                 {% if ind.sex_human in ['female','male'] %}
-                    {% if ind.sex_human == 'female' %}
-                      F
-                    {% elif ind.sex_human == 'male' %}
-                      M
-                    {% else %}
-                      {{ind.sex_human}}
-                    {% endif %}
+                  {% if ind.sex_human == 'female' %}
+                    F
+                  {% elif ind.sex_human == 'male' %}
+                    M
+                  {% else %}
+                    {{ind.sex_human}}
                   {% endif %}
+                {% endif %}
                 {% if ind.confirmed_sex %}
                   <i class="fa fa-check"></i>
+                {% else %}
+                  <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
                 {% endif %}
               </td>
               <td>{{ ind.phenotype_human }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -112,7 +112,7 @@
                 {% if ind.confirmed_sex %}
                   <i class="fa fa-check"></i>
                 {% else %}
-                  <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
+                  <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
                 {% endif %}
               </td>
               <td>{{ ind.phenotype_human }}</td>

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -1,6 +1,6 @@
 {% extends "cases/case_tabular_view.html" %}
 {% from "utils.html" import comments_panel, activity_panel %}
-{% from "cases/utils.html" import individuals_table %}
+{% from "cases/utils.html" import individuals_table, sex_table_cell_content %}
 {% from "cases/utils.html" import sex_table_cell_content %}
 
 {% block title %}

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -149,6 +149,8 @@
                   {% endif %}
                   {% if ind.confirmed_sex %}
                     <i class="fa fa-check"></i>
+                  {% else %}
+                    <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
                   {% endif %}
                 </div>
               </td>

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -1,3 +1,4 @@
+{% from "cases/utils.html" import sex_table_cell_content %}
 
 {% macro cancer_individuals_table(case, institute, tissues, gens_info=None) %}
 <form method="POST" action="{{ url_for('cases.update_cancer_sample', institute_id=institute._id, case_name=case.display_name) }}">
@@ -138,20 +139,7 @@
                   <option {% if not ind.sex_human in ["female", "male"] %} selected= {% endif %} value="unknown">Unknown</option>
                 </select>
                 <div class="sex-display fw-bold">
-                  {% if ind.sex_human in ['female','male'] %}
-                    {% if ind.sex_human == 'female' %}
-                      F
-                    {% elif ind.sex_human == 'male' %}
-                      M
-                    {% else %}
-                      {{ind.sex_human}}
-                    {% endif %}
-                  {% endif %}
-                  {% if ind.confirmed_sex %}
-                    <i class="fa fa-check"></i>
-                  {% else %}
-                    <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
-                  {% endif %}
+                  {{ sex_table_cell_content(ind) }}
                 </div>
               </td>
               <td><input name="age_{{ind.individual_id}}" type="number" step="0.1" min="0"

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -150,7 +150,7 @@
                   {% if ind.confirmed_sex %}
                     <i class="fa fa-check"></i>
                   {% else %}
-                    <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex not confirmed."></span>
+                    <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
                   {% endif %}
                 </div>
               </td>

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -681,3 +681,20 @@
     </div>
   </form>
 {% endmacro %}
+
+{% macro sex_table_cell_content(ind) %}
+  {% if ind.sex_human in ['female','male'] %}
+    {% if ind.sex_human == 'female' %}
+      F
+    {% elif ind.sex_human == 'male' %}
+      M
+    {% else %}
+      {{ind.sex_human}}
+    {% endif %}
+  {% endif %}
+  {% if ind.confirmed_sex %}
+    <i class="fa fa-check"></i>
+  {% else %}
+    <span class="fa fa-exclamation-circle text-danger" data-bs-toggle='tooltip' title="Sex is not confirmed."></span>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Trying again with no slashes in the branch name.

Adds warning icon when sex is not confirmed in case tables. Close #4621 . I looked for locations in the code where `ind.confirmed_sex` is used.

It might be that our geneticists also want warnings for non male/females, but I'll ask them for more details and if so, come back with another issue / PR.

Suggestions are extra welcome as this is my first Scout-PR. On the code but also on PR etiquette. I see the testing checklist, but I guess it is for Stockholm devs with access to that environment.

Tested for the trio in the demo data. After updating the "confirmed_sex" field to "false" in the mongo db as such:

```
db.case.findOne({}, {individuals: 1})
{                                                                                                                   
  _id: 'internal_id',                                                                                                                                                                                                                    
  individuals: [                                                                                                                                                                                                                         
    {                                                                                                                                                                                                                                    
      individual_id: 'ADM1059A2',
      display_name: 'NA12882',
      ...
      confirmed_sex: false,
```

The notice is triggered on the case page.

Before update:

<img width="504" alt="sex_not_confirmed_before" src="https://github.com/Clinical-Genomics/scout/assets/7374399/eb0865d7-8288-4a1a-809e-896c9baa9ed0">

After update:

<img width="507" alt="sex_not_confirmed" src="https://github.com/Clinical-Genomics/scout/assets/7374399/474835b7-207b-4f93-a7fe-879545497270">

Also in the report (unsure here, let me know if not desirable).

Before

<img width="386" alt="case_report_before" src="https://github.com/Clinical-Genomics/scout/assets/7374399/e09d5ab0-4744-4344-8f4e-8d73e43a7902">

After

<img width="268" alt="case_report_after" src="https://github.com/Clinical-Genomics/scout/assets/7374399/cc09634e-7e60-4903-89db-561db7f68207">


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
