### PR TITLE
Parse and show CoLoRSdb frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parse DROP Fraser and Outrider TSVs
 - Display omics variants - wts outliers (Fraser, Outrider)
 - Parse GNOMAD `gnomad_af` and `gnomad_popmax_af` keys from variants annotated with `echtvar`
+- Parse `colorsdb_af` values from variants annotated with `echtvar`
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parse DROP Fraser and Outrider TSVs
 - Display omics variants - wts outliers (Fraser, Outrider)
 - Parse GNOMAD `gnomad_af` and `gnomad_popmax_af` keys from variants annotated with `echtvar`
-- Parse `colorsdb_af` values from variants annotated with `echtvar`
+- Parse CoLoRSsb frequencies annotated in the variant INFO field with the `colorsdb_af` key
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -460,6 +460,7 @@ def add_frequencies(variant_obj, frequencies):
     variant_obj["thousand_genomes_frequency_right"] = call_safe(
         float, frequencies.get("thousand_g_right")
     )
+    variant_obj["colorsdb_af"] = call_safe(float, frequencies.get("colorsdb_af"))
 
     # Add the sv counts:
     variant_obj["clingen_cgh_benign"] = frequencies.get("clingen_benign")

--- a/scout/parse/variant/frequency.py
+++ b/scout/parse/variant/frequency.py
@@ -75,6 +75,7 @@ def parse_frequencies(variant, transcripts):
     # These are SV-specific frequencies
     update_frequency_from_vcf(frequencies, variant, ["left_1000GAF"], "thousand_g_left")
     update_frequency_from_vcf(frequencies, variant, ["right_1000GAF"], "thousand_g_right")
+    update_frequency_from_vcf(frequencies, variant, ["colorsdb_af"], "colorsdb_af")
 
     # Search transcripts CSQ if not found in VCF INFO
     if not frequencies:
@@ -123,6 +124,7 @@ def parse_sv_frequencies(variant: cyvcf2.Variant) -> Dict:
     update_sv_frequency_from_vcf(sv_frequencies, variant, SWEGEN_KEYS, "swegen")
     update_sv_frequency_from_vcf(sv_frequencies, variant, DECIPHER_KEYS, "decipher")
     update_sv_frequency_from_vcf(sv_frequencies, variant, CG_KEYS, "clingen_mip")
+    update_sv_frequency_from_vcf(sv_frequencies, variant, ["colorsdb_af"], "colorsdb_af")
 
     return sv_frequencies
 
@@ -136,6 +138,7 @@ def parse_mei_frequencies(variant: cyvcf2.Variant) -> Dict:
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_HERV_KEYS, "swegen_herv")
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_L1_KEYS, "swegen_l1")
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_SVA_KEYS, "swegen_sva")
+    update_sv_frequency_from_vcf(mei_frequencies, variant, ["colorsdb_af"], "colorsdb_af")
 
     if any(mei_frequencies.values()):
         max_mei_frequency = max(mei_frequencies.values())

--- a/scout/parse/variant/frequency.py
+++ b/scout/parse/variant/frequency.py
@@ -138,7 +138,6 @@ def parse_mei_frequencies(variant: cyvcf2.Variant) -> Dict:
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_HERV_KEYS, "swegen_herv")
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_L1_KEYS, "swegen_l1")
     update_sv_frequency_from_vcf(mei_frequencies, variant, SWEGEN_SVA_KEYS, "swegen_sva")
-    update_sv_frequency_from_vcf(mei_frequencies, variant, ["colorsdb_af"], "colorsdb_af")
 
     if any(mei_frequencies.values()):
         max_mei_frequency = max(mei_frequencies.values())

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -333,6 +333,14 @@ def predictions(genes):
     return data
 
 
