### PR TITLE
Fix #4624 - show ExHu STR sizes again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Fixed
-- Warning icon in case pages for individuals where `confirmed_sex` is false 
+- Warning icon in case pages for individuals where `confirmed_sex` is false
+- Show allele sizes form ExpansionHunter on STR variantS page again
 
 ## [4.82.1]
 ### Fixed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -941,7 +941,6 @@ def parse_variant(
         variant_obj["end_chrom"] = variant_obj["chromosome"]
 
     # common motif count for STR variants
-
     variant_obj["str_mc"] = get_str_mc(variant_obj)
 
     # variant level links shown on variants page
@@ -970,7 +969,6 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
     from the variant FORMAT field, or as a number given in the ALT on the form
     '<STR123>'.
     """
-
     alt_mc = None
     if variant_obj["alternative"] == ".":
         return alt_mc
@@ -982,9 +980,9 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
     if alt_mc:
         return alt_mc
 
-    alt_num = NUM.match(variant_obj["alternative"])
+    alt_num = NUM.search(variant_obj["alternative"])
     if alt_num:
-        alt_mc = int(alt_num)
+        alt_mc = int(alt_num.group())
         return alt_mc
 
     return None

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -93,7 +93,7 @@
             <td class="str-link">{{ str_locus_info(variant) }}</td>
 	          <td class="text-end">{{ variant.str_display_ru or variant.str_ru or variant.reference }}</td>
             <td class="text-end"><b><span data-bs-toggle="tooltip" title="{{ variant.alternative }}">{{ variant.str_mc }}</span></b></td>
-        <td class="text-end"><span data-bs-toggle="tooltip" title="{{ variant.reference }}">{{ variant.str_ref or "." }}</span></td>
+            <td class="text-end"><span data-bs-toggle="tooltip" title="{{ variant.reference }}">{{ variant.str_ref or "." }}</span></td>
             <td>{{ str_status(variant) }}</td>
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

I was so sure I tested that? Sorry! 😊 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
