### PR TITLE
Fix benign moderate modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Variants query backend allows rank_score filtering
 - Added script to tabulate causatives clinical filter rank
 - Do not display inheritance models associated to ORPHA terms on variant page
-###
+### Fixed
 - Make BA1 fully stand-alone to Benign prediction
+- Modifying Benign terms to "Moderate" has no effect under Richards. Ignored completely before, will retain unmodified significance now
 
 ## [4.89.2]
 ## Fixed

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -212,6 +212,8 @@ def get_acmg(acmg_terms):
                     if term.startswith(prefix):
                         term_list.append(term)
                         break
+                else:
+                    continue
                 break
         else:
             # Do we match any of the two standalone terms

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -378,7 +378,7 @@ def test_is_benign_2():
 
 
 def test_get_acmg_no_terms():
-    acmg_terms = []
+    acmg_terms = set()
     res = get_acmg(acmg_terms)
     assert res is None
 
@@ -427,3 +427,9 @@ def test_acmg_modifier_on_both_benign_and_pathogenic():
     acmg_terms = ["PS3_Moderate", "PP1_Moderate", "PP3", "BS1_Supporting"]
     res = get_acmg(acmg_terms)
     assert res == "uncertain_significance"
+
+
+def test_acmg_benign_moderate():
+    acmg_terms = {"BP1_Moderate", "BS1"}
+    res = get_acmg(acmg_terms)
+    assert res == "likely_benign"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4926 

✅ 
![Screenshot 2024-10-10 at 10 55 49](https://github.com/user-attachments/assets/60633723-c765-482c-a9ca-cca48c7a2e60)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
