### PR TITLE
Fix #4909 - Tavtigian Bayesian point sums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to chanjo2 MANE coverage overview on case page and panel page
 - More SVI recommendation links on the ACMG page
 - IGV buttons for SMN CN page
+- Warnings on ACMG classifications for potentially conflicting classification pairs
 - ACMG Bayesian foundation point scale after Tavtigian for variant heat profile
 ### Changed
 - Variants query backend allows rank_score filtering

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ## Added
 - Link to chanjo2 MANE coverage overview on case page and panel page
+- ACMG Bayesian foundation point scale after Tavtigian for variant heat profile
 ### Changed
 - Variants query backend allows rank_score filtering
 - Added script to tabulate causatives clinical filter rank

--- a/scout/constants/acmg.py
+++ b/scout/constants/acmg.py
@@ -297,7 +297,7 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
                     (
                         "BP7",
                         {
-                            "short": "(not in use)",
+                            "short": "Synonymous, no impact on splicing",
                             "description": "A synonymous variant for which splicing prediction algorithms predict no impact to the splice consensus sequence nor the creation of a new splice site",
                         },
                     ),
@@ -306,3 +306,51 @@ ACMG_CRITERIA["benign impact"] = OrderedDict(
         ),
     ]
 )
+
+ACMG_POTENTIAL_CONFLICTS = [
+    (
+        "PVS1",
+        "PM4",
+        "Use of PVS1 and PM4 together risks double-counting evidence (Tayoun et al 2019).",
+    ),
+    (
+        "PVS1",
+        "PM1",
+        "Use of PVS1 and PM1 together is not recommended (Durkie et al 2024).",
+    ),
+    (
+        "PVS1",
+        "PP2",
+        "Use of PVS1 and PP2 together is not recommended (Durkie et al 2024).",
+    ),
+    (
+        "PVS1",
+        "PS3",
+        "Note that for RNA PS3 should only be taken with PVS1 for well established functional assays, not splicing alone (Walker 2023).",
+    ),
+    (
+        "PS1",
+        "PM4",
+        "Use of PS1 and PM4 together is not recommended (Durkie et al 2024).",
+    ),
+    (
+        "PS1",
+        "PM5",
+        "Use of PS1 and PM5 together conflicts with original definition (Richards et al 2015).",
+    ),
+    (
+        "PS1",
+        "PP3",
+        "Use of PS1 and PP3 together risks double-counting evidence (Tayoun et al 2019).",
+    ),
+    (
+        "PS2",
+        "PM6",
+        "Use of PS2 and PM6 together conflicts with original definition (Richards et al 2015).",
+    ),
+    (
+        "PM1",
+        "PP2",
+        "Avoid double-counting evidence for constraints in both PM1 and PP2 (Durkie et al 2024).",
+    ),
+]

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -45,7 +45,9 @@
           <!-- classification preview in the footer-->
           <div class="mt-3 fixed-bottom bg-light border">
             <div class="row">
-            <div class="col-3"><a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/">Tavtigian et al</a> <span id="temperature_span" class="badge"></span></div>
+              <div class="col-3">
+                <a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a>
+              </div>
               <div class="col-6 text-center">
                 {% for option in ACMG_OPTIONS %}
                   <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -42,19 +42,7 @@
           {% elif not evaluation %}
             <button class="btn btn-primary form-control">Submit</button>
           {% endif %}
-          <!-- classification preview in the footer-->
-          <div class="mt-3 fixed-bottom bg-light border">
-            <div class="row">
-              <div class="col-3" style="font-size:1.5em">
-                <a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a></p>
-              </div>
-              <div class="col-6 text-center">
-                {% for option in ACMG_OPTIONS %}
-                  <a id="acmg-{{ option.code }}" href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" class="btn acmg-preview" data-bs-toggle="tooltip" title="Suggested classification based on Richards et al 2015.">{{ option.label }}</a>
-                {% endfor %}
-              </div>
-            </div>
-          </div>
+          <div id="conflicts_div" class="bg-warning"></div>
         </div>
       </div>
 
@@ -113,6 +101,14 @@
           </div>
         {% endfor %}
       </div>
