### PR TITLE
Option to override the ClinVar API URL to test against ClinVar 'apitest'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- `CLINVAR_API_URL` param can be specified in app settings to override the URL used to send ClinVar submissions to. Intended for testing.
+
 ## [4.85]
 ### Added
 - Load also genes which are missing Ensembl gene ID (72 in both builds), including immunoglobulins and fragile sites

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -1,4 +1,4 @@
-CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/"
+CLINVAR_API_URL_DEFAULT = "https://submit.ncbi.nlm.nih.gov/api/v1/submissions/"
 PRECLINVAR_URL = "https://preclinvar.scilifelab.se"
 
 ASSERTION_METHOD = "ACMG Guidelines, 2015"

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -98,6 +98,7 @@ def configure_extensions(app):
     extensions.store.init_app(app)
     extensions.login_manager.init_app(app)
     extensions.mail.init_app(app)
+    extensions.clinvar_api.init_app(app)
 
     if app.config.get("SQLALCHEMY_DATABASE_URI"):
         extensions.chanjo_report.init_app(app)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -7,7 +7,7 @@ from typing import Dict, Union
 from urllib.parse import parse_qsl, unquote, urlsplit
 
 import coloredlogs
-from flask import Flask, current_app, redirect, request, url_for
+from flask import Flask, redirect, request, url_for
 from flask_cors import CORS
 from flask_login import current_user
 from markdown import markdown as python_markdown

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -442,11 +442,14 @@ def send_api_submission(institute_id, submission_id, key):
     if clinvar_id:  # Check if submission object has already an associated ClinVar ID
         conversion_res["submissionName"] = clinvar_id
 
-    code, submit_res = clinvar_api.submit_json(conversion_res, key)
+    service_url, code, submit_res = clinvar_api.submit_json(conversion_res, key)
 
     if code in [200, 201]:
         clinvar_id = submit_res.json().get("id")
-        flash(f"Submission saved successfully with ID: {clinvar_id}", "success")
+        flash(
+            f"Submission sent to API URL '{service_url}'. Saved successfully with ID: {clinvar_id}",
+            "success",
+        )
 
         # Update ClinVar submission ID with the ID returned from ClinVar
         store.update_clinvar_id(
@@ -459,7 +462,10 @@ def send_api_submission(institute_id, submission_id, key):
         )
 
     else:
-        flash(str(submit_res.json()), "warning")
+        flash(
+            f"Submission sent to API URL '{service_url}'. Returned the following error: {str(submit_res.json())}",
+            "warning",
+        )
 
 
 def clinvar_submission_file(submission_id, csv_type, clinvar_subm_id):

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -64,6 +64,10 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # BEACON_URL = "http://localhost:6000/apiv1.0"
 # BEACON_TOKEN = "DEMO"
 
+# ClinVar API URL
+# An alternative URL that will be used to send ClinVar submissions to. Just uncomment the line below to use the test API
+# CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions/"
+
 # connection details for LoqusDB MongoDB database
 # Example with 2 instances of LoqusDB, one using a binary file and one instance connected via REST API
 # When multiple instances are available, admin users can modify which one is in use for a given institute from the admin settings page

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import requests
-from flask import current_app, flash
+from flask import flash
 
 from scout.constants.clinvar import CLINVAR_API_URL, PRECLINVAR_URL
 

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -17,7 +17,7 @@ class ClinVarApi:
 
     def init_app(self, app):
         self.convert_service = "/".join([PRECLINVAR_URL, "csv_2_json"])
-        self.submit_service = app.config.get("CLINVAR_API_URL") or CLINVAR_API_URL
+        self.submit_service_url = app.config.get("CLINVAR_API_URL") or CLINVAR_API_URL_DEFAULT
 
     def set_header(self, api_key) -> dict:
         """Creates a header to be submitted a in a POST rquest to the CLinVar API

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -71,16 +71,16 @@ class ClinVarApi:
             "actions": [{"type": "AddData", "targetDb": "clinvar", "data": {"content": json_data}}]
         }
         try:
-            resp = requests.post(self.submit_service, data=json.dumps(data), headers=header)
-            return self.submit_service, resp.status_code, resp
+            resp = requests.post(self.submit_service_url, data=json.dumps(data), headers=header)
+            return self.submit_service_url, resp.status_code, resp
 
         except Exception as ex:
-            return self.submit_service, None, ex
+            return self.submit_service_url, None, ex
 
     def show_submission_status(self, submission_id: str, api_key=None):
         """Retrieve the status of a ClinVar submission using the https://submit.ncbi.nlm.nih.gov/api/v1/submissions/SUBnnnnnn/actions/ endpoint."""
 
         header: dict = self.set_header(api_key)
-        actions_url = f"{self.submit_service}{submission_id}/actions/"
+        actions_url = f"{self.submit_service_url}{submission_id}/actions/"
         actions_resp: requests.models.Response = requests.get(actions_url, headers=header)
         flash(f"Response from ClinVar: {actions_resp.json()}", "primary")

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -4,7 +4,7 @@ import logging
 import requests
 from flask import flash
 
-from scout.constants.clinvar import CLINVAR_API_URL, PRECLINVAR_URL
+from scout.constants.clinvar import CLINVAR_API_URL_DEFAULT, PRECLINVAR_URL
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -75,7 +75,7 @@ class ClinVarApi:
             return self.submit_service, resp.status_code, resp
 
         except Exception as ex:
-            return None, ex
+            return self.submit_service, None, ex
 
     def show_submission_status(self, submission_id: str, api_key=None):
         """Retrieve the status of a ClinVar submission using the https://submit.ncbi.nlm.nih.gov/api/v1/submissions/SUBnnnnnn/actions/ endpoint."""

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -1,7 +1,7 @@
 import responses
 from flask import url_for
 
-from scout.constants.clinvar import CLINVAR_API_URL, PRECLINVAR_URL
+from scout.constants.clinvar import CLINVAR_API_URL_DEFAULT, PRECLINVAR_URL
 from scout.server.extensions import store
 
 SAVE_ENDPOINT = "clinvar.clinvar_save"
@@ -320,7 +320,7 @@ def test_clinvar_api_status(app):
 
     responses.add(
         responses.GET,
-        f"{CLINVAR_API_URL}{DEMO_SUBMISSION_ID}/actions/",
+        f"{CLINVAR_API_URL_DEFAULT}{DEMO_SUBMISSION_ID}/actions/",
         json={"actions": actions},
         status=200,
     )
@@ -372,7 +372,7 @@ def test_clinvar_api_submit(app, institute_obj, case_obj, clinvar_form):
         # GIVEN a mocked ClinVar API service
         responses.add(
             responses.POST,
-            CLINVAR_API_URL,
+            CLINVAR_API_URL_DEFAULT,
             json={"id": "SUB1234567"},
             status=201,
         )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4611

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Update stage server's [scout config file](https://github.com/Clinical-Genomics/servers/blob/master/config/CGVS/config/app/cg-services-stage.scilifelab.se/scout.conf.py) with this line:
CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions/" 
1. Restart scout stage
1. Stry to send a submission to ClinVar using a valid key. Make sure that response contains the URL of the apitest 

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
