### PR TITLE
Fix #4907 - add more ACMG ClinGen SVI links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Added
 - Link to chanjo2 MANE coverage overview on case page and panel page
+- More SVI recommendation links on the ACMG page
 ### Changed
 - Variants query backend allows rank_score filtering
 - Added script to tabulate causatives clinical filter rank

--- a/scout/constants/acmg.py
+++ b/scout/constants/acmg.py
@@ -67,9 +67,9 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                     (
                         "PS2",
                         {
-                            "short": "De novo (confirmed)",
+                            "short": "<i>De novo</i> (confirmed)",
                             "description": "De novo (both maternity and paternity confirmed) in a patient with the disease and no family history",
-                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI de novo</a>.',
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI <i>de novo</i></a>.',
                         },
                     ),
                     (
@@ -135,9 +135,9 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                     (
                         "PM6",
                         {
-                            "short": "De novo (unconfirmed)",
+                            "short": "<i>De novo</i> (unconfirmed)",
                             "description": "Assumed de novo, but without confirmation of paternity and maternity",
-                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI de novo</a>.',
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI <i>de novo</i></a>.',
                         },
                     ),
                 ]

--- a/scout/constants/acmg.py
+++ b/scout/constants/acmg.py
@@ -77,6 +77,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Functional damage",
                             "description": "Well-established in vitro or in vivo functional studies supportive of a damaging effect on the gene or gene product, and the evidence is strong",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/recommendations-for-application-of-the-functional-evidence-ps3-bs3-criterion-using-the-acmg-amp-sequence-variant-interpretation/" target="_blank">Brnich 2019</a>.',
                         },
                     ),
                     (
@@ -152,6 +153,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Cosegregation",
                             "description": "Cosegregation with disease in multiple affected family members in a gene definitively known to cause the disease, and the evidence is weak",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/clingen-guidance-for-use-of-the-pp1-bs4-co-segregation-and-pp4-phenotype-specificity-criteria-for-sequence-variant/" target="_blank">Biesecker et al 2023</a>',
                         },
                     ),
                     (
@@ -166,6 +168,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Predicted pathogenic",
                             "description": "Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc)",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/calibration-of-computational-tools-for-missense-variant-pathogenicity-classification-and-clingen-recommendations-for-pp3-bp4-cri/" target="_blank">Pejaver et al</a>',
                         },
                     ),
                     (
@@ -173,6 +176,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Phenotype: single gene",
                             "description": "Patient's phenotype or family history is highly specific for a disease with a single genetic etiology",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/clingen-guidance-for-use-of-the-pp1-bs4-co-segregation-and-pp4-phenotype-specificity-criteria-for-sequence-variant/" target="_blank">Biesecker et al 2023</a>',
                         },
                     ),
                     (
@@ -180,6 +184,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Reported pathogenic, evidence unavailable",
                             "description": "Reputable source recently reports variant as pathogenic, but the evidence is not available to the laboratory to perform an independent evaluation",
+                            "documentation": 'Deprecated by ClinGen SVI <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6709533/" target="_blank">Biesecker et al 2018</a>.',
                         },
                     ),
                 ]
@@ -197,8 +202,9 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                     (
                         "BA1",
                         {
-                            "short": "Frequency >=hi_freq_cutoff",
-                            "description": "Allele frequency is >=hi_freq_cutoff in ESP, 1000G or ExAC",
+                            "short": "Frequency >=0.05",
+                            "description": "Allele frequency is >=0.05 in a general continental population dataset",
+                            "documentation": 'For clarification and exceptions see <a href="https://clinicalgenome.org/docs/updated-recommendation-for-the-benign-stand-alone-acmg-amp-criterion/" target="_blank">Ghosh et al</a>',
                         },
                     )
                 ]
@@ -227,6 +233,7 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                         {
                             "short": "No functional damage",
                             "description": "Well-established in vitro or in vivo functional studies show no damaging effect on protein function or splicing, and the evidence is strong",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/recommendations-for-application-of-the-functional-evidence-ps3-bs3-criterion-using-the-acmg-amp-sequence-variant-interpretation/" target="_blank">Brnich 2019</a>.',
                         },
                     ),
                     (
@@ -234,6 +241,7 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                         {
                             "short": "Non-segregation",
                             "description": "Lack of segregation in affected members of a family, and the evidence is strong",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/docs/clingen-guidance-for-use-of-the-pp1-bs4-co-segregation-and-pp4-phenotype-specificity-criteria-for-sequence-variant/" target="_blank">Biesecker et al 2023</a>',
                         },
                     ),
                 ]
