### PR TITLE
Fix ExAC links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display omics variants - wts outliers (Fraser, Outrider)
 - Parse GNOMAD `gnomad_af` and `gnomad_popmax_af` keys from variants annotated with `echtvar`
 - Make removed panel optionally visible to non-admin or non maintainers
-- Parse CoLoRSsb frequencies annotated in the variant INFO field with the `colorsdb_af` key
+- Parse CoLoRSdb frequencies annotated in the variant INFO field with the `colorsdb_af` key
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Splice junction merged track height offset in IGV.js
 - Splice junction initiation crash with empty variant obj
 - Splice junction variant routing for cases with WTS but without outlier data
+- Variant links to ExAC, now pointing to gnomAD, since the ExAC browser is no longer available
 
 ## [4.85]
 ### Added

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -563,9 +563,9 @@ def decipher_link(variant_obj, build=37):
 def exac_link(variant_obj):
     """Compose link to ExAC website for a variant position."""
     url_template = (
-        "https://exac.broadinstitute.org/variant/"
+        "https://gnomad.broadinstitute.org/variant/"
         "{this[chromosome]}-{this[position]}-{this[reference]}"
-        "-{this[alternative]}"
+        "-{this[alternative]}?dataset=exac"
     )
     return url_template.format(this=variant_obj)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4748 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Check ExAC links on variant page and on case report

**Expected outcome**:
1. Links to ExAC should show stuff

**Review:**
- [ ] code approved by
- [x] tests executed by CR
