### PR TITLE
Sort select default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Unfreeze werkzeug again
 ### Fixed
 - Sort "select default panels" dropdown menu options on case page
+- Show gene panel removed status on case page
 
 ## [4.84]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Unfreeze werkzeug again
-
+### Fixed
+- Sort "select default panels" dropdown menu options on case page
 
 ## [4.84]
 ### Changed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -452,6 +452,7 @@ def case(
         "hide_matching": hide_matching,
     }
 
+    flash("DEBUG panels {}".format(case_obj["panels"]))
     return data
 
 
@@ -514,8 +515,12 @@ def _get_default_panel_genes(store: MongoAdapter, case_obj: dict) -> list:
         panel_info["removed"] = (
             latest_panel.get("hidden", False) if latest_panel is not None else False
         )
-        if panel_info["removed"]:
-            flash(f"Setting panel removed for panel '{panel_name}'.")
+        if "removed" in panel_info:
+            flash(
+                "Setting panel removed for panel {} to {}.".format(
+                    panel_name, panel_info["removed"]
+                )
+            )
         if not panel_obj:
             panel_obj = latest_panel
             if not panel_obj:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -510,7 +510,11 @@ def _get_default_panel_genes(store: MongoAdapter, case_obj: dict) -> list:
             projection=PANEL_PROJECTION,
         )
         latest_panel = store.gene_panel(panel_name, projection=PANEL_PROJECTION)
