### PR TITLE
Fix #4970 - empty custom images dict does not crash on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
+### Fixed
+- Empty custom_images dicts in case load config do not crash
 
 ## [4.90.1]
 ### Fixed

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -553,7 +553,6 @@ class CaseLoader(BaseModel):
     def parse_custom_images(cls, custom_images: RawCustomImages) -> ParsedCustomImages:
         """Fixes image path and image data for each custom image in variant_custom_images and case_images."""
 
-        LOG.warning(f"custom_images: {custom_images}")
         custom_images.str_variants_images = set_custom_images(
             images=custom_images.str_variants_images
         )

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -553,14 +553,16 @@ class CaseLoader(BaseModel):
     def parse_custom_images(cls, custom_images: RawCustomImages) -> ParsedCustomImages:
         """Fixes image path and image data for each custom image in variant_custom_images and case_images."""
 
+        LOG.warning(f"custom_images: {custom_images}")
         custom_images.str_variants_images = set_custom_images(
             images=custom_images.str_variants_images
         )
 
-        for key, images in custom_images.case_images.items():
-            custom_images.case_images[key] = set_custom_images(
-                images=custom_images.case_images[key]
-            )
+        if custom_images.case_images:
+            for key, images in custom_images.case_images.items():
+                custom_images.case_images[key] = set_custom_images(
+                    images=custom_images.case_images[key]
+                )
 
         return custom_images
 


### PR DESCRIPTION
- Fix #4970. Notice that panels already has checks for empty values. The custom images dict is a little bit more involved, since it gets reformatted a bit into its member class objects before the offending crash. Ignoring empty ones on parsing appears to successfully leave the main key unset on db, fixing the issue.

Tested on local, with normal `custom_images`, `custom_images` set to `{}` and for a case config without `custom_images`.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. edit a demo load config to have a `custom_images: {}` line.
2. see error with current main
3. load with this branch and see it working, also clicking a case page, a variant and an STR variant to be sure those are not affected
4. load a case with proper custom_images to make sure its parsing is not affected
5. load a case with no custom_images to make sure its parsing is not affected

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
