### PR TITLE
Fix #4769 - users can disable gene track and still see sashimi view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Splice junction variant routing for cases with WTS but without outlier data
 - Variant links to ExAC, now pointing to gnomAD, since the ExAC browser is no longer available
 - Style of HPO terms assigned to a case, now one phenotype per line
+- RNA sashimi view rendering should work also if the gene track is user disabled
 
 ## [4.85]
 ### Added

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -36,7 +36,6 @@
             return allTracks[i];
           }
         }
-        return false
     }
     var geneTrack = getGeneTrack({{custom_tracks|safe}});
 
@@ -95,7 +94,7 @@
                                   },
                                 ]
                               }, // end of sashimi track with data
-                              {% if geneTrack %}
+                              {% if custom_tracks|selectattr("name","equalto", "Genes")|list|length > 0 %}
                                 { // genes track
                                   name: geneTrack.name,
                                   type: geneTrack.type,

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -36,6 +36,7 @@
             return allTracks[i];
           }
         }
+        return false
     }
     var geneTrack = getGeneTrack({{custom_tracks|safe}});
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -94,20 +94,22 @@
                                   },
                                 ]
                               }, // end of sashimi track with data
-                              { // genes track
-                                name: geneTrack.name,
-                                type: geneTrack.type,
-                                format: geneTrack.format,
-                                sourceType: geneTrack.sourceType,
-                                url: geneTrack.url,
-                                indexURL: geneTrack.indexURL,
-                                displayMode: geneTrack.displayMode,
-                                visibilityWindow: 300000000,
-                                height: 100,
-                                searchable: true,
-                                order: {{counter.loop}},
-                                infoURL: "https://www.ncbi.nlm.nih.gov/gene/?term=$$"
-                              }, // end of genes track
+                              {% if geneTrack %}
+                                { // genes track
+                                  name: geneTrack.name,
+                                  type: geneTrack.type,
+                                  format: geneTrack.format,
+                                  sourceType: geneTrack.sourceType,
+                                  url: geneTrack.url,
+                                  indexURL: geneTrack.indexURL,
+                                  displayMode: geneTrack.displayMode,
+                                  visibilityWindow: 300000000,
+                                  height: 100,
+                                  searchable: true,
+                                  order: {{counter.loop}},
+                                  infoURL: "https://www.ncbi.nlm.nih.gov/gene/?term=$$"
+                                }, // end of genes track
+                              {% endif %}
                             {% endif %}
                         {% endfor %}
                     ] // end of tracks


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Not super pretty without genes, but the user can now at least opt to disable them without making the view go down.
![Screenshot 2024-08-22 at 08 08 33](https://github.com/user-attachments/assets/bbd8af17-68b0-40aa-b4af-43a7f88e067b)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CD
- [x] tests executed by DN
