### PR TITLE
Speedup case page by saving in database (institute document) the list of safe genes for the institute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide mtDNA report and coverage report links on case sidebar for cases with WTS data only
 - Modified OMIM-AUTO gene panel to include genes in both genome builds
 - Moved chanjo code into a dedicated extension
+- Speed up case loading by save the list of genes included in `Gene panels available for other variants matching` (institute settings) in institute's database documents
 ### Fixed
 - Fix several tests that relied on number of events after setup to be 0
 - Removed unused load case function

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -96,7 +96,7 @@ class InstituteHandler(object):
             "frequency_cutoff": frequency_cutoff,
             "gene_panels": gene_panels,
             "gene_panels_matching": gene_panels_matching,
-            "loqusdb_id": loqusdb_ids,
+            "safe_genes_matching": self.safe_genes_filter(internal_id),
             "sanger_recipients": sanger_recipients,
             "clinvar_submitters": clinvar_submitters,
         }
@@ -158,7 +158,7 @@ class InstituteHandler(object):
 
         return institute_obj
 
-    def safe_genes_filter(self, institute_id):
+    def safe_genes_filter(self, institute_id) -> List[int]:
         """Returns a list of "safe" HGNC IDs to filter variants with. These genes are retrieved from the institute.gene_panels_matching
         Can be used to limit secondary findings when retrieving other causatives or matching managed variants
 
@@ -174,7 +174,7 @@ class InstituteHandler(object):
             return safe_genes  # return an empty list
         for panel_name in institute_obj.get("gene_panels_matching", {}).keys():
             safe_genes += self.panel_to_genes(panel_name=panel_name, gene_format="hgnc_id")
-        return safe_genes
+        return list(set(safe_genes))
 
     def institutes(self, institute_ids=None):
         """Fetch all institutes.

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -96,7 +96,6 @@ class InstituteHandler(object):
             "frequency_cutoff": frequency_cutoff,
             "gene_panels": gene_panels,
             "gene_panels_matching": gene_panels_matching,
-            "safe_genes_matching": self.safe_genes_filter(internal_id),
             "loqusdb_id": loqusdb_ids,
             "sanger_recipients": sanger_recipients,
             "clinvar_submitters": clinvar_submitters,
@@ -145,10 +144,22 @@ class InstituteHandler(object):
 
             LOG.info("Institute updated")
 
+        self.update_institutes_safe_genes(institute_id=internal_id)
+
         return updated_institute
 
+    def update_institutes_safe_genes(self, institute_id: str):
+        """Update the list of genes from gene panels considered safe for matching variants for one institute.
+        These panels are set by modifying the `Gene panels available for other variants matching` multiselect on institute's settings page.
+        """
+        self.institute_collection.find_one_and_update(
+            {"_id": institute_id},
+            {"$set": {"safe_genes_matching": self.safe_genes_filter(institute_id)}},
+        )
+        LOG.warning("Updated list of institute's safe genes.")
+
     def institute(self, institute_id: str):
-        """Featch a single institute from the backend
+        """Fetch a single institute from the backend
 
         Returns:
             Institute object

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -97,6 +97,7 @@ class InstituteHandler(object):
             "gene_panels": gene_panels,
             "gene_panels_matching": gene_panels_matching,
             "safe_genes_matching": self.safe_genes_filter(internal_id),
+            "loqusdb_id": loqusdb_ids,
             "sanger_recipients": sanger_recipients,
             "clinvar_submitters": clinvar_submitters,
         }

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -195,6 +195,9 @@ class PanelHandler:
         # Else create a new panel document with a given version
         result = self.panel_collection.insert_one(panel_obj)
         LOG.debug("Panel saved")
+
+        self.update_institutes_safe_genes(institute_id=panel_obj["institute"])
+
         return result.inserted_id
 
     def panel(
@@ -225,6 +228,7 @@ class PanelHandler:
         LOG.warning(
             "Deleting panel %s, version %s" % (panel_obj["panel_name"], panel_obj["version"])
         )
+        self.update_institutes_safe_genes(institute_id=panel_obj["institute"])
         return res
 
     def gene_panel(
@@ -367,7 +371,7 @@ class PanelHandler:
         return gene_list
 
     def update_panel(self, panel_obj, version=None, date_obj=None, maintainer=None):
-        """Replace a existing gene panel with a new one
+        """Replace an existing gene panel with a new one
 
         Keeps the object id
 
@@ -403,7 +407,6 @@ class PanelHandler:
             panel_obj,
             return_document=pymongo.ReturnDocument.AFTER,
         )
-
         return updated_panel
 
     def add_pending(self, panel_obj, hgnc_gene, action, info=None):
@@ -548,6 +551,8 @@ class PanelHandler:
 
             # insert the new panel
             inserted_id = self.panel_collection.insert_one(new_panel).inserted_id
+
+        self.update_institutes_safe_genes(institute_id=panel_obj["institute"])
 
         return inserted_id
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -398,14 +398,16 @@ def case(store, institute_obj, case_obj):
         )
 
     # Limit secondary findings according to institute settings
-    limit_genes = store.safe_genes_filter(institute_obj["_id"])
+    institute_safe_genes: List[int] = institute_obj.get(
+        "safe_genes_matching"
+    ) or store.safe_genes_filter(institute_obj["_id"])
 
     limit_genes_default_panels = _limit_genes_on_default_panels(
-        case_obj["default_genes"], limit_genes
+        case_obj["default_genes"], institute_safe_genes
     )
 
     other_causatives, other_causatives_in_default_panels = _matching_causatives(
-        store, case_obj, limit_genes, limit_genes_default_panels
+        store, case_obj, institute_safe_genes, limit_genes_default_panels
     )
 
     data = {
@@ -414,7 +416,7 @@ def case(store, institute_obj, case_obj):
         "other_causatives": other_causatives,
         "default_other_causatives": other_causatives_in_default_panels,
         "managed_variants": [
-            var for var in store.check_managed(case_obj=case_obj, limit_genes=limit_genes)
+            var for var in store.check_managed(case_obj=case_obj, limit_genes=institute_safe_genes)
         ],
         "default_managed_variants": [
             var

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -400,9 +400,11 @@ def case(store, institute_obj, case_obj):
         )
 
     # Limit secondary findings according to institute settings
-    institute_safe_genes: List[int] = institute_obj.get(
-        "safe_genes_matching"
-    ) or store.safe_genes_filter(institute_obj["_id"])
+    institute_safe_genes: List[int] = (
+        institute_obj["safe_genes_matching"]
+        if "safe_genes_matching" in institute_obj
+        else store.safe_genes_filter(institute_obj["_id"])
+    )
 
     limit_genes_default_panels = _limit_genes_on_default_panels(
         case_obj["default_genes"], institute_safe_genes


### PR DESCRIPTION
This PR adds a functionality
- Speed up case loading by save the list of genes included in `Gene panels available for other variants matching` (institute settings) in institute's database documents

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Go to institute settings and select as many panels as possible in this multiselect:
<img width="479" alt="image" src="https://github.com/Clinical-Genomics/scout/assets/28093618/8332ecd1-7011-4448-a390-f5cbde0db520">

1. **Save institute settings and go to a case (Save also if you haven't changed any settings)**

**Expected outcome**:
1. Case page should load a bit faster

**Review:**
- [ ] code approved by
- [ ] tests executed by