### PR TITLE
Clearer chanjo-report error message only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Clearer error message when a loqusdb query fails for an instance that initially connected
-- Less alarming warning at scout boot when chanjo-report lib is not available and no reports will be generated
+- Do not load chanjo-report module if not needed and more visible message when it fails loading
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Clearer error message when a loqusdb query fails for an instance that initially connected
+- Less alarming warning at scout boot when chanjo-report lib is not available and no reports will be generated
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -17,7 +17,7 @@ except ImportError as error:
     chanjo_api = None
     report_bp = None
     configure_template_filters = None
-    LOG.warning("chanjo-report is not properly installed! %s.", error)
+    LOG.warning(f"{error} - coverage reports will not be available for this instance.")
 
 
 class ChanjoReport:

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -9,21 +9,23 @@ from flask_babel import Babel
 from markupsafe import Markup
 
 LOG = logging.getLogger(__name__)
-try:
-    from chanjo_report.server.app import configure_template_filters
-    from chanjo_report.server.blueprints import report_bp
-    from chanjo_report.server.extensions import api as chanjo_api
-except ImportError as error:
-    chanjo_api = None
-    report_bp = None
-    configure_template_filters = None
-    LOG.warning(f"{error} - coverage reports will not be available for this instance.")
 
 
 class ChanjoReport:
     """Interfaces with chanjo-report. Creates the /reports endpoints in scout domain. Use Babel to set report language."""
 
     def init_app(self, app):
+
+        try:
+            from chanjo_report.server.app import configure_template_filters
+            from chanjo_report.server.blueprints import report_bp
+            from chanjo_report.server.extensions import api as chanjo_api
+        except ImportError as error:
+            chanjo_api = None
+            report_bp = None
+            configure_template_filters = None
+            LOG.error(f"{error}")
+
         if not chanjo_api:
             raise ImportError(
                 "An SQL db path was given, but chanjo-report could not be registered."

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -23,7 +23,7 @@ class ChanjoReport:
             chanjo_api = None
             report_bp = None
             configure_template_filters = None
-            LOG.error(f"{error}")
+            LOG.error(error)
 
         if not chanjo_api:
             raise ImportError(

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -15,7 +15,6 @@ class ChanjoReport:
     """Interfaces with chanjo-report. Creates the /reports endpoints in scout domain. Use Babel to set report language."""
 
     def init_app(self, app):
-
         try:
             from chanjo_report.server.app import configure_template_filters
             from chanjo_report.server.blueprints import report_bp

--- a/tests/adapter/mongo/test_variant_handling.py
+++ b/tests/adapter/mongo/test_variant_handling.py
@@ -3,8 +3,6 @@
 import logging
 import os
 
-TRAVIS = os.getenv("TRAVIS")
-
 LOG = logging.getLogger(__name__)
 
 

--- a/tests/adapter/mongo/test_variant_handling.py
+++ b/tests/adapter/mongo/test_variant_handling.py
@@ -1,7 +1,6 @@
 """Tests for variant handling"""
 
 import logging
-import os
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4675. Don't try to import the chanjo-report lib unless `SQLALCHEMY_DATABASE_URI` is present in settings

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
