### PR TITLE
Fix panel version cosistency when panel is created using the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Update IGV.js to v3.0.9
 - Managed variants VCF export more verbose on SVs
 - `/api/v1/hpo-terms` returns pymongo OperationFailure errors when provided query string contains problematic characters
+- Gene panel version are saved as decimals to enforce consistency, especially when panels are created using the command line
 ### Fixed
 - Empty custom_images dicts in case load config do not crash
 - Tracks missing alignment files are now properly skipped on generating IGV views

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -194,6 +194,7 @@ class PanelHandler:
             LOG.debug("Panel replaced")
             return new_panel["_id"]
         # Else create a new panel document with a given version
+
         result = self.panel_collection.insert_one(panel_obj)
         LOG.debug("Panel saved")
         return result.inserted_id
@@ -273,7 +274,7 @@ class PanelHandler:
                 {"hidden": False},
             ]
 
-        return self.panel_collection.find(query)
+        return self.panel_collection.find(query).sort("version", pymongo.DESCENDING)
 
     def gene_panels_dict(self, panel_names: List[str]) -> Dict[str, Dict]:
         """

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -4,6 +4,7 @@ import datetime as dt
 import logging
 import math
 from copy import deepcopy
+from decimal import Decimal
 from typing import Dict, List, Optional, Union
 
 import pymongo
@@ -230,7 +231,7 @@ class PanelHandler:
         return res
 
     def gene_panel(
-        self, panel_id: str, version: Optional[str] = None, projection: Optional[Dict] = None
+        self, panel_id: str, version: Union[str, Decimal] = None, projection: Optional[Dict] = None
     ) -> Optional[Dict]:
         """Fetch gene panel.
 

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Union
 
 import pymongo
-from bson import ObjectId
+from bson import Decimal128, ObjectId
 from bson.errors import InvalidId
 
 from scout.build import build_panel
@@ -171,6 +171,9 @@ class PanelHandler:
         """
         panel_name = panel_obj["panel_name"]
         panel_version = panel_obj["version"]
+        if isinstance(panel_version, Decimal):
+            panel_version = Decimal128(panel_version)
+            panel_obj["version"] = panel_version
         display_name = panel_obj.get("display_name", panel_name)
 
         LOG.info("loading panel %s, version %s to database", display_name, panel_version)
@@ -231,7 +234,10 @@ class PanelHandler:
         return res
 
     def gene_panel(
-        self, panel_id: str, version: Union[str, Decimal] = None, projection: Optional[Dict] = None
+        self,
+        panel_id: str,
+        version: Union[str, Decimal, float] = None,
+        projection: Optional[Dict] = None,
     ) -> Optional[Dict]:
         """Fetch gene panel.
 
@@ -239,6 +245,8 @@ class PanelHandler:
         """
         query = {"panel_name": panel_id}
         if version:
+            if isinstance(version, Decimal):
+                version = Decimal128(version)
             LOG.info("Fetch gene panel {0}, version {1} from database".format(panel_id, version))
             query["version"] = version
             return self.panel_collection.find_one(query, projection)

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -101,7 +101,7 @@ def build_panel(panel_info, adapter):
 
     panel_obj["institute"] = panel_info["institute"]
 
-    panel_obj["version"] = float(panel_info["version"])
+    panel_obj["version"] = panel_info["version"]
 
     try:
         panel_obj["date"] = panel_info["date"]

--- a/scout/build/panel.py
+++ b/scout/build/panel.py
@@ -101,6 +101,7 @@ def build_panel(panel_info, adapter):
 
     panel_obj["institute"] = panel_info["institute"]
 
+    LOG.error(type(panel_info["version"]))
     panel_obj["version"] = panel_info["version"]
 
     try:

--- a/scout/commands/load/panel.py
+++ b/scout/commands/load/panel.py
@@ -92,20 +92,18 @@ def panel(
     if path is None:
         LOG.info("Please provide a panel")
         return
-    # try:
-    load_panel(
-        panel_path=path,
-        adapter=adapter,
-        date=date,
-        display_name=display_name,
-        version=version,
-        panel_type=panel_type,
-        panel_id=panel_id,
-        institute=institute,
-        maintainer=maintainer,
-    )
-    """
+    try:
+        load_panel(
+            panel_path=path,
+            adapter=adapter,
+            date=date,
+            display_name=display_name,
+            version=version,
+            panel_type=panel_type,
+            panel_id=panel_id,
+            institute=institute,
+            maintainer=maintainer,
+        )
     except Exception as err:
         LOG.warning(err)
         raise click.Abort()
