### PR TITLE
Stricter coordinate checks in BND variants queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - On variant page, RefSeq transcripts panel, truncate very long protein change descriptions
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
+- Stricter coordinate check in BND variants queries (affecting search results on SV variants page)
 ### Fixed
 - UCSC hg38 links are updated
 - Variants page tooltip errors

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -528,7 +528,12 @@ class QueryHandler(object):
                     },  # 4
                 ]
             }
-            coordinate_query = {"$and": [chromosome_query, position_query]}
+            coordinate_query = {
+                "or": [
+                    {"$and": [{"chromosome": query["chrom"]}, position_query]},
+                    {"$and": [{"end_chrom": query["chrom"]}, position_query]},
+                ]
+            }
         else:
             coordinate_query = chromosome_query
         return coordinate_query

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -486,8 +486,6 @@ class QueryHandler(object):
             coordinate_query(dict): returned object contains coordinate filters for sv variant
 
         """
-        coordinate_query = None
-        chromosome_query = {"$or": [{"chromosome": query["chrom"]}, {"end_chrom": query["chrom"]}]}
         if query.get("start") and query.get("end"):
             # Query for overlapping intervals. Taking into account these cases:
             # 1
@@ -528,14 +526,17 @@ class QueryHandler(object):
                     },  # 4
                 ]
             }
+            # Apply position search to both chromosome and end_chrom separately
             coordinate_query = {
-                "or": [
+                "$or": [
                     {"$and": [{"chromosome": query["chrom"]}, position_query]},
                     {"$and": [{"end_chrom": query["chrom"]}, position_query]},
                 ]
             }
         else:
-            coordinate_query = chromosome_query
+            coordinate_query = {
+                "$or": [{"chromosome": query["chrom"]}, {"end_chrom": query["chrom"]}]
+            }
         return coordinate_query
 
     def gene_filter(self, query, build="37"):

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -306,12 +306,13 @@ class VariantHandler(VariantLoader):
                 "end": variant_obj["end"],
             }
         )
+
         query = {
             "case_id": case_id,
             "category": variant_obj["category"],  # sv
             "variant_type": variant_obj["variant_type"],  # clinical or research
             "sub_category": variant_obj["sub_category"],  # example -> "del"
-            "$and": coordinate_query["$and"],  # query for overlapping SV variants
+            "$and": coordinate_query["$or"],  # query for overlapping SV variants
         }
 
         overlapping_svs = list(

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -619,9 +619,13 @@ def test_build_sv_coordinate_query(adapter):
         ]
     }
 
-    assert mongo_query["$and"][0]["$or"] == [
-        {"$and": [{"chromosome": chrom}, coordinates_part]},
-        {"$and": [{"end_chrom": chrom}, coordinates_part]},
+    assert mongo_query["$and"] == [
+        {
+            "$or": [
+                {"$and": [{"chromosome": chrom}, coordinates_part]},
+                {"$and": [{"end_chrom": chrom}, coordinates_part]},
+            ]
+        }
     ]
 
 

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -610,7 +610,6 @@ def test_build_sv_coordinate_query(adapter):
     query = {"chrom": "1", "start": start, "end": end}
     mongo_query = adapter.build_query(case_id, query=query, category="sv")
 
-    chrom_part = {"$or": [{"chromosome": chrom}, {"end_chrom": chrom}]}
     coordinates_part = {
         "$or": [
             {"end": {"$gte": start, "$lte": end}},  # 1
@@ -620,7 +619,10 @@ def test_build_sv_coordinate_query(adapter):
         ]
     }
 
-    assert mongo_query["$and"] == [{"$and": [chrom_part, coordinates_part]}]
+    assert mongo_query["$and"][0]["$or"] == [
+        {"$and": [{"chromosome": chrom}, coordinates_part]},
+        {"$and": [{"end_chrom": chrom}, coordinates_part]},
+    ]
 
 
 def test_build_ngi_sv(adapter):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Possible fix for #5127

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
