### PR TITLE
Small event projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide mtDNA report and coverage report links on case sidebar for cases with WTS data only
 - Modified OMIM-AUTO gene panel to include genes in both genome builds
 - Moved chanjo code into a dedicated extension
+- Users must actively select "show matching causatives/managed" on a case page to see matching numbers
 ### Fixed
 - Fix several tests that relied on number of events after setup to be 0
 - Removed unused load case function

--- a/scout/adapter/client.py
+++ b/scout/adapter/client.py
@@ -4,6 +4,7 @@ client.py
 Establish a connection to the database
 
 """
+
 import logging
 
 from pymongo import MongoClient

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -543,7 +543,7 @@ class VariantHandler(VariantLoader):
                 "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
                 "category": "variant",
             },
-            {"case": 1, "link": 1},
+            {"case": 1, "link": 1, "subject": 1},
         )
 
         positional_variant_ids = set()

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -542,7 +542,8 @@ class VariantHandler(VariantLoader):
                 "institute": case_obj["owner"],
                 "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
                 "category": "variant",
-            }
+            },
+            {"case": 1, "link": 1},
         )
 
         positional_variant_ids = set()
@@ -553,7 +554,7 @@ class VariantHandler(VariantLoader):
 
             other_case = self.case(var_event["case"], CASE_CAUSATIVES_PROJECTION)
             if other_case is None:
-                # Other variant belongs to a case that   doesn't exist any more
+                # Other variant belongs to a case that doesn't exist anymore
                 continue
             other_link = var_event["link"]
             # link contains other variant ID

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -1,4 +1,5 @@
 """Code for CLI base"""
+
 import logging
 import pathlib
 

--- a/scout/parse/disease_terms.py
+++ b/scout/parse/disease_terms.py
@@ -1,4 +1,5 @@
 """Code for parsing disease terms from OMIM and ORPHA data"""
+
 import logging
 from typing import Dict, List
 

--- a/scout/parse/omim.py
+++ b/scout/parse/omim.py
@@ -1,4 +1,5 @@
 """Code for parsing OMIM formatted files"""
+
 import logging
 from typing import Any, Dict, Iterable
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -281,7 +281,7 @@ def sma_case(store, institute_obj, case_obj):
     return data
 
 
-def case(store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching: str) -> dict:
+def case(store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching = "yes": str) -> dict:
     """Preprocess a single case.
 
     Prepare the case to be displayed in the case view.

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -391,19 +391,19 @@ def case(store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching
             "case_images", case_obj["custom_images"].get("case", {})
         )
 
-    # Limit secondary findings according to institute settings
-    limit_genes = store.safe_genes_filter(institute_obj["_id"])
-
-    limit_genes_default_panels = _limit_genes_on_default_panels(
-        case_obj["default_genes"], limit_genes
-    )
-
     other_causatives = []
     other_causatives_in_default_panels = []
     default_managed_variants = []
     managed_variants = []
 
     if hide_matching == "no":
