### PR TITLE
Respect igv tracks settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Splice junction variant routing for cases with WTS but without outlier data
 - Variant links to ExAC, now pointing to gnomAD, since the ExAC browser is no longer available
 - Style of HPO terms assigned to a case, now one phenotype per line
+- Respect IGV tracks chosen by user in variant IGV settings
 
 ## [4.85]
 ### Added

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -313,9 +313,6 @@ def set_config_custom_tracks(display_obj: dict, build: str):
     """Set up custom public or private tracks stored in a cloud bucket or locally. These tracks were those specified in the Scout config file.
     Respect user's preferences."""
     user_obj = store.user(email=current_user.email)
-    custom_tracks_names = user_obj.get("igv_tracks")
-
-    LOG.error(custom_tracks_names)
 
     config_custom_tracks = []
 

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -47,6 +47,7 @@ def update_tracks_settings():
     # update user in database with custom tracks info
     user_obj["igv_tracks"] = selected_tracks
     store.update_user(user_obj)
+    setattr(current_user, "igv_tracks", selected_tracks)
     return redirect(request.referrer)
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4770 - Now you can enable or disable whichever track you want

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
