### PR TITLE
Linter python versions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -13,10 +13,10 @@ jobs:
    - name: Check out git repository
      uses: actions/checkout@v4
 
-   - name: Set up Python 3.7
+   - name: Set up Python 3.11
      uses: actions/setup-python@v5
      with:
-      python-version: 3.7
+      python-version: 3.11
 
    - name: Install build tools
      run: >-

--- a/.github/workflows/linting_and_fixing.yml
+++ b/.github/workflows/linting_and_fixing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
 
     steps:
 

--- a/.github/workflows/linting_only.yml
+++ b/.github/workflows/linting_only.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.11]
 
     steps:
 

--- a/.github/workflows/validate_internal_docs_links.yml
+++ b/.github/workflows/validate_internal_docs_links.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
-                  python-version: 3.8
+                  python-version: 3.11
 
             -   name: Install deps
                 run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not load chanjo-report module if not needed and more visible message when it fails loading
 - Converted the HgncGene class into a Pydantic class
 - Swap menu open and collapse indicator chevrons - down is now displayed-open, right hidden-closed
+- Linters and actions now all use python 3.11
 ### Fixed
 - Safer way to update variant genes and compounds that avoids saving temporary decorators into variants' database documents
 - Link to HGNC gene report on gene page

--- a/scout/commands/download/ensembl.py
+++ b/scout/commands/download/ensembl.py
@@ -1,4 +1,5 @@
 """Code for handling downloading of ensembl files used by scout from CLI"""
+
 import logging
 import pathlib
 from typing import List, Optional

--- a/scout/commands/download/everything.py
+++ b/scout/commands/download/everything.py
@@ -1,6 +1,7 @@
 """Code for handling downloading Download all necessary resources for scout used by scout from
 CLI
 """
+
 import logging
 import pathlib
 

--- a/scout/commands/download/exac.py
+++ b/scout/commands/download/exac.py
@@ -1,4 +1,5 @@
 """Code for handling downloading of the ExAC genes file used by scout from CLI"""
+
 import logging
 import pathlib
 

--- a/scout/commands/download/hgnc.py
+++ b/scout/commands/download/hgnc.py
@@ -1,4 +1,5 @@
 """Code for handling downloading of HPO files used by scout from CLI"""
+
 import logging
 import pathlib
 

--- a/scout/commands/download/hpo.py
+++ b/scout/commands/download/hpo.py
@@ -1,4 +1,5 @@
 """Code for handling downloading of HPO files used by scout from CLI"""
+
 import logging
 import pathlib
 

--- a/scout/commands/download/omim.py
+++ b/scout/commands/download/omim.py
@@ -1,4 +1,5 @@
 """Code for handling downloading of HPO files used by scout from CLI"""
+
 import logging
 from pathlib import Path
 from typing import Dict

--- a/scout/commands/export/database.py
+++ b/scout/commands/export/database.py
@@ -3,6 +3,7 @@
 Since the variants collection is very large this dump will be optional.
 
 """
+
 import logging
 import subprocess
 from subprocess import CalledProcessError

--- a/scout/commands/load/panel.py
+++ b/scout/commands/load/panel.py
@@ -1,4 +1,5 @@
 """Code for scout load panel CLI functionality"""
+
 import logging
 
 import click

--- a/scout/commands/load/report.py
+++ b/scout/commands/load/report.py
@@ -1,4 +1,5 @@
 """Code for updating reports"""
+
 import logging
 
 import click

--- a/scout/commands/update/omim.py
+++ b/scout/commands/update/omim.py
@@ -1,4 +1,5 @@
 """Code to handle updates of the OMIM-AUTO gene panel via scout CLI"""
+
 import logging
 
 import click

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -1,4 +1,5 @@
 """Code to handle updates of the PANELAPP-GREEN gene panel via scout CLI"""
+
 import logging
 
 import click

--- a/scout/export/exon.py
+++ b/scout/export/exon.py
@@ -11,6 +11,7 @@ head develop/mip_references/grch37_scout_exons_-2017-01-.bed
 7	65413656	65413769	7-65413658-65413767	NM_173517	21492	VKORC1L1
 5	159776172	159776790	5-159776174-159776788	NM_031908	14325	C1QTNF2
 """
+
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/scout/models/phenotype_term.py
+++ b/scout/models/phenotype_term.py
@@ -14,9 +14,9 @@ class HpoTerm(BaseModel):
     """
 
     hpo_id: str  # id field in the hpo.obo file
-    hpo_number: Optional[
-        int
-    ] = None  # id field in the hpo.obo file, stripped of the 'HP:' part and the zeroes
+    hpo_number: Optional[int] = (
+        None  # id field in the hpo.obo file, stripped of the 'HP:' part and the zeroes
+    )
     description: str  # name field in the hpo.obo file
     ancestors: List = []
     all_ancestors: List = []

--- a/scout/parse/orpha.py
+++ b/scout/parse/orpha.py
@@ -1,4 +1,5 @@
 """Code for parsing ORPHA formatted files"""
+
 import logging
 from typing import Any, Dict, List
 from xml.etree.ElementTree import Element

--- a/scout/parse/variant/conservation.py
+++ b/scout/parse/variant/conservation.py
@@ -1,4 +1,5 @@
 """Code for parsing conservation"""
+
 import logging
 import numbers
 

--- a/scout/server/blueprints/panels/forms.py
+++ b/scout/server/blueprints/panels/forms.py
@@ -1,4 +1,5 @@
 """Code for panel gene form"""
+
 from flask_wtf import FlaskForm
 from wtforms import BooleanField, SelectMultipleField, StringField
 

--- a/scout/server/extensions/bionano_extension.py
+++ b/scout/server/extensions/bionano_extension.py
@@ -6,6 +6,7 @@
     For further development, the server has a Swagger-like demo interface at https://bionano-access.scilifelab.se/Bnx/
     which is useful for details, and for sniffing actual message content structure, required cookie variable names etc.
 """
