### PR TITLE
Fix #4782 - explicit igv.js chr alias option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tooltip on RNA alignments now shows RNA genome build version
 ### Fixed
 - Style of "SNVs" and "SVs" buttons on WTS Outliers page
+- Chromosome alias files for igv.js
 
 ## [4.86.1]
 ### Fixed

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -4,8 +4,11 @@ HG19REF_URL = (
 )
 HG19REF_INDEX_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/1kg_v37/human_g1k_v37_decoy.fasta.fai"
 HG19CYTOBAND_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg19/cytoBand.txt"
+HG19ALIAS_URL = "https://s3.amazonaws.com/igv.org.genomes/hg19/hg19_alias.tab"
+
 HG38REF_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa"
 HG38REF_INDEX_URL = "https://s3.amazonaws.com/igv.broadinstitute.org/genomes/seq/hg38/hg38.fa.fai"
+HG38ALIAS_URL = "https://s3.amazonaws.com/igv.org.genomes/hg38/hg38_alias.tab"
 HG38CYTOBAND_URL = (
     "https://s3.amazonaws.com/igv.broadinstitute.org/annotations/hg38/cytoBandIdeo.txt"
 )
@@ -33,6 +36,7 @@ HUMAN_REFERENCE_37 = {
     "fastaURL": HG19REF_URL,
     "indexURL": HG19REF_INDEX_URL,
     "cytobandURL": HG19CYTOBAND_URL,
+    "aliasURL": HG19ALIAS_URL,
 }
 
 # Human genome reference genome build 38. Always displayed
@@ -41,6 +45,7 @@ HUMAN_REFERENCE_38 = {
     "fastaURL": HG38REF_URL,
     "indexURL": HG38REF_INDEX_URL,
     "cytobandURL": HG38CYTOBAND_URL,
+    "aliasURL": HG38ALIAS_URL,
 }
 
 # igv.js track settings common for all users and all cases. Selectable by users

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -49,7 +49,8 @@
                         id: "{{ reference_track.id }}",
                         fastaURL: "{{ reference_track.fastaURL }}",
                         indexURL: "{{ reference_track.indexURL }}",
-                        cytobandURL: "{{ reference_track.cytobandURL }}"
+                        cytobandURL: "{{ reference_track.cytobandURL }}",
+                        aliasURL: "{{ reference_track.aliasURL }}"
                     },
                 locus: '{{ locus }}',
                 tracks:

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -46,7 +46,8 @@
                         id: "{{ reference_track.id }}",
                         fastaURL: "{{ reference_track.fastaURL }}",
                         indexURL: "{{ reference_track.indexURL }}",
-                        cytobandURL: "{{ reference_track.cytobandURL }}"
+                        cytobandURL: "{{ reference_track.cytobandURL }}",
+                        aliasURL: "{{ reference_track.aliasURL }}"
                     },
                     locus: "{{locus}}",
                     tracks: [


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4782 with igv.js alias files

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

**How to test**:
1. find a variant on X, Y, MT for a case with alignment files - e.g. https://scout-stage.scilifelab.se/cust000/15026-mip7/a173fd6d7d5cba5cdab9b3b8b2281585 and https://scout-stage.scilifelab.se/cust000/F0005756-mip7/a16b311a8140e6ce56772b764286afd9/igv. For hg38 say https://scout-stage.scilifelab.se/cust000/sighthound/165f2ab79d655cf04ee7d245058c110c/igv. 
2. visit the IGV.js alignment view from the variant page
3. notice no result and JS errors for main and 4.86.1 (any IGV.js >v3, most likely)
4. apply patch and notice it working

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
 