+    <!-- classification preview in the footer-->
+      <div class="mt-3 fixed-bottom bg-light border">
+        <div class="text-center">
+          {% for option in ACMG_OPTIONS %}
+            <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
+          {% endfor %}
+        </div>
+      </div>
     </form>
   </div>
 {% endblock %}
@@ -167,9 +163,14 @@
         $('.acmg-preview').removeClass('btn-primary');
         // add new selection
         $('#acmg-' + data.classification).addClass('btn-primary');
+
         var temperature_span = document.getElementById("temperature_span");
         temperature_span.innerHTML = 'Score ' + data.points + ' <span class="fa ' + data.temperature_icon + '"></span> ' + data.temperature + ' (' + data.point_classification + ')'
         temperature_span.className = 'badge bg-' + data.temperature_class
+
+        // Update any classification conflicts
+        var conflicts_div = document.getElementById("conflicts_div");
+        conflicts_div.innerHTML = data.conflicts.join("<br>");
       });
     }
   </script>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -103,10 +103,15 @@
       </div>
     <!-- classification preview in the footer-->
       <div class="mt-3 fixed-bottom bg-light border">
-        <div class="text-center">
+        <div class="row">
+          <div class="col-3" style="font-size:1.5em">
+            <a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a>
+          </div>
+          <div class="col-6 text-center">
           {% for option in ACMG_OPTIONS %}
-            <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
+            <a id="acmg-{{ option.code }}" href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" class="btn acmg-preview" data-bs-toggle="tooltip" title="Suggested classification based on Richards et al 2015.">{{ option.label }}</a>
           {% endfor %}
+          </div>
         </div>
       </div>
     </form>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -44,11 +44,13 @@
           {% endif %}
           <!-- classification preview in the footer-->
           <div class="mt-3 fixed-bottom bg-light border">
+
               <div class="text-center">
                 {% for option in ACMG_OPTIONS %}
                   <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
                 {% endfor %}
               </div>
+              <div class="text-center" id="temperature_div"></div>
           </div>
         </div>
       </div>
@@ -112,15 +114,6 @@
   </div>
 {% endblock %}
 
-{% macro preview() %}
-  <div class="card panel-default">
-    <div class="card-body">
-      <span class="text-muted">Classification</span>
-      <h5>Likely Pathogenic</h5>
-    </div>
-  </div>
-{% endmacro %}
-
 {% block scripts %}
   {{ super() }}
 
@@ -166,12 +159,13 @@
         return 'criterion=' + elem.value
       });
 
-
       $.getJSON('/api/v1/acmg?' + criteria.toArray().join('&'), function(data) {
         // reset the selection
         $('.acmg-preview').removeClass('btn-primary');
         // add new selection
         $('#acmg-' + data.classification).addClass('btn-primary');
+        var temperature_div = document.getElementById("temperature_div");
+        temperature_div.innerHTML = data.points + ' - ' + data.temperature + ' - ' + data.point_classification
       });
     }
   </script>

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -46,11 +46,11 @@
           <div class="mt-3 fixed-bottom bg-light border">
             <div class="row">
               <div class="col-3">
-                <a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a>
+                <h4><a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a></h4>
               </div>
               <div class="col-6 text-center">
                 {% for option in ACMG_OPTIONS %}
-                  <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
+                  <a id="acmg-{{ option.code }}" href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf" class="btn acmg-preview" data-bs-toggle="tooltip" title="Suggested classification based on Richards et al 2015.">{{ option.label }}</a>
                 {% endfor %}
               </div>
             </div>
@@ -168,7 +168,7 @@
         // add new selection
         $('#acmg-' + data.classification).addClass('btn-primary');
         var temperature_span = document.getElementById("temperature_span");
-        temperature_span.innerHTML = 'Score ' + data.points + ' <span class="fa ' + data.temperature_icon + '"></span> ' + data.temperature + ' - (' + data.point_classification + ')'
+        temperature_span.innerHTML = 'Score ' + data.points + ' <span class="fa ' + data.temperature_icon + '"></span> ' + data.temperature + ' (' + data.point_classification + ')'
         temperature_span.className = 'badge bg-' + data.temperature_class
       });
     }

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -45,8 +45,8 @@
           <!-- classification preview in the footer-->
           <div class="mt-3 fixed-bottom bg-light border">
             <div class="row">
