### PR TITLE
Add ACMG VUS Bayesian score / temperature on case reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- ACMG VUS Bayesian score / temperature on case reports
+
 ## [4.93.1]
 ### Fixed
 - Updated PyPi build GitHub action to explicitly include setuptools (for Python 3.12 distro)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -619,9 +619,7 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
 
     # Collect causative, partial causative and suspected variants
     for eval_category, case_key in CASE_REPORT_VARIANT_TYPES.items():
-        LOG.error(eval_category)
         for var_id in case_obj.get(case_key, []):
-            LOG.warning(var_id)
             var_obj = store.variant(document_id=var_id)
             if not var_obj:
                 continue

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -615,13 +615,16 @@ def check_outdated_gene_panel(panel_obj, latest_panel):
 def add_bayesian_acmg_classification(variant_obj: dict):
     """Append info to display the ACMG VUS Bayesian score / temperature."""
     # Append info to display the ACMG VUS Bayesian score / temperature
-    variant_acmg_classifications = store.get_evaluations_case_specific(
-        document_id=variant_obj["_id"]
+    variant_acmg_classifications = list(
+        store.get_evaluations_case_specific(document_id=variant_obj["_id"])
     )
     if variant_acmg_classifications:
         variant_obj["bayesian_acmg"] = get_acmg_temperature(
             set(
-                [criterium["term"] for criterium in variant_acmg_classifications[0].get("criteria")]
+                [
+                    criterium.get("term")
+                    for criterium in variant_acmg_classifications[0].get("criteria", [])
+                ]
             )
         )
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -614,7 +614,6 @@ def check_outdated_gene_panel(panel_obj, latest_panel):
 
 def add_bayesian_acmg_classification(variant_obj: dict):
     """Append info to display the ACMG VUS Bayesian score / temperature."""
-    # Append info to display the ACMG VUS Bayesian score / temperature
     variant_acmg_classifications = list(
         store.get_evaluations_case_specific(document_id=variant_obj["_id"])
     )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -665,14 +665,18 @@ def _append_evaluated_variant_by_type(
     """
     for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
         if variant_key in var_obj and var_obj[variant_key] is not None:
+
+            decorated_variant = _get_decorated_var(
+                var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj
+            )
             if (
                 eval_category == "classified_detailed"
             ):  # Append info to display the ACMG VUS Bayesian score / temperature
                 variant_acmg_classifications = store.get_evaluations_case_specific(
-                    document_id=var_obj["_id"]
+                    document_id=decorated_variant["_id"]
                 )
                 if variant_acmg_classifications:
-                    var_obj["bayesian_acmg"] = get_acmg_temperature(
+                    decorated_variant["bayesian_acmg"] = get_acmg_temperature(
                         set(
                             [
                                 criterium["term"]
@@ -680,10 +684,7 @@ def _append_evaluated_variant_by_type(
                             ]
                         )
                     )
-                    print(f"var[bayesian_acmg] is -->{var_obj['bayesian_acmg']}")
-            evaluated_variants_by_type[eval_category].append(
-                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
-            )
+            evaluated_variants_by_type[eval_category].append(decorated_variant)
 
 
 def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -680,6 +680,7 @@ def _append_evaluated_variant_by_type(
                             ]
                         )
                     )
+                    print(f"var[bayesian_acmg] is -->{var_obj['bayesian_acmg']}")
             evaluated_variants_by_type[eval_category].append(
                 _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
             )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -673,10 +673,12 @@ def _append_evaluated_variant_by_type(
                 )
                 if variant_acmg_classifications:
                     var_obj["bayesian_acmg"] = get_acmg_temperature(
-                        [
-                            criterium["term"]
-                            for criterium in variant_acmg_classifications[0].get("criteria")
-                        ]
+                        set(
+                            [
+                                criterium["term"]
+                                for criterium in variant_acmg_classifications[0].get("criteria")
+                            ]
+                        )
                     )
             evaluated_variants_by_type[eval_category].append(
                 _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -612,6 +612,20 @@ def check_outdated_gene_panel(panel_obj, latest_panel):
     return extra_genes, missing_genes
 
 
+def add_bayesian_acmg_classification(variant_obj: dict):
+    """Append info to display the ACMG VUS Bayesian score / temperature."""
+    # Append info to display the ACMG VUS Bayesian score / temperature
+    variant_acmg_classifications = store.get_evaluations_case_specific(
+        document_id=variant_obj["_id"]
+    )
+    if variant_acmg_classifications:
+        variant_obj["bayesian_acmg"] = get_acmg_temperature(
+            set(
+                [criterium["term"] for criterium in variant_acmg_classifications[0].get("criteria")]
+            )
+        )
+
+
 def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dict, data: dict):
     """Gather evaluated variants info to include in case report."""
 
@@ -625,6 +639,7 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
                 continue
             if case_key == "partial_causatives":
                 var_obj["phenotypes"] = case_obj["partial_causatives"][var_id]
+            add_bayesian_acmg_classification(var_obj)
             evaluated_variants_by_type[eval_category].append(
                 _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
             )
@@ -632,7 +647,6 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
     for var_obj in store.evaluated_variants(
         case_id=case_obj["_id"], institute_id=institute_obj["_id"]
     ):
-
         _append_evaluated_variant_by_type(
             evaluated_variants_by_type, var_obj, institute_obj, case_obj
         )
@@ -666,25 +680,11 @@ def _append_evaluated_variant_by_type(
     for eval_category, variant_key in CASE_REPORT_VARIANT_TYPES.items():
         if variant_key in var_obj and var_obj[variant_key] is not None:
 
-            decorated_variant = _get_decorated_var(
-                var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj
+            add_bayesian_acmg_classification(var_obj)
+
+            evaluated_variants_by_type[eval_category].append(
+                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
             )
-            if (
-                eval_category == "classified_detailed"
-            ):  # Append info to display the ACMG VUS Bayesian score / temperature
-                variant_acmg_classifications = store.get_evaluations_case_specific(
-                    document_id=decorated_variant["_id"]
-                )
-                if variant_acmg_classifications:
-                    decorated_variant["bayesian_acmg"] = get_acmg_temperature(
-                        set(
-                            [
-                                criterium["term"]
-                                for criterium in variant_acmg_classifications[0].get("criteria")
-                            ]
-                        )
-                    )
-            evaluated_variants_by_type[eval_category].append(decorated_variant)
 
 
 def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -668,6 +668,7 @@
               <th>Inheritance models</th>
             {% endif %}
             <th>ACMG classification</th>
+            <th>Bayesian classification</th>
             {% if cancer %}
             <th>ClinGen-CGC-VICC classification</th>
             {% endif %}
@@ -718,6 +719,13 @@
               {% else %}
                 -
               {% endif %}
+            <td>
+              {% if variant.bayesian_acmg %}
+                <span class="badge rounded-pill bg-{{variant.bayesian_acmg.temperature_class}}">Score {{variant.bayesian_acmg.points|string}} <span class='fa {{variant.bayesian_acmg.temperature_icon}}'></span> {{variant.bayesian_acmg.temperature}} ({{variant.bayesian_acmg.point_classification}})</span>
+              {% else %}
+                -
+              {% endif %}
+            </td>
             </td>
             {% if cancer %}
             <td>

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -1,12 +1,9 @@
 # coding=UTF-8
 
-import logging
 from typing import Optional
 
 from scout.constants import ACMG_COMPLETE_MAP
 from scout.constants.acmg import ACMG_POTENTIAL_CONFLICTS
-
-LOG = logging.getLogger(__name__)
 
 
 def is_pathogenic(pvs, ps_terms, pm_terms, pp_terms):
@@ -305,7 +302,6 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         (points, temperature, point_classification)
 
     """
-    LOG.warning(f"acmg_terms received:{acmg_terms}")
     TEMPERATURE_STRINGS = {
         -1: {"label": "B/LB", "color": "success", "icon": "fa-times"},
         0: {"label": "Ice cold", "color": "info", "icon": "fa-icicles"},

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -1,10 +1,12 @@
 # coding=UTF-8
 
-
+import logging
 from typing import Optional
 
 from scout.constants import ACMG_COMPLETE_MAP
 from scout.constants.acmg import ACMG_POTENTIAL_CONFLICTS
+
+LOG = logging.getLogger(__name__)
 
 
 def is_pathogenic(pvs, ps_terms, pm_terms, pp_terms):
@@ -303,6 +305,7 @@ def get_acmg_temperature(acmg_terms: set) -> Optional[dict]:
         (points, temperature, point_classification)
 
     """
+    LOG.warning(f"acmg_terms received:{acmg_terms}")
     TEMPERATURE_STRINGS = {
         -1: {"label": "B/LB", "color": "success", "icon": "fa-times"},
         0: {"label": "Ice cold", "color": "info", "icon": "fa-icicles"},


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5099

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/3386b1ea-7f3b-433d-aa61-a3b931bf8cf2" />



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
