### PR TITLE
Triallelic cancer VAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
 - WTS outlier position copy button
 - Update IGV.js to v3.0.9
-- Prioritise caller AF if present (especially for cancer multiallelic variants)
+- Prioritise caller AF if present
 ### Fixed
 - Empty custom_images dicts in case load config do not crash
 - Tracks missing alignment files are now properly skipped on generating IGV views

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
 - WTS outlier position copy button
 - Update IGV.js to v3.0.9
+- Prioritise caller AF if present (especially for cancer multiallelic variants)
 ### Fixed
 - Empty custom_images dicts in case load config do not crash
 - Tracks missing alignment files are now properly skipped on generating IGV views

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -291,11 +291,12 @@ def get_split_reads(variant, pos):
 
 
 def get_alt_frequency(variant, pos):
-    """ """
-    alt_frequency = float(variant.gt_alt_freqs[pos])
-    if alt_frequency == -1:
-        if "AF" in variant.FORMAT:
-            alt_frequency = float(variant.format("AF")[pos][0])
+    """AF - prioritise caller AF if set"""
+    if "AF" in variant.FORMAT:
+        alt_frequency = float(variant.format("AF")[pos][0])
+    else:
+        alt_frequency = float(variant.gt_alt_freqs[pos])
+
     return alt_frequency
 
 

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -291,7 +291,7 @@ def get_split_reads(variant, pos):
 
 
 def get_alt_frequency(variant, pos):
-    """AF - prioritise caller AF if set"""
+    """AF - prioritise caller AF if set in FORMAT (e.g. DeepVariant does an INFO field)"""
     if "AF" in variant.FORMAT:
         alt_frequency = float(variant.format("AF")[pos][0])
     else:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

For the vast majority of all variants, even for cancer this appears a non-issue. Larger variants are more susceptible, and in particular some dubious SNVs that VarDict still passes in the SNV file instead of marking as SVs. But they are clinically important, the current guesstimate for ref-alt allele depth is not very good and the fix is easy.

Before 
![Screenshot 2024-11-04 at 19 33 04](https://github.com/user-attachments/assets/fce57e82-3f51-44d2-a287-c40df83ee755)
After
![Screenshot 2024-11-04 at 20 04 24](https://github.com/user-attachments/assets/ab8fcd8a-62b6-4d2b-904e-e21d3b58e39f)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