+        # Limit secondary findings according to institute settings
+        limit_genes = store.safe_genes_filter(institute_obj["_id"])
+
+        limit_genes_default_panels = _limit_genes_on_default_panels(
+            case_obj["default_genes"], limit_genes
+        )
+
         other_causatives, other_causatives_in_default_panels = _matching_causatives(
             store, case_obj, limit_genes, limit_genes_default_panels
         )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1424,13 +1424,13 @@ def _matching_causatives(
     other_causatives_in_default_panels = []
 
     for causative in matching_causatives:
-        hgnc_ids = [gene.get("hgnc_id") for gene in causative.get("genes", [])]
+        hgnc_ids = {gene.get("hgnc_id") for gene in causative.get("genes", [])}
         # Fetch all matching causatives if no causatives_filter defined
         # or only causatives matching the filter:
-        if not other_causatives_filter or (set(hgnc_ids) & set(other_causatives_filter)):
+        if not other_causatives_filter or (hgnc_ids & set(other_causatives_filter)):
             other_causatives.append(causative)
         # Only matching causatives in default gene panels:
-        if set(hgnc_ids) & set(other_causatives_in_default_panels_filter):
+        if hgnc_ids & set(other_causatives_in_default_panels_filter):
             other_causatives_in_default_panels.append(causative)
 
     return other_causatives, other_causatives_in_default_panels

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -281,22 +281,14 @@ def sma_case(store, institute_obj, case_obj):
     return data
 
 
-def case(store, institute_obj, case_obj):
+def case(store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching: str) -> dict:
     """Preprocess a single case.
 
     Prepare the case to be displayed in the case view.
 
-    Args:
-        store(adapter.MongoAdapter)
-        institute_obj(models.Institute)
-        case_obj(models.Case)
-
-    Returns:
-        data(dict): includes the cases, how many there are and the limit.
-
+    The return data dict includes the cases, how many there are and the limit.
     """
     # Convert individual information to more readable format
-
     _populate_case_individuals(case_obj)
 
     case_obj["assignees"] = [
@@ -406,24 +398,33 @@ def case(store, institute_obj, case_obj):
         case_obj["default_genes"], limit_genes
     )
 
-    other_causatives, other_causatives_in_default_panels = _matching_causatives(
-        store, case_obj, limit_genes, limit_genes_default_panels
-    )
+    other_causatives = []
+    other_causatives_in_default_panels = []
+    default_managed_variants = []
+    managed_variants = []
+
+    if hide_matching == "no":
+        other_causatives, other_causatives_in_default_panels = _matching_causatives(
+            store, case_obj, limit_genes, limit_genes_default_panels
+        )
+
+        managed_variants = [
+            var for var in store.check_managed(case_obj=case_obj, limit_genes=limit_genes)
+        ]
+        default_managed_variants = [
+            var
+            for var in store.check_managed(
+                case_obj=case_obj, limit_genes=limit_genes_default_panels
+            )
+        ]
 
     data = {
         "institute": institute_obj,
         "case": case_obj,
         "other_causatives": other_causatives,
         "default_other_causatives": other_causatives_in_default_panels,
-        "managed_variants": [
-            var for var in store.check_managed(case_obj=case_obj, limit_genes=limit_genes)
-        ],
-        "default_managed_variants": [
-            var
-            for var in store.check_managed(
-                case_obj=case_obj, limit_genes=limit_genes_default_panels
-            )
-        ],
+        "managed_variants": managed_variants,
+        "default_managed_variants": default_managed_variants,
         "comments": store.events(institute_obj, case=case_obj, comments=True),
         "hpo_groups": pheno_groups,
         "case_groups": case_groups,
@@ -445,6 +446,7 @@ def case(store, institute_obj, case_obj):
         "mme_nodes": matchmaker.connected_nodes,
         "gens_info": gens.connection_settings(case_obj.get("genome_build")),
         "display_rerunner": rerunner.connection_settings.get("display", False),
+        "hide_matching": hide_matching,
     }
 
     return data

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -282,7 +282,7 @@ def sma_case(store, institute_obj, case_obj):
 
 
 def case(
-    store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching: str = "yes"
+    store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching: bool = True
 ) -> dict:
     """Preprocess a single case.
 
@@ -398,7 +398,7 @@ def case(
     default_managed_variants = []
     managed_variants = []
 
-    if hide_matching == "no":
+    if hide_matching is False:
         # Limit secondary findings according to institute settings
         limit_genes = store.safe_genes_filter(institute_obj["_id"])
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -281,7 +281,9 @@ def sma_case(store, institute_obj, case_obj):
     return data
 
 
-def case(store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching = "yes": str) -> dict:
+def case(
+    store: MongoAdapter, institute_obj: dict, case_obj: dict, hide_matching: str = "yes"
+) -> dict:
     """Preprocess a single case.
 
     Prepare the case to be displayed in the case view.

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -147,7 +147,7 @@
         <div class="row mt-0">
           <div class="col-sm-12 col-md-12">
            <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
-            that have been marked as causative in another case for this insitute, or are on the managed variants list.">
+            that have been marked as causative in another case for this institute, or are on the managed variants list.">
               <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body">Show matching causatives and managed variants</a></strong>
            </div>
           </div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -120,30 +120,39 @@
       </div>
 
       <div class="card panel-default" >
-      {% if other_causatives|length > 0%}
-        <div class="row mt-0">
-          <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
-        </div>
-      {% endif %}
-      {% if default_other_causatives|length > 0%}
-        <div class="row mt-0">
-          <div class="col-xs-12 col-md-12">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
-        </div>
-      {% endif %}
+      {% if hide_matching == "no" %}
+        {% if other_causatives|length > 0%}
+          <div class="row mt-0">
+            <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
+          </div>
+        {% endif %}
+        {% if default_other_causatives|length > 0%}
+          <div class="row mt-0">
+            <div class="col-xs-12 col-md-12">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
+          </div>
+        {% endif %}
 
-      {% if managed_variants|length > 0%}
+        {% if managed_variants|length > 0%}
+          <div class="row mt-0">
+            <div class="col-sm-12 col-md-12">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
+          </div>
+        {% endif %}
+
+        {% if default_managed_variants|length > 0%}
+          <div class="row mt-0">
+            <div class="col-sm-12 col-md-12">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
+          </div>
+        {% endif %}
+      {% else %}
         <div class="row mt-0">
-          <div class="col-sm-12 col-md-12">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
+          <div class="col-sm-12 col-md-12">
+           <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
+            that have been marked as causative in another case for this insitute, or are on the managed variants list.">
+              <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='no') }}" class="text-body">Show matching causatives and managed variants</a></strong>
+           </div>
+          </div>
         </div>
       {% endif %}