-        panel_info["removed"] = False if latest_panel is None else latest_panel.get("hidden", False)
+        panel_info["removed"] = (
+            latest_panel.get("hidden", False) if latest_panel is not None else False
+        )
+        if panel_info["removed"]:
+            flash(f"Setting panel removed for panel '{panel_name}'.")
         if not panel_obj:
             panel_obj = latest_panel
             if not panel_obj:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -338,7 +338,7 @@ def case(
     case_obj["clinvar_variants_not_in_suspects"] = clinvar_variants_not_in_suspects
 
     case_obj["default_genes"] = _get_default_panel_genes(store, case_obj)
-    flash("DEBUG panels ".format(case_obj["panels"]))
+    flash("DEBUG panels {}".format(case_obj["panels"]))
 
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -63,7 +63,7 @@ JSON_HEADERS = {
 
 COVERAGE_REPORT_TIMEOUT = 20
 
-PANEL_PROJECTION = {"version": 1, "display_name": 1, "genes": 1}
+PANEL_PROJECTION = {"version": 1, "display_name": 1, "genes": 1, "hidden": 1}
 
 
 def phenomizer_diseases(hpo_ids, case_obj, p_value_treshold=1):

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -338,6 +338,7 @@ def case(
     case_obj["clinvar_variants_not_in_suspects"] = clinvar_variants_not_in_suspects
 
     case_obj["default_genes"] = _get_default_panel_genes(store, case_obj)
+    flash("DEBUG panels %s", case_obj["panels"])
 
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -338,7 +338,7 @@ def case(
     case_obj["clinvar_variants_not_in_suspects"] = clinvar_variants_not_in_suspects
 
     case_obj["default_genes"] = _get_default_panel_genes(store, case_obj)
-    flash("DEBUG panels %s", case_obj["panels"])
+    flash("DEBUG panels ".format(case_obj["panels"]))
 
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -9,7 +9,7 @@
         <thead class="table-light thead">
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by gene panel name"></i></th>
-            <th >Default <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by default panel"></i></th>
+            <th>Status <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel status"></i></th>
             <th>Version <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel version"></i></th>
             <th>Genes <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by number of genes"></i></th>
           </tr>
@@ -20,14 +20,14 @@
               <td>
                 <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}">
                   {{ panel.display_name|truncate(30, True) }}
-                  {% if panel.removed %}
-                    <span class="badge bg-danger">Removed</span>
-                  {% endif %}
                 </a>
               </td>
               <td >
                 {% if panel.is_default %}
                   <span class="badge bg-dark">Default</span>
+                {% endif %}
+                {% if panel.removed %}
+                  <span class="badge bg-danger">Removed</span>
                 {% endif %}
               </td>
               <td>{{ panel.version }} <small class="text">({{ panel.updated_at.date() }})</small></td>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -41,47 +41,31 @@
         </tbody>
       </table>
     </div>
-    <div class="card-body">
-      <form action="{{ url_for('cases.default_panels', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
-        <div class="row">
-          <label>Change default gene panels</label>
-        </div>
-        <div class="row">
-          <div class="col-8">
-            <select name="panel_ids" class="selectpicker" multiple="multiple" data-style="btn-secondary">
-              {% for panel in case.panels %}
-                <option value="{{ panel.panel_id }}" {% if panel.is_default %} selected {% endif %}>{{ panel.display_name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="col-4">
-            <button class="btn btn-secondary form-control">Save</button>
-          </div>
-        </div>
-      </form>
-    </div>
+    {{ change_default_panels(case, institute) }}
+
   </div>
 {% endmacro %}
 
 {% macro change_default_panels(case, institute) %}
-  <div class="card panel-default">
-    <div class="panel-heading">Change default gene panels</div>
-    <div class="card-body">
-      <form action="{{ url_for('cases.default_panels', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
-        <div class="row">
-          <div class="col-xs-4">
-            <select name="panel_ids" class="form-control" multiple>
-              {% for panel in case.panels %}
-                <option value="{{ panel.panel_id }}" {% if panel.is_default %} selected {% endif %}>{{ panel.display_name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="col-xs-4">
-            <button class="btn btn-secondary form-control">Save</button>
-          </div>
+  <div class="card-body">
+    <form action="{{ url_for('cases.default_panels', institute_id=institute._id, case_name=case.display_name) }}" method="POST">
+      <div class="row">
+        <label>Change default gene panels</label>
+      </div>
+
+      <div class="row">
+        <div class="col-8">
+          <select name="panel_ids" class="selectpicker" multiple="multiple" data-style="btn-secondary">
+            {% for panel in case.panels|sort(attribute='display_name')  %}
+              <option value="{{ panel.panel_id }}" {% if panel.is_default %} selected {% endif %}>{{ panel.display_name }}</option>
+            {% endfor %}
+          </select>
         </div>
-      </form>
-    </div>
+        <div class="col-4">
+          <button class="btn btn-secondary form-control">Save</button>
+        </div>
+      </div>
+    </form>
   </div>
 {% endmacro %}
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -9,7 +9,7 @@
         <thead class="table-light thead">
           <tr style="cursor: pointer; white-space: nowrap">
             <th>Panel <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by gene panel name"></i></th>
-            <th>Status <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel status"></i></th>
+            <th>Default <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by if panel is default"></i></th>
             <th>Version <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by panel version"></i></th>
             <th>Genes <i class="fas fa-sort" data-bs-toggle="tooltip" title="Sort by number of genes"></i></th>
           </tr>
@@ -21,13 +21,13 @@
                 <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}">
                   {{ panel.display_name|truncate(30, True) }}
                 </a>
+                {% if panel.removed %}
+                  <span class="badge bg-danger">Removed</span>
+                {% endif %}
               </td>
               <td >
                 {% if panel.is_default %}
                   <span class="badge bg-dark">Default</span>
-                {% endif %}
-                {% if panel.removed %}
-                  <span class="badge bg-danger">Removed</span>
                 {% endif %}
               </td>
               <td>{{ panel.version }} <small class="text">({{ panel.updated_at.date() }})</small></td>
@@ -35,7 +35,7 @@
             </tr>
           {% else %}
             <tr>
-              <td colspan="5">No panels linked to case</td>
+              <td colspan="4">No panels linked to case</td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4695 
- Fix sorting of the select default panels dropdown - as discussed in #4695 

Marking this as a bug fix as the display of the "removed" badge was there once upon a time, but now only for the default panels. Refactored a little to do the panel hiding check separate from the default panel check and latest panel genes update.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. remove a panel present on a case
2. look at the case page and its dropdown
✅ ![Screenshot 2024-07-03 at 11 45 52](https://github.com/Clinical-Genomics/scout/assets/758570/56c4531e-62b0-4f6d-b6a0-271ca554705b)
✅ ![Screenshot 2024-07-03 at 11 47 08](https://github.com/Clinical-Genomics/scout/assets/758570/82779233-1733-4c0e-8aa6-9b6393d083c3)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
