### PR TITLE
Swap menu chevrons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Clearer error message when a loqusdb query fails for an instance that initially connected
 - Do not load chanjo-report module if not needed and more visible message when it fails loading
 - Converted the HgncGene class into a Pydantic class
+- Swap menu open and collapse indicator chevrons - down is now displayed-open, right hidden-closed
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 - Link to HGNC gene report on gene page

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -65,7 +65,7 @@
                 <span class="badge rounded-pill bg-info text-body" data-bs-toggle="tooltip" data-bs-placement="left" title="Matching causatives and managed variants displayed on case page are NOT filtered by gene panel. Use caution to avoid incidental findings.">off</span>
               {% endif %}
             </div>
-        </div> <!--end of div class="row" -->
+        </div> <!--end of row -->
         <div class="row">
           <form id="case_status_form" method="POST" action="{{ url_for('cases.status', institute_id=institute._id, case_name=case.display_name) }}">
               <div class="btn-toolbar ms-2" role="toolbar">
@@ -105,7 +105,7 @@
                     {{ 'Inactive' if case.status == 'ignored' else 'Ignored' }}
                   </button>
                 </div>
-                <div class="btn-group ms-2 role="group">
+                <div class="btn-group ms-2" role="group">
                   <select name="tags" id="status_tags_case" multiple class="selectpicker" data-style="btn btn-secondary">
                     {% for tag, data in case_tag_options.items() %}
                       <option {% if 'tags' in case and tag~"" in case.tags %} selected {% endif %} value="{{ tag }}" title="{{ data.label }}">
@@ -119,103 +119,65 @@
         </div>
       </div>
 
+      {{ matching_variants() }}
+
       <div class="card panel-default" >
-        <div class="row mt-0">
-          <div class="col-sm-12 col-md-12 ms-3">
-           <div data-bs-toggle='tooltip' class="panel-heading" title="Check if there are any variants in this case
-              marked as causative in another case for this institute, or are on the managed variants list.">
-             <strong>{% if hide_matching == false %}
-               <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='True') }}" class="text-body"><span class="me-1 fa fa-caret-right"></span>Search for matching causatives and managed variants</a>
-             {% else %}
-               <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body"><span class="me-1 fa fa-caret-down"></span>Search for matching causatives and managed variants</a>
-             {% endif %}
-             </strong>
-           </div>
-          </div>
-        </div>
-        {% if hide_matching == false %}
-        {% if other_causatives|length > 0 %}
-          <div class="row mt-0 ms-3">
-            <div class="col-xs-12 col-md-12 ms-3">{{ matching_causatives(other_causatives, institute, case) }}</div>
-          </div>
-        {% endif %}
-        {% if default_other_causatives|length > 0%}
-          <div class="row mt-0 ms-3">
-            <div class="col-xs-12 col-md-12 ms-3">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
-          </div>
-        {% endif %}
-        {% if managed_variants|length > 0%}
-          <div class="row mt-0 ms-3">
-            <div class="col-sm-12 col-md-12 ms-3">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
-          </div>
-        {% endif %}
-        {% if default_managed_variants|length > 0%}
-          <div class="row mt-0 ms-3">
-            <div class="col-sm-12 col-md-12 ms-3">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
-          </div>
-        {% endif %}
-        {% if other_causatives|length == 0 and default_other_causatives|length == 0 and managed_variants|length == 0 and default_managed_variants|length == 0%}
-          <div class="row mt-0 ms-3">
-            <div class="col-sm-12 col-md-12 ms-3">No matching causatives or managed variants found</div>
-          </div>
-        {% endif %}
-      {% endif %}
-      <div class="row">
-        <div class="col">{{ causatives_list(causatives, partial_causatives, evaluated_variants, institute, case, manual_rank_options, cancer_tier_options) }}</div>
-        <div class="col">{{ suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) }}</div>
-        <!-- end of data sharing panels -->
-      </div>
-
-      <div class="row">
-        {% if case.track == 'cancer' %}
-          <div class="col-sm-12 col-md-12 mt-3">{{ cancer_individuals_table(case, institute, tissue_types, gens_info) }}</div>
-        {% else %}
-          <div class="mt-3 col-sm-8 col-md-{{"8" if case.madeline_info and case.individuals|length > 1 else "12"}}">{{ individuals_table(case, institute, tissue_types, display_rerunner, gens_info) }}</div>
-          {% if case.madeline_info and case.individuals|length > 1 %}
-            <div class="col-sm-4">
-              {{ pedigree_panel(case) }}
-            </div>
-          {% endif %}
-        {% endif %}
-      </div>
-
-      <div class="row mt-3">
-        <div class="col-6">{{ synopsis_panel() }}</div>
-        <div class="col-6">{{ comments_panel(institute, case, current_user, comments) }}</div>
-      </div>
-
-      <div class="row">
-        <div class="col-sm-12">
-          {{ insert_multi_image_panel() }}
-        </div>
-      </div>
-
-      <div class="row">
-        <div class="col-sm-12">
-          {{ custom_image_panels() }}
-        </div>
-      </div>
-
-      <!-- CASE DIAGNOSES AND PHENOTYPES -->
-      <div class="panel-default">
-        <div class="panel-heading"><span class="fa fa-user-md"></span>&nbsp;Phenotypes & diagnoses</div>
         <div class="row">