-
-      {% if default_managed_variants|length > 0%}
-        <div class="row mt-0">
-          <div class="col-sm-12 col-md-12">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
-        </div>
-      {% endif %}
-      </div>
-
       <div class="row">
         <div class="col">{{ causatives_list(causatives, partial_causatives, evaluated_variants, institute, case, manual_rank_options, cancer_tier_options) }}</div>
         <div class="col">{{ suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) }}</div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -120,38 +120,45 @@
       </div>
 
       <div class="card panel-default" >
-      {% if hide_matching == false %}
-        {% if other_causatives|length > 0%}
-          <div class="row mt-0">
-            <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
-          </div>
-        {% endif %}
-        {% if default_other_causatives|length > 0%}
-          <div class="row mt-0">
-            <div class="col-xs-12 col-md-12">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
-          </div>
-        {% endif %}
-
-        {% if managed_variants|length > 0%}
-          <div class="row mt-0">
-            <div class="col-sm-12 col-md-12">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
-          </div>
-        {% endif %}
-
-        {% if default_managed_variants|length > 0%}
-          <div class="row mt-0">
-            <div class="col-sm-12 col-md-12">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
-          </div>
-        {% endif %}
-      {% else %}
         <div class="row mt-0">
-          <div class="col-sm-12 col-md-12">
-           <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
-            that have been marked as causative in another case for this institute, or are on the managed variants list.">
-              <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body">Show matching causatives and managed variants</a></strong>
+          <div class="col-sm-12 col-md-12 ms-3">
+           <div data-bs-toggle='tooltip' class="panel-heading" title="Check if there are any variants in this case
+              marked as causative in another case for this institute, or are on the managed variants list.">
+             <strong>{% if hide_matching == false %}
+               <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='True') }}" class="text-body"><span class="me-1 fa fa-caret-right"></span>Search for matching causatives and managed variants</a>
+             {% else %}
+               <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body"><span class="me-1 fa fa-caret-down"></span>Search for matching causatives and managed variants</a>
+             {% endif %}
+             </strong>
            </div>
           </div>
         </div>
