### PR TITLE
Igv locus make fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Include both creation and last modification dates in gene panels pages
 - Moved code to collect MT copy number stats for the MT report to the chanjo extension
 - On the gene panelS page, show expanded gene panel version list in one column only
+- WTS loci default to zoom to a region around a variant instead of whole gene
 ### Fixed
 - Broken heading anchors in the documentation (`admin-guide/login-system.md` and `admin-guide/setup-scout.md` files)
 - Avoid open login redirect attacks by always redirecting to cases page upon user login

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Include both creation and last modification dates in gene panels pages
 - Moved code to collect MT copy number stats for the MT report to the chanjo extension
 - On the gene panelS page, show expanded gene panel version list in one column only
-- WTS loci default to zoom to a region around a variant instead of whole gene
+- IGV.js WTS loci default to zoom to a region around a variant instead of whole gene
 ### Fixed
 - Broken heading anchors in the documentation (`admin-guide/login-system.md` and `admin-guide/setup-scout.md` files)
 - Avoid open login redirect attacks by always redirecting to cases page upon user login

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -217,16 +217,18 @@ def find_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tu
             mapped_start = mapped_coords[0]["mapped"].get("start")
             mapped_end = mapped_coords[0]["mapped"].get("end") or mapped_start
             locus_start_coord = mapped_start
-            locus_end_coords = mapped_end
-
-    variant_size_offset = (variant_obj.get("end") - variant_obj.get("position")) / 10
-    if variant_size_offset < MIN_LOCUS_SIZE_OFFSET:
-        variant_size_offset = MIN_LOCUS_SIZE_OFFSET
+            locus_end_coord = mapped_end
 
     if not locus_start_coord:
-        locus_start_coord = variant_obj.get("position") - variant_size_offset
+        locus_start_coord = variant_obj.get("position")
     if not locus_end_coord:
-        locus_end_coord = variant_obj.get("end") + variant_size_offset
+        locus_end_coord = variant_obj.get("end")
+
+    variant_size_offset = (variant_obj.get("end") - variant_obj.get("position")) / 10
+    if variant_size_offset < (MIN_LOCUS_SIZE_OFFSET * 2):
+        variant_size_offset = MIN_LOCUS_SIZE_OFFSET
+    locus_start_coord -= variant_size_offset
+    locus_end_coord += variant_size_offset
 
     return (variant_obj["chromosome"], locus_start_coord, locus_end_coord)
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -197,7 +197,7 @@ def make_merged_splice_track(ind: dict) -> dict:
     return track
 
 
-def find_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tuple:
+def get_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tuple:
     """
     Check if variant coordinates are in genome build 38, otherwise do variant coords liftover.
     Use original coordinates only if genome build was already 38 or liftover didn't work.
@@ -236,7 +236,7 @@ def find_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tu
 def make_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> str:
     """Given a variant obj, construct a locus string across variant plus a percent size offset around the variant."""
 
-    (chrom, locus_start, locus_end) = find_locus_from_variant(variant_obj, case_obj, build)
+    (chrom, locus_start, locus_end) = get_locus_from_variant(variant_obj, case_obj, build)
     return f"{chrom}:{locus_start}-{locus_end}"
 
 
@@ -249,7 +249,7 @@ def make_locus_from_gene(variant_obj: Dict, case_obj: Dict, build: str) -> str:
     The returned locus will so span all genes the variant falls into.
     """
 
