### PR TITLE
Fix string pattern warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Stricter check of ID of gene panels to prevent file downloading vulnerability
 - Removed link to the retired SPANR service. SPIDEX scores are still parsed and displayed if available from variant annotation.
 - Omics variant view test coverage
+- String pattern escape warnings
 
 ## [4.88.1]
 ### Fixed

--- a/scout/constants/disease_parsing.py
+++ b/scout/constants/disease_parsing.py
@@ -1,7 +1,7 @@
 import re
 
-MIMNR_PATTERN = re.compile("[0-9]{6,6}")
-ENTRY_PATTERN = re.compile("\([1,2,3,4]\)")
+MIMNR_PATTERN = re.compile(r"[0-9]{6,6}")
+ENTRY_PATTERN = re.compile(r"\([1-4]\)")
 
 DISEASE_INHERITANCE_TERMS = [
     "Autosomal recessive",

--- a/scout/parse/omim.py
+++ b/scout/parse/omim.py
@@ -49,7 +49,7 @@ def parse_genemap2_diseases(phenotype_entry, mim_number=None):
         i = 0
         splitted_info = phenotype_info.split(",")
         for i, text in enumerate(splitted_info):
-            # Everything before ([1,2,3])
+            # Everything before ([1,2,3,4])
             # We check if we are in the part where the mim number exists
             match = ENTRY_PATTERN.search(text)
             if not match:
@@ -75,7 +75,7 @@ def parse_genemap2_diseases(phenotype_entry, mim_number=None):
             {
                 "mim_number": disease_mim,
                 "inheritance": inheritance,
-                "description": disease_description.strip("?\{\}"),
+                "description": disease_description.strip(r"?{}"),
                 "status": disease_status,
             }
         )

--- a/scout/utils/convert.py
+++ b/scout/utils/convert.py
@@ -53,7 +53,7 @@ def amino_acid_residue_change_3_to_1(protein_sequence_name):
     if protein_sequence_name is None:
         return None
 
-    p = re.compile(r"p.([A-Za-z]+)(\d+)([A-Za-z]+)")
+    p = re.compile(r"p\.([A-Za-z]+)(\d+)([A-Za-z]+)")
     m = p.match(protein_sequence_name)
     if m is None:
         return None

--- a/scout/utils/convert.py
+++ b/scout/utils/convert.py
@@ -53,7 +53,7 @@ def amino_acid_residue_change_3_to_1(protein_sequence_name):
     if protein_sequence_name is None:
         return None
 
-    p = re.compile("p.([A-Za-z]+)(\d+)([A-Za-z]+)")
+    p = re.compile(r"p.([A-Za-z]+)(\d+)([A-Za-z]+)")
     m = p.match(protein_sequence_name)
     if m is None:
         return None

--- a/scout/utils/date.py
+++ b/scout/utils/date.py
@@ -11,7 +11,7 @@ def match_date(date):
     Returns:
         bool
     """
-    date_pattern = re.compile("^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])")
+    date_pattern = re.compile(r"^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])")
     if re.match(date_pattern, date):
         return True
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4851 - string escape warnings on tests

Before:
![Screenshot 2024-09-16 at 15 56 38](https://github.com/user-attachments/assets/5aa10f84-d04c-4be7-a237-bcc72749a211)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. automated tests - but I guess depending on if you see some possible ill effects, we should go with individual possibly affected components, like OMIM loading, non-hgvs AA link outs etc.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by automated tests 
