### PR TITLE
Optimise safe genes by avoiding duplicates when collecting genes from many panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Hide mtDNA report and coverage report links on case sidebar for cases with WTS data only
 - Modified OMIM-AUTO gene panel to include genes in both genome builds
 - Moved chanjo code into a dedicated extension
+- Optimise the function that collects "match-safe" genes for an institute by avoiding duplicated genes from different panels
 ### Fixed
 - Fix several tests that relied on number of events after setup to be 0
 - Removed unused load case function

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -158,15 +158,9 @@ class InstituteHandler(object):
 
         return institute_obj
 
-    def safe_genes_filter(self, institute_id):
+    def safe_genes_filter(self, institute_id: str) -> List[int]:
         """Returns a list of "safe" HGNC IDs to filter variants with. These genes are retrieved from the institute.gene_panels_matching
-        Can be used to limit secondary findings when retrieving other causatives or matching managed variants
-
-        Args:
-            institute_id(str): _id of an institute
-
-        Returns:
-            safe_genes(list of HGNC ids)
+        Can be used to limit secondary findings when retrieving other causatives or matching managed variants.
         """
         safe_genes = []
         institute_obj = self.institute(institute_id)
@@ -174,7 +168,7 @@ class InstituteHandler(object):
             return safe_genes  # return an empty list
         for panel_name in institute_obj.get("gene_panels_matching", {}).keys():
             safe_genes += self.panel_to_genes(panel_name=panel_name, gene_format="hgnc_id")
-        return safe_genes
+        return list(set(safe_genes))
 
     def institutes(self, institute_ids=None):
         """Fetch all institutes.


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- This is a fix also present in #4658

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR 
