### PR TITLE
Fix #4958 - IGV button names and IGV MT overview link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
+- Names on IGV buttons, including an overview level IGV MT button
 
 ## [4.90.1]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -30,61 +30,56 @@
   <div class="card col-md-12">
     <h4 class="mt-3">Case: {{case.display_name}}</h4>
     <div class="card-body">
-
       <div class="row">
-            <div class="col-xs-12 col-md-12">{{ smn_individuals_table(case, institute, tissue_types) }}</div>
-        </div> <!-- end of div class row -->
-        <div class="row">
-          <div class="col-md-4">
-            {% if case.madeline_info and case.individuals|length > 1 %}
-              {{ pedigree_panel() }}
-            {% else %}
-              <p>No pedigree picture available.</p>
-            {% endif %}
-          </div>
-          <div class="col-md-8">
-            {{ synopsis_panel() }}
-            <div class="panel-default">
-            {{ comments_panel(institute, case, current_user, comments) }}
-            </div>
-          </div>
-        </div> <!-- end of div class row -->
-
-        <span class="d-flex">
-          {% if case.vcf_files.vcf_snv %}
-          <span class="me-3">
-            <form action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name) }}">
-              <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
-              <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
-              <span><button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes SMN1 and SMN2">SNVs</button></span>
-            </form>
-          </span>
+        <div class="col-xs-12 col-md-12">{{ smn_individuals_table(case, institute, tissue_types) }}</div>
+      </div> <!-- end of div class row -->
+      <div class="row">
+        <div class="col-md-4">
+          {% if case.madeline_info and case.individuals|length > 1 %}
+            {{ pedigree_panel() }}
+          {% else %}
+            <p>No pedigree picture available.</p>
           {% endif %}
-          {% if case.vcf_files.vcf_sv %}
+        </div>
+        <div class="col-md-8">
+          {{ synopsis_panel() }}
+          <div class="panel-default">
+          {{ comments_panel(institute, case, current_user, comments) }}
+          </div>
+        </div>
+      </div> <!-- end of div class row -->
+
+      <span class="d-flex">
+        {% if case.vcf_files.vcf_snv %}
+        <span class="me-3">
+          <form action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name) }}">
+            <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
+            <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
+            <span><button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes SMN1 and SMN2">SNVs</button></span>
+          </form>
+        </span>
+        {% endif %}
+        {% if case.vcf_files.vcf_sv %}
           <span class="me-3">
             <form action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name) }}">
               <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
               <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
-              <button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Structural variants view filtered for the genes SMN1 and SMN2">SVs</button></span>
+              <button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Structural variants view filtered for the genes SMN1 and SMN2">SVs</button>
             </form>
           </span>
-          {% endif %}
-          {% if case.bam_files %}
-            <span class="me-3"><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], chrom=region['smn1']['chrom'], start=region['smn1']['start'], stop=region['smn1']['end'] )}}" target="_blank">IGV viewer SMN1</a></span>
-            <span class="me-3"><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], chrom=region['smn2']['chrom'], start=region['smn2']['start'], stop=region['smn2']['end'] )}}" target="_blank">IGV viewer SMN2</a></span>
-          {% else %}
-            <span class="me-3 text-muted">BAM file(s) missing</span>
-          {% endif %}
-        </div>
+        {% endif %}
 
-        <div class="row">
-          <div class="col-sm-12">{{activity_panel(events)}}</div>
-        </div>
+        <span class="me-3"><a class="btn btn-secondary btn-sm text-white" {% if not case.bam_files %}title="Alignment file(s) missing" data-bs-toggle="tooltip" disabled{% endif %} href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], chrom=region['smn1']['chrom'], start=region['smn1']['start'], stop=region['smn1']['end'] )}}" target="_blank">IGV DNA SMN1</a></span>
+        <span class="me-3"><a class="btn btn-secondary btn-sm text-white" {% if not case.bam_files %}title="Alignment file(s) missing" data-bs-toggle="tooltip" disabled{% endif %} href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], chrom=region['smn2']['chrom'], start=region['smn2']['start'], stop=region['smn2']['end'] )}}" target="_blank">IGV DNA SMN2</a></span>
+      </span>
 
-        {{ modal_synopsis() }}
+      <div class="row">
+        <div class="col-sm-12">{{activity_panel(events)}}</div>
+      </div>
+
+      {{ modal_synopsis() }}
     </div> <!-- end of card body -->
   </div> <!-- end of card div-->
