### PR TITLE
Add MANE badges to the long list of transcripts on variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Added
+- MANE badges on list of variant's Genes/Transcripts/Proteins table, this way also SVs will display MANE annotations
 ### Changed
 - On genes panel page and gene panel PDF export, it's more evident which genes were newly introduced into the panel
 - WTS outlier position copy button

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -63,6 +63,7 @@ def tx_overview(variant_obj: dict):
         variant_obj(dict)
     """
     overview_txs = []  # transcripts to be shown in transcripts overview
+    ensembl_txid_mane_transcripts = {}
     if variant_obj.get("genes") is None:
         variant_obj["overview_transcripts"] = []
         return
@@ -89,7 +90,6 @@ def tx_overview(variant_obj: dict):
             ovw_tx["muted_refseq_ids"] = []
 
             for refseq_id in tx.get("refseq_identifiers", []):
-                decorated_tx = None
                 if ovw_tx["mane"] and ovw_tx["mane"].startswith(refseq_id):
                     decorated_tx = ovw_tx["mane"]
                 elif ovw_tx["mane_plus"] and ovw_tx["mane_plus"].startswith(refseq_id):
@@ -121,12 +121,17 @@ def tx_overview(variant_obj: dict):
             ovw_tx["cbioportal_link"] = tx.get("cbioportal_link")
             ovw_tx["mycancergenome_link"] = tx.get("mycancergenome_link")
 
+            ensembl_txid_mane_transcripts[tx.get("transcript_id")] = {
+                "mane": ovw_tx["mane"],
+                "mane_plus": ovw_tx["mane_plus"],
+            }
             overview_txs.append(ovw_tx)
 
     # sort txs for the presence of "mane_select_transcript" and "mane_plus_clinical_transcript"
     variant_obj["overview_transcripts"] = sorted(
         overview_txs, key=lambda tx: (tx["mane"], tx["mane_plus"]), reverse=True
     )
+    variant_obj["mane_transcripts"] = ensembl_txid_mane_transcripts
 
 
 def get_igv_tracks(build: str = "37") -> set:

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -250,7 +250,7 @@
                 {% endif %}
               </td>
               <td>
-                {{ transcript.refseq_identifiers|join(',') }}
+                {{ transcript.refseq_identifiers|join(', ') }}
               </td>
               <td>{{ transcript.biotype or '' }}</td>
               <td data-bs-toggle="tooltip" data-bs-placement="right" title="{{ transcript.functional_annotations|join(', ') }}">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -239,11 +239,13 @@
                 <a target="_blank" class="float-start" href="{{ transcript.ensembl_link }}">
                   {{ transcript.transcript_id }}
                 </a>
-                {% if transcript.mane %}
-                    <a href="#" data-bs-toggle="tooltip" title="MANE Select - {{transcript.mane}}"><span class="badge bg-success ms-3" title="MANE Select">M</span></a>
-                {% endif %}
-                {% if transcript.mane_plus %}
-                    <a href="#" data-bs-toggle="tooltip" title="MANE Plus Clinical - {{transcript.mane_plus}}"><span class="badge bg-success ms-3" title="MANE Plus Clinical">M+</span></a>
+                {% if transcript.transcript_id in variant.mane_transcripts %}
+                  {% if variant.mane_transcripts[transcript.transcript_id].mane %}
+                    <a href="#" data-bs-toggle="tooltip" title="MANE Select - {{variant.mane_transcripts[transcript.transcript_id].mane}}"><span class="badge bg-success ms-3" title="MANE Select">M</span></a>
+                  {% endif %}
+                  {% if variant.mane_transcripts[transcript.transcript_id].mane_plus %}
+                    <a href="#" data-bs-toggle="tooltip" title="MANE Plus Clinical - {{variant.mane_transcripts[transcript.transcript_id].mane_plus}}"><span class="badge bg-success ms-3" title="MANE Plus Clinical">M+</span></a>
+                  {% endif %}
                 {% endif %}
                 {% if transcript.is_canonical %}
                   <span class="badge bg-info ms-3">C</span>

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -235,12 +235,18 @@
                   {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
               </td>
-              <td class="d-flex justify-content-around align-items-center">
-                <a target="_blank" href="{{ transcript.ensembl_link }}">
+              <td class="d-flex align-items-center">
+                <a target="_blank" class="float-start" href="{{ transcript.ensembl_link }}">
                   {{ transcript.transcript_id }}
                 </a>
+                {% if transcript.mane %}
+                    <a href="#" data-bs-toggle="tooltip" title="MANE Select - {{transcript.mane}}"><span class="badge bg-success ms-3" title="MANE Select">M</span></a>
+                {% endif %}
+                {% if transcript.mane_plus %}
+                    <a href="#" data-bs-toggle="tooltip" title="MANE Plus Clinical - {{transcript.mane_plus}}"><span class="badge bg-success ms-3" title="MANE Plus Clinical">M+</span></a>
+                {% endif %}
                 {% if transcript.is_canonical %}
-                  <span class="badge bg-info">C</span>
+                  <span class="badge bg-info ms-3">C</span>
                 {% endif %}
               </td>
               <td>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5004  --> I have reasoned that it is better to add MANE tags down in the transcripts table **because a SV variant can have many genes and we don't want the variant page swamped with refseq transcritps, which will happen if we introduce the `RefSeq transcripts` panel as we have on SNV variant page**

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Check out [this variant](http://localhost:5000/cust000/rnafusion_case/6f8db5007cdabbb348cf60a935768fdc) from a demo case with build 38, both on main branch and this branch

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
