### PR TITLE
Fix MT-report crash when one of the samples is not in chanjo db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed unused load case function
 - Artwork logo sync sketch with png and export svg
 - Clearer exception handling on chanjo-report setup - fail early and visibly
-- mtDNA report crashing one or more samples from a case is not in the chanjo database
+- mtDNA report crashing when one or more samples from a case is not in the chanjo database
 
 ## [4.82.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed unused load case function
 - Artwork logo sync sketch with png and export svg
 - Clearer exception handling on chanjo-report setup - fail early and visibly
-- MT-report crashing when one of the case samples is not in chanjo database
+- mtDNA report crashing one or more samples from a case is not in the chanjo database
 
 ## [4.82.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed unused load case function
 - Artwork logo sync sketch with png and export svg
 - Clearer exception handling on chanjo-report setup - fail early and visibly
+- MT-report crashing when one of the case samples is not in chanjo database
 
 ## [4.82.2]
 ### Fixed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -766,7 +766,7 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
                 Report_Sheet.write(row, col, field)
 
         if coverage_stats and coverage_stats.get(sample_id):
-            # it's None if app is not connected to Chanjo or {} if samples are not in Chanjo db
+            # coverage_stats is None if app is not connected to Chanjo or {} if samples are not in Chanjo db
             # Write coverage stats header after introducing 2 empty lines
             for col, field in enumerate(MT_COV_STATS_HEADER):
                 Report_Sheet.write(row + 3, col, field)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -764,8 +764,8 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
             for col, field in enumerate(line):  # each field in line becomes a cell
                 Report_Sheet.write(row, col, field)
 
+        # coverage_stats is None if app is not connected to Chanjo or {} if samples are not in Chanjo db
         if coverage_stats and sample_id in coverage_stats:
-            # coverage_stats is None if app is not connected to Chanjo or {} if samples are not in Chanjo db
             # Write coverage stats header after introducing 2 empty lines
             for col, field in enumerate(MT_COV_STATS_HEADER):
                 Report_Sheet.write(row + 3, col, field)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -765,7 +765,7 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
             for col, field in enumerate(line):  # each field in line becomes a cell
                 Report_Sheet.write(row, col, field)
 
-        if coverage_stats and coverage_stats.get(sample_id):
+        if coverage_stats and sample_id in coverage_stats:
             # coverage_stats is None if app is not connected to Chanjo or {} if samples are not in Chanjo db
             # Write coverage stats header after introducing 2 empty lines
             for col, field in enumerate(MT_COV_STATS_HEADER):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -732,7 +732,6 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
     """
     today = datetime.datetime.now().strftime(DATE_DAY_FORMATTER)
     samples = case_obj.get("individuals")
-    file_header = MT_EXPORT_HEADER
     coverage_stats = None
     # if chanjo connection is established, include MT vs AUTOSOME coverage stats
     if current_app.config.get("chanjo_report"):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -674,7 +674,7 @@ def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict
     return data
 
 
-def mt_coverage_stats(individuals, ref_chrom="14"):
+def mt_coverage_stats(individuals, ref_chrom="14") -> dict:
     """Send a request to chanjo report endpoint to retrieve MT vs autosome coverage stats
 
     Args:
@@ -765,9 +765,8 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
             for col, field in enumerate(line):  # each field in line becomes a cell
                 Report_Sheet.write(row, col, field)
 
-        if bool(
-            coverage_stats
-        ):  # it's None if app is not connected to Chanjo or {} if samples are not in Chanjo db
+        if coverage_stats and coverage_stats.get(sample_id):
+            # it's None if app is not connected to Chanjo or {} if samples are not in Chanjo db
             # Write coverage stats header after introducing 2 empty lines
             for col, field in enumerate(MT_COV_STATS_HEADER):
                 Report_Sheet.write(row + 3, col, field)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4637

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy and test the MT-report on the case that triggered the bug --> https://scout-stage.scilifelab.se/cust003/21166-trio

**Expected outcome**:
- [x] MT-report should not crash but 2 or the 3 samples will lack coverage data in the Excel reports

**Review:**
- [ ] code approved by
- [x] tests executed by CR