-    (chrom, locus_start, locus_end) = find_locus_from_variant(variant_obj, case_obj, build)
+    (chrom, locus_start, locus_end) = get_locus_from_variant(variant_obj, case_obj, build)
     locus_start_coords = [locus_start]
     locus_end_coords = [locus_end]
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -140,7 +140,6 @@ def make_sashimi_tracks(
     if "37" in str(case_obj.get("rna_genome_build", "38")):
         build = "37"
 
-
     if variant_id:
         variant_obj = store.variant(document_id=variant_id)
         locus = make_locus_from_gene(variant_obj, case_obj, build)

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -205,6 +205,9 @@ def get_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tup
     """
     MIN_LOCUS_SIZE_OFFSET = 100
 
+    locus_start_coord = variant_obj.get("position")
+    locus_end_coord = variant_obj.get("end")
+
     if build not in str(case_obj.get("genome_build")):
         client = EnsemblRestApiClient()
         mapped_coords = client.liftover(
@@ -218,11 +221,6 @@ def get_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tup
             mapped_end = mapped_coords[0]["mapped"].get("end") or mapped_start
             locus_start_coord = mapped_start
             locus_end_coord = mapped_end
-
-    if not locus_start_coord:
-        locus_start_coord = variant_obj.get("position")
-    if not locus_end_coord:
-        locus_end_coord = variant_obj.get("end")
 
     variant_size_offset = (variant_obj.get("end") - variant_obj.get("position")) / 10
     if variant_size_offset < (MIN_LOCUS_SIZE_OFFSET * 2):

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -125,7 +125,9 @@ def make_sashimi_tracks(
     case_obj: dict, variant_id: Optional[str] = None, omics_variant_id: Optional[str] = None
 ):
     """Create a dictionary containing the required tracks for a splice junction plot
-    If either a regular variant_id or an omics variant id is passed, set display to a particular locus.
+    If either a regular variant_id set display to a particular gene locus.
+    If an omics variant id is passed, set display to a window surrounding the variant, which can be a
+    gene or an affected region.
     Otherwise defaults to whole genome "All" view.
 
     Returns:
@@ -133,18 +135,18 @@ def make_sashimi_tracks(
     """
 
     locus = "All"
-    variant_obj = None
-
-    if variant_id:
-        variant_obj = store.variant(document_id=variant_id)
-    if omics_variant_id:
-        variant_obj = store.omics_variant(variant_id=omics_variant_id)
 
     build = "38"
     if "37" in str(case_obj.get("rna_genome_build", "38")):
         build = "37"
 
-    if variant_obj:
+    variant_obj = None
+
+    if variant_id:
+        variant_obj = store.variant(document_id=variant_id)
+        locus = make_locus_from_gene(variant_obj, case_obj, build)
+    if omics_variant_id:
+        variant_obj = store.omics_variant(variant_id=omics_variant_id)
         locus = make_locus_from_variant(variant_obj, case_obj, build)
 
     display_obj = {"locus": locus, "tracks": []}
@@ -195,17 +197,13 @@ def make_merged_splice_track(ind: dict) -> dict:
     return track
 
 
-def make_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> str:
-    """Given a variant obj, construct a locus string across any gene touched for IGV to display.
-
-    Initialize locus coordinates with variant coordinates so it won't crash if variant gene(s) no longer exist in database.
+def find_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> tuple:
+    """
     Check if variant coordinates are in genome build 38, otherwise do variant coords liftover.
     Use original coordinates only if genome build was already 38 or liftover didn't work.
-    Collect locus coordinates. Take into account that variant can hit multiple genes.
-    The returned locus will so span all genes the variant falls into.
+    Collect locus coordinates.
     """
-    locus_start_coords = []
-    locus_end_coords = []
+    MIN_LOCUS_SIZE_OFFSET = 100
 
     if build not in str(case_obj.get("genome_build")):
         client = EnsemblRestApiClient()
@@ -218,13 +216,40 @@ def make_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> st
         if mapped_coords:
             mapped_start = mapped_coords[0]["mapped"].get("start")
             mapped_end = mapped_coords[0]["mapped"].get("end") or mapped_start
-            locus_start_coords.append(mapped_start)
-            locus_end_coords.append(mapped_end)
+            locus_start_coord = mapped_start
+            locus_end_coords = mapped_end
 
-    if not locus_start_coords:
-        locus_start_coords.append(variant_obj.get("position"))
-    if not locus_end_coords:
-        locus_end_coords.append(variant_obj.get("end"))
+    variant_size_offset = (variant_obj.get("end") - variant_obj.get("position")) / 10
+    if variant_size_offset < MIN_LOCUS_SIZE_OFFSET:
+        variant_size_offset = MIN_LOCUS_SIZE_OFFSET
+
+    if not locus_start_coord:
+        locus_start_coord = variant_obj.get("position") - variant_size_offset
+    if not locus_end_coord:
+        locus_end_coord = variant_obj.get("end") + variant_size_offset
+
+    return (variant_obj["chromosome"], locus_start_coord, locus_end_coord)
+
+
+def make_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> str:
+    """Given a variant obj, construct a locus string across variant plus a percent size offset around the variant."""
+
+    (chrom, locus_start, locus_end) = find_locus_from_variant(variant_obj, case_obj, build)
+    return f"{chrom}:{locus_start}-{locus_end}"
+
+
+def make_locus_from_gene(variant_obj: Dict, case_obj: Dict, build: str) -> str:
+    """Given a variant obj, construct a locus string across any gene touched for IGV to display.
+    Initialize locus coordinates with variant coordinates so it won't crash if variant gene(s) no longer exist in database.
+    Check if variant coordinates are in genome build 38, otherwise do variant coords liftover.
+    Use original coordinates only if genome build was already 38 or liftover didn't work.
+    Collect locus coordinates. Take into account that variant can hit multiple genes.
+    The returned locus will so span all genes the variant falls into.
+    """
+
+    (chrom, locus_start, locus_end) = find_locus_from_variant(variant_obj, case_obj, build)
+    locus_start_coords = [locus_start]
+    locus_end_coords = [locus_end]
 
     variant_genes_ids = [gene["hgnc_id"] for gene in variant_obj.get("genes", [])]
     for gene_id in variant_genes_ids:
@@ -237,7 +262,7 @@ def make_locus_from_variant(variant_obj: Dict, case_obj: Dict, build: str) -> st
     locus_start = min(locus_start_coords)
     locus_end = max(locus_end_coords)
 
-    return f"{variant_obj['chromosome']}:{locus_start}-{locus_end}"
+    return f"{chrom}:{locus_start}-{locus_end}"
 
 
 def set_tracks(name, file_list):

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -126,7 +126,7 @@ def make_sashimi_tracks(
 ):
     """Create a dictionary containing the required tracks for a splice junction plot
     If a regular variant_id is passed, set display to a particular gene locus.
-    If an omics variant id is passed, set display to a window surrounding the variant, which can be a
+    If an omics_variant_id is passed, set display to a window surrounding the variant, which can be a
     gene or an affected region.
     Otherwise defaults to whole genome "All" view.
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -125,7 +125,7 @@ def make_sashimi_tracks(
     case_obj: dict, variant_id: Optional[str] = None, omics_variant_id: Optional[str] = None
 ):
     """Create a dictionary containing the required tracks for a splice junction plot
-    If either a regular variant_id set display to a particular gene locus.
+    If a regular variant_id is passed, set display to a particular gene locus.
     If an omics variant id is passed, set display to a window surrounding the variant, which can be a
     gene or an affected region.
     Otherwise defaults to whole genome "All" view.

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -140,7 +140,6 @@ def make_sashimi_tracks(
     if "37" in str(case_obj.get("rna_genome_build", "38")):
         build = "37"
 
-    variant_obj = None
 
     if variant_id:
         variant_obj = store.variant(document_id=variant_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1210,6 +1210,8 @@ def one_cancer_variant(request, cancer_snv_file):
     variant = next(variant_parser)
     return variant
 
+def one_omics_variant(omics_file):
+
 
 @pytest.fixture(scope="function")
 def parsed_cancer_variant(request, cancer_variants, one_cancer_variant, cancer_case_obj):
@@ -1225,7 +1227,6 @@ def parsed_cancer_variant(request, cancer_variants, one_cancer_variant, cancer_c
 
     return variant_dict
 
-
 @pytest.fixture(scope="function")
 def cancer_variant_obj(request, parsed_cancer_variant):
     LOG.info("Return one cancer variant obj")
@@ -1234,6 +1235,20 @@ def cancer_variant_obj(request, parsed_cancer_variant):
     variant = build_variant(parsed_cancer_variant, institute_id=institute_id)
     return variant
 
+
+@pytest.fixture(scope="function")
+def parsed_omics_variant(one_omics_variant, case_obj):
+
+
+
+@pytest.fixture(scope="function")
+def omics_variant_obj(parsed_omics_variant):
+    LOG.info("Return one OMICS variant obj")
+
+    institute_id = "cust000"
+
+    variant = build_variant(parsed_omics_variant, institute_id=institute_id)
+    return variant
 
 @pytest.fixture(scope="function")
 def one_variant_customannotation(request, customannotation_snv_file):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1210,8 +1210,6 @@ def one_cancer_variant(request, cancer_snv_file):
     variant = next(variant_parser)
     return variant
 
-def one_omics_variant(omics_file):
-
 
 @pytest.fixture(scope="function")
 def parsed_cancer_variant(request, cancer_variants, one_cancer_variant, cancer_case_obj):
@@ -1227,6 +1225,7 @@ def parsed_cancer_variant(request, cancer_variants, one_cancer_variant, cancer_c
 
     return variant_dict
 
+
 @pytest.fixture(scope="function")
 def cancer_variant_obj(request, parsed_cancer_variant):
     LOG.info("Return one cancer variant obj")
@@ -1235,20 +1234,6 @@ def cancer_variant_obj(request, parsed_cancer_variant):
     variant = build_variant(parsed_cancer_variant, institute_id=institute_id)
     return variant
 
-
-@pytest.fixture(scope="function")
-def parsed_omics_variant(one_omics_variant, case_obj):
-
-
-
-@pytest.fixture(scope="function")
-def omics_variant_obj(parsed_omics_variant):
-    LOG.info("Return one OMICS variant obj")
-
-    institute_id = "cust000"
-
-    variant = build_variant(parsed_omics_variant, institute_id=institute_id)
-    return variant
 
 @pytest.fixture(scope="function")
 def one_variant_customannotation(request, customannotation_snv_file):

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -123,3 +123,7 @@ def set_case_specific_tracks():
     controllers.set_case_specific_tracks(display_obj, form_data)
     assert display_obj["rhocall_bed"]["url"] == form_data["rhocall_bed"]
     assert display_obj["tiddit_coverage_wig"] == form_data["tiddit_coverage_wig"]
+
+
+def test_make_omics_locus(app, case_obj, omics_variant_obj):
+    omics_variant_obj[""]

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -133,9 +133,9 @@ def test_make_omics_locus(app, case_obj):
 
     # GIVEN that the OMICS variant is the same buid as the case (liftover not triggered)
     build = case_obj["genome_build"]
-    omics_variant_obj["build"] = build
+    omics_variant["build"] = build
 
     # WHEN asking for a locus for the OMICS variant
     locus_str = controllers.make_locus_from_variant(omics_variant, case_obj, build)
     # THEN a locus is returned on the right chromosome
-    assert omics_variant_obj["chromosome"] in locus_str
+    assert omics_variant["chromosome"] in locus_str

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -125,5 +125,17 @@ def set_case_specific_tracks():
     assert display_obj["tiddit_coverage_wig"] == form_data["tiddit_coverage_wig"]
 
 
-def test_make_omics_locus(app, case_obj, omics_variant_obj):
-    omics_variant_obj[""]
+def test_make_omics_locus(app, case_obj):
+    """Test making loci for IGV viewing for OMICS variants."""
+
+    # GIVEN an OMICS variants
+    omics_variant = store.omics_variant_collection.find_one({"hgnc_symbols": ["POT1"]})
+
+    # GIVEN that the OMICS variant is the same buid as the case (liftover not triggered)
+    build = case_obj["genome_build"]
+    omics_variant_obj["build"] = build
+
+    # WHEN asking for a locus for the OMICS variant
+    locus_str = controllers.make_locus_from_variant(omics_variant, case_obj, build)
+    # THEN a locus is returned on the right chromosome
+    assert omics_variant_obj["chromosome"] in locus_str

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -141,6 +141,28 @@ def test_igv_authorized(app, user_obj, case_obj, variant_obj):
 
         # THEN the response should be a valid HTML page
         assert resp.status_code == 200
-        # AND when the reponse is closed case IGV tracks should be removed from session
+        # AND when the response is closed case IGV tracks should be removed from session
         resp.close()
         assert session.get("igv_tracks") is None
+
+
+def test_sashimi_igv(app, user_obj, case_obj, variant_obj):
+    """Test view requests and produces igv alignments, when the user has access to the case"""
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # GIVEN that the user is logged in
+        client.get(url_for("auto_login"))
+
+        # WHEN the igv endpoint is invoked with the right parameters
+        resp = client.get(
+            url_for(
+                "alignviewers.sashimi_igv",
+                institute_id=case_obj["owner"],
+                case_name=case_obj["display_name"],
+                variant_id=variant_obj["_id"],
+            )
+        )
+
+        # THEN the response should be a valid HTML page
+        assert resp.status_code == 200


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fix #4835 - use OMICS variant with a surrounding window for IGV view locus 

Help out finding aberration causes by centring in on the OMICS variant if given.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. with a case with omics variants (e.g. https://scout-stage.scilifelab.se/cust002/F0057227)
2. test clicking splicing and expression outliers of small and large size and note new functionality (padded variant locus - typically the gene in the case of expression outliers)
3. test e.g. clicking the sashimi view from a regular DNA variant and note the original gene(s) view is still intact

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