+        {% if hide_matching == false %}
+        {% if other_causatives|length > 0 %}
+          <div class="row mt-0 ms-3">
+            <div class="col-xs-12 col-md-12 ms-3">{{ matching_causatives(other_causatives, institute, case) }}</div>
+          </div>
+        {% endif %}
+        {% if default_other_causatives|length > 0%}
+          <div class="row mt-0 ms-3">
+            <div class="col-xs-12 col-md-12 ms-3">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
+          </div>
+        {% endif %}
+        {% if managed_variants|length > 0%}
+          <div class="row mt-0 ms-3">
+            <div class="col-sm-12 col-md-12 ms-3">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
+          </div>
+        {% endif %}
+        {% if default_managed_variants|length > 0%}
+          <div class="row mt-0 ms-3">
+            <div class="col-sm-12 col-md-12 ms-3">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
+          </div>
+        {% endif %}
+        {% if other_causatives|length == 0 and default_other_causatives|length == 0 and managed_variants|length == 0 and default_managed_variants|length == 0%}
+          <div class="row mt-0 ms-3">
+            <div class="col-sm-12 col-md-12 ms-3">No matching causatives or managed variants found</div>
+          </div>
+        {% endif %}
       {% endif %}
       <div class="row">
         <div class="col">{{ causatives_list(causatives, partial_causatives, evaluated_variants, institute, case, manual_rank_options, cancer_tier_options) }}</div>

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -120,7 +120,7 @@
       </div>
 
       <div class="card panel-default" >
-      {% if hide_matching == "no" %}
+      {% if hide_matching == false %}
         {% if other_causatives|length > 0%}
           <div class="row mt-0">
             <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
@@ -148,7 +148,7 @@
           <div class="col-sm-12 col-md-12">
            <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
             that have been marked as causative in another case for this insitute, or are on the managed variants list.">
-              <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='no') }}" class="text-body">Show matching causatives and managed variants</a></strong>
+              <strong><a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body">Show matching causatives and managed variants</a></strong>
            </div>
           </div>
         </div>

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -633,8 +633,8 @@
 
 {% macro matching_causatives(other_causatives, institute, case, default=False) %}
     <div data-bs-toggle='tooltip' class="panel-heading" title="If there are any variants in this case
-      that have been marked as causative in another case for this insitute. {% if default %}Variants in default panels for the case only.{% endif %}">
-      <strong><a data-bs-toggle="collapse" href="#matchingCausatives{% if default %}Default{% endif %}" class="text-body">Matching causatives {% if default %}in case default panels{% endif %}({{other_causatives|length}})</a></strong>
+      matching a causative in another case for this institute. {% if default %}Variants in default panels for the case only.{% endif %}">
+      <strong><a data-bs-toggle="collapse" href="#matchingCausatives{% if default %}Default{% endif %}" class="text-body" aria-expanded="false"><span class="collapse-icon me-1"></span>Matching causatives {% if default %}in case default panels{% endif %}({{other_causatives|length}})</a></strong>
     </div>
     <ul class="list-group collapse" id="matchingCausatives{% if default %}Default{% endif %}">
       {% for variant in other_causatives %}
@@ -650,7 +650,7 @@
 {% macro matching_managed_variants(managed_variants, institute, case, default=False) %}
     <div data-bs-toggle='tooltip' class="panel-heading" title="Any variants in this case
       that have been marked as managed. {% if default %}Variants in default panels for the case only.{% endif %}">
-      <strong><a data-bs-toggle="collapse" class="text-body" href="#matchingManaged{% if default %}Default{% endif %}">Managed variants {% if default %}in case default panels{% endif %}({{managed_variants|length}})</a></strong>
+      <strong><a data-bs-toggle="collapse" class="text-body" href="#matchingManaged{% if default %}Default{% endif %}" aria-expanded="false"><span class="collapse-icon me-1"></span>Managed variants {% if default %}in case default panels{% endif %}({{managed_variants|length}})</a></strong>
     </div>
     <ul class="list-group">
       {% for variant in managed_variants %}

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -4,8 +4,8 @@ import json
 import logging
 import os.path
 import shutil
