### PR TITLE
Fix #5075 - variant filters is redecorated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Gene panel indexes to reflect the indexes used in production database
 - Panel version check while editing the genes of a panel
 - Display unknown filter tags as "danger" marked badges
+- Variant filters redecoration from multiple classifications crashes general case report
 
 
 ## [4.91.1]

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -620,7 +620,7 @@ def get_filters(variant_obj: dict) -> List[Dict[str, str]]:
     for redecoration. Check if the filter strings have already been converted
     to dicts before attemting to convert them.
     """
-    variant_filters = variant_obj["filters"]
+    variant_filters = variant_obj.get("filters",[])
 
     filters: List[Dict[str, str]] = []
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -620,7 +620,7 @@ def get_filters(variant_obj: dict) -> List[Dict[str, str]]:
     for redecoration. Check if the filter strings have already been converted
     to dicts before attemting to convert them.
     """
-    variant_filters = variant_obj.get("filters",[])
+    variant_filters = variant_obj.get("filters", [])
 
     filters: List[Dict[str, str]] = []
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -615,19 +615,31 @@ def get_filters(variant_obj: dict) -> List[Dict[str, str]]:
     """Return a list with richer format descriptions about filter status,
     if available. Fall back to display the filter status in a "danger" badge
     if it is not known from the VARIANT_FILTERS constant.
+
+    Currently, the controller may be applied repeatedly to the same variant object
+    for redecoration. Check if the filter strings have already been converted
+    to dicts before attemting to convert them.
     """
-    return [
-        (
-            VARIANT_FILTERS[f]
-            if f in VARIANT_FILTERS
-            else {
-                "label": f.replace("_", " ").upper(),
-                "description": f.replace("_", " "),
-                "label_class": "danger",
-            }
-        )
-        for f in map(lambda x: x.lower(), variant_obj["filters"])
-    ]
+    variant_filters = variant_obj["filters"]
+
+    filters: List[Dict[str, str]] = []
+
+    for f in variant_filters:
+        if isinstance(f, str):
+            if f.lower() in VARIANT_FILTERS:
+                filters.append(f)
+            else:
+                filters.append(
+                    {
+                        "label": f.replace("_", " ").upper(),
+                        "description": f.replace("_", " "),
+                        "label_class": "danger",
+                    }
+                )
+        elif isinstance(f, dict):
+            filters.append(f)
+
+    return filters
 
 
 def associate_variant_genes_with_case_panels(case_obj: Dict, variant_obj: Dict) -> None:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5075

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. add multiple categories of annotations (e.g. causative, pin, comment, classification, evaluation) to a variant
2. note the general case report crashing
3. apply patch, and see report working

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by CR
