### PR TITLE
Fix PanelApp panel not saving genes with empty `EnsembleGeneIds` list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Agile issue templates were added globally to the CG-org. Adding custom issue templates to avoid exposing customers
 - PanelApp panel not saving genes with empty `EnsembleGeneIds` list
 
-
 ## [4.82.2]
 ### Fixed
 - Warning icon in case pages for individuals where `confirmed_sex` is false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Clearer exception handling on chanjo-report setup - fail early and visibly
 - mtDNA report crashing when one or more samples from a case is not in the chanjo database
 - Case page crashing on missing phenotype terms
-- PanelApp genes not saving genes with empty `EnsembleGeneIds` list
+- PanelApp panel not saving genes with empty `EnsembleGeneIds` list
 
 ## [4.82.2]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Clearer exception handling on chanjo-report setup - fail early and visibly
 - mtDNA report crashing when one or more samples from a case is not in the chanjo database
 - Case page crashing on missing phenotype terms
+- PanelApp genes not saving genes with empty `EnsembleGeneIds` list
 
 ## [4.82.2]
 ### Fixed

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -376,7 +376,14 @@ class GeneHandler(object):
            mapping(dict): {"A1BG": "ENSG00000121410".}
         """
         pipeline = [
-            {"$group": {"_id": {"ensembl_id": "$ensembl_id", "hgnc_symbol": "$hgnc_symbol"}}}
+            {
+                "$group": {
+                    "_id": {
+                        "hgnc_symbol": "$hgnc_symbol",
+                        "ensembl_id": "$ensembl_id",
+                    }
+                }
+            }
         ]
         result = self.hgnc_collection.aggregate(pipeline)
         mapping = {res["_id"]["hgnc_symbol"]: res["_id"]["ensembl_id"] for res in result}

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Dict
 
 import intervaltree
 from pymongo.errors import BulkWriteError, DuplicateKeyError
@@ -357,15 +358,28 @@ class GeneHandler(object):
 
         return alias_genes
 
-    def ensembl_to_hgnc_mapping(self):
+    def ensembl_to_hgnc_id_mapping(self) -> Dict[str, int]:
         """Return a dictionary with Ensembl ids as keys and hgnc_ids as values
 
         Returns:
-            mapping(dict): {"ENSG00000121410":"A1BG", ...}
+            mapping(dict): {"ENSG00000121410": 5, ...}
         """
         pipeline = [{"$group": {"_id": {"ensembl_id": "$ensembl_id", "hgnc_id": "$hgnc_id"}}}]
         result = self.hgnc_collection.aggregate(pipeline)
         mapping = {res["_id"]["ensembl_id"]: res["_id"]["hgnc_id"] for res in result}
+        return mapping
+
+    def hgnc_symbol_ensembl_id_mapping(self) -> Dict[str, str]:
+        """Return a dictionary with HGNC symbols as keys and Ensembl ids as values.
+
+        Returns:
+           mapping(dict): {"A1BG": "ENSG00000121410".}
+        """
+        pipeline = [
+            {"$group": {"_id": {"ensembl_id": "$ensembl_id", "hgnc_symbol": "$hgnc_symbol"}}}
+        ]
+        result = self.hgnc_collection.aggregate(pipeline)
+        mapping = {res["_id"]["hgnc_symbol"]: res["_id"]["ensembl_id"] for res in result}
         return mapping
 
     def ensembl_genes(self, build=None, add_transcripts=False, id_transcripts=False):

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -130,11 +130,14 @@ def _parse_panelapp_panel(adapter, panel_id, institute, confidence):
             {'version': 3.3, 'date': datetime.datetime(2023, 1, 31, 16, 43, 37, 521719), 'display_name': 'Diabetes - neonatal onset - [GREEN]', 'institute': 'cust000', 'panel_type': 'clinical', 'genes': [list of genes], 'panel_id': '55a9041e22c1fc6711b0c6c0'}
 
     """
-    hgnc_map = adapter.ensembl_to_hgnc_mapping()
+    ensembl_gene_hgnc_id_map: Dict[str, int] = adapter.ensembl_to_hgnc_id_mapping()
+    hgnc_symbol_ensembl_gene_map: Dict[str, str] = adapter.hgnc_symbol_ensembl_id_mapping()
+
     json_lines = fetch_resource(PANELAPP_BASE_URL.format("get_panel") + panel_id, json=True)
     parsed_panel = parse_panel_app_panel(
         panel_info=json_lines["result"],
-        hgnc_map=hgnc_map,
+        ensembl_gene_hgnc_id_map=ensembl_gene_hgnc_id_map,
+        hgnc_symbol_ensembl_gene_map=hgnc_symbol_ensembl_gene_map,
         institute=institute,
         confidence=confidence,
     )

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -7,7 +7,7 @@ functions to load panels into the database
 import logging
 import math
 from datetime import datetime