+def set_colorsdb_freq(variant_obj: dict, freqs: dict) -> None:
+    """Add CoLoRS DB frequencies to variants, if available."""
+    COLORSDB_KEY = "colorsdb_af"
+    if variant_obj.get(COLORSDB_KEY) is None:
+        return
+    freqs[COLORSDB_KEY] = {"display_name": "CoLoRSdb", "link": None}
+
+
 def frequencies(variant_obj):
     """Add frequencies in the correct way for the template
 
@@ -433,6 +441,7 @@ def frequencies(variant_obj):
                 "link": variant_obj.get("gnomad_link"),
             },
         }
+    set_colorsdb_freq(variant_obj, freqs)
     frequency_list = []
     for freq_key in freqs:
         display_name = freqs[freq_key]["display_name"]

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -333,131 +333,72 @@ def predictions(genes):
     return data
 
 
-def set_colorsdb_freq(variant_obj: dict, freqs: dict) -> None:
-    """Add CoLoRS DB frequencies to variants, if available."""
-    COLORSDB_KEY = "colorsdb_af"
-    if variant_obj.get(COLORSDB_KEY) is None:
-        return
-    freqs[COLORSDB_KEY] = {"display_name": "CoLoRSdb", "link": None}
-
-
 def frequencies(variant_obj):
-    """Add frequencies in the correct way for the template
-
-    This function converts the raw annotations to something better to visualize.
-    GnomAD is mandatory and will always be shown.
+    """Convert raw annotations to a more visual format with frequencies.
 
     Args:
         variant_obj(scout.models.Variant)
 
     Returns:
-        frequencies(list(tuple)): A list of frequencies to display
+        list of tuple: A list of frequencies to display.
     """
     is_mitochondrial_variant = variant_obj.get("chromosome") == "MT"
+    category = variant_obj["category"]
 
-    if variant_obj["category"] == "sv":
-        freqs = {
-            "gnomad_frequency": {
-                "display_name": "GnomAD",
-                "link": variant_obj.get("gnomad_sv_link"),
-            },
-            "clingen_cgh_benign": {
-                "display_name": "ClinGen CGH (benign)",
-                "link": None,
-            },
-            "clingen_cgh_pathogenic": {
-                "display_name": "ClinGen CGH (pathogenic)",
-                "link": None,
-            },
-            "clingen_ngi": {"display_name": "ClinGen NGI", "link": None},
-            "clingen_mip": {"display_name": "ClinGen MIP", "link": None},
-            "swegen": {"display_name": "SweGen", "link": None},
-            "decipher": {"display_name": "Decipher", "link": None},
-            "thousand_genomes_frequency": {"display_name": "1000G", "link": None},
-            "thousand_genomes_frequency_left": {
-                "display_name": "1000G(left)",
-                "link": None,
-            },
-            "thousand_genomes_frequency_right": {
-                "display_name": "1000G(right)",
-                "link": None,
-            },
-        }
-    elif variant_obj["category"] == "mei":
-        freqs = {
-            "swegen_alu": {
-                "display_name": "SweGen ALU",
-                "link": None,
-            },
-            "swegen_herv": {
-                "display_name": "SweGen HERV",
-                "link": None,
-            },
-            "swegen_l1": {
-                "display_name": "SweGen L1",
-                "link": None,
-            },
-            "swegen_sva": {
-                "display_name": "SweGen SVA",
-                "link": None,
-            },
-            "swegen_mei_max": {
-                "display_name": "SweGen MEI(max)",
-                "link": None,
-            },
-        }
-    else:
-        freqs = {
-            "gnomad_frequency": {
-                "display_name": "GnomAD",
-                "link": variant_obj.get("gnomad_link"),
-            },
-            "thousand_genomes_frequency": {
-                "display_name": "1000G",
-                "link": variant_obj.get("thousandg_link"),
-            },
-            "max_thousand_genomes_frequency": {
-                "display_name": "1000G(max)",
-                "link": variant_obj.get("thousandg_link"),
-            },
-            "exac_frequency": {
-                "display_name": "ExAC",
-                "link": variant_obj.get("exac_link"),
-            },
-            "max_exac_frequency": {
-                "display_name": "ExAC(max)",
-                "link": variant_obj.get("exac_link"),
-            },
-            "swegen": {
-                "display_name": "SweGen",
-                "link": variant_obj.get("swegen_link"),
-            },
-            "gnomad_mt_homoplasmic_frequency": {
-                "display_name": "GnomAD MT, homoplasmic",
-                "link": variant_obj.get("gnomad_link"),
-            },
-            "gnomad_mt_heteroplasmic_frequency": {
-                "display_name": "GnomAD MT, heteroplasmic",
-                "link": variant_obj.get("gnomad_link"),
-            },
-        }
-    set_colorsdb_freq(variant_obj, freqs)
+    # Define frequency mappings for each category
+    frequency_mappings = {
+        "sv": {
+            "gnomad_frequency": ("GnomAD", variant_obj.get("gnomad_sv_link")),
+            "clingen_cgh_benign": ("ClinGen CGH (benign)", None),
+            "clingen_cgh_pathogenic": ("ClinGen CGH (pathogenic)", None),
+            "clingen_ngi": ("ClinGen NGI", None),
+            "clingen_mip": ("ClinGen MIP", None),
+            "swegen": ("SweGen", None),
+            "decipher": ("Decipher", None),
+            "thousand_genomes_frequency": ("1000G", None),
+            "thousand_genomes_frequency_left": ("1000G(left)", None),
+            "thousand_genomes_frequency_right": ("1000G(right)", None),
+            "colorsdb_af": ("CoLoRSdb", None),
+        },
+        "mei": {
+            "swegen_alu": ("SweGen ALU", None),
+            "swegen_herv": ("SweGen HERV", None),
+            "swegen_l1": ("SweGen L1", None),
+            "swegen_sva": ("SweGen SVA", None),
+            "swegen_mei_max": ("SweGen MEI(max)", None),
+        },
+        "snv": {
+            "gnomad_frequency": ("GnomAD", variant_obj.get("gnomad_link")),
+            "thousand_genomes_frequency": ("1000G", variant_obj.get("thousandg_link")),
+            "max_thousand_genomes_frequency": ("1000G(max)", variant_obj.get("thousandg_link")),
+            "exac_frequency": ("ExAC", variant_obj.get("exac_link")),
+            "max_exac_frequency": ("ExAC(max)", variant_obj.get("exac_link")),
+            "swegen": ("SweGen", variant_obj.get("swegen_link")),
+            "gnomad_mt_homoplasmic_frequency": (
+                "GnomAD MT, homoplasmic",
+                variant_obj.get("gnomad_link"),
+            ),
+            "gnomad_mt_heteroplasmic_frequency": (
+                "GnomAD MT, heteroplasmic",
+                variant_obj.get("gnomad_link"),
+            ),
+            "colorsdb_af": ("CoLoRSdb", None),
+        },
+    }
+
+    # Select the appropriate frequency dictionary
+    freqs = frequency_mappings.get(category, frequency_mappings["snv"])
+
     frequency_list = []
