### PR TITLE
Fix missing track round3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - STRs variants page when one or more variants have Swegen mean frequency but lack Short Tandem Repeat motif count
 - ClinVar submission enquiry status for all submissions after the latest
 - Typing error when running commands using python 3.9
+- Refactored and fixed the function creating alignment files (scout.utils.case_append_alignments)
 
 ## [4.90.1]
 ### Fixed

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -321,7 +321,7 @@ def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
             return
 
         for count, sample in enumerate(case.get("sample_names")):
-            if case[track_items][count] == "missing":
+            if case[track_items][count] == "missing" or case[track_index_items][count] == "missing":
                 continue
             sample_tracks.append(
                 {

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -297,13 +297,10 @@ def _check_path_name(ind: Dict, path_name: str) -> bool:
     return False
 
 
-def case_append_alignments(case_obj):
+def case_append_alignments(case_obj: dict):
     """Deconvolute information about files to case_obj.
 
     This function prepares bam/cram files and their indexes for easy access in templates.
-
-    Args:
-        case_obj (scout.models.Case): The case object to process.
     """
     unwrap_settings = [
         {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -300,49 +300,43 @@ def _check_path_name(ind: Dict, path_name: str) -> bool:
 def case_append_alignments(case_obj):
     """Deconvolute information about files to case_obj.
 
-    This function prepares the bam/cram files in a certain way so that they are easily accessed in
-    the templates.
-
-    Loops over the the individuals and gather bam/cram files, indexes and sample display names in
-    lists
+    This function prepares bam/cram files and their indexes for easy access in templates.
 
     Args:
-        case_obj(scout.models.Case)
+        case_obj (scout.models.Case): The case object to process.
     """
     unwrap_settings = [
         {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
         {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
-        {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": "no_index"},
-        {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": "no_index"},
-        {
-            "path": "upd_regions_bed",
-            "append_to": "upd_regions_beds",
-            "index": "no_index",
-        },
-        {"path": "upd_sites_bed", "append_to": "upd_sites_beds", "index": "no_index"},
-        {
-            "path": "tiddit_coverage_wig",
-            "append_to": "tiddit_coverage_wigs",
-            "index": "no_index",
-        },
+        {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
+        {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
+        {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},
+        {"path": "upd_sites_bed", "append_to": "upd_sites_beds", "index": None},
+        {"path": "tiddit_coverage_wig", "append_to": "tiddit_coverage_wigs", "index": None},
     ]
 
-    for individual in case_obj["individuals"]:
+    def process_file(case_obj, individual, setting):
+        """Process a single file and its optional index."""
+        file_path = individual.get(setting["path"])
         append_safe(
             case_obj,
-            "sample_names",
-            case_obj.get("display_name", "") + " - " + individual.get("display_name", ""),
+            setting["append_to"],
+            file_path if file_path and os.path.exists(file_path) else "missing",
         )
+        if setting["index"]:
+            index_path = (
+                find_index(file_path) if file_path and os.path.exists(file_path) else "missing"
+            )
+            append_safe(case_obj, setting["index"], index_path)
+
+    for individual in case_obj["individuals"]:
+        # Add sample name
+        sample_name = f"{case_obj.get('display_name', '')} - {individual.get('display_name', '')}"
+        append_safe(case_obj, "sample_names", sample_name)
+
+        # Process all file settings
         for setting in unwrap_settings:
-            file_path = individual.get(setting["path"])
-            if not (file_path and os.path.exists(file_path)):
-                append_safe(case_obj, setting["append_to"], "missing")
-                continue
-            append_safe(case_obj, setting["append_to"], file_path)
-            if not setting["index"] == "no_index":
-                append_safe(
-                    case_obj, setting["index"], find_index(file_path)
-                )  # either bai_files or mt_bais
+            process_file(case_obj, individual, setting)
 
 
 def append_safe(obj, obj_index, elem):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5049 - The specific issue is due to the presence of the index but the lack of the bam

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Try with [the case described in the original issue](https://scout-stage.scilifelab.se/cust000/SWEDAC-2019-HG-05-Trio-NovaSeq)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
