### PR TITLE
Fix #4969 - adress the VCF output of given managed variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
+- Managed variants VCF export more verbose on SVs
 
 ## [4.90.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tracks missing alignment files are now properly skipped on generating IGV views
 
 
-
 ## [4.90.1]
 ### Fixed
 - Parsing Matchmaker Exchange's matches dates

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -191,7 +191,7 @@ def get_vcf_entry(variant_obj, case_id=None):
     Returns:
         variant_string(str): string representing variant in vcf format
     """
-    if variant_obj["category"] == "snv":
+    if variant_obj["category"] == "snv" or variant_obj["category"] == "cancer":
         var_type = "TYPE"
     else:
         var_type = "SVTYPE"
@@ -203,12 +203,22 @@ def get_vcf_entry(variant_obj, case_id=None):
         ]
     )
 
+    reference = variant_obj["reference"]
+    if reference == ".":
+        reference = "N"
+
+    alternative = variant_obj["alternative"]
+    if alternative == "." or alternative == variant_obj["sub_category"]:
+        alternative = "N"
+        if variant_obj["category"] == "sv":
+            alternative = f"<{variant_obj['sub_category'].upper()}>"
+
     variant_string = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\t{7}".format(
         variant_obj["chromosome"],
         variant_obj["position"],
         variant_obj.get("dbsnp_id", "."),
-        variant_obj["reference"],
-        variant_obj["alternative"],
+        reference,
+        alternative,
         variant_obj.get("quality", "."),
         ";".join(variant_obj.get("filters", [])),
         info_field,

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -208,7 +208,7 @@ def get_vcf_entry(variant_obj, case_id=None):
         reference = "N"
 
     alternative = variant_obj["alternative"]
-    if alternative in ["", ".", variant_obj["sub_category"]]:
+    if alternative in ["", ".", "-", variant_obj["sub_category"]]:
         alternative = "N"
         if variant_obj["category"] == "sv":
             alternative = f"<{variant_obj['sub_category'].upper()}>"

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -204,11 +204,11 @@ def get_vcf_entry(variant_obj, case_id=None):
     )
 
     reference = variant_obj["reference"]
-    if reference == ".":
+    if reference in [".", ""]:
         reference = "N"
 
     alternative = variant_obj["alternative"]
-    if alternative == "." or alternative == variant_obj["sub_category"]:
+    if alternative in [".", variant_obj["sub_category"]]:
         alternative = "N"
         if variant_obj["category"] == "sv":
             alternative = f"<{variant_obj['sub_category'].upper()}>"

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -191,7 +191,7 @@ def get_vcf_entry(variant_obj, case_id=None):
     Returns:
         variant_string(str): string representing variant in vcf format
     """
-    if variant_obj["category"] == "snv" or variant_obj["category"] == "cancer":
+    if variant_obj["category"] in ["snv", "cancer"]:
         var_type = "TYPE"
     else:
         var_type = "SVTYPE"

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -220,7 +220,7 @@ def get_vcf_entry(variant_obj, case_id=None):
         reference,
         alternative,
         variant_obj.get("quality", "."),
-        ";".join(variant_obj.get("filters", [])),
+        ";".join(variant_obj.get("filters", [])) or ".",
         info_field,
     )
 

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -208,7 +208,7 @@ def get_vcf_entry(variant_obj, case_id=None):
         reference = "N"
 
     alternative = variant_obj["alternative"]
-    if alternative in [".", variant_obj["sub_category"]]:
+    if alternative in ["", ".", variant_obj["sub_category"]]:
         alternative = "N"
         if variant_obj["category"] == "sv":
             alternative = f"<{variant_obj['sub_category'].upper()}>"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4969 - specifically the variants mentioned there.

First we confirmed on db that the variants were input as noted in the issue. For the future, this can be adressed in #4972. 

Here we ensure that each of
- `ALT=""`
- `REF=""`
- `ALT = "del"` or `"ins"` (rather than `<DEL>` or `<INS>`). 
are converted to sensible values during VCF export.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