-    for freq_key in freqs:
-        display_name = freqs[freq_key]["display_name"]
+    for freq_key, (display_name, link) in freqs.items():
         value = variant_obj.get(freq_key)
-        link = freqs[freq_key]["link"]
-        # Always add gnomad for non-mitochondrial variants
+
         if freq_key == "gnomad_frequency":
             if is_mitochondrial_variant:
                 continue
-            # If gnomad not found search for exac
-            if not value:
-                value = variant_obj.get("exac_frequency")
-            value = value or "NA"
+            value = value or variant_obj.get("exac_frequency") or "NA"
 
-        # Always add gnomad MT frequencies for mitochondrial variants
-        elif freq_key.startswith("gnomad_mt_") and is_mitochondrial_variant:
+        if freq_key.startswith("gnomad_mt_") and is_mitochondrial_variant:
             value = value or "NA"
 
         if value:

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -483,6 +483,7 @@ def frequency(variant_obj):
         variant_obj.get("gnomad_frequency") or 0,
         variant_obj.get("gnomad_mt_homoplasmic_frequency") or 0,
         variant_obj.get("swegen_mei_max") or 0,
+        variant_obj.get("colorsdb_af") or 0,
     )
 
     if most_common_frequency > 0.05:

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from scout.adapter import MongoAdapter
 from scout.constants import ACMG_COMPLETE_MAP, CALLERS, CLINSIG_MAP, SO_TERMS
@@ -333,7 +333,7 @@ def predictions(genes):
     return data
 
 
-def frequencies(variant_obj):
+def frequencies(variant_obj: dict) -> list[Tuple]:
     """Convert raw annotations to a more visual format with frequencies.
 
     Args:

--- a/tests/parse/test_frequency.py
+++ b/tests/parse/test_frequency.py
@@ -182,3 +182,16 @@ def test_parse_sv_frequencies_ngi(cyvcf2_variant):
 
     # THEN assert that the last frequency is returned
     assert frequencies["clingen_ngi"] == float(variant.INFO["clingen_ngi"])
+
+
+def test_parse_colorsdb(cyvcf2_variant):
+    """Make sure CoLoRSdb AF is parsed correctly from variants.."""
+    variant = cyvcf2_variant
+    # GIVEN a variant with CoLoRSdb AF in the INFO field
+    variant.INFO["colorsdb_af"] = "0.4982"
+
+    # WHEN frequencies are parsed
+    frequencies = parse_frequencies(variant, [])
+
+    # THEN assert that CoLoRSdb frequency is collected
+    assert frequencies["colorsdb_af"] == float(variant.INFO["colorsdb_af"])


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4742

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by FL
- [x] tests executed by CR, automatic tests
