### PR TITLE
Fix #4734 - spliceJunction height offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Alphabetically sort IGV track available for custom selection
 ### Fixed
 - Only add expected caller keys to variant (FOUND_IN or SVDB_ORIGIN)
+- Splice junction merged track height offset in IGV.js
 
 ## [4.85]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Only add expected caller keys to variant (FOUND_IN or SVDB_ORIGIN)
 - Splice junction merged track height offset in IGV.js
+- Splice junction initiation crash with empty variant obj
 
 ## [4.85]
 ### Added

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -134,6 +134,8 @@ def make_sashimi_tracks(
     build = "38"  # This feature is only available for RNA tracks in build 38
 
     locus = "All"
+    variant_obj = None
+
     if variant_id:
         variant_obj = store.variant(document_id=variant_id)
     if omics_variant_id:

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -79,6 +79,7 @@
                                     type: 'wig',
                                     format: "bigwig",
                                     url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig) }}",
+                                    height: 500,
                                   },
                                   {
                                     type: 'spliceJunctions',
@@ -88,7 +89,8 @@
                                     labelUniqueReadCount: true,
                                     url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed) }}",
                                     indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index) }}",
-                                    minUniquelyMappedReads: 1
+                                    minUniquelyMappedReads: 1,
+                                    height: 500,
                                   },
                                 ]
                               }, // end of sashimi track with data


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4734 - spliceJunction tracks

Before:
❌ 
![Screenshot 2024-08-07 at 13 29 09](https://github.com/user-attachments/assets/5714fe8d-c1db-4901-aa71-66c7a9da4938)

✅ After:
![Screenshot 2024-08-07 at 13 42 36](https://github.com/user-attachments/assets/a297b06f-0556-4d77-9c95-aedf7a485dc4)

- Fix #4737 
Click 
![Screenshot 2024-08-07 at 13 57 30](https://github.com/user-attachments/assets/e2850c99-cfd8-48f0-a3a6-74904d7a90e3)
Before: crash email
After: no crash

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
