### PR TITLE
Fix #4862 - ORPHA inheritance patterns hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Moved code to collect MT copy number stats for the MT report to the chanjo extension
 - On the gene panelS page, show expanded gene panel version list in one column only
 - IGV.js WTS loci default to zoom to a region around a variant instead of whole gene
+- Case general report no longer shows ORPHA inheritance models. OMIM models are shown colored.
 ### Fixed
 - Broken heading anchors in the documentation (`admin-guide/login-system.md` and `admin-guide/setup-scout.md` files)
 - Avoid open login redirect attacks by always redirecting to cases page upon user login
 - Stricter check of ID of gene panels to prevent file downloading vulnerability
 - Removed link to the retired SPANR service. SPIDEX scores are still parsed and displayed if available from variant annotation.
 - Omics variant view test coverage
+
 
 ## [4.88.1]
 ### Fixed

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -20,6 +20,7 @@ from scout.constants import (
     CASE_TAGS,
     CUSTOM_CASE_REPORTS,
     DATE_DAY_FORMATTER,
+    INHERITANCE_PALETTE,
     MITODEL_HEADER,
     MT_COV_STATS_HEADER,
     MT_EXPORT_HEADER,
@@ -700,6 +701,7 @@ def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict
         category="case", institute=institute_obj, case=case_obj, verb="filter_audit"
     )
 
+    data["inherit_palette"] = INHERITANCE_PALETTE
     data["manual_rank_options"] = MANUAL_RANK_OPTIONS
     data["genetic_models"] = dict(GENETIC_MODELS)
     data["report_created_at"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1,5 +1,6 @@
 {% from "cases/utils.html" import variant_transcripts, filter_audits %}
 {% from "utils.html" import comments_table, variant_related_comments_table %}
+{% from "variant/gene_disease_relations.html" import inheritance_badge %}
 {% from "variants/components.html" import fusion_variants_header, default_fusion_variant_cells %}
 
 {% extends "report_base.html" %}
@@ -712,7 +713,9 @@
                 <td>
                   <ul class="p-0" style="list-style-type: none;">
                   {% for disease_term in gene.disease_terms %}
-                    <li class="d-flex align-items-baseline"><span class="badge bg-secondary m-1">{{ disease_term._id}}</span>&nbsp;<span>{{ disease_term.description }}&nbsp;{{ disease_term.inheritance }}</span></li>
+                    <li class="d-flex align-items-baseline"><span class="badge bg-secondary m-1">{{ disease_term._id}}</span>&nbsp;<span>{{ disease_term.description }}&nbsp;{% if disease_term.source != 'ORPHA' and disease_term.inheritance %}
+                      {% for model in disease_term.inheritance %} {{ inheritance_badge(model,inherit_palette) }}{% endfor %}
+                    {% endif %}</span></li>
                   {% endfor %}
                 </ul>
                 </td>

--- a/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
+++ b/scout/server/blueprints/variant/templates/variant/gene_disease_relations.html
@@ -50,7 +50,7 @@
               {% if gene.common and gene.disease_terms %}
                 {% for disease_term in gene.disease_terms %}
                   {% if disease_term.source == 'ORPHA' %}
-                    <tr data-bs-toggle="tooltip" title="Some ORPHA disorders are phenotypic umbrella terms for multiple genetic entities. The inheritance models are in this case a set derived from all those entities, not necessarily the inheritance mode known for this gene.">
+                    <tr data-bs-toggle="tooltip" title="Some ORPHA disorders are phenotypic umbrella terms for multiple genetic entities. The inheritance models are in this case a set derived from all those entities, not necessarily modes of inheritance known for this gene. ORPHA inheritance modes will not be shown on the general case report.">
                       <td>
                           <a href="http://omim.org/entry/{{ gene.common.omim_id }}" rel="noopener" target="_blank">
                             {{ gene.common.hgnc_symbol }}

--- a/scout/server/templates/report_base.html
+++ b/scout/server/templates/report_base.html
@@ -11,7 +11,6 @@
 		tr.light-grey td{
 			background-color: LightGray;
 		}
-
   </style>
 	{% endblock %}
 

--- a/scout/server/templates/report_base.html
+++ b/scout/server/templates/report_base.html
@@ -12,65 +12,6 @@
 			background-color: LightGray;
 		}
 
