### PR TITLE
Revert table style and remove font awesome from IGV template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parse CoLoRSdb frequencies annotated in the variant INFO field with the `colorsdb_af` key
 - Download -omics variants using the `Filter and export button`
 - Clickable COSMIC links on IGV tracks
+- Apply css style to custom IGV track table
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Download -omics variants using the `Filter and export button`
 - Clickable COSMIC links on IGV tracks
 - Possibility to un-audit previously audited filters
-- Re-apply css style to custom IGV track tables
+- Reverted table style and removed font awesome style from IGV template
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Download -omics variants using the `Filter and export button`
 - Clickable COSMIC links on IGV tracks
 - Possibility to un-audit previously audited filters
-- Apply css style to custom IGV track tables
+- Re-apply css style to custom IGV track tables
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parse CoLoRSdb frequencies annotated in the variant INFO field with the `colorsdb_af` key
 - Download -omics variants using the `Filter and export button`
 - Clickable COSMIC links on IGV tracks
-- Apply css style to custom IGV track table
+- Apply css style to custom IGV track tables
 ### Changed
 - Updated igv.js to v3.0.1
 - Alphabetically sort IGV track available for custom selection

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -18,6 +18,28 @@
     <link rel="stylesheet" type="text/css"
           href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css"/>
 
+    <style>
+        .styled-table {
+            font-size: 0.9em;
+            font-family: sans-serif;
+        }
+        .styled-table th,
+        .styled-table td {
+            padding: 12px 15px;
+        }
+        .styled-table tbody tr {
+            border-bottom: 1px solid #dddddd;
+        }
+
+        .styled-table tbody tr:nth-of-type(even) {
+            background-color: #f3f3f3;
+        }
+
+        .styled-table tbody tr:last-of-type {
+            border-bottom: 2px solid #009879;
+        }
+    </style>
+
     <!-- jQuery JS -->
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script type="text/javascript"
@@ -154,44 +176,39 @@
               };
       igv.createBrowser(div, options)
       .then(function (browser) {
-          browser.on('trackclick', function (track, popoverData) {
+            browser.on('trackclick', (track, popoverData) => {
 
-              var markup = "<table>";
+                let markup = '<table class="styled-table">'
 
-              // Don't show a pop-over when there's no data.
-              if (!popoverData || !popoverData.length) {
-                  return false;
-              }
+                // Don't show a pop-over when there's no data.
+                if (!popoverData || !popoverData.length) {
+                    return false;
+                }
 
-              popoverData.forEach(function (nameValue) {
-
-              if (nameValue.name) {
-
-                  var value = nameValue.value;
-                  for (var key in outLinks) {
-                    if (nameValue.value.toString().startsWith(key) && nameValue.name.toLowerCase() === 'name') {
-                      value = '<a href="' + outLinks[key] + value + '" target="_blank" rel="noopener noreferrer">' + nameValue.value + '</a>';
+                for (const nameValue of popoverData) {
+                    if (nameValue.name) {
+                        var value = nameValue.value;
+                        for (var key in outLinks) {
+                          if (nameValue.value.toString().startsWith(key) && nameValue.name.toLowerCase() === 'name') {
+                            value = '<a href="' + outLinks[key] + value + '" target="_blank" rel="noopener noreferrer">' + nameValue.value + '</a>';
+                          }
+                        }
+                        markup += "<tr><td>" + nameValue.name + "</td><td>" + value + "</td></tr>";
                     }
-                  }
+                    else {
+                        // not a name/value pair
+                        markup += "<tr><td>" + nameValue.toString() + "</td></tr>";
+                    }
 
-                  markup += "<tr><td class=\"igv-popover-td\">"
-                          + "<div class=\"igv-popover-name-value\">"
-                          + "<span class=\"igv-popover-name\">" + nameValue.name + "</span>&nbsp;"
-                          + "<span class=\"igv-popover-value\">" + value + "</span>"
-                          + "</div>" + "</td></tr>";
-                  }
-                  else {
-                      // not a name/value pair
-                      markup += "<tr><td>" + nameValue.toString() + "</td></tr>";
-                  }
-                });
+                }
 
                 markup += "</table>";
 
-              // By returning a string from the trackclick handler we're asking IGV to use our custom HTML in its pop-over.
-              return markup;
-          });
+                // By returning a string from the trackclick handler we're asking IGV to use our custom HTML in its pop-over.
+                return markup;
+            });
       });
+
   });
 </script>
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -14,21 +14,6 @@
     <link rel="stylesheet" type="text/css"
           href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.2/themes/smoothness/jquery-ui.css"/>
 
