### PR TITLE
Move the code to collect MT copy number stats for MT report to the chanjo extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Documentation for OMICS variants and updating a case
 - Include both creation and last modification dates in gene panels pages
-- Moved code to collect MT copy number stats for MT report to the chanjo extension
+- Moved code to collect MT copy number stats for the MT report to the chanjo extension
 ### Fixed
 - Broken heading anchors in the documentation (`admin-guide/login-system.md` and `admin-guide/setup-scout.md` files)
 - Avoid open login redirect attacks by always redirecting to cases page upon user login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Documentation for OMICS variants and updating a case
 - Include both creation and last modification dates in gene panels pages
+- Moved code to collect MT copy number stats for MT report to the chanjo extension
 ### Fixed
 - Broken heading anchors in the documentation (`admin-guide/login-system.md` and `admin-guide/setup-scout.md` files)
 - Avoid open login redirect attacks by always redirecting to cases page upon user login

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -729,8 +729,6 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
     if current_app.config.get("chanjo_report"):
         coverage_stats = ChanjoReport.mt_coverage_stats(samples)
 
-    LOG.warning(coverage_stats)
-
     query = {"chrom": "MT"}
     mt_variants = list(
         store.variants(case_id=case_obj["_id"], query=query, nr_of_variants=-1, sort_key="position")

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -41,9 +41,9 @@ from scout.parse.matchmaker import genomic_features, hpo_terms, omim_terms, pars
 from scout.server.blueprints.variant.controllers import variant as variant_decorator
 from scout.server.blueprints.variants.controllers import get_manual_assessments
 from scout.server.extensions import (
-    ChanjoReport,
     RerunnerError,
     bionano_access,
+    chanjo_report,
     gens,
     matchmaker,
     rerunner,
@@ -727,7 +727,7 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
     coverage_stats = None
     # if chanjo connection is established, include MT vs AUTOSOME coverage stats
     if current_app.config.get("chanjo_report"):
-        coverage_stats = ChanjoReport.mt_coverage_stats(samples)
+        coverage_stats = chanjo_report.mt_coverage_stats(individuals=samples)
 
     query = {"chrom": "MT"}
     mt_variants = list(

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -5,7 +5,8 @@
 import json
 import logging
 
-from flask import current_app, request
+import requests
+from flask import current_app, request, url_for
 from flask_babel import Babel
 from markupsafe import Markup
 

--- a/scout/server/extensions/matchmaker_extension.py
+++ b/scout/server/extensions/matchmaker_extension.py
@@ -3,7 +3,6 @@
 """
 
 import datetime
-import json
 import logging
 
 from werkzeug.datastructures import Headers

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,7 +1,7 @@
 """Tests for the cases controllers"""
 
 import responses
-from flask import Blueprint, Flask, url_for
+from flask import Flask, url_for
 
 from scout.server.blueprints.cases.controllers import (
     case,

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,13 +1,11 @@
 """Tests for the cases controllers"""
 
-import requests
 import responses
 from flask import Blueprint, Flask, url_for
 
 from scout.server.blueprints.cases.controllers import (
     case,
     coverage_report_contents,
-    mt_coverage_stats,
     phenotypes_genes,
 )
 from scout.server.extensions import store
@@ -107,45 +105,6 @@ def test_phenotype_genes_matching_phenotypes(gene_database, case_obj, hpo_term, 
 
     # THEN it should return a dictionary containing the 3 genes without associated HPO terms
     assert len(pheno_dict["Analysed genes"]["genes"].split(", ")) == 3
-
-
-def test_coverage_stats(app, monkeypatch):
-    """Test the function that sends requests to Chanjo to get MT vs autosomal coverage stats"""
-
-    # GIVEN a mock connection to chanjo and an available json_chrom_coverage endpoint
-    bp = Blueprint("report", __name__)
-
-    @bp.route("/chanjo_endpoint", methods=["POST"])
-    def json_chrom_coverage():
-        pass
-
-    app.register_blueprint(bp)
-
-    def mock_post(*args, **kwargs):
-        return MockResponse()
-
-    # AND a mock response from chanjo API with coverage stats for some samples
-    class MockResponse:
-        def __init__(self):
-            self.text = '{"sample1":36, "sample2": 32, "sample3": 34}'
-
-    monkeypatch.setattr(requests, "post", mock_post)
-
-    # Given a case with the same samples
-    individuals = []
-    samples = ["sample1", "sample2", "sample3"]
-    for sample in samples:
-        individuals.append({"individual_id": sample})
-
-    with app.app_context():
-        # WHEN the function to get the MT vs autosome coverage stats is invoked
-        coverage_stats = mt_coverage_stats(individuals, "14")
-        expected_keys = ["mt_coverage", "autosome_cov", "mt_copy_number"]
-        # THEN it should return stats for each sample, and all expected key/values for each sample
-        for sample in samples:
-            assert sample in coverage_stats
-            for key in expected_keys:
-                assert key in coverage_stats[sample]
 
 
 def test_case_controller_rank_model_link(adapter, institute_obj, test_case):

--- a/tests/server/extensions/test_chanjo_extension.py
+++ b/tests/server/extensions/test_chanjo_extension.py
@@ -2,6 +2,7 @@ import requests
 from scout.server.extensions import chanjo_report
 from flask import Blueprint
 
+
 def test_chanjo_mt_coverage_stats(app, monkeypatch):
     """Test the function that sends requests to Chanjo to get MT vs autosomal coverage stats"""
 

--- a/tests/server/extensions/test_chanjo_extension.py
+++ b/tests/server/extensions/test_chanjo_extension.py
@@ -11,6 +11,7 @@ def test_chanjo_mt_coverage_stats(app, monkeypatch):
 
     @bp.route("/chanjo_endpoint", methods=["POST"])
     def json_chrom_coverage():
+        """This is the mocker function"""
         pass
 
     app.register_blueprint(bp)

--- a/tests/server/extensions/test_chanjo_extension.py
+++ b/tests/server/extensions/test_chanjo_extension.py
@@ -1,6 +1,7 @@
 import requests
-from scout.server.extensions import chanjo_report
 from flask import Blueprint
+
+from scout.server.extensions import chanjo_report
 
 
 def test_chanjo_mt_coverage_stats(app, monkeypatch):

--- a/tests/server/extensions/test_chanjo_extension.py
+++ b/tests/server/extensions/test_chanjo_extension.py
@@ -1,0 +1,41 @@
+import requests
+from scout.server.extensions import chanjo_report
+from flask import Blueprint
+
+def test_chanjo_mt_coverage_stats(app, monkeypatch):
+    """Test the function that sends requests to Chanjo to get MT vs autosomal coverage stats"""
+
+    # GIVEN a mock connection to chanjo and an available json_chrom_coverage endpoint
+    bp = Blueprint("report", __name__)
+
+    @bp.route("/chanjo_endpoint", methods=["POST"])
+    def json_chrom_coverage():
+        pass
+
+    app.register_blueprint(bp)
+
+    def mock_post(*args, **kwargs):
+        return MockResponse()
+
+    # AND a mock response from chanjo API with coverage stats for some samples
+    class MockResponse:
+        def __init__(self):
+            self.text = '{"sample1":36, "sample2": 32, "sample3": 34}'
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    # Given a case with the same samples
+    individuals = []
+    samples = ["sample1", "sample2", "sample3"]
+    for sample in samples:
+        individuals.append({"individual_id": sample})
+
+    with app.app_context():
+        # WHEN the function to get the MT vs autosome coverage stats is invoked
+        coverage_stats = chanjo_report.mt_coverage_stats(individuals=individuals)
+        expected_keys = ["mt_coverage", "autosome_cov", "mt_copy_number"]
+        # THEN it should return stats for each sample, and all expected key/values for each sample
+        for sample in samples:
+            assert sample in coverage_stats
+            for key in expected_keys:
+                assert key in coverage_stats[sample]


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Move chanjo-specific code to the chanjo extension instead of having it on the cases controllers - Simplify before addressing #4836 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy on stage and make sure that MT report is the same as before. Tip: use [this case](https://scout-stage.scilifelab.se/cust003/21116), which has chanjo data on the server

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
