### PR TITLE
Fix delete icons on ClinVar submissions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Omics variant view test coverage
 - String pattern escape warnings
 - Code creating Alamut links for variant genes without canonical_transcript set
+- Variant delete button in ClinVar submissions page
 
 ## [4.88.1]
 ### Fixed

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -160,7 +160,7 @@
                   <td>{{subm_variant.clinsig}}</td>
                   <td>{{subm_variant.added_by or "N/A"}}</td>
                   <form id="delete_variant_{{subm_variant._id}}" action="{{ url_for('clinvar.clinvar_delete_object', submission=subm_obj._id, object_type='variant_data') }}" method="POST">
-                    <td><button type="submit" name="delete_object" value="{{subm_variant._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash fa-lg" aria-hidden="true"></span></button></td>
+                    <td><button type="submit" name="delete_object" value="{{subm_variant._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash" aria-hidden="true"></span></button></td>
                   </form>
                 </tr>
                 <tr>
@@ -217,7 +217,7 @@
                     <td>{{var_key_name[case.linking_id]|truncate(25,true,'..')}}</td>
                     <td>{{case.allele_origin}}</td>
                     <form id="delete_casedata_{{case._id}}" action="{{ url_for('clinvar.clinvar_delete_object', submission=subm_obj._id, object_type='case_data') }}" method="POST">
-                      <td><button type="submit" name="delete_object" value="{{case._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash fa-lg" aria-hidden="true"></span></button></td>
+                      <td><button type="submit" name="delete_object" value="{{case._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash" aria-hidden="true"></span></button></td>
                     </form>
                   </tr>
                   <tr>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4870

### Main branch:

<img width="401" alt="image" src="https://github.com/user-attachments/assets/fcf23093-fe10-4959-bd43-e076c75c8eb4">

### This branch:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/21a5648e-fe6c-4b0c-8afd-dc6fe27797da">


**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