-</div>
 </div> <!-- end of div class col -->
 {% endmacro %}
 

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -197,22 +197,29 @@
       <span class="menu-collapsed">Genome build {{ case.genome_build }}</span>
   </div>
 </div>
-<div href="#" class="bg-dark list-group-item d-inline-block text-white">
-  {% if case.bam_files %}
-    <form action="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name']) }}" target="_blank" rel="noopener">
-      <button role="submit" class="btn btn-xs form-control btn-secondary">I<span class="menu-collapsed">GV viewer</span></button>
-    </form>
-  {% else %}
-    <span class="fa fa-times-circle fa-fw me-3"></span><span class="text-muted menu-collapsed">Alignment missing</span>
-  {% endif %}
-</div>
-{% if has_rna_tracks %}
   <div href="#" class="bg-dark list-group-item d-inline-block text-white">
-    <form action="{{url_for('alignviewers.sashimi_igv', institute_id=case['owner'], case_name=case['display_name']) }}" target="_blank" rel="noopener">
-      <button role="submit" data-bs-toggle="tooltip" data-bs-placement="top" title="Available in build GRCh{{ case.rna_genome_build or '38' }}" class="btn btn-xs form-control btn-secondary">R<span class="menu-collapsed">NA splicing</span></button>
+    <form action="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name']) }}" target="_blank" rel="noopener">
+      <button role="submit" class="btn btn-xs form-control btn-secondary"
+        {% if not case.bam_files %}
+          title="Alignment file(s) missing" disabled="disabled"><span class="fa fa-times-circle fa-fw me-1"></span>
+        {% else %}><span class="fa fa-magnifying-glass fa-fw me-1"></span>
+        {% endif %}
+        <span class="menu-collapsed">IGV </span>D<span class="menu-collapsed">NA</span>
+      </button>
     </form>
   </div>
-{% endif %}
+  <div href="#" class="bg-dark list-group-item d-inline-block text-white">
+    <form action="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], chrom='M', start=1, stop=16569) }}" target="_blank" rel="noopener">
+      <button role="submit" class="btn btn-xs form-control btn-secondary" {% if not case.mt_bams %}title="Alignment file(s) missing" data-bs-toggle="tooltip"><span class="fa fa-times-circle fa-fw me-1"></span>{% else %}><span class="fa fa-magnifying-glass fa-fw me-1"></span>{% endif %}<span class="menu-collapsed">IGV </span>M<span class="menu-collapsed">T</span></button>
+    </form>
+  </div>
+  {% if has_rna_tracks %}
+    <div href="#" class="bg-dark list-group-item d-inline-block text-white">
+      <form action="{{url_for('alignviewers.sashimi_igv', institute_id=case['owner'], case_name=case['display_name']) }}" target="_blank" rel="noopener">
+        <button role="submit" class="btn btn-xs form-control btn-secondary" data-bs-toggle="tooltip" data-bs-placement="top" title="Available in build GRCh{{ case.rna_genome_build or '38' }}"><span class="fa fa-magnifying-glass fa-fw me-1"></span><span class="menu-collapsed">IGV </span>R<span class="menu-collapsed">NA</span></button>
+      </form>
+    </div>
+  {% endif %}
 {% endmacro %}
 
 {% macro rank_model(case) %}

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -36,10 +36,10 @@
 {% macro splice_junctions_button(institute_id, case, variant_id, omics_variant_id) %}
   {% if omics_variant_id %}
     <a class="btn btn-sm btn-secondary text-white" href="{{url_for('alignviewers.sashimi_igv', institute_id=institute_id, case_name=case.display_name, omics_variant_id=omics_variant_id)}}" target="_blank"
-    data-bs-toggle="tooltip" data-bs-placement="top" title="Only available in build GRCh{{ case.rna_genome_build or '38' }}">RNA splicing</a>
+    data-bs-toggle="tooltip" data-bs-placement="top" title="Only available in build GRCh{{ case.rna_genome_build or '38' }}"><span class="fa fa-magnifying-glass fa-fw me-1"></span>IGV RNA</a>
   {% else %}
     <a class="btn btn-sm btn-secondary text-white" href="{{url_for('alignviewers.sashimi_igv', institute_id=institute_id, case_name=case.display_name, variant_id=variant_id)}}" target="_blank"
