### PR TITLE
Add panel indexes and better version check when editing a panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Stranger TRGT parsing of `.` in `FORMAT.MC`
 - Parse ClinVar low-penetrance info and display it alongside Pathogenic and likely pathogenic on SNVs pages
+- Gene panel indexes to reflect the indexes used in production database
+- Panel version check while editing the genes of a panel
 
 ## [4.91.1]
 ### Fixed

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -501,7 +501,7 @@ class PanelHandler:
         new_panel["version"] = float(version)
 
         # Update same version or create new version
-        if version == panel_obj["version"]:
+        if new_panel["version"] == panel_obj["version"]:
             result = self.panel_collection.find_one_and_replace(
                 {"_id": panel_obj["_id"]}, new_panel, return_document=pymongo.ReturnDocument.AFTER
             )

--- a/scout/constants/indexes.py
+++ b/scout/constants/indexes.py
@@ -8,6 +8,17 @@ INDEXES = {
             name="genes",
         )
     ],
+    "gene_panel": [
+        IndexModel(
+            [("panel_name", ASCENDING), ("version", ASCENDING)],
+            name="panel_name_version",
+            unique=True,
+        ),
+        IndexModel(
+            [("genes.hgnc_id", ASCENDING)],
+            name="genes.hgnc_id",
+        ),
+    ],
     "hgnc_gene": [
         IndexModel(
             [("build", ASCENDING), ("chromosome", ASCENDING)],

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -163,7 +163,9 @@ def test_case_controller_with_panel(app, institute_obj, panel, test_case):
     store.case_collection.insert_one(test_case)
 
     # GIVEN an adapter with a gene panel
-    store.panel_collection.insert_one(panel)
+    assert store.panel_collection.find_one(
+        {"panel_name": panel["panel_name"], "version": panel["version"]}
+    )
     fetched_case = store.case_collection.find_one()
     app = Flask(__name__)
     # WHEN fetching a case with the controller


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5066 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Make sure that the issue can't be reproduced locally, because of missing indexes in the demo DB, [see this comment](https://github.com/Clinical-Genomics/scout/issues/5066#issuecomment-2497932117)
2. Switch to this branch and run the commend `scout setup demo `
3. At this point the gene panel collection in the database should have 3 indexes.
4. Try to edit a gene panel again while keeping the same version and see that the panel has actually maintained its version, as intended by the user.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DNIL
- [x] tests executed by CR
