### PR TITLE
Fix #4974 - crash on missing aln file for one of the inds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
+### Fixed
+- Tracks missing alignment files are now properly skipped on generating IGV views
+
 
 ## [4.90.1]
 ### Fixed

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -328,15 +328,15 @@ def case_append_alignments(case_obj):
     ]
 
     for individual in case_obj["individuals"]:
-        append_safe(
-            case_obj,
-            "sample_names",
-            case_obj.get("display_name", "") + " - " + individual.get("display_name", ""),
-        )
         for setting in unwrap_settings:
             file_path = individual.get(setting["path"])
             if not (file_path and os.path.exists(file_path)):
                 continue
+            append_safe(
+                case_obj,
+                "sample_names",
+                case_obj.get("display_name", "") + " - " + individual.get("display_name", ""),
+            )
             append_safe(case_obj, setting["append_to"], file_path)
             if not setting["index"] == "no_index":
                 append_safe(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4974 - don't crash on missing cram files for one sample
 
<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. ensure that for existing, complete cases this looks the same as main, case-sample labels and all
2. remove an alignment file from db, or from the config and reload case
3. see crash with main
4. open with this branch and notice it ok, minus one aln

- main and branch alike show all three alns correctly if all are configure on load
![Screenshot 2024-10-21 at 18 12 48](https://github.com/user-attachments/assets/4a3d1422-a4ff-4e55-908e-138ba3b1859f)

- remove an aln (second ind, NA12877)
![Screenshot 2024-10-21 at 18 10 00](https://github.com/user-attachments/assets/d2fcd76e-66f6-4d50-91ad-de5fa356b9f1)
- crash on main
![Screenshot 2024-10-21 at 18 08 56](https://github.com/user-attachments/assets/2d3305a5-e350-43e6-8e1f-c535ec19ca45)
- ok on this pr: displays only two inds, and the right ones (1 and 3)
![Screenshot 2024-10-21 at 18 11 03](https://github.com/user-attachments/assets/b44d0b95-19a2-42f9-968e-5fa2f9c9e7b0)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
