### PR TITLE
Fix multigene panels count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Limit the size of custom images displayed on case and variant page and add a link to display them in full size in a new tab
 - Classified variants not showing on case report when collaborator adds classification
+- On variantS page, when a variant has more than one gene, then the gene panel badge reflect the panels each gene is actually in
 
 ## [4.92]
 ### Added

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -193,8 +193,15 @@
       </a>
     {% endmacro %}
 
-    {% macro panel_badge(variant) %}
-      {% set panel_count = variant.case_panels|rejectattr('removed')|list|length %}
+    {% macro panel_badge(variant, gene_id) %}
+      {% set matching_panels = [] %}
+      {% for panel in variant.case_panels|rejectattr('removed')|list %}
+        {% if gene_id in panel.genes %}
+           {% set _ = matching_panels.append(panel) %}
+        {% endif %}
+      {% endfor %}
+
+      {% set panel_count = matching_panels|length %}
       {% if panel_count > 0 %}
         <a
           class="badge bg-secondary text-white"
@@ -202,7 +209,7 @@
           data-bs-html="true"
           data-bs-trigger="hover click"
           title="Overlapping gene panels"
-          data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
+          data-bs-content="{% for panel in matching_panels %}
             {{ panel.panel_name|safe }}<br>
           {% endfor %}"
         >{{ panel_count }}</a>
@@ -216,7 +223,7 @@
           ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})
         </span>
       {% endif %}
-      {{ panel_badge(variant) }}
+      {{ panel_badge(variant, variant.first_rep_gene.hgnc_id) }}
     {% else %}
       {% for gene in variant.genes %}
         <div>
@@ -224,7 +231,7 @@
           {% for model in gene.inheritance %}
             {{ inheritance_badge(model, inherit_palette) }}
           {% endfor %}
-          {{ panel_badge(variant) }}
+          {{ panel_badge(variant, gene.hgnc_id) }}
         </div>
       {% endfor %}
     {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -193,7 +193,8 @@
       </a>
     {% endmacro %}
 
-    {% macro panel_badge(variant, gene_id) %}
+    {% macro panel_badge(variant, gene_id=0) %}
+
       {% set matching_panels = [] %}
       {% for panel in variant.case_panels|rejectattr('removed')|list %}
         {% if gene_id in panel.hgnc_ids %}
@@ -221,8 +222,9 @@
           ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})
         </span>
       {% endif %}
-
-      {{ panel_badge(variant, variant.first_rep_gene.hgnc_id or variant.second_rep_gene.hgnc_id) }}
+      {% if variant.first_rep_gene or variant.second_rep_gene %}
+        {{ panel_badge(variant, variant.first_rep_gene.hgnc_id or variant.second_rep_gene.hgnc_id) }}
+      {% endif %}
     {% else %}
       {% for gene in variant.genes %}
         <div>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -196,24 +196,22 @@
     {% macro panel_badge(variant, gene_id) %}
       {% set matching_panels = [] %}
       {% for panel in variant.case_panels|rejectattr('removed')|list %}
-        {% if gene_id in panel.genes %}
+        {% if gene_id in panel.hgnc_ids %}
            {% set _ = matching_panels.append(panel) %}
         {% endif %}
       {% endfor %}
 
       {% set panel_count = matching_panels|length %}
-      {% if panel_count > 0 %}
-        <a
-          class="badge bg-secondary text-white"
-          data-bs-toggle="popover"
-          data-bs-html="true"
-          data-bs-trigger="hover click"
-          title="Overlapping gene panels"
-          data-bs-content="{% for panel in matching_panels %}
-            {{ panel.panel_name|safe }}<br>
-          {% endfor %}"
-        >{{ panel_count }}</a>
-      {% endif %}
+      <a
+        class="badge bg-secondary text-white"
+        data-bs-toggle="popover"
+        data-bs-html="true"
+        data-bs-trigger="hover click"
+        title="Overlapping gene panels"
+        data-bs-content="{% for panel in matching_panels %}
+          {{ panel.panel_name|safe }}<br>
+        {% endfor %}"
+      >{{ panel_count }}</a>
     {% endmacro %}
 
     {% if variant.category in ["cancer", "sv_cancer"] %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -221,7 +221,8 @@
           ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})
         </span>
       {% endif %}
-      {{ panel_badge(variant, variant.first_rep_gene.hgnc_id) }}
+
+      {{ panel_badge(variant, variant.first_rep_gene.hgnc_id or variant.second_rep_gene.hgnc_id) }}
     {% else %}
       {% for gene in variant.genes %}
         <div>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -161,94 +161,74 @@
 
 {% macro gene_cell(variant, inherit_palette) %}
   <div class="align-items-center">
-    {% if variant.category == "cancer" or variant.category == "sv_cancer" %}
-      <a data-bs-toggle="tooltip" data-bs-html="true" title="
+
+    {% macro gene_tooltip(gene) %}
+      <div>
         <div>
+          <strong>{{ gene.hgnc_symbol }}</strong>: {{ gene.description }}
+        </div>
+        {% if gene.inheritance %}
           <div>
-            <strong>{{ variant.first_rep_gene.hgnc_symbol }}</strong>: {{ variant.first_rep_gene.description }}
+            <strong>Models</strong>: {{ gene.inheritance|join(',') }}
           </div>
