### PR TITLE
Fix errors while setting igv tracks for cases with individuals missing alignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cancer SV variantS page spinner on variant export
 - STRs variants export
 - ClinVar submission enquiry status for all submissions after the latest
+- Error while setting igv tracks for cases with individuals missing alignments
 
 ## [4.90.1]
 ### Fixed

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -321,15 +321,16 @@ def set_sample_tracks(display_obj, case_groups, chromosome):
             return
 
         for count, sample in enumerate(case.get("sample_names")):
-            sample_tracks.append(
-                {
-                    "name": sample,
-                    "url": case[track_items][count],
-                    "indexURL": case[track_index_items][count],
-                    "format": case[track_items][count].split(".")[-1],  # "bam" or "cram"
-                    "height": 700,
-                }
-            )
+            if sample.get(track_items) and sample.get(track_index_items):
+                sample_tracks.append(
+                    {
+                        "name": sample,
+                        "url": case[track_items][count],
+                        "indexURL": case[track_index_items][count],
+                        "format": case[track_items][count].split(".")[-1],  # "bam" or "cram"
+                        "height": 700,
+                    }
+                )
         display_obj["sample_tracks"] = sample_tracks
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fixes the following issue:

```
traceback (most recent call last):
  File "/venv/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/flask_cors/extension.py", line 194, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/scout/server/blueprints/alignviewers/views.py", line 146, in igv
    display_obj = controllers.make_igv_tracks(case_obj, variant_id, chrom, start, stop)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/worker/app/scout/server/blueprints/alignviewers/controllers.py", line 110, in make_igv_tracks
    set_sample_tracks(display_obj, grouped_cases, chromosome)
  File "/home/worker/app/scout/server/blueprints/alignviewers/controllers.py", line 327, in set_sample_tracks
    "url": case[track_items][count],
           ~~~~~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range
```

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
