### PR TITLE
Fix typo in callers redecoration fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - PanelApp panels update documentation to reflect the latest changes in the command line
 - Display panel IDs alongside panel display names on gene panels page
 - Just one `Hide removed panels` checkbox for all panels on gene panels page
-- Variant filters redecoration from multiple classifications crashes general case report
+- Variant filters redecoration from multiple classifications crash on general case report
 
 ## [4.91.1]
 ### Fixed

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -627,7 +627,7 @@ def get_filters(variant_obj: dict) -> List[Dict[str, str]]:
     for f in variant_filters:
         if isinstance(f, str):
             if f.lower() in VARIANT_FILTERS:
-                filters.append(f)
+                filters.append(VARIANT_FILTERS[f.lower()])
             else:
                 filters.append(
                     {


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

I'll do a couple of uploads as well to be more sure.

While better:
![Screenshot 2024-11-26 at 15 38 47](https://github.com/user-attachments/assets/1be83a8a-34a6-4738-b22e-305632fc062d)

It was again, due to a typo in the fix for the redecoration issue:
![Screenshot 2024-11-26 at 15 47 45](https://github.com/user-attachments/assets/a6ef18aa-db35-4139-9c7a-2a94868dfa05)

Fixed again:
![Screenshot 2024-11-26 at 15 47 52](https://github.com/user-attachments/assets/b63518cd-f9d6-4f85-9696-d2438a4c6813)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
