### PR TITLE
Flash an alert when loqus instance is not reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Changed
-- Clearer error message when scout fails to connect to a loqusdb instance
+- Clearer error message when a loqusdb query fails for an instance that initially connected
 
 ## [4.83]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- Clearer error message when scout fails to connect to a loqusdb instance
+
 ## [4.83]
 ### Added
 - Edit ACMG classifications from variant page (only for classifications with criteria)

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -488,14 +488,8 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
-        if obs_data[loqus_id] is None:
-            flash(
-                f"Connection to Loqusdb instance '{loqus_id}' returned error",
-                "warning",
-            )
-            obs_data[loqus_id] = {"observations": "N/A"}
-            continue
-        elif obs_data[loqus_id] == {}:  # Variant was not found
+
+        if obs_data[loqus_id] == {}:  # Variant was not found
             obs_data[loqus_id]["observations"] = 0
             continue
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -486,7 +486,6 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     loqus_query = loqusdb.get_loqus_query(variant_obj, category)
 
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
-
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
         if obs_data[loqus_id] is None:

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -486,26 +486,20 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     loqus_query = loqusdb.get_loqus_query(variant_obj, category)
 
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
-        obs_data[loqus_id] = {}
-        loqus_settings = loqusdb.loqusdb_settings.get(loqus_id)
 
-        if loqus_settings is None:  # An instance might have been renamed or removed
+        # collect observation on that loqusdb instance
+        obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
+        if obs_data[loqus_id] is None:
             flash(
-                f"Could not connect to the preselected loqusdb '{loqus_id}' instance",
+                f"Connection to Loqusdb instance '{loqus_id}' returned error",
                 "warning",
             )
-            obs_data[loqus_id]["total"] = "N/A"
+            obs_data[loqus_id] = {"observations": "N/A"}
             continue
-        obs_data[loqus_id] = loqusdb.get_variant(
-            loqus_query, loqusdb_id=loqus_id
-        )  # collect observation on that loqus instance
+        elif obs_data[loqus_id] == {}:  # Variant was not found
+            obs_data[loqus_id]["observations"] = 0
+            continue
 
-        if not obs_data[loqus_id]:  # data is an empty dictionary
-            # Collect count of variants in variant's case
-            obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
-            if obs_data[loqus_id].get("total"):
-                obs_data[loqus_id]["observations"] = 0
-            continue
         # Check if the current case is represented in the loqusdb instance
         obs_data[loqus_id]["case_match"] = variant_obj["case_id"] in obs_data[loqus_id].get(
             "families", []

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -489,6 +489,14 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
 
+        if obs_data[loqus_id] is None:
+            flash(
+                f"Could not find a Loqus instance with id:{loqus_id}",
+                "warning",
+            )
+            obs_data[loqus_id]["observations"] = "N/A"
+            continue
+
         if obs_data[loqus_id] == {}:  # Variant was not found
             obs_data[loqus_id]["observations"] = 0
             continue

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -134,7 +134,7 @@ class LoqusDB:
     def get_api_loqus_version(api_url):
         """Get version of LoqusDB instance available from a REST API"""
         if api_url is None:
-            return None
+            return
         json_resp = api_get("".join([api_url, "/"]))
         version = json_resp.get("content", {}).get("loqusdb_version")
         return version
@@ -233,7 +233,7 @@ class LoqusDB:
 
         search_resp = api_get(search_url)
         if search_resp.get("status_code") != 200:
-            return None
+            return
         return search_resp.get("content")
 
     def get_exec_loqus_variant(self, loqus_instance, variant_info):

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -227,9 +227,9 @@ class LoqusDB:
             search_url = f"{search_url}/?chrom={chrom}&end_chrom={end_chrom}&pos={pos}&end={end}&sv_type={sv_type}"
 
         search_resp = api_get(search_url)
-        variant_content: dict = search_resp.get("content")
-        if variant_content:
-            return variant_content
+
+        if search_resp.get("status_code") == 200:
+            return search_resp.get("content")
         if search_resp.get("message"):  # An error occurred during the request
             flash(
                 f"Connection to Loqusdb instance returned error: '{search_resp['message']}'",

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -9,7 +9,7 @@ import logging
 import subprocess
 import traceback
 from subprocess import CalledProcessError
-from typing import Dict, Optional
+from typing import Dict
 
 from flask import flash
 
@@ -199,7 +199,7 @@ class LoqusDB:
         return self.get_api_loqus_variant(loqus_instance.get(API_URL), variant_info)
 
     @staticmethod
-    def get_api_loqus_variant(api_url, variant_info) -> Optional[dict]:
+    def get_api_loqus_variant(api_url, variant_info) -> dict:
         """get variant data using a Loqus instance available via REST API
 
         SNV/INDELS can be queried in loqus by defining a simple id. For SVs we need to call them

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -3,11 +3,13 @@
 * Requires loqusdb version 2.5 or greater.
 * If multiple instances are configured, version will be default's.
 """
+
 import json
 import logging
 import subprocess
 import traceback
 from subprocess import CalledProcessError
+from typing import Optional
 
 from scout.exceptions.config import ConfigError
 from scout.utils.scout_requests import get_request_json as api_get
@@ -202,7 +204,7 @@ class LoqusDB:
         return self.get_api_loqus_variant(loqus_instance.get(API_URL), variant_info)
 
     @staticmethod
-    def get_api_loqus_variant(api_url, variant_info):
+    def get_api_loqus_variant(api_url: str, variant_info: dict) -> Optional[dict]:
         """get variant data using a Loqus instance available via REST API
 
         SNV/INDELS can be queried in loqus by defining a simple id. For SVs we need to call them
@@ -231,8 +233,7 @@ class LoqusDB:
 
         search_resp = api_get(search_url)
         if search_resp.get("status_code") != 200:
-            LOG.info(search_resp.get("detail"))
-            return {}
+            return None
         return search_resp.get("content")
 
     def get_exec_loqus_variant(self, loqus_instance, variant_info):

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -227,17 +227,15 @@ class LoqusDB:
             search_url = f"{search_url}/?chrom={chrom}&end_chrom={end_chrom}&pos={pos}&end={end}&sv_type={sv_type}"
 
         search_resp = api_get(search_url)
-
-        # Variant not found in loqusdb instance
-        if search_resp.get("status_code") != 200:
-            if "details" not in search_resp.get("message", {}):  # Connection error
-                flash(
-                    f"Connection to Loqusdb instance returned error: '{search_resp['message']}'",
-                    "warning",
-                )
-            return {}
-
-        return search_resp.get("content")
+        variant_content: dict = search_resp.get("content")
+        if variant_content:
+            return variant_content
+        if search_resp.get("message"):  # An error occurred during the request
+            flash(
+                f"Connection to Loqusdb instance returned error: '{search_resp['message']}'",
+                "warning",
+            )
+        return {}
 
     def get_exec_loqus_variant(self, loqus_instance, variant_info):
         """Get variant data using a local executable instance of Loqus

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -9,7 +9,7 @@ import logging
 import subprocess
 import traceback
 from subprocess import CalledProcessError
-from typing import Dict
+from typing import Dict, Optional
 
 from flask import flash
 
@@ -184,7 +184,7 @@ class LoqusDB:
         }
         return loqus_query
 
-    def get_variant(self, variant_info: dict, loqusdb_id: str = "default") -> Dict:
+    def get_variant(self, variant_info: dict, loqusdb_id: str = "default") -> Optional[Dict]:
         """Return information for a variant (SNV or SV) from loqusdb"""
 
         loqus_instance = self.loqusdb_settings.get(loqusdb_id)

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -85,7 +85,7 @@ def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_v
         var_info = loqusdb.get_variant({"_id": "a variant", "category": "snv"})
 
         # THEN the loqusdb extensions should return no content
-        assert var_info == None
+        assert var_info is None
 
 
 def test_loqusdb_api_sv_variant(loqus_api_app, monkeypatch, loqus_api_variant):

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -1,8 +1,5 @@
 """Tests for the loqusdb REST API extension"""
 
-import pytest
-
-from scout.exceptions.config import ConfigError
 from scout.server.extensions import loqus_extension, loqusdb
 
 
@@ -87,7 +84,7 @@ def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_v
         # WHEN fetching the variant info
         var_info = loqusdb.get_variant({"_id": "a variant", "category": "snv"})
 
-        # THEN the loqus extensions should return an empty dictionary
+        # THEN the loqusdb extensions should return no content
         assert var_info == None
 
 

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -76,7 +76,7 @@ def test_loqusdb_api_snv_variant(loqus_api_app, monkeypatch, loqus_api_variant):
 def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_variant):
     # GIVEN a mocked loqus API that doesn't return usable info
     def mockapi(*args):
