### PR TITLE
Missing track item pt2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Increased visibility of variant callers's "Pass" or "Filtered" on the following pages: SNV variants (cancer cases), SV variants (both RD and cancer cases)
 ### Fixed
 - Empty custom_images dicts in case load config do not crash
-- Tracks missing alignment files are now properly skipped on generating IGV views
+- Tracks missing alignment files are skipped on generating IGV views
 - ClinVar form to accept MedGen phenotypes
 - Cancer SV variantS page spinner on variant export
 - STRs variants export

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -300,7 +300,7 @@ def set_common_tracks(display_obj, build):
 def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
     """Set up individual-specific alignment tracks (bam/cram files)
 
-    Given a dictionary containing all tracks info, a list of case group dictionaries
+    Given a dictionary containing all tracks info (display_obj), a list of case group dictionaries
     A chromosome string argument is used to check if we should look at mt alignment files for MT.
 
     A missing file is indicated with the string "missing", and no track is made for such entries.

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -297,14 +297,14 @@ def set_common_tracks(display_obj, build):
             display_obj["custom_tracks"].append(track)
 
 
-def set_sample_tracks(display_obj, case_groups, chromosome):
+def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
     """Set up individual-specific alignment tracks (bam/cram files)
 
-    Args:
-        display_obj(dict): dictionary containing all tracks info
-        case_groups(list): a list of case dictionaries
-        chromosome(str) [1-22],X,Y,M or "All"
-    """
+    Given a dictionary containing all tracks info, a list of case group dictionaries
+    A chromosome string argument is used to check if we should look at mt alignment files for MT.
+
+    A missing file is indicated with the string "missing", and no track is made for such entries.
+   """
     sample_tracks = []
 
     track_items = "mt_bams" if chromosome == "M" else "bam_files"
@@ -321,7 +321,8 @@ def set_sample_tracks(display_obj, case_groups, chromosome):
             return
 
         for count, sample in enumerate(case.get("sample_names")):
-
+            if case.get[track_items][count] == "missing":
+                continue
             sample_tracks.append(
                 {
                     "name": sample,

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -321,6 +321,7 @@ def set_sample_tracks(display_obj, case_groups, chromosome):
             return
 
         for count, sample in enumerate(case.get("sample_names")):
+
             sample_tracks.append(
                 {
                     "name": sample,

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -304,7 +304,7 @@ def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
     A chromosome string argument is used to check if we should look at mt alignment files for MT.
 
     A missing file is indicated with the string "missing", and no track is made for such entries.
-   """
+    """
     sample_tracks = []
 
     track_items = "mt_bams" if chromosome == "M" else "bam_files"

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -321,7 +321,7 @@ def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
             return
 
         for count, sample in enumerate(case.get("sample_names")):
-            if case.get[track_items][count] == "missing":
+            if case[track_items][count] == "missing":
                 continue
             sample_tracks.append(
                 {

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -336,6 +336,7 @@ def case_append_alignments(case_obj):
         for setting in unwrap_settings:
             file_path = individual.get(setting["path"])
             if not (file_path and os.path.exists(file_path)):
+                append_safe(case_obj, setting["append_to"], "missing")
                 continue
             append_safe(case_obj, setting["append_to"], file_path)
             if not setting["index"] == "no_index":

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -328,15 +328,15 @@ def case_append_alignments(case_obj):
     ]
 
     for individual in case_obj["individuals"]:
+        append_safe(
+            case_obj,
+            "sample_names",
+            case_obj.get("display_name", "") + " - " + individual.get("display_name", ""),
+        )
         for setting in unwrap_settings:
             file_path = individual.get(setting["path"])
             if not (file_path and os.path.exists(file_path)):
                 continue
-            append_safe(
-                case_obj,
-                "sample_names",
-                case_obj.get("display_name", "") + " - " + individual.get("display_name", ""),
-            )
             append_safe(case_obj, setting["append_to"], file_path)
             if not setting["index"] == "no_index":
                 append_safe(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4974 for a more general situation (any and all files can be missing)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