-          {% if variant.first_rep_gene.inheritance %}
-            <div>
-              <strong>Models</strong>: {{ variant.first_rep_gene.inheritance|join(',') }}
-            </div>
-          {% endif %}
-        {% if variant.first_rep_gene.phenotypes %}
+        {% endif %}
+        {% if gene.phenotypes %}
           <div><strong>OMIM disease</strong>
-          {% for disease in variant.first_rep_gene.phenotypes %}
-            <div>
-                {{ disease.description }}
-            </div>
+          {% for disease in gene.phenotypes %}
+            <div>{{ disease.description }}</div>
           {% endfor %}
           </div>
         {% endif %}
-        </div>"
-        {% if variant.first_rep_gene %}
-          href="{{ url_for('genes.gene', hgnc_id=variant.first_rep_gene.hgnc_id) }}"
-        {% endif %}>
-        {{ variant.first_rep_gene.hgnc_symbol or variant.first_rep_gene.hgnc_id }}
-        {% if variant.secondary_gene %}
-          <span class="text-muted">
-            ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})
-          </span>
-        {% endif %}
-      </a>
+      </div>
+    {% endmacro %}
 
+    {% macro gene_link(gene) %}
+      <a
+        data-bs-toggle="tooltip"
+        data-bs-html="true"
+        title="{{ gene_tooltip(gene) }}"
+        href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}"
+      >
+        {{ gene.hgnc_symbol or gene.hgnc_id }}
+      </a>
+    {% endmacro %}
+
+    {% macro panel_badge(variant) %}
       {% set panel_count = variant.case_panels|rejectattr('removed')|list|length %}
-      {% if panel_count > 0%}
-          <a
-            class="badge bg-secondary text-white"
-            data-bs-toggle="popover"
-            data-bs-html="true"
-            data-bs-trigger="hover click"
-            title="Overlapping gene panels"
-            data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
-              {{ panel.panel_name|safe }}<br>
-              {% endfor %}"
-            >{{panel_count}}
-          </a>
+      {% if panel_count > 0 %}
+        <a
+          class="badge bg-secondary text-white"
+          data-bs-toggle="popover"
+          data-bs-html="true"
+          data-bs-trigger="hover click"
+          title="Overlapping gene panels"
+          data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
+            {{ panel.panel_name|safe }}<br>
+          {% endfor %}"
+        >{{ panel_count }}</a>
       {% endif %}
+    {% endmacro %}
+
+    {% if variant.category in ["cancer", "sv_cancer"] %}
+      {{ gene_link(variant.first_rep_gene) }}
+      {% if variant.secondary_gene %}
+        <span class="text-muted">
+          ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})
+        </span>
+      {% endif %}
+      {{ panel_badge(variant) }}
     {% else %}
-      {% set panel_count = variant.case_panels|rejectattr('removed')|list|count %}
       {% for gene in variant.genes %}
         <div>
-        <a data-bs-toggle="tooltip" data-bs-html="true" title="
-        <div>
-          <div>
-            <strong>{{ gene.hgnc_symbol }}</strong>: {{ gene.description }}
-          </div>
-          {% if gene.inheritance %}
-            <div>
-              <strong>Models</strong>: {{ gene.inheritance|join(',') }}
-            </div>
-          {% endif %}
-          {% if gene.phenotypes %}
-            <div><strong>OMIM disease</strong>
-            {% for disease in gene.phenotypes %}
-              <div>
-                  {{ disease.description }}
-              </div>
-            {% endfor %}
-            </div>
-          {% endif %}
-        </div>"
-          href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">{{ gene.hgnc_symbol or gene.hgnc_id }}
-        {% for model in gene.inheritance %} {{ inheritance_badge(model,inherit_palette) }}{% endfor %}</a>
-        {% if panel_count > 0 %}
-          <a
-            class="badge bg-secondary text-white"
-            data-bs-toggle="popover"
-            data-bs-html="true"
-            data-bs-trigger="hover click"
-            data-bs-content="{% for panel in variant.case_panels|sort(attribute='panel_name',case_sensitive=False)|rejectattr('removed') %}
-              {{ panel.panel_name|safe }}<br>
-              {% endfor %}"
-            title="Overlapping gene panels">{{panel_count}}
-          </a>
-        {% endif %}
-      </div>
+          {{ gene_link(gene) }}
+          {% for model in gene.inheritance %}
+            {{ inheritance_badge(model, inherit_palette) }}
+          {% endfor %}
+          {{ panel_badge(variant) }}
+        </div>
       {% endfor %}
-
     {% endif %}
+
   </div>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -216,7 +216,9 @@
     {% endmacro %}
 
     {% if variant.category in ["cancer", "sv_cancer"] %}
-      {{ gene_link(variant.first_rep_gene) }}
+      {% if variant.first_rep_gene %}
+        {{ gene_link(variant.first_rep_gene) }}
+      {% endif %}
       {% if variant.secondary_gene %}
         <span class="text-muted">
           ({{ variant.second_rep_gene.hgnc_symbol or variant.second_rep_gene.hgnc_id }})


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- On variantS page, when a variant has more than one gene, then the gene panel badge reflect the panels each gene is actually in (fix #5087)

### Before

<img width="555" alt="image" src="https://github.com/user-attachments/assets/ad02850e-2d30-42fe-ace6-a791eb8748d9">


### After

<img width="566" alt="image" src="https://github.com/user-attachments/assets/0fb0ed9a-cb1a-444d-9f1e-d38ed3c3b90e">



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