-          <div class="col-sm-6 ">
-            <div class="card h-100">
-              <div class="card-body">
-                {{ hpo_panel(case, institute, config) }}
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6">
-            <div class="card h-100">
-              <div class="card-body">
-                {{ hpo_genelist_panel(case, institute, config) }}
-              </div>
-            </div>
-          </div>
-        </div> <!--end of <div class="row">-->
+          <div class="col">{{ causatives_list(causatives, partial_causatives, evaluated_variants, institute, case, manual_rank_options, cancer_tier_options) }}</div>
+          <div class="col">{{ suspects_list(suspects, institute, case, manual_rank_options, cancer_tier_options) }}</div>
+          <!-- end of data sharing panels -->
         </div>
+
+        <div class="row">
+          {% if case.track == 'cancer' %}
+            <div class="col-sm-12 col-md-12 mt-3">{{ cancer_individuals_table(case, institute, tissue_types, gens_info) }}</div>
+          {% else %}
+            <div class="mt-3 col-sm-8 col-md-{{"8" if case.madeline_info and case.individuals|length > 1 else "12"}}">{{ individuals_table(case, institute, tissue_types, display_rerunner, gens_info) }}</div>
+            {% if case.madeline_info and case.individuals|length > 1 %}
+              <div class="col-sm-4">
+                {{ pedigree_panel(case) }}
+              </div>
+            {% endif %}
+          {% endif %}
+        </div>
+
+        <div class="row mt-3">
+          <div class="col-6">{{ synopsis_panel() }}</div>
+          <div class="col-6">{{ comments_panel(institute, case, current_user, comments) }}</div>
+        </div>
+
+        <div class="row">
+          <div class="col-sm-12">
+            {{ insert_multi_image_panel() }}
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-sm-12">
+            {{ custom_image_panels() }}
+          </div>
+        </div>
+
+        <!-- CASE DIAGNOSES AND PHENOTYPES -->
+        <div class="panel-default">
+          <div class="panel-heading"><span class="fa fa-user-md"></span>&nbsp;Phenotypes & diagnoses</div>
+          <div class="row">
+            <div class="col-sm-6 ">
+              <div class="card h-100">
+                <div class="card-body">
+                  {{ hpo_panel(case, institute, config) }}
+                </div>
+              </div>
+            </div>
+            <div class="col-sm-6">
+              <div class="card h-100">
+                <div class="card-body">
+                  {{ hpo_genelist_panel(case, institute, config) }}
+                </div>
+              </div>
+            </div>
+          </div> <!--end of row>-->
+        </div> <!--end of card panel-default  -->
 
           <!-- diagnoses-related code-->
         {% if not case.track == 'cancer' %}
@@ -259,8 +221,8 @@
       {{ reanalysis_modal(institute, case) }}
       {{ beacon_modal(institute, case) }}
       {{ matchmaker_modal(institute, case, suspects, mme_nodes) }}
-  </div><!-- end of <div containter> -->
-</div><!-- end of <div col> -->
+  </div><!-- end of containter -->
+</div><!-- end of col -->
 {% endmacro %}
 
 {% macro variants_buttons() %}
@@ -398,7 +360,7 @@
           </div>
         {% endfor %}
       {% endif %}
-      </div> <!-- end of <div class="list-group" style="max-height:200px; overflow-y: scroll;" -->
+      </div> <!-- end of list-group -->
     </div>
   </div>
 {% endmacro %}
@@ -574,6 +536,51 @@
 </div>
 {% endmacro %}
 
