### PR TITLE
Fix #4895 - missing STR source crash in general report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+
+##[unreleased]
+### Fixed
+- general case report generation crash when encountering STR variants without "source" tags
+
 ## [4.89]
 ### Added
 - Button on SMN CN page to search variants within SMN1 and SMN2 genes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ##[unreleased]
 ### Fixed
-- general case report generation crash when encountering STR variants without "source" tags
+- general case report crash when encountering STR variants without "source" tags
 
 ## [4.89]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1140,7 +1140,7 @@
     {{ variant_phenotypes(variant) }}
   </div>
   <div class="card-body">
-    <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent; margin-left:-.3rem;>
+    <table id="panel-table" class="table table-sm table-bordered" style="background-color: transparent; margin-left:-.3rem;">
       <thead>
         <tr class="table-secondary">
           <th>Variant type</th>
@@ -1262,7 +1262,7 @@
             {{ variant.str_inheritance_mode if variant.str_inheritance_mode else "-" }}
           </td>
           <td>
-            {% if variant.str_source.display %}
+            {% if variant.str_source and variant.str_source.display %}
               <a style="text-decoration:none;" href="{{variant.str_source_link}}" target="_blank" rel="noopener noreferrer">{{ variant.str_source.display }} </a>
             {% else %}
               "-"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4895 

Before: 
![Screenshot 2024-09-30 at 17 24 38](https://github.com/user-attachments/assets/02304e8c-eb6f-4978-ade3-3532f6013cd0)

After:
![Screenshot 2024-09-30 at 17 28 43](https://github.com/user-attachments/assets/19e1ce69-9b3f-4ea4-aa7a-d6207525cc45)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. pin e.g. a ZFHX3 variant
2. look at general report

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