-              <div class="col-3">
-                <h4><a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a></h4>
+              <div class="col-3" style="font-size:1.5em">
+                <a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/" data-bs-toggle="tooltip" title="Classification based on the Bayesian score model in Tavtigian et al." rel="noopener noreferrer" target="_blank"><span id="temperature_span" class="badge"></span></a></p>
               </div>
               <div class="col-6 text-center">
                 {% for option in ACMG_OPTIONS %}

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -44,13 +44,14 @@
           {% endif %}
           <!-- classification preview in the footer-->
           <div class="mt-3 fixed-bottom bg-light border">
-
-              <div class="text-center">
+            <div class="row">
+            <div class="col-3"><a href="https://clinicalgenome.org/docs/modeling-the-acmg-amp-variant-classification-gudielines-as-a-bayesian-classification-framework/">Tavtigian et al</a> <span id="temperature_span" class="badge"></span></div>
+              <div class="col-6 text-center">
                 {% for option in ACMG_OPTIONS %}
                   <a id="acmg-{{ option.code }}" class="btn acmg-preview">{{ option.label }}</a>
                 {% endfor %}
               </div>
-              <div class="text-center" id="temperature_div"></div>
+            </div>
           </div>
         </div>
       </div>
@@ -164,8 +165,9 @@
         $('.acmg-preview').removeClass('btn-primary');
         // add new selection
         $('#acmg-' + data.classification).addClass('btn-primary');
-        var temperature_div = document.getElementById("temperature_div");
-        temperature_div.innerHTML = data.points + ' - ' + data.temperature + ' - ' + data.point_classification
+        var temperature_span = document.getElementById("temperature_span");
+        temperature_span.innerHTML = 'Score ' + data.points + ' <span class="fa ' + data.temperature_icon + '"></span> ' + data.temperature + ' - (' + data.point_classification + ')'
+        temperature_span.className = 'badge bg-' + data.temperature_class
       });
     }
   </script>

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -347,15 +347,8 @@ def acmg():
     """Calculate an ACMG classification from submitted criteria."""
     criteria = request.args.getlist("criterion")
     classification = get_acmg(criteria)