+{% macro matching_variants() %}
+<div class="card mt-3">
+  <div class="row mt-0 ms-3">
+    <div class="col-sm-12 col-md-12">
+      <div data-bs-toggle='tooltip' class="panel-heading" title="Check if there are any variants in this case
+        marked as causative in another case for this institute, or are on the managed variants list.">
+        <strong>
+        {% if hide_matching == false %}
+          <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='True') }}" class="text-body"><span class="me-1 fa fa-caret-down"></span>Search for matching causatives and managed variants</a>
+        {% else %}
+          <a href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name, hide_matching='False') }}" class="text-body"><span class="me-1 fa fa-caret-right"></span>Search for matching causatives and managed variants</a>
+        {% endif %}
+        </strong>
+      </div>
+    </div>
+    {% if hide_matching == false %}
+      {% if other_causatives|length > 0 %}
+        <div class="row mt-0 ms-3">
+          <div class="col-xs-12 col-md-12">{{ matching_causatives(other_causatives, institute, case) }}</div>
+        </div>
+      {% endif %}
+      {% if default_other_causatives|length > 0%}
+        <div class="row mt-0 ms-3">
+          <div class="col-xs-12 col-md-12">{{ matching_causatives(default_other_causatives, institute, case, default=True) }}</div>
+        </div>
+      {% endif %}
+      {% if managed_variants|length > 0%}
+        <div class="row mt-0 ms-3">
+          <div class="col-sm-12 col-md-12">{{ matching_managed_variants(managed_variants, institute, case) }}</div>
+        </div>
+      {% endif %}
+      {% if default_managed_variants|length > 0%}
+        <div class="row mt-0 ms-3">
+          <div class="col-sm-12 col-md-12">{{ matching_managed_variants(default_managed_variants, institute, case, default=True) }}</div>
+        </div>
+      {% endif %}
+      {% if other_causatives|length == 0 and default_other_causatives|length == 0 and managed_variants|length == 0 and default_managed_variants|length == 0%}
+        <div class="row mt-0 ms-3">
+          <div class="col-sm-12 col-md-12">No matching causatives or managed variants found</div>
+        </div>
+      {% endif %}
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}
 
 {% block scripts %}
 {{ super() }}

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[
-                snp
-            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            snp_links[snp] = (
+                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            )
 
     return snp_links
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[snp] = (
-                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
-            )
+            snp_links[
+                snp
+            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
 
     return snp_links
 

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -333,7 +333,7 @@ body {
 
 /* Closed submenu icon */
 #sidebar-container .list-group .list-group-item[aria-expanded="false"] .submenu-icon::after {
-  content: " \f0d7";
+  content: " \f0da";
   font-family: "Font Awesome 5 Free", ui-monospace;
   font-weight: 900;
   display: inline;
@@ -342,7 +342,7 @@ body {
 }
 /* Opened submenu icon */
 #sidebar-container .list-group .list-group-item[aria-expanded="true"] .submenu-icon::after {
-  content: " \f0da";
+  content: " \f0d7";
   font-family: "Font Awesome 5 Free", ui-monospace;
   font-weight: 900;
   display: inline;
@@ -353,7 +353,7 @@ body {
 
 /* Closed submenu icon - general case */
 .text-body[aria-expanded="false"] .collapse-icon::after {
-  content: " \f0d7";
+  content: " \f0da";
   font-family: "Font Awesome 5 Free", ui-monospace;
   font-weight: 900;
   display: inline;
@@ -361,7 +361,7 @@ body {
 }
 /* Opened submenu icon - general case */
 .text-body[aria-expanded="true"] .collapse-icon::after {
-  content: " \f0da";
+  content: " \f0d7";
   font-family: "Font Awesome 5 Free", ui-monospace;
   font-weight: 900;
   display: inline;

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -359,7 +359,7 @@ body {
   display: inline;
   text-align: left;
 }
-/* Opened submenu icon - general case */
+/* Openeqd submenu icon - general case */
 .text-body[aria-expanded="true"] .collapse-icon::after {
   content: " \f0d7";
   font-family: "Font Awesome 5 Free", ui-monospace;


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4681

Swapped filled chevrons/arrows to indicate "what is" in the menu state, rather than what "will be" when the icon is clicked. This behaviour is probably a bit more common, though both certainly have merit. Also added a separate card to make the hidden/folded matching vars stand out a bit more.

![Screenshot 2024-06-19 at 10 48 40](https://github.com/Clinical-Genomics/scout/assets/758570/a167f05a-bf8d-4c64-8d2f-cdbbfcdc1e50)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
