### PR TITLE
Fix #5128 - visibility of muted vaf counts, position on cancer variantS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
 ### Fixed
 - UCSC hg38 links are updated
+- Cancer variantS page had poor visibility of VAF and chromosome coordinate on causatives (green background)
 
 
 ## [4.93.1]

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -180,7 +180,7 @@
 
 {% macro allele_cell(allele) %}
   {% if 'alt_freq' in allele %}
-    <b><span class="text-body">{{ allele.alt_freq|round(4)  }}</span></b>
+    <span class="text-body"><b>{{ allele.alt_freq|round(4) }}</b></span>
     <br>
     <small class="text-body">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
   {% else %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -175,16 +175,16 @@
 {% endmacro %}
 
 {% macro position_cell(variant) %}
-  {{ variant.chromosome }}<span class="text-muted">:{{ variant.position }}</span>
+  <span class="text-body"><b>{{ variant.chromosome }}</b>:{{ variant.position }}</span>
 {% endmacro %}
 
 {% macro allele_cell(allele) %}
   {% if 'alt_freq' in allele %}
-    {{ allele.alt_freq|round(4)  }}
+    <b><span class="text-body">{{ allele.alt_freq|round(4)  }}</span></b>
     <br>
-    <small class="text-muted">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
+    <small class="text-body">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
   {% else %}
-    <span class="text-muted">N/A</span>
+    <span class="text-body">N/A</span>
   {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5128

Trying to retain some of the proportion of emphasis between chr-pos and var-counts:
![Screenshot 2024-12-18 at 09 41 37](https://github.com/user-attachments/assets/a9bc092a-b5dd-4066-b9bc-829dc1f0b433)
![Screenshot 2024-12-18 at 09 38 26](https://github.com/user-attachments/assets/34b099ed-7bfb-491a-a0fc-bc635e3fe557)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
