### PR TITLE
Try to convert to float only GNOMAD POPMAX values that are numerical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Unfreeze werkzeug again
 - Show "(Removed)" after removed panels in dropdown
 - The REVEL score is collected as the maximum REVEL score from all of the variant's transcripts
+- Parse GNOMAD POPMAX values only if they are numerical when loading variants
 ### Fixed
 - Sort "select default panels" dropdown menu options on case page
 - Show gene panel removed status on case page
-
 
 ## [4.84]
 ### Changed

--- a/scout/parse/variant/transcript.py
+++ b/scout/parse/variant/transcript.py
@@ -324,7 +324,7 @@ def set_variant_frequencies(transcript, entry):
                 continue
 
             value = entry[key]
-            if not value or value == ".":
+            if not value or value == "." or value.isalpha():
                 continue
 
             if key in THOUSAND_GENOMES_CSQ_KEYS:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4714 --> Try to parse to float only GNOMAD POPMAX values that are numerical

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by Jakob37
- [x] tests executed by Jakob37
