### PR TITLE
Make ba stand alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-## Added
+### Added
 - Link to chanjo2 MANE coverage overview on case page and panel page
 ### Changed
 - Variants query backend allows rank_score filtering
 - Added script to tabulate causatives clinical filter rank
 - Do not display inheritance models associated to ORPHA terms on variant page
+###
+- Make BA1 fully stand-alone to Benign prediction
 
 ## [4.89.2]
 ## Fixed

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -231,7 +231,9 @@ def get_acmg(acmg_terms):
     benign = is_benign(ba, bs_terms)
     likely_benign = is_likely_benign(bs_terms, bp_terms)
 
-    if pathogenic or likely_pathogenic:
+    if ba:
+        prediction = "benign"
+    elif pathogenic or likely_pathogenic:
         if benign or likely_benign:
             prediction = "uncertain_significance"
         elif pathogenic:

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -408,6 +408,10 @@ def test_get_acmg_uncertain():
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
+    acmg_terms = ["PVS1", "PS1", "BS1", "BS2"]
+    res = get_acmg(acmg_terms)
+    assert res == "uncertain_significance"
+
 
 def test_get_acmg_stand_alone_benign():
     acmg_terms = ["PVS1", "PS1", "BA1"]

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -408,9 +408,15 @@ def test_get_acmg_uncertain():
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
 
+
+def test_get_acmg_stand_alone_benign():
     acmg_terms = ["PVS1", "PS1", "BA1"]
     res = get_acmg(acmg_terms)
-    assert res == "uncertain_significance"
+    assert res == "benign"
+
+    bs_terms = ["BA1", "BS1", "BP1"]
+    res = get_acmg(acmg_terms)
+    assert res == "benign"
 
 
 def test_acmg_modifier_on_both_benign_and_pathogenic():


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4921 

On re-reading Richards 2015, while not explicitly clear from figures, the wording on "Stand Alone" benign, in combination with the efforts to exclude the handful of clearly pathogenic variants at the original "ba1" frequency level (https://www.clinicalgenome.org/site/assets/files/3460/ba1_exception_list_07_30_2018.pdf) it seems rather clear that this should really be Stand Alone.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