-    <!-- Font Awesome CSS -->
-    <link rel="stylesheet" type="text/css"
-          href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css"/>
-
-    <style>
-        .styled-table {
-            font-size: 0.9em;
-            font-family: sans-serif;
-        }
-        .styled-table th,
-        .styled-table td {
-            padding: 12px 15px;
-        }
-    </style>
-
     <!-- jQuery JS -->
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script type="text/javascript"
@@ -165,39 +150,44 @@
               };
       igv.createBrowser(div, options)
       .then(function (browser) {
-            browser.on('trackclick', (track, popoverData) => {
+          browser.on('trackclick', function (track, popoverData) {
 
-                let markup = '<table class="styled-table">'
+              var markup = "<table class=\"igv-popover-table\">";
 
-                // Don't show a pop-over when there's no data.
-                if (!popoverData || !popoverData.length) {
-                    return false;
-                }
+              // Don't show a pop-over when there's no data.
+              if (!popoverData || !popoverData.length) {
+                  return false;
+              }
 
-                for (const nameValue of popoverData) {
-                    if (nameValue.name) {
-                        var value = nameValue.value;
-                        for (var key in outLinks) {
-                          if (nameValue.value.toString().startsWith(key) && nameValue.name.toLowerCase() === 'name') {
-                            value = '<a href="' + outLinks[key] + value + '" target="_blank" rel="noopener noreferrer">' + nameValue.value + '</a>';
-                          }
-                        }
-                        markup += "<tr><td>" + nameValue.name + "</td><td>" + value + "</td></tr>";
+              popoverData.forEach(function (nameValue) {
+
+              if (nameValue.name) {
+
+                  var value = nameValue.value;
+                  for (var key in outLinks) {
+                    if (nameValue.value.toString().startsWith(key) && nameValue.name.toLowerCase() === 'name') {
+                      value = '<a href="' + outLinks[key] + value + '" target="_blank" rel="noopener noreferrer">' + nameValue.value + '</a>';
                     }
-                    else {
-                        // not a name/value pair
-                        markup += "<tr><td>" + nameValue.toString() + "</td></tr>";
-                    }
+                  }
 
-                }
+                  markup += "<tr><td class=\"igv-popover-td\">"
+                          + "<div class=\"igv-popover-name-value\">"
+                          + "<span class=\"igv-popover-name\">" + nameValue.name + "</span>&nbsp;"
+                          + "<span class=\"igv-popover-value\">" + value + "</span>"
+                          + "</div>" + "</td></tr>";
+                  }
+                  else {
+                      // not a name/value pair
+                      markup += "<tr><td>" + nameValue.toString() + "</td></tr>";
+                  }
+                });
 
                 markup += "</table>";
 
-                // By returning a string from the trackclick handler we're asking IGV to use our custom HTML in its pop-over.
-                return markup;
-            });
+              // By returning a string from the trackclick handler we're asking IGV to use our custom HTML in its pop-over.
+              return markup;
+          });
       });
-
   });
 </script>
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -27,17 +27,6 @@
         .styled-table td {
             padding: 12px 15px;
         }
-        .styled-table tbody tr {
-            border-bottom: 1px solid #dddddd;
-        }
-
-        .styled-table tbody tr:nth-of-type(even) {
-            background-color: #f3f3f3;
-        }
-
-        .styled-table tbody tr:last-of-type {
-            border-bottom: 2px solid #009879;
-        }
     </style>
 
     <!-- jQuery JS -->

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -171,10 +171,9 @@
                   }
 
                   markup += "<tr><td class=\"igv-popover-td\">"
-                          + "<div class=\"igv-popover-name-value\">"
                           + "<span class=\"igv-popover-name\">" + nameValue.name + "</span>&nbsp;"
                           + "<span class=\"igv-popover-value\">" + value + "</span>"
-                          + "</div>" + "</td></tr>";
+                          + "</td></tr>";
                   }
                   else {
                       // not a name/value pair


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Simplify and apply CSS style to custom IGV tracks tables

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