-from typing import List
+from typing import Dict, List
 
 from click import Abort
 from flask.cli import current_app

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -7,6 +7,7 @@ functions to load panels into the database
 import logging
 import math
 from datetime import datetime
+from typing import List
 
 from click import Abort
 from flask.cli import current_app
@@ -110,7 +111,7 @@ def load_panel(panel_path, adapter, **kwargs):
         raise err
 
 
-def _panelapp_panel_ids():
+def _panelapp_panel_ids() -> List[str]:
     """Fetch all PanelApp panel IDs"""
     json_lines = fetch_resource(PANELAPP_BASE_URL.format("list_panels"), json=True)
     return [panel_info["Panel_Id"] for panel_info in json_lines.get("result", [])]
@@ -132,6 +133,7 @@ def _parse_panelapp_panel(adapter, panel_id, institute, confidence):
     hgnc_map = adapter.ensembl_to_hgnc_mapping()
     json_lines = fetch_resource(PANELAPP_BASE_URL.format("get_panel") + panel_id, json=True)
     parsed_panel = parse_panel_app_panel(
+        adapter=adapter,
         panel_info=json_lines["result"],
         hgnc_map=hgnc_map,
         institute=institute,
@@ -160,7 +162,7 @@ def load_panelapp_panel(adapter, panel_id=None, institute="cust000", confidence=
 
     if not panel_id:
         LOG.info("Fetching all panel app panels")
-        panel_ids = _panelapp_panel_ids()
+        panel_ids: List[str] = _panelapp_panel_ids()
 
     for _ in panel_ids:
         parsed_panel = _parse_panelapp_panel(adapter, _, institute, confidence)

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -133,7 +133,6 @@ def _parse_panelapp_panel(adapter, panel_id, institute, confidence):
     hgnc_map = adapter.ensembl_to_hgnc_mapping()
     json_lines = fetch_resource(PANELAPP_BASE_URL.format("get_panel") + panel_id, json=True)
     parsed_panel = parse_panel_app_panel(
-        adapter=adapter,
         panel_info=json_lines["result"],
         hgnc_map=hgnc_map,
         institute=institute,

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -293,13 +293,16 @@ def parse_panel_app_gene(
 
     ensembl_ids = app_gene["EnsembleGeneIds"]
 
-    if (
-        not ensembl_ids and hgnc_symbol in hgnc_symbol_ensembl_gene_map
-    ):  # This gene is probably tagged as ensembl_ids_known_missing on PanelApp
-        LOG.warning(
-            f"PanelApp gene {hgnc_symbol} does not contain Ensembl IDs. Using Ensembl IDs from internal gene collection instead."
-        )
-        ensembl_ids = [hgnc_symbol_ensembl_gene_map[hgnc_symbol]]
+    if not ensembl_ids:  # This gene is probably tagged as ensembl_ids_known_missing on PanelApp
+        if hgnc_symbol in hgnc_symbol_ensembl_gene_map:
+            LOG.warning(
+                f"PanelApp gene {hgnc_symbol} does not contain Ensembl IDs. Using Ensembl IDs from internal gene collection instead."
+            )
+            ensembl_ids = [hgnc_symbol_ensembl_gene_map[hgnc_symbol]]
+        else:
+            LOG.warning(
+                f"PanelApp gene {hgnc_symbol} does not contain Ensembl IDs and gene symbol does not correspond to a gene in scout."
+            )
 
     hgnc_ids = set(
         ensembl_gene_hgnc_id_map.get(ensembl_id)

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -297,7 +297,7 @@ def parse_panel_app_gene(
         not ensembl_ids and hgnc_symbol in hgnc_symbol_ensembl_gene_map
     ):  # This gene is probably tagged as ensembl_ids_known_missing on PanelApp
         LOG.warning(
-            f"Gene {hgnc_symbol} does not contain Ensembl IDs. Retrieving Ensembl IDs from Scout instead."
+            f"PanelApp gene {hgnc_symbol} does not contain Ensembl IDs. Using Ensembl IDs from internal gene collection instead."
         )
         ensembl_ids = [hgnc_symbol_ensembl_gene_map[hgnc_symbol]]
 

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -278,7 +278,7 @@ def parse_gene_panel(
 def parse_panel_app_gene(
     app_gene: dict,
     ensembl_gene_hgnc_id_map: Dict[str, int],
-    hgnc_symbol_ensembl_gene_map: [str, str],
+    hgnc_symbol_ensembl_gene_map: Dict[str, str],
     confidence: str,
 ) -> dict:
     """Parse a panel app-formatted gene."""

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -2,7 +2,7 @@
 
 import logging
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from scout.constants import (
     INCOMPLETE_PENETRANCE_MAP,
@@ -276,7 +276,7 @@ def parse_gene_panel(
 
 
 def parse_panel_app_gene(
-    adapter: "scout.adapter.MongoAdapter", app_gene: dict, hgnc_map: Dict[str, int], confidence: str
+    adapter, app_gene: dict, hgnc_map: Dict[str, int], confidence: str
 ) -> dict:
     """Parse a panel app-formatted gene."""
 
@@ -324,7 +324,7 @@ def parse_panel_app_gene(
 
 
 def parse_panel_app_panel(
-    adapter: "scout.adapter.MongoAdapter",
+    adapter,
     panel_info: dict,
     hgnc_map: Dict[str, int],
     institute: Optional[str] = "cust000",

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -275,9 +275,7 @@ def parse_gene_panel(
     return gene_panel
 
 
-def parse_panel_app_gene(
-    adapter, app_gene: dict, hgnc_map: Dict[str, int], confidence: str
-) -> dict:
+def parse_panel_app_gene(app_gene: dict, hgnc_map: Dict[str, int], confidence: str) -> dict:
     """Parse a panel app-formatted gene."""
 
     gene_info = {}
@@ -294,9 +292,11 @@ def parse_panel_app_gene(
         LOG.warning(
             f"Gene {hgnc_symbol} does not contain Ensembl IDs. Retrieving Ensembl IDs from Scout instead."
         )
+        """
         scout_genes_by_symbol: List[dict] = adapter.gene_by_symbol_or_aliases(symbol=hgnc_symbol)
         for scout_gene in scout_genes_by_symbol:
             ensembl_ids.append(scout_gene.get("ensembl_id"))
+        """
 
     hgnc_ids = set(
         hgnc_map.get(ensembl_id) for ensembl_id in ensembl_ids if hgnc_map.get(ensembl_id)

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -438,6 +438,32 @@ def test_gene_by_symbol_or_aliases(adapter, parsed_gene):
     assert type(result) != list
 
 
+def test_ensembl_to_hgnc_id_mapping(adapter, parsed_gene):
+    """Test the function that maps Ensembl gene IDs to HGNC gene IDs."""
+
+    # GIVEN a database containing a gene
+    adapter.load_hgnc_gene(parsed_gene)
+
+    # WHEN using the mapping function
+    result = adapter.ensembl_to_hgnc_id_mapping()
+
+    # THEN it should return the expected result
+    assert result == {parsed_gene["ensembl_id"]: parsed_gene["hgnc_id"]}
+
+
+def test_hgnc_symbol_ensembl_id_mapping(adapter, parsed_gene):
+    """Test the function that maps HGNC symbols to Ensembl gene IDs."""
+
+    # GIVEN a database containing a gene
+    adapter.load_hgnc_gene(parsed_gene)
+
+    # WHEN using the mapping function
+    result = adapter.hgnc_symbol_ensembl_id_mapping()
+
+    # THEN it should return the expected result
+    assert result == {parsed_gene["hgnc_symbol"]: parsed_gene["ensembl_id"]}
+
+
 #################### HGNC transcript tests ####################
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix [this issue](https://github.com/Clinical-Genomics/scout/issues/4070#issuecomment-2136766038)

Note that there are some genes that are missing Ensembl IDs in PanelApp, for instance [KCNJ18](https://panelapp.genomicsengland.co.uk/panels/entities/KCNJ18) (only by chance this gene is present only in build 38 in scout)

<img width="851" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/bdfe675c-2237-4f88-8168-e45a4765ef26">

The problem is that scout relies on Ensembl gene - HGNC ID  mappings to load the genes in PanelApp panels


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

**How to test**:
Try loading the panel 229 (all genes, also red ones) in scout using main branch and this branch (you should load genes in both builds first):

`scout --demo load panel --panel-app --institute cust000 --panel-id 229 --panel-app-confidence red`


**Expected outcome**:
- Using this branch KCNJ18 gene should be saved in the panel and the loading process should be showing a warning for missing Ensembl Ids in the PanelApp gene.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