@@ -283,6 +291,7 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                         {
                             "short": "Reported benign, evidence unavailable",
                             "description": "Reputable source recently reports variant as benign, but the evidence is not available to the laboratory to perform an independent evaluation",
+                            "documentation": 'Deprecated by ClinGen SVI <a href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6709533/" target="_blank">Biesecker et al</a>.',
                         },
                     ),
                     (

--- a/scout/constants/acmg.py
+++ b/scout/constants/acmg.py
@@ -47,7 +47,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "Null variant",
                             "description": "Null variant (nonsense, frameshift, canonical +/- 2 bp splice sites, initiation codon, single or multiexon deletion) in a gene where LOF is a known mechanism of disease.",
-                            "documentation": 'Strength can be modified based on <a href="https://pubmed.ncbi.nlm.nih.gov/30192042/" target="_blank">Tayoun et al</a> and <a href="http://autopvs1.genetics.bgi.com/" target="_blank">AutoPVS1</a>.',
+                            "documentation": 'Strength can be modified based on <a href="https://pubmed.ncbi.nlm.nih.gov/30192042/" target="_blank">Tayoun et al</a> and <a href="http://autopvs1.genetics.bgi.com/" target="_blank">AutoPVS1</a>, or for RNA <a href="https://www.clinicalgenome.org/docs/application-of-the-acmg-amp-framework-to-capture-evidence-relevant-to-predicted-and-observed-impact-on-splicing-recommendations/" target="_blank">Walker et al</a>.',
                         },
                     )
                 ]
@@ -60,7 +60,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                     (
                         "PS1",
                         {
-                            "short": "Known pathogenic aa (HQ)",
+                            "short": "Known pathogenic aa",
                             "description": "Same amino acid change as a previously established pathogenic variant regardless of nucleotide change",
                         },
                     ),
@@ -69,12 +69,13 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "De novo (confirmed)",
                             "description": "De novo (both maternity and paternity confirmed) in a patient with the disease and no family history",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI de novo</a>.',
                         },
                     ),
                     (
                         "PS3",
                         {
-                            "short": "Functional damage (HQ)",
+                            "short": "Functional damage",
                             "description": "Well-established in vitro or in vivo functional studies supportive of a damaging effect on the gene or gene product, and the evidence is strong",
                         },
                     ),
@@ -113,7 +114,8 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         "PM3",
                         {
                             "short": "In trans pathogenic & AR",
-                            "description": "For recessive disorders, detected in trans with a pathogenic variant.",
+                            "description": "For recessive disorders, detected in trans with a pathogenic variant",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3717/svi_proposal_for_pm3_criterion_-_version_1.pdf" target="_blank">SVI in <i>trans</i></a>.',
                         },
                     ),
                     (
@@ -126,8 +128,8 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                     (
                         "PM5",
                         {
-                            "short": "Similar to known pathogenic aa (HQ)",
-                            "description": "Novel missense change at an amino acid residue where a different missense change determined to be pathogenic has been seen before,  the amino acids have similar properties and the evidence is strong",
+                            "short": "Similar to known pathogenic aa",
+                            "description": "Novel missense change at an amino acid residue where a different missense change determined to be pathogenic has been seen before, the amino acids have similar properties and the evidence is strong",
                         },
                     ),
                     (
@@ -135,6 +137,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         {
                             "short": "De novo (unconfirmed)",
                             "description": "Assumed de novo, but without confirmation of paternity and maternity",
+                            "documentation": 'Strength can be modified based on <a href="https://clinicalgenome.org/site/assets/files/3461/svi_proposal_for_de_novo_criteria_v1_1.pdf" target="_blank">SVI de novo</a>.',
                         },
                     ),
                 ]
@@ -147,7 +150,7 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                     (
                         "PP1",
                         {
-                            "short": "Cosegregation (WQ)",
+                            "short": "Cosegregation",
                             "description": "Cosegregation with disease in multiple affected family members in a gene definitively known to cause the disease, and the evidence is weak",
                         },
                     ),
