### PR TITLE
Fix tooltips on variants not overlapping with any gene panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
 ### Fixed
 - UCSC hg38 links are updated
-
+- Variants page tooltip errors
 
 ## [4.93.1]
 ### Fixed

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -211,7 +211,7 @@
         title="Overlapping gene panels"
         data-bs-content="{% for panel in matching_panels %}
           {{ panel.panel_name|safe }}<br>
-        {% endfor %}"
+        {% else %} No ovelapping gene panels {% endfor %}"
       >{{ panel_count }}</a>
     {% endmacro %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5126

Tested on local research variants

### Main branch

<img width="634" alt="image" src="https://github.com/user-attachments/assets/e7bdc2c9-ec0a-4867-94cb-f7d1571b52ed" />

<img width="532" alt="image" src="https://github.com/user-attachments/assets/8c965a63-1f3f-491a-899e-735d5db738d4" />


### This branch

<img width="342" alt="image" src="https://github.com/user-attachments/assets/036a3931-cda0-4fd7-9341-634ef5898560" />

<img width="336" alt="image" src="https://github.com/user-attachments/assets/bbb85111-14fb-4280-a95f-544481057965" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
