### PR TITLE
Fix #4729 - check caller keys also from FOUND_IN and SVDB_ORIGIN before adding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection
-
+### Fixed
+- Only add expected caller keys to variant (FOUND_IN or SVDB_ORIGIN)
 
 ## [4.85]
 ### Added

--- a/scout/parse/variant/callers.py
+++ b/scout/parse/variant/callers.py
@@ -22,6 +22,7 @@ def parse_callers(variant, category="snv"):
     """
     relevant_callers = CALLERS[category]
     callers = {caller["id"]: None for caller in relevant_callers}
+    callers_keys = set(callers.keys())
 
     other_info = variant.INFO.get("FOUND_IN")
     svdb_origin = variant.INFO.get("svdb_origin")
@@ -30,10 +31,12 @@ def parse_callers(variant, category="snv"):
     if other_info:
         for info in other_info.split(","):
             called_by = info.split("|")[0]
-            callers[called_by] = "Pass"
+            if called_by in callers_keys:
+                callers[called_by] = "Pass"
     elif svdb_origin:
         for called_by in svdb_origin.split("|"):
-            callers[called_by] = "Pass"
+            if called_by in callers_keys:
+                callers[called_by] = "Pass"
     elif raw_info:
         info = raw_info.split("-")
         for call in info:
@@ -47,7 +50,7 @@ def parse_callers(variant, category="snv"):
                 for caller in callers:
                     if caller in call:
                         callers[caller] = "Filtered"
-            elif call in set(callers.keys()):
+            elif call in callers_keys:
                 callers[call] = "Pass"
 
     if raw_info or svdb_origin or other_info:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. load or check an existing demo case with MEI variants, e.g. 643594. Note odd keys on variants on the format `SAMPLE_FILE_ALL_ME = Pass`. No caller should be visible on MEI variant GTs.
2. delete case and load again with the current patch
3. keys should be gone from db, and still no caller visible on MEI variant GTs.

Or just check keys, drop demo db and setup demo.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