-    data-bs-toggle="tooltip" data-bs-placement="top" title="Only available in build GRCh{{ case.rna_genome_build or '38' }}">RNA splicing</a>
+    data-bs-toggle="tooltip" data-bs-placement="top" title="Only available in build GRCh{{ case.rna_genome_build or '38' }}"><span class="fa fa-magnifying-glass fa-fw me-1"></span>IGV RNA</a>
   {%  endif  %}
 {% endmacro %}
 

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -68,11 +68,18 @@
 {% macro alignments(institute, case, variant, current_user, config, igv_tracks, has_rna_tracks=False) %}
    <ul class="list-group">
         <li class="list-group-item d-flex justify-content-between">
-          {% if variant.chromosome in ["MT","M"] and case.mt_bams or case.bam_files %}
-            <span><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}" target="_blank">IGV viewer</a></span>
-          {% else %}
-            <span class="text-muted">BAM file(s) missing</span>
-          {% endif %}
+
+            <span>
+              <a href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}"
+                target="_blank"
+                role="button"
+                class="btn btn-secondary btn-sm text-white
+                {% if not (variant.chromosome in ["MT","M"] and case.mt_bams) or not case.bam_files %}
+                  disabled" title="Alignment file(s) missing" data-bs-toggle="tooltip" aria-disabled="true"><span class="fa fa-times-circle fa-fw me-1"></span>
+                {% else %}"><span class="fa fa-magnifying-glass fa-fw me-1"></span>{% endif %}IGV
+                {% if variant.chromosome in ["MT","M"] %}MT{% else %}DNA{% endif %}
+              </a>
+            </span>
           {% if variant.category == "str" %}
             <div class="ms-1">
               {{ reviewer_button(case,variant,case_groups,institute._id) }}

--- a/scout/server/blueprints/variant/templates/variant/str-variant-reviewer.html
+++ b/scout/server/blueprints/variant/templates/variant/str-variant-reviewer.html
@@ -2,7 +2,7 @@
 {% from "utils.html" import comments_table, pedigree_panel %}
 {% from "variants/components.html" import frequency_cell_general %}
 {% from "variants/utils.html" import cell_rank, dismiss_variants_block, filter_form_footer, update_stash_filter_button_status, pagination_footer, pagination_hidden_div, str_filters %}
-{% from "variant/buttons.html" import igv_button, reviewer_button%}
+{% from "variant/buttons.html" import reviewer_button%}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - STR variants

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -347,8 +347,8 @@
     {% endif %}
     </div>
     <div class="col-3">
-    {% if variant.is_mitochondrial and case.mt_bams or case.bam_files %}
-      <span><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], variant_id=variant['_id'], chrom=chrom, start=align_start, stop=align_end) }}" target="_blank">IGV viewer</a></span>
+    {% if variant.is_mitochondrial and case.mt_bams %}
+      <span><a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=case['owner'], case_name=case['display_name'], variant_id=variant['_id'], chrom=chrom, start=align_start, stop=align_end) }}" target="_blank"><span class="fa fa-magnifying-glass fa-fw me-1"></span>IGV MT</a></span>
     {% else %}
       - BAM file(s) missing
     {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -108,9 +108,9 @@
               {{ variant.position|human_longint|safe }}</span>
               {{ reviewer_button(case,variant,case_groups,institute._id) }}
               {% if case.bam_files %}
-                <a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}" rel="noopener" target="_blank">IGV viewer</a>
+                <a class="btn btn-secondary btn-sm text-white" href="{{url_for('alignviewers.igv', institute_id=institute['_id'], case_name=case['display_name'], variant_id=variant['_id'])}}" rel="noopener" target="_blank"><span class="fa fa-magnifying-glass fa-fw me-1">IGV DNA</a>
               {% else %}
-                <button title="BAM file(s) missing" class="btn btn-secondary btn-sm" disabled>IGV viewer</button>
+                <button title="BAM file(s) missing" class="btn btn-secondary btn-sm" disabled></span><span class="fa fa-times-circle fa-fw me-1"></span>IGV DNA</button>
               {% endif %}
 
             </td>


### PR DESCRIPTION
This PR changes the names on IGV buttons (to IGV DNA, IGV RNA, IGV MT), avoiding the "viewer" tautology and the use of "splicing" when we also have full RNA alignments. Also adds an IGV MT overview button from the collapsible toolbar. Also added a magnifying glass icon for existing data, and use the ring-X icon consistently for missing data.

- Fix #4958
 
Partly by following the style on one page, I reverted to disable and tooltip to indicate missing alignments. The tooltips are not really available without viewing source on disabled buttons in the current bootstrap. It would be possible to get them displayed by moving them to regular html title tooltips, or a separate js tooltip class, setting `pointer-events: none;` to avoid the bootstrap pointer block,  if we feel this is important.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