-    """

--- a/scout/commands/load/panel.py
+++ b/scout/commands/load/panel.py
@@ -1,6 +1,7 @@
 """Code for scout load panel CLI functionality"""
 
 import logging
+from decimal import Decimal
 
 import click
 from flask.cli import current_app, with_appcontext
@@ -21,7 +22,7 @@ LOG = logging.getLogger(__name__)
 )
 @click.option("-d", "--date", help="date of gene panel on format 2017-12-24, default is today.")
 @click.option("-n", "--display-name", help="display name for the panel, optional")
-@click.option("-v", "--version", type=float)
+@click.option("-v", "--version", type=Decimal)
 @click.option(
     "-t",
     "--panel-type",
@@ -91,18 +92,20 @@ def panel(
     if path is None:
         LOG.info("Please provide a panel")
         return
-    try:
-        load_panel(
-            panel_path=path,
-            adapter=adapter,
-            date=date,
-            display_name=display_name,
-            version=version,
-            panel_type=panel_type,
-            panel_id=panel_id,
-            institute=institute,
-            maintainer=maintainer,
-        )
+    # try:
+    load_panel(
+        panel_path=path,
+        adapter=adapter,
+        date=date,
+        display_name=display_name,
+        version=version,
+        panel_type=panel_type,
+        panel_id=panel_id,
+        institute=institute,
+        maintainer=maintainer,
+    )
+    """
     except Exception as err:
         LOG.warning(err)
         raise click.Abort()
+    """

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -9,6 +9,7 @@ import math
 from datetime import datetime
 from typing import Dict, List
 
+from bson import Decimal128
 from click import Abort
 from flask.cli import current_app
 
@@ -40,7 +41,7 @@ def load_panel(panel_path, adapter, **kwargs):
     version = kwargs.get("version")
 
     try:
-        # This will parse panel metadata if includeed in panel file
+        # This will parse panel metadata if included in panel file
         panel_info = get_panel_info(
             panel_lines=panel_lines,
             panel_id=kwargs.get("panel_id"),
@@ -54,7 +55,7 @@ def load_panel(panel_path, adapter, **kwargs):
         raise err
 
     if panel_info.get("version"):
-        version = float(panel_info["version"])
+        version = Decimal128(panel_info["version"])
 
     panel_id = panel_info["panel_id"]
     display_name = panel_info["display_name"] or panel_id

--- a/scout/load/panel.py
+++ b/scout/load/panel.py
@@ -9,7 +9,6 @@ import math
 from datetime import datetime
 from typing import Dict, List
 
-from bson import Decimal128
 from click import Abort
 from flask.cli import current_app
 
@@ -30,7 +29,7 @@ def load_panel(panel_path, adapter, **kwargs):
         adapter(scout.adapter.MongoAdapter)
         date(str): date of gene panel on format 2017-12-24
         display_name(str)
-        version(float)
+        version(float or Decimal)
         panel_type(str)
         panel_id(str)
         institute(str)
@@ -55,7 +54,7 @@ def load_panel(panel_path, adapter, **kwargs):
         raise err
 
     if panel_info.get("version"):
-        version = Decimal128(panel_info["version"])
+        version = panel_info["version"]
 
     panel_id = panel_info["panel_id"]
     display_name = panel_info["display_name"] or panel_id

--- a/scout/parse/panel.py
+++ b/scout/parse/panel.py
@@ -254,7 +254,7 @@ def parse_gene_panel(
     gene_panel["panel_id"] = panel_id
     gene_panel["type"] = panel_type
     gene_panel["date"] = kwargs.get("date") or datetime.now()
-    gene_panel["version"] = float(kwargs.get("version") or 1.0)
+    gene_panel["version"] = kwargs.get("version") or 1.0
     gene_panel["display_name"] = kwargs.get("display_name") or panel_id
 
     if not path:

--- a/scout/server/blueprints/panels/templates/panels/panels.html
+++ b/scout/server/blueprints/panels/templates/panels/panels.html
@@ -222,7 +222,7 @@
 {% macro history_view(panel_id, panel_name) %}
   <div id="paneldiv_{{panel_id}}" class="collapse">
     <ul>
-    {% for version in panel_versions[panel_name]|sort(attribute='version', reverse=True) %}
+    {% for version in panel_versions[panel_name] %}
       <li><a href={{ url_for('panels.panel', panel_id=version._id) }}>{{ version.version }} {{ version.date.date() }} {{ version.genes|length }} genes</a></li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4986 

This is a solution that will create mixed values for panel versions:

<img width="534" alt="image" src="https://github.com/user-attachments/assets/27aa42fe-a7fc-46c0-a5ec-984f5536e73a">

--> CLI panels with --version options will create panels with version as a Decimal128
--> Panels updated/created using the web portal will continue to have double (float) panel versions

I am not very fond of this solution but I gave it a try locally and it seems to work.


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test by creating panels using the cli and the panels web page. Make sure that the issues described in #4986 are solved by this PR

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
