### PR TITLE
REVEL score deep parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Load also genes which are missing Ensembl gene ID (72 in both builds), including immunoglobulins and fragile sites
 ### Changed
 - Unfreeze werkzeug again
-- Show "(Removed)" after removed panels in dropdown 
+- Show "(Removed)" after removed panels in dropdown
+- The REVEL score is collected as the maximum REVEL score from all of the variant's transcripts
 ### Fixed
 - Sort "select default panels" dropdown menu options on case page
 - Show gene panel removed status on case page

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -260,11 +260,9 @@ def parse_variant(
 
 def get_highest_revel_score(parsed_transcripts: List[dict]) -> Optional[float]:
     """Retrieve the highest REVEL_score value from parsed variant transcripts."""
-    LOG.warning("HERE BITCHES")
     tx_revel_scores: List(float) = [
         tx.get("revel_raw_score") for tx in parsed_transcripts if tx.get("revel_raw_score") != None
     ]
-    LOG.error(tx_revel_scores)
     if tx_revel_scores:
         return max(tx_revel_scores)
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -257,10 +257,13 @@ def parse_variant(
     remove_nonetype(parsed_variant)
     return parsed_variant
 
+
 def get_highest_revel_score(parsed_transcripts: List[dict]) -> Optional[float]:
     """Retrieve the highest REVEL_score value from parsed variant transcripts."""
     LOG.warning("HERE BITCHES")
-    tx_revel_scores: List(float) = [tx.get("revel_raw_score") for tx in parsed_transcripts if tx.get("revel_raw_score") != None]
+    tx_revel_scores: List(float) = [
+        tx.get("revel_raw_score") for tx in parsed_transcripts if tx.get("revel_raw_score") != None
+    ]
     LOG.error(tx_revel_scores)
     if tx_revel_scores:
         return max(tx_revel_scores)

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -229,7 +229,7 @@ def parse_variant(
 
     if len(parsed_transcripts) > 0:
         parsed_variant["revel_score"] = parsed_transcripts[0].get(
-            "revel"
+            "revel_rankscore"
         )  # This is actually the value of REVEL_rankscore
         parsed_variant["revel"] = get_highest_revel_score(parsed_transcripts)
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -229,12 +229,9 @@ def parse_variant(
 
     if len(parsed_transcripts) > 0:
         parsed_variant["revel_score"] = parsed_transcripts[0].get(
-            "revel_rankscore"
+            "revel"
         )  # This is actually the value of REVEL_rankscore
-
-        parsed_variant["revel"] = parsed_transcripts[0].get(
-            "revel_raw_score"
-        )  # This is actually the value of REVEL_score
+        parsed_variant["revel"] = get_highest_revel_score(parsed_transcripts)
 
     ###################### Add conservation ######################
     parsed_variant["conservation"] = parse_conservations(variant, parsed_transcripts)
@@ -259,6 +256,14 @@ def parse_variant(
 
     remove_nonetype(parsed_variant)
     return parsed_variant
+
+def get_highest_revel_score(parsed_transcripts: List[dict]) -> Optional[float]:
+    """Retrieve the highest REVEL_score value from parsed variant transcripts."""
+    LOG.warning("HERE BITCHES")
+    tx_revel_scores: List(float) = [tx.get("revel_raw_score") for tx in parsed_transcripts if tx.get("revel_raw_score") != None]
+    LOG.error(tx_revel_scores)
+    if tx_revel_scores:
+        return max(tx_revel_scores)
 
 
 def get_genmod_key(case):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug:

REVEL score is collected as the maximum REVEL score from all of the variant's transcripts (closes #4693 )

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Load a case and make sure REVEL score and REVEL rank score are loaded

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by Jakob37
- [x] tests executed by GitHub actions
