### PR TITLE
A small projection on panels, and use sets instead of explicit loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ACMG benign modifiers
 - Speed up tests by caching python env correctly in Github action
 - Agile issue templates were added globally to the CG-org. Adding custom issue templates to avoid exposing customers.
+- Speed up checking outdated gene panels
 
 ## [4.82.2]
 ### Fixed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -63,6 +63,8 @@ JSON_HEADERS = {
 
 COVERAGE_REPORT_TIMEOUT = 20
 
+PANEL_PROJECTION = {"version": 1, "display_name": 1, "genes": 1}
+
 
 def phenomizer_diseases(hpo_ids, case_obj, p_value_treshold=1):
     """Return the list of HGNC symbols that match annotated HPO terms on Phenomizer
@@ -498,8 +500,12 @@ def _get_default_panel_genes(store: MongoAdapter, case_obj: dict) -> list:
             continue
         panel_name = panel_info["panel_name"]
         panel_version = panel_info.get("version")
-        panel_obj = store.gene_panel(panel_name, version=panel_version)
-        latest_panel = store.gene_panel(panel_name)
+        panel_obj = store.gene_panel(
+            panel_name,
+            version=panel_version,
+            projection=PANEL_PROJECTION,
+        )
+        latest_panel = store.gene_panel(panel_name, projection=PANEL_PROJECTION)
         panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
         if not panel_obj:
             panel_obj = latest_panel
@@ -557,19 +563,17 @@ def check_outdated_gene_panel(panel_obj, latest_panel):
         missing_genes, extra_genes
     """
     # Create a list of minified gene object for the case panel {hgnc_id, gene_symbol}
-    case_panel_genes = [
-        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
-        for gene in panel_obj["genes"]
-    ]
+    case_panel_genes = set([gene.get("symbol", gene["hgnc_id"]) for gene in panel_obj["genes"]])
     # And for the latest panel
-    latest_panel_genes = [
-        {"hgnc_id": gene["hgnc_id"], "symbol": gene.get("symbol", gene["hgnc_id"])}
-        for gene in latest_panel["genes"]
-    ]
+    latest_panel_genes = set(
+        [gene.get("symbol", gene["hgnc_id"]) for gene in latest_panel["genes"]]
+    )
     # Extract the genes unique to case panel
-    extra_genes = [gene["symbol"] for gene in case_panel_genes if gene not in latest_panel_genes]
+    extra_genes = case_panel_genes.difference(latest_panel_genes)
+
     # Extract the genes unique to latest panel
-    missing_genes = [gene["symbol"] for gene in latest_panel_genes if gene not in case_panel_genes]
+    missing_genes = latest_panel_genes.difference(case_panel_genes)
+
     return extra_genes, missing_genes
 
 


### PR DESCRIPTION
This PR speeds up a slow controller, partially addressing #4655.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, also automated tests since this is supposed to be just a refactor