-    /* affected, archived and similar accents */
-    .bg-danger-light {
-        background-color: var(--bs-info);
-    }
-
-    /* define colors to be used as class items */
-    .bg-red {
-     background-color: var(--bs-red);
-    }
-
-    .bg-orange {
-      background-color: var(--bs-orange);
-    }
-
-    .bg-blue {
-     background-color: var(--bs-blue);
-    }
-
-    .bg-teal {
-     background-color: var(--bs-teal);
-    }
-
-    .bg-green {
-     background-color: var(--bs-green);
-    }
-
-    .bg-gray {
-     background-color: var(--bs-gray);
-    }
-
-    .bg-pink {
-     background-color: var(--bs-pink);
-    }
-
-    .bg-purple {
-     background-color: var(--bs-purple);
-    }
-
-    .bg-cyan {
-     background-color: var(--bs-cyan);
-    }
-
-    .bg-gray-400 {
-       background-color: var(--bs-gray-400);
-    }
-
-    .bg-gray-dark {
-     background-color: var(--bs-gray-dark);
-    }
-
-    .bg-yellow {
-     background-color: var(--bs-yellow);
-    }
-
-    .bg-light {
-       background-color: var(--bs-light);
-    }
-    /* End of css colors */
-
   </style>
 	{% endblock %}
 

--- a/scout/server/templates/report_base.html
+++ b/scout/server/templates/report_base.html
@@ -6,10 +6,71 @@
 	{% block css %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='bs_styles.css') }}">
     <style>
 		tr.light-grey td{
 			background-color: LightGray;
 		}
+
+    /* affected, archived and similar accents */
+    .bg-danger-light {
+        background-color: var(--bs-info);
+    }
+
+    /* define colors to be used as class items */
+    .bg-red {
+     background-color: var(--bs-red);
+    }
+
+    .bg-orange {
+      background-color: var(--bs-orange);
+    }
+
+    .bg-blue {
+     background-color: var(--bs-blue);
+    }
+
+    .bg-teal {
+     background-color: var(--bs-teal);
+    }
+
+    .bg-green {
+     background-color: var(--bs-green);
+    }
+
+    .bg-gray {
+     background-color: var(--bs-gray);
+    }
+
+    .bg-pink {
+     background-color: var(--bs-pink);
+    }
+
+    .bg-purple {
+     background-color: var(--bs-purple);
+    }
+
+    .bg-cyan {
+     background-color: var(--bs-cyan);
+    }
+
+    .bg-gray-400 {
+       background-color: var(--bs-gray-400);
+    }
+
+    .bg-gray-dark {
+     background-color: var(--bs-gray-dark);
+    }
+
+    .bg-yellow {
+     background-color: var(--bs-yellow);
+    }
+
+    .bg-light {
+       background-color: var(--bs-light);
+    }
+    /* End of css colors */
+
   </style>
 	{% endblock %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Hide ORPHA inheritance patterns on general report, as they can be misleading. Compare note on variant view. 
Also added colored badges for the OMIM inheritance models for consistency with the variant page.

Before: 
<img width="247" alt="Screenshot 2024-09-17 at 15 59 27" src="https://github.com/user-attachments/assets/d92a53d5-4723-440e-90ef-372d7db9b5e4">

After:
<img width="220" alt="Screenshot 2024-09-17 at 15 56 05" src="https://github.com/user-attachments/assets/4e414726-3e3f-429e-bbb9-8cc3a8313dfa">

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