-from io import BytesIO
 from ast import literal_eval
+from io import BytesIO
 from operator import itemgetter
 from typing import Generator, Optional, Union
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -5,6 +5,7 @@ import logging
 import os.path
 import shutil
 from io import BytesIO
+from ast import literal_eval
 from operator import itemgetter
 from typing import Generator, Optional, Union
 
@@ -102,7 +103,9 @@ def case(
         return redirect(request.referrer)
 
     hide_matching = (
-        request.args.get("hide_matching") if request.args.get("hide_matching") else "yes"
+        literal_eval(request.args.get("hide_matching"))
+        if request.args.get("hide_matching")
+        else True
     )
     data = controllers.case(store, institute_obj, case_obj, hide_matching)
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -86,7 +86,6 @@ def case(
     So do case_id, but we still call institute_and_case again to fetch institute
     and reuse its user access verification.
     """
-
     if case_id:
         case_obj = store.case(case_id=case_id, projection={"display_name": 1, "owner": 1})
 
@@ -102,7 +101,10 @@ def case(
         flash("Case {} does not exist in database!".format(case_name))
         return redirect(request.referrer)
 
-    data = controllers.case(store, institute_obj, case_obj)
+    hide_matching = (
+        request.args.get("hide_matching") if request.args.get("hide_matching") else "yes"
+    )
+    data = controllers.case(store, institute_obj, case_obj, hide_matching)
 
     return dict(
         **data,

--- a/scout/server/extensions/beacon_extension.py
+++ b/scout/server/extensions/beacon_extension.py
@@ -1,6 +1,7 @@
 """Scout supports integration with the Clinical Genomics SciLifeLab Beacon
    cgbeacon2: https://github.com/Clinical-Genomics/cgbeacon2
 """
+
 import datetime
 import logging
 

--- a/scout/server/extensions/phenopacket_extension.py
+++ b/scout/server/extensions/phenopacket_extension.py
@@ -3,6 +3,7 @@ Extension to Scout for Phenopacket integration (http://phenopackets.org).
 Write and read JSON Phenopackets, and interact with phenopacket-api backend
 (https://github.com/squeezeday/phenopacket-api).
 """
+
 import json as json_lib
 import logging
 

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -351,6 +351,24 @@ body {
 }
 /* end of sidebar-related stuff */
 
+/* Closed submenu icon - general case */
+.text-body[aria-expanded="false"] .collapse-icon::after {
+  content: " \f0d7";
+  font-family: "Font Awesome 5 Free", ui-monospace;
+  font-weight: 900;
+  display: inline;
+  text-align: left;
+}
+/* Opened submenu icon - general case */
+.text-body[aria-expanded="true"] .collapse-icon::after {
+  content: " \f0da";
+  font-family: "Font Awesome 5 Free", ui-monospace;
+  font-weight: 900;
+  display: inline;
+  text-align: left;
+}
+/* end of sidebar-related stuff */
+
 option {
   width: 100%;
 }

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,4 +1,5 @@
 """Tests for the cases controllers"""
+
 import requests
 import responses
 from flask import Blueprint, Flask, url_for


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

I added a very simple hiding functionality for matching causatives. They will now only show (and compute) on the case page if requested. 

![Screenshot 2024-06-04 at 13 16 59](https://github.com/Clinical-Genomics/scout/assets/758570/5ef439c7-ff95-4b10-bc6a-5b52799ce6ce)

And clicking it:
![Screenshot 2024-06-04 at 13 17 07](https://github.com/Clinical-Genomics/scout/assets/758570/d25ba889-ac39-4ec8-a31d-53d53f0866a3)

I'm sure this could be rather smoothly done in js as well with a request to fill in that part of the document and does the compute in a new api endpoint. But simple can be good. Thoughts?

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