-        return {"message": {"details": "not found"}}
+        return {"details": "not found", "status_code": 404}
 
     monkeypatch.setattr(loqus_extension, "api_get", mockapi)
 

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -84,8 +84,8 @@ def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_v
         # WHEN fetching the variant info
         var_info = loqusdb.get_variant({"_id": "a variant", "category": "snv"})
 
-        # THEN the loqusdb extensions should return no content
-        assert var_info is None
+        # THEN the loqusdb extensions should return an empty dictionary
+        assert var_info == {}
 
 
 def test_loqusdb_api_sv_variant(loqus_api_app, monkeypatch, loqus_api_variant):

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -1,4 +1,5 @@
 """Tests for the loqusdb REST API extension"""
+
 import pytest
 
 from scout.exceptions.config import ConfigError
@@ -87,7 +88,7 @@ def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_v
         var_info = loqusdb.get_variant({"_id": "a variant", "category": "snv"})
 
         # THEN the loqus extensions should return an empty dictionary
-        assert var_info == {}
+        assert var_info == None
 
 
 def test_loqusdb_api_sv_variant(loqus_api_app, monkeypatch, loqus_api_variant):

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -76,7 +76,7 @@ def test_loqusdb_api_snv_variant(loqus_api_app, monkeypatch, loqus_api_variant):
 def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_variant):
     # GIVEN a mocked loqus API that doesn't return usable info
     def mockapi(*args):
-        return {"message": {"detail": "Not Found"}, "status_code": 404}
+        return {"content": {"detail": "Not Found"}, "status_code": 404}
 
     monkeypatch.setattr(loqus_extension, "api_get", mockapi)
 

--- a/tests/server/extensions/test_loqusdb_api_extension.py
+++ b/tests/server/extensions/test_loqusdb_api_extension.py
@@ -76,7 +76,7 @@ def test_loqusdb_api_snv_variant(loqus_api_app, monkeypatch, loqus_api_variant):
 def test_loqus_api_snv_variant_not_found(loqus_api_app, monkeypatch, loqus_api_variant):
     # GIVEN a mocked loqus API that doesn't return usable info
     def mockapi(*args):
-        return {"details": "not found", "status_code": 404}
+        return {"message": {"detail": "Not Found"}, "status_code": 404}
 
     monkeypatch.setattr(loqus_extension, "api_get", mockapi)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4669

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test -- on cg-vm1**:
1. Change the settings of a scout institute to connect to a broken or not existent loqus instance
2. Go to a variant page

**How to test -- locally**:
1. Uncomment the lines in the config file relative to the loqusdb API instance
2. Go to a variant page

**Expected outcome**:
- You should see a flashed error warning

**Review:**
- [x] code approved by DNIL
- [x] tests executed by DNIL, CR
