### PR TITLE
Workaround fix #4682 - sort case file load order alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 - Link to HGNC gene report on gene page
-- Case file load order set alphabetical with variant category (SNV before SV) giving consistent variant_id collision resolution
+- Case file load priority so that e.g. SNV get loaded before SV, or clinical before research, for consistent variant_id collisions
 
 ## [4.83]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 - Link to HGNC gene report on gene page
+- Case file load order set alphabetical with variant category (SNV before SV) giving consistent variant_id collision resolution
 
 ## [4.83]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -14,6 +14,7 @@ from scout.constants import ACMG_MAP, FILE_TYPE_MAP, ID_PROJECTION
 from scout.exceptions import ConfigError, IntegrityError
 from scout.parse.variant.ids import parse_document_id
 from scout.utils.algorithms import ui_score
+from scout.utils.sort import get_lowest_load_priority
 
 LOG = logging.getLogger(__name__)
 
@@ -904,7 +905,10 @@ class CaseHandler(object):
                     continue
                 load_variants.add((vcf_file["variant_type"], vcf_file["category"]))
 
-            for variant_type, category in sorted(load_variants, key=lambda tup: tup[1]):
+            for variant_type, category in sorted(
+                load_variants,
+                key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
+            ):
                 if update:
                     self.delete_variants(
                         case_id=case_obj["_id"],

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -904,7 +904,7 @@ class CaseHandler(object):
                     continue
                 load_variants.add((vcf_file["variant_type"], vcf_file["category"]))
 
-            for variant_type, category in load_variants:
+            for variant_type, category in sorted(load_variants, key=lambda tup: tup[1]):
                 if update:
                     self.delete_variants(
                         case_id=case_obj["_id"],

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -14,7 +14,7 @@ from scout.constants import ACMG_MAP, FILE_TYPE_MAP, ID_PROJECTION
 from scout.exceptions import ConfigError, IntegrityError
 from scout.parse.variant.ids import parse_document_id
 from scout.utils.algorithms import ui_score
-from scout.utils.sort import get_lowest_load_priority
+from scout.utils.sort import get_load_priority
 
 LOG = logging.getLogger(__name__)
 
@@ -907,7 +907,7 @@ class CaseHandler(object):
 
             for variant_type, category in sorted(
                 load_variants,
-                key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
+                key=lambda tup: get_load_priority(variant_type=tup[0], category=tup[1]),
             ):
                 if update:
                     self.delete_variants(

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -27,7 +27,7 @@ from scout.parse.variant.headers import (
 from scout.parse.variant.ids import parse_simple_id
 from scout.parse.variant.managed_variant import parse_managed_variant_id
 from scout.parse.variant.rank_score import parse_rank_score
-from scout.utils.sort import get_lowest_load_priority
+from scout.utils.sort import get_load_priority
 
 LOG = logging.getLogger(__name__)
 
@@ -216,7 +216,7 @@ class VariantLoader(object):
             intervals = coding_intervals.get(chrom, IntervalTree())
             for var_type, category in sorted(
                 list(load_variants),
-                key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
+                key=lambda tup: get_load_priority(variant_type=tup[0], category=tup[1]),
             ):
                 LOG.info(
                     "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -203,14 +203,12 @@ class VariantLoader(object):
         case_id = case_obj["_id"]
         # Possible categories 'snv', 'sv', 'str', 'cancer', 'cancer_sv'. Sort according to load order to ensure Cancer SNVs before
         # Cancer SVs, in particular, and keep a consistent variant_id collision resolution order.
-        # Possible variant types 'clinical', 'research':
-        load_variants = set()
-
-        for file_type in FILE_TYPE_MAP:
-            if case_obj.get("vcf_files", {}).get(file_type):
-                load_variants.add(
-                    (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
-                )
+        # Possible variant types are 'clinical', 'research'.
+        load_variants = {
+            (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
+            for file_type in FILE_TYPE_MAP
+            if case_obj.get("vcf_files", {}).get(file_type)
+        }
 
         coding_intervals = self.get_coding_intervals(build=build)
         # Loop over all intervals

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -200,7 +200,8 @@ class VariantLoader(object):
         """
 
         case_id = case_obj["_id"]
-        # Possible categories 'snv', 'sv', 'str', 'cancer', 'cancer_sv':
+        # Possible categories 'snv', 'sv', 'str', 'cancer', 'cancer_sv'. Sort alphabetically to ensure Cancer SNVs before
+        # Cancer SVs, in particular, and keep a consistent variant_id collision resolution order.
         categories = set()
         # Possible variant types 'clinical', 'research':
         variant_types = set()
@@ -215,7 +216,7 @@ class VariantLoader(object):
         for chrom in CHROMOSOMES:
             intervals = coding_intervals.get(chrom, IntervalTree())
             for var_type in variant_types:
-                for category in categories:
+                for category in sorted(categories):
                     LOG.info(
                         "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(
                             chrom, var_type, category, case_id

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -216,7 +216,7 @@ class VariantLoader(object):
         for chrom in CHROMOSOMES:
             intervals = coding_intervals.get(chrom, IntervalTree())
             for var_type in variant_types:
-                for category in sorted(categories):
+                for category in sorted(list(categories)):
                     LOG.info(
                         "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(
                             chrom, var_type, category, case_id

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -203,89 +203,88 @@ class VariantLoader(object):
         case_id = case_obj["_id"]
         # Possible categories 'snv', 'sv', 'str', 'cancer', 'cancer_sv'. Sort according to load order to ensure Cancer SNVs before
         # Cancer SVs, in particular, and keep a consistent variant_id collision resolution order.
-        categories = set()
         # Possible variant types 'clinical', 'research':
-        variant_types = set()
+        load_variants = set()
 
         for file_type in FILE_TYPE_MAP:
             if case_obj.get("vcf_files", {}).get(file_type):
-                categories.add(FILE_TYPE_MAP[file_type]["category"])
-                variant_types.add(FILE_TYPE_MAP[file_type]["variant_type"])
+                load_variants.add(
+                    (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
+                )
 
         coding_intervals = self.get_coding_intervals(build=build)
         # Loop over all intervals
         for chrom in CHROMOSOMES:
             intervals = coding_intervals.get(chrom, IntervalTree())
-            for var_type in variant_types:
-                for category in sorted(
-                    list(categories),
-                    key=lambda cat: get_lowest_load_priority(category=cat, variant_type=var_type),
-                ):
-                    LOG.info(
-                        "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(
-                            chrom, var_type, category, case_id
-                        )
+            for var_type, category in sorted(
+                list(load_variants),
+                key=lambda tup: get_lowest_load_priority(var_type=tup[0], category=tup[1]),
+            ):
+                LOG.info(
+                    "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(
+                        chrom, var_type, category, case_id
+                    )
+                )
+
+                # Fetch all variants from a chromosome
+                query = {"variant_type": var_type, "chrom": chrom}
+
+                # Get all variants from the database of the specific type
+                variant_objs = self.variants(
+                    case_id=case_id,
+                    query=query,
+                    category=category,
+                    nr_of_variants=-1,
+                    sort_key="position",
+                )
+
+                # Initiate a bulk
+                bulk = {}
+                current_region = None
+                special = False
+
+                # Loop over the variants and check if they are in a coding region
+                for var_obj in variant_objs:
+                    var_id = var_obj["_id"]
+                    var_chrom = var_obj["chromosome"]
+                    var_start = var_obj["position"]
+                    var_end = var_obj["end"] + 1
+
+                    update_bulk = True
+                    new_region = None
+
+                    # Check if the variant is in a coding region
+                    genomic_regions = coding_intervals.get(var_chrom, IntervalTree()).overlap(
+                        var_start, var_end
                     )
 
-                    # Fetch all variants from a chromosome
-                    query = {"variant_type": var_type, "chrom": chrom}
+                    # If the variant is in a coding region
+                    if genomic_regions:
+                        # We know there is data here so get the interval id
+                        new_region = genomic_regions.pop().data
 
-                    # Get all variants from the database of the specific type
-                    variant_objs = self.variants(
-                        case_id=case_id,
-                        query=query,
-                        category=category,
-                        nr_of_variants=-1,
-                        sort_key="position",
-                    )
+                    if new_region and (new_region == current_region):
+                        # If the variant is in the same region as previous
+                        # we add it to the same bulk
+                        update_bulk = False
 
-                    # Initiate a bulk
-                    bulk = {}
-                    current_region = None
-                    special = False
+                    current_region = new_region
 
-                    # Loop over the variants and check if they are in a coding region
-                    for var_obj in variant_objs:
-                        var_id = var_obj["_id"]
-                        var_chrom = var_obj["chromosome"]
-                        var_start = var_obj["position"]
-                        var_end = var_obj["end"] + 1
+                    # If the variant is not in a current region we update the compounds
+                    # from the previous region, if any. Otherwise continue
+                    if update_bulk and bulk:
+                        self.update_compounds(bulk)
+                        self.update_mongo_compound_variants(bulk)
+                        bulk = {}
 
-                        update_bulk = True
-                        new_region = None
+                    if new_region:
+                        bulk[var_id] = var_obj
 
-                        # Check if the variant is in a coding region
-                        genomic_regions = coding_intervals.get(var_chrom, IntervalTree()).overlap(
-                            var_start, var_end
-                        )
+                if not bulk:
+                    continue
 
-                        # If the variant is in a coding region
-                        if genomic_regions:
-                            # We know there is data here so get the interval id
-                            new_region = genomic_regions.pop().data
-
-                        if new_region and (new_region == current_region):
-                            # If the variant is in the same region as previous
-                            # we add it to the same bulk
-                            update_bulk = False
-
-                        current_region = new_region
-
-                        # If the variant is not in a current region we update the compounds
-                        # from the previous region, if any. Otherwise continue
-                        if update_bulk and bulk:
-                            self.update_compounds(bulk)
-                            self.update_mongo_compound_variants(bulk)
-                            bulk = {}
-
-                        if new_region:
-                            bulk[var_id] = var_obj
-
-                    if not bulk:
-                        continue
-
-                    self.update_compounds(bulk)
-                    self.update_mongo_compound_variants(bulk)
+                self.update_compounds(bulk)
+                self.update_mongo_compound_variants(bulk)
 
         LOG.info("All compounds updated")
 

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -218,7 +218,7 @@ class VariantLoader(object):
             intervals = coding_intervals.get(chrom, IntervalTree())
             for var_type, category in sorted(
                 list(load_variants),
-                key=lambda tup: get_lowest_load_priority(var_type=tup[0], category=tup[1]),
+                key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
             ):
                 LOG.info(
                     "Updating compounds on chromosome:{0}, type:{1}, category:{2} for case:{3}".format(

--- a/scout/constants/file_types.py
+++ b/scout/constants/file_types.py
@@ -1,21 +1,90 @@
 # Collect general information about the file types used in Scout
+# Load priority determines load order, with lowest value loaded first.
 
 FILE_TYPE_MAP = {
-    "vcf_cancer": {"category": "cancer", "variant_type": "clinical"},
-    "vcf_cancer_research": {"category": "cancer", "variant_type": "research"},
-    "vcf_cancer_sv": {"category": "cancer_sv", "variant_type": "clinical"},
-    "vcf_cancer_sv_research": {"category": "cancer_sv", "variant_type": "research"},
-    "vcf_fusion": {"category": "fusion", "variant_type": "clinical"},
-    "vcf_fusion_research": {"category": "fusion", "variant_type": "research"},
-    "vcf_mei": {"category": "mei", "variant_type": "clinical"},
-    "vcf_mei_research": {"category": "mei", "variant_type": "research"},
-    "vcf_snv": {"category": "snv", "variant_type": "clinical"},
-    "vcf_snv_mt": {"category": "snv", "variant_type": "clinical"},
-    "vcf_snv_research": {"category": "snv", "variant_type": "research"},
-    "vcf_snv_research_mt": {"category": "snv", "variant_type": "research"},
-    "vcf_sv": {"category": "sv", "variant_type": "clinical"},
-    "vcf_sv_mt": {"category": "sv", "variant_type": "clinical"},
-    "vcf_sv_research": {"category": "sv", "variant_type": "research"},
-    "vcf_sv_research_mt": {"category": "sv", "variant_type": "research"},
-    "vcf_str": {"category": "str", "variant_type": "clinical"},
+    "vcf_cancer": {
+        "category": "cancer",
+        "variant_type": "clinical",
+        "load_priority": 10,
+    },
+    "vcf_cancer_research": {
+        "category": "cancer",
+        "variant_type": "research",
+        "load_priority": 110,
+    },
+    "vcf_cancer_sv": {
+        "category": "cancer_sv",
+        "variant_type": "clinical",
+        "load_priority": 20,
+    },
+    "vcf_cancer_sv_research": {
+        "category": "cancer_sv",
+        "variant_type": "research",
+        "load_priority": 120,
+    },
+    "vcf_fusion": {
+        "category": "fusion",
+        "variant_type": "clinical",
+        "load_priority": 70,
+    },
+    "vcf_fusion_research": {
+        "category": "fusion",
+        "variant_type": "research",
+        "load_priority": 170,
+    },
+    "vcf_mei": {
+        "category": "mei",
+        "variant_type": "clinical",
+        "load_priority": 60,
+    },
+    "vcf_mei_research": {
+        "category": "mei",
+        "variant_type": "research",
+        "load_priority": 160,
+    },
+    "vcf_snv": {
+        "category": "snv",
+        "variant_type": "clinical",
+        "load_priority": 30,
+    },
+    "vcf_snv_mt": {
+        "category": "snv",
+        "variant_type": "clinical",
+        "load_priority": 35,
+    },
+    "vcf_snv_research": {
+        "category": "snv",
+        "variant_type": "research",
+        "load_priority": 130,
+    },
+    "vcf_snv_research_mt": {
+        "category": "snv",
+        "variant_type": "research",
+        "load_priority": 135,
+    },
+    "vcf_sv": {
+        "category": "sv",
+        "variant_type": "clinical",
+        "load_priority": 40,
+    },
+    "vcf_sv_mt": {
+        "category": "sv",
+        "variant_type": "clinical",
+        "load_priority": 45,
+    },
+    "vcf_sv_research": {
+        "category": "sv",
+        "variant_type": "research",
+        "load_priority": 140,
+    },
+    "vcf_sv_research_mt": {
+        "category": "sv",
+        "variant_type": "research",
+        "load_priority": 145,
+    },
+    "vcf_str": {
+        "category": "str",
+        "variant_type": "clinical",
+        "load_priority": 50,
+    },
 }

--- a/scout/constants/file_types.py
+++ b/scout/constants/file_types.py
@@ -2,11 +2,13 @@
 
 FILE_TYPE_MAP = {
     "vcf_cancer": {"category": "cancer", "variant_type": "clinical"},
-    "vcf_cancer_sv": {"category": "cancer_sv", "variant_type": "clinical"},
     "vcf_cancer_research": {"category": "cancer", "variant_type": "research"},
+    "vcf_cancer_sv": {"category": "cancer_sv", "variant_type": "clinical"},
     "vcf_cancer_sv_research": {"category": "cancer_sv", "variant_type": "research"},
     "vcf_fusion": {"category": "fusion", "variant_type": "clinical"},
     "vcf_fusion_research": {"category": "fusion", "variant_type": "research"},
+    "vcf_mei": {"category": "mei", "variant_type": "clinical"},
+    "vcf_mei_research": {"category": "mei", "variant_type": "research"},
     "vcf_snv": {"category": "snv", "variant_type": "clinical"},
     "vcf_snv_mt": {"category": "snv", "variant_type": "clinical"},
     "vcf_snv_research": {"category": "snv", "variant_type": "research"},
@@ -16,6 +18,4 @@ FILE_TYPE_MAP = {
     "vcf_sv_research": {"category": "sv", "variant_type": "research"},
     "vcf_sv_research_mt": {"category": "sv", "variant_type": "research"},
     "vcf_str": {"category": "str", "variant_type": "clinical"},
-    "vcf_mei": {"category": "mei", "variant_type": "clinical"},
-    "vcf_mei_research": {"category": "mei", "variant_type": "research"},
 }

--- a/scout/constants/file_types.py
+++ b/scout/constants/file_types.py
@@ -45,42 +45,42 @@ FILE_TYPE_MAP = {
     "vcf_snv": {
         "category": "snv",
         "variant_type": "clinical",
-        "load_priority": 30,
+        "load_priority": 35,
     },
     "vcf_snv_mt": {
         "category": "snv",
         "variant_type": "clinical",
-        "load_priority": 35,
+        "load_priority": 30,
     },
     "vcf_snv_research": {
         "category": "snv",
         "variant_type": "research",
-        "load_priority": 130,
+        "load_priority": 135,
     },
     "vcf_snv_research_mt": {
         "category": "snv",
         "variant_type": "research",
-        "load_priority": 135,
+        "load_priority": 130,
     },
     "vcf_sv": {
         "category": "sv",
         "variant_type": "clinical",
-        "load_priority": 40,
+        "load_priority": 45,
     },
     "vcf_sv_mt": {
         "category": "sv",
         "variant_type": "clinical",
-        "load_priority": 45,
+        "load_priority": 40,
     },
     "vcf_sv_research": {
         "category": "sv",
         "variant_type": "research",
-        "load_priority": 140,
+        "load_priority": 145,
     },
     "vcf_sv_research_mt": {
         "category": "sv",
         "variant_type": "research",
-        "load_priority": 145,
+        "load_priority": 140,
     },
     "vcf_str": {
         "category": "str",

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -62,7 +62,7 @@ def load_region(adapter, case_id, hgnc_id=None, chrom=None, start=None, end=None
                 (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
             )
 
-    for variant_type, category in case_file_types.sort(key=lambda tup: tup[1]):
+    for variant_type, category in sorted(case_file_types, key=lambda tup: tup[1]):
         if variant_type == "research" and not case_obj["is_research"]:
             continue
 

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -62,7 +62,7 @@ def load_region(adapter, case_id, hgnc_id=None, chrom=None, start=None, end=None
                 (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
             )
 
-    for variant_type, category in case_file_types:
+    for variant_type, category in case_file_types.sort(key=lambda tup: tup[1]):
         if variant_type == "research" and not case_obj["is_research"]:
             continue
 

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -3,6 +3,7 @@ import logging
 
 from scout.constants import FILE_TYPE_MAP
 from scout.exceptions.config import ConfigError
+from scout.utils.sort import get_lowest_load_priority
 
 LOG = logging.getLogger(__name__)
 
@@ -62,7 +63,10 @@ def load_region(adapter, case_id, hgnc_id=None, chrom=None, start=None, end=None
                 (FILE_TYPE_MAP[file_type]["variant_type"], FILE_TYPE_MAP[file_type]["category"])
             )
 
-    for variant_type, category in sorted(case_file_types, key=lambda tup: tup[1]):
+    for variant_type, category in sorted(
+        case_file_types,
+        key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
+    ):
         if variant_type == "research" and not case_obj["is_research"]:
             continue
 

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -3,7 +3,7 @@ import logging
 
 from scout.constants import FILE_TYPE_MAP
 from scout.exceptions.config import ConfigError
-from scout.utils.sort import get_lowest_load_priority
+from scout.utils.sort import get_load_priority
 
 LOG = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ def load_region(adapter, case_id, hgnc_id=None, chrom=None, start=None, end=None
 
     for variant_type, category in sorted(
         case_file_types,
-        key=lambda tup: get_lowest_load_priority(variant_type=tup[0], category=tup[1]),
+        key=lambda tup: get_load_priority(variant_type=tup[0], category=tup[1]),
     ):
         if variant_type == "research" and not case_obj["is_research"]:
             continue

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -461,7 +461,7 @@ def get_variant_links(institute_obj: dict, variant_obj: dict, build: int = None)
     """Return links for a variant object
 
     Args:
-        variant_obj(scout.models.Variant)
+        variant_obj(scout.models.Variant)A
         build(int)
 
     Returns:
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[
-                snp
-            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            snp_links[snp] = (
+                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            )
 
     return snp_links
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -461,7 +461,7 @@ def get_variant_links(institute_obj: dict, variant_obj: dict, build: int = None)
     """Return links for a variant object
 
     Args:
-        variant_obj(scout.models.Variant)A
+        variant_obj(scout.models.Variant)
         build(int)
 
     Returns:
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[
-                snp
-            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            snp_links[snp] = (
+                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            )
 
     return snp_links
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[
-                snp
-            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            snp_links[snp] = (
+                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            )
 
     return snp_links
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[snp] = (
-                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
-            )
+            snp_links[
+                snp
+            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
 
     return snp_links
 

--- a/scout/utils/sort.py
+++ b/scout/utils/sort.py
@@ -1,12 +1,10 @@
 from scout.constants import FILE_TYPE_MAP
 
 
-def get_lowest_load_priority(
-    category: str = None, variant_type: str = None, file_type: str = None
-) -> int:
+def get_load_priority(category: str = None, variant_type: str = None, file_type: str = None) -> int:
     """
-    Returns lowest load priority for the given variables from a FILE_TYPE_MAP dict of dicts.
-    Helper useful in a sort function.
+    Returns most urgent, highest load priority (numerically the lowest prio number) for the given variables
+    from a FILE_TYPE_MAP dict of dicts. Helper useful in a sort function.
     """
     ordered_file_type_map = sorted(FILE_TYPE_MAP.items(), key=lambda ftm: ftm[1]["load_priority"])
 

--- a/scout/utils/sort.py
+++ b/scout/utils/sort.py
@@ -1,0 +1,23 @@
+from scout.constants import FILE_TYPE_MAP
+
+
+def get_lowest_load_priority(
+    category: str = None, variant_type: str = None, file_type: str = None
+) -> int:
+    """
+    Returns lowest load priority for the given variables from a FILE_TYPE_MAP dict of dicts.
+    Helper useful in a sort function.
+    """
+    ordered_file_type_map = sorted(FILE_TYPE_MAP.items(), key=lambda ftm: ftm[1]["load_priority"])
+
+    for ftm in ordered_file_type_map:
+        if file_type and file_type != ftm[0]:
+            continue
+
+        if category and category != ftm[1]["category"]:
+            continue
+
+        if variant_type and variant_type != ftm[1]["variant_type"]:
+            continue
+
+        return ftm[1]["load_priority"]

--- a/tests/utils/test_sort.py
+++ b/tests/utils/test_sort.py
@@ -1,0 +1,36 @@
+from scout.utils.sort import get_load_priority
+
+
+def test_category_load_priority():
+    """
+    Test load priority helper, file type category.
+    """
+
+    # GIVEN an SNV and SV file category
+    category_cancer_snv = "cancer"
+    category_cancer_sv = "cancer_sv"
+    variant_type = "clinical"
+
+    # WHEN asking for the priority, as eg in a sort lambda function
+    snv_prio = get_load_priority(category=category_cancer_snv, variant_type=variant_type)
+    sv_prio = get_load_priority(category=category_cancer_sv, variant_type=variant_type)
+
+    # THEN SNVs are given precedence, which has importance for variant id assignment collisions
+    assert snv_prio < sv_prio
+
+
+def test_file_load_priority():
+    """
+    Test load priority helper, explicit file type e.g. within category.
+    """
+
+    # GIVEN two different SV file category files
+    general_sv = "vcf_sv"
+    mt_sv = "vcf_sv_mt"
+
+    # WHEN asking for the priority, as eg in a sort lambda function
+    general_sv_prio = get_load_priority(file_type=general_sv)
+    mt_sv_prio = get_load_priority(file_type=mt_sv)
+
+    # THEN the more specific MT vars are given precedence, which has importance for variant id assignment collisions
+    assert mt_sv_prio < general_sv_prio


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The load order was perturbed last week with 4.83 introducing sets of file type categories, to accommodate nf-core raredisease MT VCFs. Introducing an alpabetical sort will work around the problem encountered in #4682 in the sense that SNVs will be loaded before SVs, and in particular `cancer` before `cancer_sv`, and the collision resolution should be consistent.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