@@ -155,14 +158,14 @@ ACMG_CRITERIA["pathogenicity"] = OrderedDict(
                         "PP2",
                         {
                             "short": "Missense: important",
-                            "description": "Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease.",
+                            "description": "Missense variant in a gene that has a low rate of benign missense variation and in which missense variants are a common mechanism of disease",
                         },
                     ),
                     (
                         "PP3",
                         {
                             "short": "Predicted pathogenic",
-                            "description": "Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc.)",
+                            "description": "Multiple lines of computational evidence support a deleterious effect on the gene or gene product (conservation, evolutionary, splicing impact, etc)",
                         },
                     ),
                     (
@@ -222,14 +225,14 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                     (
                         "BS3",
                         {
-                            "short": "No functional damage (HQ)",
+                            "short": "No functional damage",
                             "description": "Well-established in vitro or in vivo functional studies show no damaging effect on protein function or splicing, and the evidence is strong",
                         },
                     ),
                     (
                         "BS4",
                         {
-                            "short": "Non-segregation (HQ)",
+                            "short": "Non-segregation",
                             "description": "Lack of segregation in affected members of a family, and the evidence is strong",
                         },
                     ),

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -77,7 +77,7 @@
                         {{ criterion.short|safe}}
                       </div>
                       <div class="form-check form-switch">
-                        <input type="checkbox" class="form-check-input" id="checkbox-{{ criterion_code }}" name="criteria" value="{{ criterion_code }}" {{ 'checked' if evaluation and criterion_code in evaluation.criteria }} {{ 'disabled' if evaluation and edit is false}}>
+                        <input type="checkbox" class="form-check-input" id="checkbox-{{ criterion_code }}" name="criteria" value="{{ criterion_code }}" {{ 'checked' if evaluation and criterion_code in evaluation.criteria }} {{ 'disabled' if evaluation and edit is false }}>
                         <label class="form-check-label" for="checkbox-{{ criterion_code }}"></label>
                       </div>
                     </div>
@@ -88,7 +88,7 @@
                           <option value="" {% if not modifier %}selected{% endif %}>Strength modifier...</option>
                           {% for level in "Strong", "Moderate", "Supporting" %}
                             {% if(level != evidence) %}
-                              <option id="{{criterion_code}}-{{level}}" value="{{level}}" {% if modifier == level %}selected{% endif%}>{{ level }}</option>
+                              <option id="{{ criterion_code }}-{{ level }}" value="{{ level }}" {% if modifier == level %}selected{% endif %}>{{ level }}</option>
                             {% endif %}
                           {% endfor %}
                         </select>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -82,7 +82,7 @@
                       </div>
                     </div>
                     <div id="comment-{{ criterion_code }}" class="{{ 'collapse' if not (comment or link or modifier) }} mt-2">
-                      {% if criterion.documentation %}<div class="row"><span class="me-1 fw-light text-wrap">{{ criterion.documentation | safe}}</span></div>{% endif %}
+                      {% if criterion.documentation %}<div class="row"><span class="me-1 fw-light text-wrap">{{ criterion.documentation | safe }}</span></div>{% endif %}
                       <div class="row">
                         <select {{ 'disabled' if evaluation and edit is false}} id="modifier-{{ criterion_code }}" name="modifier-{{ criterion_code }}" class="form-control form-select">
                           <option value="" {% if not modifier %}selected{% endif %}>Strength modifier...</option>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -32,7 +32,7 @@
           {% if evaluation %}
              <h4>
               {{ evaluation.classification.label }}
-              <span class="badge bg-info">{{ evaluation.classification.short }}</span>
+              <span class="badge bg-info">{{ evaluation.classification.short|safe }}</span>
             </h4>
             By {{ evaluation.user_name }} on {{ evaluation.created_at.date() }}
             {% if edit %}
@@ -72,9 +72,9 @@
                   {% endif %}
                   <div class="list-group-item">
                     <div class="d-flex justify-content-between">
-                      <div data-bs-toggle="tooltip" data-bs-placement="top" title="{{ criterion.description }}">
+                      <div data-bs-toggle="tooltip" data-bs-placement="top" title="{{ criterion.description|safe }}">
                         <span class="badge bg-info me-1">{{ criterion_code }}</span>
-                        {{ criterion.short }}
+                        {{ criterion.short|safe}}
                       </div>
                       <div class="form-check form-switch">
                         <input type="checkbox" class="form-check-input" id="checkbox-{{ criterion_code }}" name="criteria" value="{{ criterion_code }}" {{ 'checked' if evaluation and criterion_code in evaluation.criteria }} {{ 'disabled' if evaluation and edit is false}}>


### PR DESCRIPTION
This PR adds a functionality.

It turns out the SVI PVS1 flowchart is basically included in the Tayoun publication which we already link. I held off on that, but included other guidelines that were discussed in the GMCK-RD meeting, ie for RNA on PVS1/PM6, as well as in trans and *de novo* semi-quantitative approaches (PS2, PM3).

![Screenshot 2024-10-08 at 13 02 16](https://github.com/user-attachments/assets/0a4c21fc-1f8e-490e-a02a-718b34cb774d)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. look at text and click links

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