-    (points, temperature, point_classification) = get_acmg_temperature(criteria)
-    return jsonify(
-        dict(
-            classification=classification,
-            points=points,
-            temperature=temperature,
-            point_classification=point_classification,
-        )
-    )
+    acmg_bayesian = get_acmg_temperature(criteria)
+    return jsonify({classification: classification, **acmg_bayesian})
 
 
 @variant_bp.route(

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -26,11 +26,7 @@ from scout.server.blueprints.variant.verification_controllers import (
 )
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, public_endpoint, templated
-<<<<<<< HEAD
 from scout.utils.acmg import get_acmg, get_acmg_conflicts, get_acmg_temperature
-=======
-from scout.utils.acmg import get_acmg, get_acmg_conflicts
->>>>>>> main
 from scout.utils.ensembl_rest_clients import EnsemblRestApiClient
 
 LOG = logging.getLogger(__name__)
@@ -355,6 +351,7 @@ def acmg():
     acmg_bayesian = get_acmg_temperature(criteria)
     acmg_conflicts = get_acmg_conflicts(criteria)
     return jsonify({"classification": classification, "conflicts": acmg_conflicts, **acmg_bayesian})
+
 
 @variant_bp.route(
     "/<institute_id>/<case_name>/<variant_id>/<order>",

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -348,7 +348,7 @@ def acmg():
     criteria = request.args.getlist("criterion")
     classification = get_acmg(criteria)
     acmg_bayesian = get_acmg_temperature(criteria)
-    return jsonify({classification: classification, **acmg_bayesian})
+    return jsonify({"classification": classification, **acmg_bayesian})
 
 
 @variant_bp.route(

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -26,7 +26,7 @@ from scout.server.blueprints.variant.verification_controllers import (
 )
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, public_endpoint, templated
-from scout.utils.acmg import get_acmg
+from scout.utils.acmg import get_acmg, get_acmg_temperature
 from scout.utils.ensembl_rest_clients import EnsemblRestApiClient
 
 LOG = logging.getLogger(__name__)
@@ -347,7 +347,15 @@ def acmg():
     """Calculate an ACMG classification from submitted criteria."""
     criteria = request.args.getlist("criterion")
     classification = get_acmg(criteria)
-    return jsonify(dict(classification=classification))
+    (points, temperature, point_classification) = get_acmg_temperature(criteria)
+    return jsonify(
+        dict(
+            classification=classification,
+            points=points,
+            temperature=temperature,
+            point_classification=point_classification,
+        )
+    )
 
 
 @variant_bp.route(

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -26,7 +26,7 @@ from scout.server.blueprints.variant.verification_controllers import (
 )
 from scout.server.extensions import loqusdb, store
 from scout.server.utils import institute_and_case, public_endpoint, templated
-from scout.utils.acmg import get_acmg, get_acmg_temperature
+from scout.utils.acmg import get_acmg, get_acmg_conflicts, get_acmg_temperature
 from scout.utils.ensembl_rest_clients import EnsemblRestApiClient
 
 LOG = logging.getLogger(__name__)
@@ -347,8 +347,10 @@ def acmg():
     """Calculate an ACMG classification from submitted criteria."""
     criteria = request.args.getlist("criterion")
     classification = get_acmg(criteria)
+
     acmg_bayesian = get_acmg_temperature(criteria)
-    return jsonify({"classification": classification, **acmg_bayesian})
+    acmg_conflicts = get_acmg_conflicts(criteria)
+    return jsonify({"classification": classification, "conflicts": acmg_conflicts, **acmg_bayesian})
 
 
 @variant_bp.route(

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -297,13 +297,13 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
     """
     TEMPERATURE_STRINGS = {
         -1: {"label": "B/LB", "color": "success", "icon": "fa-times"},
-        0: {"label": "Ice cold", "color": "success", "icon": "fa-icicles"},
+        0: {"label": "Ice cold", "color": "info", "icon": "fa-icicles"},
         1: {"label": "Cold", "color": "info", "icon": "fa-snowman"},
         2: {"label": "Cold", "color": "info", "icon": "fa-snowflake"},
         3: {"label": "Tepid", "color": "yellow", "icon": "fa-temperature-half"},
         4: {"label": "Warm", "color": "warning", "icon": "fa-mug-hot"},
         5: {"label": "Hot", "color": "red", "icon": "fa-pepper-hot"},
-        6: {"label": "LP/P", "color": "red", "icon": "fa-stethoscope"},
+        6: {"label": "LP/P", "color": "danger", "icon": "fa-stethoscope"},
     }
 
     if not acmg_terms:

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -1,4 +1,7 @@
 # coding=UTF-8
+from typing import Optional
+
+
 def is_pathogenic(pvs, ps_terms, pm_terms, pp_terms):
     """Check if the criterias for Pathogenic is fullfilled
 
@@ -266,7 +269,7 @@ def get_acmg(acmg_terms: set) -> str:
     return prediction
 
 
-def get_acmg_temperature(acmg_terms: set) -> tuple:
+def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
     """
     Use the algorithm described in Tavtigian 2020 to classifiy variants.
 
@@ -293,7 +296,7 @@ def get_acmg_temperature(acmg_terms: set) -> tuple:
     TEMPERATURE_STRINGS = ["Ice cold", "Cold", "Cold", "Tepid", "Warm", "Hot"]
 
     if not acmg_terms:
-        return None
+        return {}
 
     (pvs, ps_terms, pm_terms, pp_terms, ba, bs_terms, bp_terms) = get_acmg_criteria(acmg_terms)
 
@@ -323,4 +326,8 @@ def get_acmg_temperature(acmg_terms: set) -> tuple:
     elif points >= 10:
         point_classification = "pathogenic"
 
-    return (points, temperature, point_classification)
+    return {
+        "points": points,
+        "temperature": temperature,
+        "point_classification": point_classification,
+    }

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -304,7 +304,7 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         1: {"label": "Cold", "color": "info", "icon": "fa-snowman"},
         2: {"label": "Cold", "color": "info", "icon": "fa-snowflake"},
         3: {"label": "Tepid", "color": "yellow", "icon": "fa-temperature-half"},
-        4: {"label": "Warm", "color": "warning", "icon": "fa-mug-hot"},
+        4: {"label": "Warm", "color": "orange", "icon": "fa-mug-hot"},
         5: {"label": "Hot", "color": "red", "icon": "fa-pepper-hot"},
         6: {"label": "LP/P", "color": "danger", "icon": "fa-stethoscope"},
     }

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -296,12 +296,14 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
 
     """
     TEMPERATURE_STRINGS = {
+        -1: {"label": "B/LB", "color": "success", "icon": "fa-times"},
         0: {"label": "Ice cold", "color": "success", "icon": "fa-icicles"},
         1: {"label": "Cold", "color": "info", "icon": "fa-snowman"},
         2: {"label": "Cold", "color": "info", "icon": "fa-snowflake"},
         3: {"label": "Tepid", "color": "yellow", "icon": "fa-temperature-half"},
         4: {"label": "Warm", "color": "warning", "icon": "fa-mug-hot"},
         5: {"label": "Hot", "color": "red", "icon": "fa-pepper-hot"},
+        6: {"label": "LP/P", "color": "red", "icon": "fa-stethoscope"},
     }
 
     if not acmg_terms:
@@ -321,23 +323,23 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
             - len(bp_terms)
         )
 
-    temperature = "NA"
-
     if points <= -7:
         point_classification = "benign"
-        temperature_class = "success"
+        temperature_icon = TEMPERATURE_STRINGS[-1].get("icon")
     elif points <= -1:
         point_classification = "likely_benign"
+        temperature_icon = TEMPERATURE_STRINGS[-1].get("icon")
     elif points <= 5:
         point_classification = "uncertain_significance"
     elif points <= 9:
         point_classification = "likely_pathogenic"
+        temperature_icon = TEMPERATURE_STRINGS[6].get("icon")
     elif points >= 10:
         point_classification = "pathogenic"
+        temperature_icon = TEMPERATURE_STRINGS[6].get("icon")
 
     temperature_class = ACMG_COMPLETE_MAP[point_classification].get("color")
     temperature = ACMG_COMPLETE_MAP[point_classification].get("label")
-    temperature_icon = ""
 
     if point_classification == "uncertain_significance":
         temperature_class = TEMPERATURE_STRINGS[points].get("color")

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -1,7 +1,9 @@
 # coding=UTF-8
+
 from typing import Optional
 
 from scout.constants import ACMG_COMPLETE_MAP
+from scout.constants.acmg import ACMG_POTENTIAL_CONFLICTS
 
 
 def is_pathogenic(pvs, ps_terms, pm_terms, pp_terms):
@@ -358,3 +360,14 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         "temperature_icon": temperature_icon,
         "point_classification": ACMG_COMPLETE_MAP[point_classification].get("short"),
     }
+
+
+def get_acmg_conflicts(acmg_terms: set) -> list:
+    """Check potential conflict paris, return list of reference strings."""
+
+    conflicts = []
+    for t1, t2, reference in ACMG_POTENTIAL_CONFLICTS:
+        if t1 in acmg_terms and t2 in acmg_terms:
+            conflicts.append(reference)
+
+    return conflicts

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -223,7 +223,7 @@ def get_acmg_criteria(acmg_terms: set) -> tuple:
     return (pvs, ps_terms, pm_terms, pp_terms, ba, bs_terms, bp_terms)
 
 
-def get_acmg(acmg_terms: set) -> str:
+def get_acmg(acmg_terms: set) -> Optional[str]:
     """Use the algorithm described in ACMG paper to get a ACMG calssification
 
 

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -1,6 +1,8 @@
 # coding=UTF-8
 from typing import Optional
 
+from scout.constants import ACMG_COMPLETE_MAP
+
 
 def is_pathogenic(pvs, ps_terms, pm_terms, pp_terms):
     """Check if the criterias for Pathogenic is fullfilled
@@ -293,7 +295,14 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         (points, temperature, point_classification)
 
     """
-    TEMPERATURE_STRINGS = ["Ice cold", "Cold", "Cold", "Tepid", "Warm", "Hot"]
+    TEMPERATURE_STRINGS = {
+        0: {"label": "Ice cold", "color": "success", "icon": "fa-icicles"},
+        1: {"label": "Cold", "color": "info", "icon": "fa-snowman"},
+        2: {"label": "Cold", "color": "info", "icon": "fa-snowflake"},
+        3: {"label": "Tepid", "color": "yellow", "icon": "fa-temperature-half"},
+        4: {"label": "Warm", "color": "warning", "icon": "fa-mug-hot"},
+        5: {"label": "Hot", "color": "red", "icon": "fa-pepper-hot"},
+    }
 
     if not acmg_terms:
         return {}
@@ -316,18 +325,29 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
 
     if points <= -7:
         point_classification = "benign"
+        temperature_class = "success"
     elif points <= -1:
         point_classification = "likely_benign"
     elif points <= 5:
         point_classification = "uncertain_significance"
-        temperature = TEMPERATURE_STRINGS[points]
     elif points <= 9:
         point_classification = "likely_pathogenic"
     elif points >= 10:
         point_classification = "pathogenic"
 
+    temperature_class = ACMG_COMPLETE_MAP[point_classification].get("color")
+    temperature = ACMG_COMPLETE_MAP[point_classification].get("label")
+    temperature_icon = ""
+
+    if point_classification == "uncertain_significance":
+        temperature_class = TEMPERATURE_STRINGS[points].get("color")
+        temperature = TEMPERATURE_STRINGS[points].get("label")
+        temperature_icon = TEMPERATURE_STRINGS[points].get("icon")
+
     return {
         "points": points,
         "temperature": temperature,
-        "point_classification": point_classification,
+        "temperature_class": temperature_class,
+        "temperature_icon": temperature_icon,
+        "point_classification": ACMG_COMPLETE_MAP[point_classification].get("short"),
     }

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -320,7 +320,7 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         point_classification = "likely_benign"
     elif points <= 5:
         point_classification = "uncertain_significance"
-        temperature = TEMPERATURE_STRINGS[point_classification]
+        temperature = TEMPERATURE_STRINGS[points]
     elif points <= 9:
         point_classification = "likely_pathogenic"
     elif points >= 10:

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -1,5 +1,6 @@
 from scout.utils.acmg import (
     get_acmg,
+    get_acmg_temperature,
     is_benign,
     is_likely_benign,
     is_likely_pathogenic,
@@ -417,3 +418,11 @@ def test_acmg_modifier_on_both_benign_and_pathogenic():
     acmg_terms = ["PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"]
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
+
+
+def test_acmg_temperature():
+    acmg_terms = ["PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"]
+    res = get_acmg_temperature(acmg_terms)
+    assert res["points"] == 4
+    assert res["label"] == "Warm"
+    assert res["point_classification"] == "uncertain_significance"

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -429,11 +429,13 @@ def test_acmg_modifier_on_both_benign_and_pathogenic():
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
+
 def test_acmg_benign_moderate():
     acmg_terms = {"BP1_Moderate", "BS1"}
     res = get_acmg(acmg_terms)
     assert res == "likely_benign"
-    
+
+
 def test_acmg_temperature():
     acmg_terms = {"PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"}
     res = get_acmg_temperature(acmg_terms)

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -1,6 +1,10 @@
 from scout.utils.acmg import (
     get_acmg,
+<<<<<<< HEAD
     get_acmg_temperature,
+=======
+    get_acmg_conflicts,
+>>>>>>> 040862aec (Fix #4906 - warn on potentially conflicting ACMG terms. (#4932))
     is_benign,
     is_likely_benign,
     is_likely_pathogenic,
@@ -434,6 +438,12 @@ def test_acmg_benign_moderate():
     acmg_terms = {"BP1_Moderate", "BS1"}
     res = get_acmg(acmg_terms)
     assert res == "likely_benign"
+
+
+def test_acmg_conflicts():
+    acmg_terms = {"PVS1", "PM4"}
+    conflicts = get_acmg_conflicts(acmg_terms)
+    assert len(conflicts) == 1
 
 
 def test_acmg_temperature():

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -437,8 +437,20 @@ def test_acmg_benign_moderate():
 
 
 def test_acmg_temperature():
+    acmg_terms = {"PVS1", "PS1", "PP1", "BS1", "BS2"}
+    res = get_acmg_temperature(acmg_terms)
+    assert res["points"] == 5
+    assert res["temperature"] == "Hot"
+    assert res["point_classification"] == "VUS"
+
     acmg_terms = {"PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"}
     res = get_acmg_temperature(acmg_terms)
     assert res["points"] == 4
     assert res["temperature"] == "Warm"
+    assert res["point_classification"] == "VUS"
+
+    acmg_terms = {"PVS1", "BS2", "BP1"}
+    res = get_acmg_temperature(acmg_terms)
+    assert res["points"] == 3
+    assert res["temperature"] == "Tepid"
     assert res["point_classification"] == "VUS"

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -379,50 +379,50 @@ def test_is_benign_2():
 
 
 def test_get_acmg_no_terms():
-    acmg_terms = []
+    acmg_terms = {}
     res = get_acmg(acmg_terms)
     assert res is None
 
 
 def test_get_acmg_pathogenic():
-    acmg_terms = ["PVS1", "PS1"]
+    acmg_terms = {"PVS1", "PS1"}
     res = get_acmg(acmg_terms)
     assert res == "pathogenic"
 
-    acmg_terms = ["PVS1", "PS1", "BS1"]
+    acmg_terms = {"PVS1", "PS1", "BS1"}
     res = get_acmg(acmg_terms)
     assert res == "pathogenic"
 
 
 def test_get_acmg_modifier():
-    acmg_terms = ["PVS1", "PS1"]
+    acmg_terms = {"PVS1", "PS1"}
     res = get_acmg(acmg_terms)
     assert res == "pathogenic"
 
-    acmg_terms = ["PVS1_Moderate", "PS1"]
+    acmg_terms = {"PVS1_Moderate", "PS1"}
     res = get_acmg(acmg_terms)
     assert res == "likely_pathogenic"
 
 
 def test_get_acmg_uncertain():
-    acmg_terms = ["PVS1"]
+    acmg_terms = {"PVS1"}
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
-    acmg_terms = ["PVS1", "PS1", "BA1"]
+    acmg_terms = {"PVS1", "PS1", "BA1"}
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
 
 def test_acmg_modifier_on_both_benign_and_pathogenic():
-    acmg_terms = ["PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"]
+    acmg_terms = {"PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"}
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
 
 def test_acmg_temperature():
-    acmg_terms = ["PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"]
+    acmg_terms = {"PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"}
     res = get_acmg_temperature(acmg_terms)
     assert res["points"] == 4
-    assert res["label"] == "Warm"
-    assert res["point_classification"] == "uncertain_significance"
+    assert res["temperature"] == "Warm"
+    assert res["point_classification"] == "VUS"


### PR DESCRIPTION
This PR adds a functionality: Bayesian point sums for an alternative ACMG classification, and temperature for VUS.
- Fix #4909 

![Screenshot 2024-10-08 at 21 29 13](https://github.com/user-attachments/assets/e025dbd5-ef89-4677-a43b-cb0798dd98d9)

Ok! I will brush up the visuals and add some tests, but kinda looks promising! 🌶️ 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. pick a variant, and classify it using the ACMG form
2. starting with supporting (1 point) and moderate (2 points) tick through the VUS scale and notice it go from Ice cold (0, starting point) to Hot (5 points).
3. Also check eg a Pathogenic Strong or Very Strong criteria and subtract single points with Supporting Benign criteria
4. Try with a few modifiers to make sure the modified level is used on the heat scale
5. click around to make sure the regular Richards ACMG classifier is not affected (the overall variant five level classification into class B-P from Tavtigian and Richards should be very similar - there are a few known exceptions, hence both shown).

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
