### PR TITLE
Safer variant updates in variantS controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Clearer error message when a loqusdb query fails for an instance that initially connected
+### Fixed
+- Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 
 ## [4.83]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -2,6 +2,7 @@
 # stdlib modules
 import logging
 import re
+from typing import Any
 
 # Third party modules
 import pymongo

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -221,6 +221,14 @@ class VariantHandler(VariantLoader):
         query = self.build_query(case_id, query=query, variant_ids=variant_ids, category=category)
         return self.variant_collection.count_documents(query)
 
+    def variant_update_field(self, variant_id: str, field_name: str, field_value: Any) -> dict:
+        """Updates the value of the given key(field_name) in the variant document in the database."""
+        return self.variant_collection.find_one_and_update(
+            {"_id": variant_id},
+            {"$set": {field_name: field_value}},
+            return_document=pymongo.ReturnDocument.AFTER,
+        )
+
     def variant(
         self,
         document_id=None,

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -3,12 +3,10 @@ import logging
 import re
 from typing import Any, Dict, List, Optional
 
-import bson
 from flask import Response, flash, session, url_for
 from flask_login import current_user
 from markupsafe import Markup
 from pymongo.cursor import CursorType
-from pymongo.errors import DocumentTooLarge
 from werkzeug.datastructures import Headers, ImmutableMultiDict, MultiDict
 from wtforms import DecimalField
 
@@ -874,7 +872,7 @@ def parse_variant(
     compounds_have_changed = False
     if get_compounds:
         compounds_have_changed = update_compounds(store, variant_obj, case_dismissed_vars)
-        if compounds_have_changed:
+        if update and compounds_have_changed:
             store.variant_update_field(
                 variant_id=variant_obj["_id"],
                 field_name="compounds",
@@ -882,7 +880,7 @@ def parse_variant(
             )
 
     genes_have_changed = update_variant_genes(store, variant_obj, genome_build)
-    if genes_have_changed:
+    if update and genes_have_changed:
         store.variant_update_field(
             variant_id=variant_obj["_id"], field_name="genes", field_value=variant_obj["genes"]
         )

--- a/tests/adapter/mongo/test_variant_handling.py
+++ b/tests/adapter/mongo/test_variant_handling.py
@@ -3,11 +3,26 @@
 import logging
 import os
 
-import pytest
-
 TRAVIS = os.getenv("TRAVIS")
 
 LOG = logging.getLogger(__name__)
+
+
+def test_variant_update_field(real_variant_database):
+    """Test the function that updates a value for a given key."""
+    adapter = real_variant_database
+    # GIVEN a variant in the database:
+    variant_obj = adapter.variant_collection.find_one()
+    # GIVEN a key not set in the variant
+    A_KEY = "a_key"
+    A_VALUE = "a_value"
+    assert A_KEY not in variant_obj
+    # WHEN setting the key using the "variant_update_field" function
+    updated_variant_obj = adapter.variant_update_field(
+        variant_id=variant_obj["_id"], field_name=A_KEY, field_value=A_VALUE
+    )
+    # THEN the returned variant document should contain the expected key/value
+    assert updated_variant_obj[A_KEY] == A_VALUE
 
 
 def test_variant(real_variant_database, variant_objs, case_obj):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
Fix #3857


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