+
 import json
 import logging
 from typing import Dict, Iterable, List, Optional, Tuple

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -2,6 +2,7 @@
 
 * Requires gens version 1.1.1 or greater
 """
+
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/scout/server/extensions/ldap_extension.py
+++ b/scout/server/extensions/ldap_extension.py
@@ -43,9 +43,11 @@ class LdapManager(LDAPConn):
         self.tls = Tls(
             local_private_key_file=app.config["LDAP_CLIENT_PRIVATE_KEY"],
             local_certificate_file=app.config["LDAP_CLIENT_CERT"],
-            validate=app.config["LDAP_REQUIRE_CERT"]
-            if app.config.get("LDAP_CLIENT_CERT")
-            else ssl.CERT_NONE,
+            validate=(
+                app.config["LDAP_REQUIRE_CERT"]
+                if app.config.get("LDAP_CLIENT_CERT")
+                else ssl.CERT_NONE
+            ),
             version=app.config["LDAP_TLS_VERSION"],
             ca_certs_file=app.config["LDAP_CA_CERTS_FILE"],
             valid_names=app.config["LDAP_VALID_NAMES"],

--- a/scout/server/extensions/matchmaker_extension.py
+++ b/scout/server/extensions/matchmaker_extension.py
@@ -1,6 +1,7 @@
 """Code for MatchMaker Exchange integration
    Tested with PatientMatcher: https://github.com/Clinical-Genomics/patientMatcher
 """
+
 import datetime
 import json
 import logging

--- a/scout/server/extensions/mongo_extension.py
+++ b/scout/server/extensions/mongo_extension.py
@@ -1,4 +1,5 @@
 """Code for flask mongodb extension in scout"""
+
 import os
 
 from scout.adapter.client import get_connection

--- a/scout/server/extensions/rerunner_extension.py
+++ b/scout/server/extensions/rerunner_extension.py
@@ -1,4 +1,5 @@
 """Code for Rerunner integration."""
+
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -679,9 +679,9 @@ def snp_links(variant_obj):
         if "rs" in snp:
             snp_links[snp] = f"https://www.ncbi.nlm.nih.gov/snp/{snp}"  # dbSNP
         elif snp.isnumeric():
-            snp_links[
-                snp
-            ] = f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            snp_links[snp] = (
+                f"https://www.ncbi.nlm.nih.gov/clinvar/variation/{snp}"  # ClinVar variation
+            )
 
     return snp_links
 

--- a/scout/utils/ensembl_rest_clients.py
+++ b/scout/utils/ensembl_rest_clients.py
@@ -1,4 +1,5 @@
 """Code for talking to ensembl rest API"""
+
 import logging
 from urllib.parse import urlencode
 

--- a/scout/utils/scout_requests.py
+++ b/scout/utils/scout_requests.py
@@ -1,4 +1,5 @@
 """Code for performing requests"""
+
 import logging
 import urllib.request
 import zlib

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for CLI tests"""
+
 import pathlib
 
 import pytest

--- a/tests/commands/test_convert_cmd.py
+++ b/tests/commands/test_convert_cmd.py
@@ -1,4 +1,5 @@
 """Test the CLI command that converts a gene panel with hgnc symbols to a new one with hgnc ids"""
+
 # -*- coding: utf-8 -*-
 
 from scout.commands import cli

--- a/tests/commands/update/test_update_individual_cmd.py
+++ b/tests/commands/update/test_update_individual_cmd.py
@@ -1,4 +1,5 @@
 """Tests for update individual command"""
+
 import pytest
 from click.testing import CliRunner
 

--- a/tests/server/blueprints/cases/conftest.py
+++ b/tests/server/blueprints/cases/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for cases"""
+
 import datetime
 
 import pytest

--- a/tests/server/extensions/conftest.py
+++ b/tests/server/extensions/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for extenstions"""
+
 import datetime
 
 import pytest

--- a/tests/server/extensions/test_bionano_extension.py
+++ b/tests/server/extensions/test_bionano_extension.py
@@ -1,6 +1,7 @@
 """
 Test Phenopacket API extension
 """
+
 import responses
 
 from scout.server.extensions import bionano_access

--- a/tests/server/extensions/test_execute_command.py
+++ b/tests/server/extensions/test_execute_command.py
@@ -1,4 +1,5 @@
 """Tests for execute commands function"""
+
 import os
 import subprocess
 

--- a/tests/server/extensions/test_rerunner_extension.py
+++ b/tests/server/extensions/test_rerunner_extension.py
@@ -1,4 +1,5 @@
 """Tests for the Case Rerunner extension"""
+
 from scout.server.extensions import rerunner
 
 

--- a/tests/utils/test_scout_requests.py
+++ b/tests/utils/test_scout_requests.py
@@ -1,4 +1,5 @@
 """Tests for scout requests"""
+
 import tempfile
 from urllib.error import HTTPError
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
Linters (especially black and iSort) were on python 3.7, meaning the latest versions could no longer be found and countless conflicts with local envs with higher versions.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [ ] tests executed by GitHub actions
