### PR TITLE
Add complexity to SV queries when SV is BND

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - On variant page, RefSeq transcripts panel, truncate very long protein change descriptions
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
+- Stricter coordinate check in BND variants queries (affecting search results on SV variants page)
 ### Fixed
 - UCSC hg38 links are updated
 - Variants page tooltip errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Variants page tooltip errors
 - Cancer variantS page had poor visibility of VAF and chromosome coordinate on causatives (green background)
 
-
 ## [4.93.1]
 ### Fixed
 - Updated PyPi build GitHub action to explicitly include setuptools (for Python 3.12 distro)

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -366,6 +366,7 @@ class QueryHandler(object):
             else:
                 mongo_query["$and"] = coordinate_query
 
+        LOG.warning(mongo_query)
         return mongo_query
 
     def affected_inds_query(self, mongo_query, case_id, gt_query):
@@ -496,6 +497,7 @@ class QueryHandler(object):
             # filter                 xxxxxxxxx
             # Variant             xxxxxxxxxxxxxx
 
+            chrom = query["chrom"]
             start = int(query["start"])
             end = int(query["end"])
 
@@ -505,8 +507,8 @@ class QueryHandler(object):
                     # Case chromosome == end_chrom
                     {
                         "$and": [
-                            {"chromosome": query["chrom"]},
-                            {"end_chrom": query["chrom"]},
+                            {"chromosome": chrom},
+                            {"end_chrom": chrom},
                             {
                                 "$or": [
                                     # Overlapping cases 1-4 (chromosome == end_chrom)
@@ -531,18 +533,18 @@ class QueryHandler(object):
                     # Case chromosome != end_chrom, position matching 'chromosome'
                     {
                         "$and": [
-                            {"chromosome": query["chrom"]},
-                            {"end_chrom": {"$ne": query["chrom"]}},
-                            {"position": {"$gte": {start}}},
+                            {"chromosome": chrom},
+                            {"end_chrom": {"$ne": chrom}},
+                            {"position": {"$gte": start}},
                             {"position": {"$lte": end}},
                         ]
                     },
                     # Case chromosome != end_chrom, position matching 'end_chrom'
                     {
                         "$and": [
-                            {"chromosome": {"$ne": query["chrom"]}},
-                            {"end_chrom": query["chrom"]},
-                            {"end": {"$gte": {start}}},
+                            {"chromosome": {"$ne": chrom}},
+                            {"end_chrom": chrom},
+                            {"end": {"$gte": start}},
                             {"end": {"$lte": end}},
                         ]
                     },

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -555,7 +555,9 @@ class QueryHandler(object):
         """Adds genomic coordinated-related filters to the query object
         This method is called to build coordinate query for sv variants
         """
-        if query.get("start") and query.get("end"):  # query contains full coordinates
+        if (
+            query.get("start") is not None and query.get("end") is not None
+        ):  # query contains full coordinates
             chrom = query["chrom"]
             start = int(query["start"])
             end = int(query["end"])

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -474,63 +474,85 @@ class QueryHandler(object):
 
         return mongo_query
 
-    def sv_coordinate_query(self, query):
+    def sv_coordinate_query(self, query: dict) -> dict:
         """Adds genomic coordinated-related filters to the query object
-            This method is called to buid coordinate query for sv variants
-
-        Args:
-            query(dict): a dictionary of query filters specified by the users
-            mongo_query(dict): the query that is going to be submitted to the database
-
-        Returns:
-            coordinate_query(dict): returned object contains coordinate filters for sv variant
-
+        This method is called to build coordinate query for sv variants
         """
-        coordinate_query = None
-        chromosome_query = {"$or": [{"chromosome": query["chrom"]}, {"end_chrom": query["chrom"]}]}
-        if query.get("start") and query.get("end"):
+        if query.get("start") and query.get("end"):  # query contains full coordinates
             # Query for overlapping intervals. Taking into account these cases:
-            # 1
+            # Case 1
             # filter                 xxxxxxxxx
             # Variant           xxxxxxxx
 
-            # 2
+            # Case 2
             # filter                 xxxxxxxxx
             # Variant                    xxxxxxxx
 
-            # 3
+            # Case 3
             # filter                 xxxxxxxxx
             # Variant                   xx
 
-            # 4
+            # Case 4
             # filter                 xxxxxxxxx
             # Variant             xxxxxxxxxxxxxx
+
+            start = int(query["start"])
+            end = int(query["end"])
+
+            # Define position queries based on chromosome equality
             position_query = {
                 "$or": [
-                    {"end": {"$gte": int(query["start"]), "$lte": int(query["end"])}},  # 1
-                    {
-                        "position": {
-                            "$lte": int(query["end"]),
-                            "$gte": int(query["start"]),
-                        }
-                    },  # 2
+                    # Case chromosome == end_chrom
                     {
                         "$and": [
-                            {"position": {"$gte": int(query["start"])}},
-                            {"end": {"$lte": int(query["end"])}},
+                            {"chromosome": query["chrom"]},
+                            {"end_chrom": query["chrom"]},
+                            {
+                                "$or": [
+                                    # Overlapping cases 1-4 (chromosome == end_chrom)
+                                    {"end": {"$gte": start, "$lte": end}},  # Case 1
+                                    {"position": {"$gte": start, "$lte": end}},  # Case 2
+                                    {
+                                        "$and": [
+                                            {"position": {"$lte": start}},
+                                            {"end": {"$gte": end}},
+                                        ]
+                                    },  # Case 3
+                                    {
+                                        "$and": [
+                                            {"position": {"$gte": start}},
+                                            {"end": {"$lte": end}},
+                                        ]
+                                    },  # Case 4
+                                ]
+                            },
                         ]
-                    },  # 3
+                    },
+                    # Case chromosome != end_chrom, position matching 'chromosome'
                     {
                         "$and": [
-                            {"position": {"$lte": int(query["start"])}},
-                            {"end": {"$gte": int(query["end"])}},
+                            {"chromosome": query["chrom"]},
+                            {"end_chrom": {"$ne": query["chrom"]}},
+                            {"position": {"$gte": {start}}},
+                            {"position": {"$lte": end}},
                         ]
-                    },  # 4
+                    },
+                    # Case chromosome != end_chrom, position matching 'end_chrom'
+                    {
+                        "$and": [
+                            {"chromosome": {"$ne": query["chrom"]}},
+                            {"end_chrom": query["chrom"]},
+                            {"end": {"$gte": {start}}},
+                            {"end": {"$lte": end}},
+                        ]
+                    },
                 ]
             }
-            coordinate_query = {"$and": [chromosome_query, position_query]}
-        else:
-            coordinate_query = chromosome_query
+            coordinate_query = position_query
+        else:  # query contains only chromosome info
+            coordinate_query = {
+                "$or": [{"chromosome": query["chrom"]}, {"end_chrom": query["chrom"]}]
+            }
         return coordinate_query
 
     def gene_filter(self, query, build="37"):

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -477,7 +477,7 @@ class QueryHandler(object):
     def get_position_query(self, chrom: str, start: int, end: int) -> dict:
         """Helper function that returns a dictionary containing start and stop coordinates.
 
-        The position query consists of 4 parts, each of them elements of the $or
+        The position query consists of 3 parts, each of them elements of the $or
         First part applies to searches when chromosome and end_chrom are the same.
         Here are the possible overlapping search scenarios:
         # Case 1

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -476,7 +476,10 @@ class QueryHandler(object):
 
     def get_position_query(self, chrom: str, start: int, end: int) -> dict:
         """Helper function that returns a dictionary containing start and stop coordinates.
-        # Query for overlapping intervals. Taking into account these cases:
+
+        The position query consists of 4 parts, each of them elements of the $or
+        First part applies to searches when chromosome and end_chrom are the same.
+        Here are the possible overlapping search scenarios:
         # Case 1
         # filter                 xxxxxxxxx
         # Variant           xxxxxxxx
@@ -492,6 +495,11 @@ class QueryHandler(object):
         # Case 4
         # filter                 xxxxxxxxx
         # Variant             xxxxxxxxxxxxxx
+
+        Second and third elements of the $or cover queries for variants where chromosome != end_chrom.
+        In this situation there are the following scenarios:
+        - Case chromosome != end_chrom, position matching 'chromosome'
+        - Case chromosome != end_chrom, position matching 'end_chrom'
         """
 
         return {

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -311,14 +311,14 @@ class VariantHandler(VariantLoader):
             "category": variant_obj["category"],  # sv
             "variant_type": variant_obj["variant_type"],  # clinical or research
             "sub_category": variant_obj["sub_category"],  # example -> "del"
-            "$and": coordinate_query["$and"],  # query for overlapping SV variants
+            "$or": coordinate_query["$or"],  # query for overlapping SV variants
         }
-
         overlapping_svs = list(
             self.variant_collection.find(
                 query,
             )
         )
+
         if not overlapping_svs:
             return None
         if len(overlapping_svs) == 1:

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -611,16 +611,54 @@ def test_build_sv_coordinate_query(adapter):
     mongo_query = adapter.build_query(case_id, query=query, category="sv")
 
     chrom_part = {"$or": [{"chromosome": chrom}, {"end_chrom": chrom}]}
-    coordinates_part = {
-        "$or": [
-            {"end": {"$gte": start, "$lte": end}},  # 1
-            {"position": {"$lte": end, "$gte": start}},  # 2
-            {"$and": [{"position": {"$gte": start}}, {"end": {"$lte": end}}]},  # 3
-            {"$and": [{"position": {"$lte": start}}, {"end": {"$gte": end}}]},
-        ]
-    }
+    coordinates_part = [
+        # Case chromosome == end_chrom
+        {
+            "$and": [
+                {"chromosome": chrom},
+                {"end_chrom": chrom},
+                {
+                    "$or": [
+                        # Overlapping cases 1-4 (chromosome == end_chrom)
+                        {"end": {"$gte": start, "$lte": end}},  # Case 1
+                        {"position": {"$gte": start, "$lte": end}},  # Case 2
+                        {
+                            "$and": [
+                                {"position": {"$lte": start}},
+                                {"end": {"$gte": end}},
+                            ]
+                        },  # Case 3
+                        {
+                            "$and": [
+                                {"position": {"$gte": start}},
+                                {"end": {"$lte": end}},
+                            ]
+                        },  # Case 4
+                    ]
+                },
+            ]
+        },
+        # Case chromosome != end_chrom, position matching 'chromosome'
+        {
+            "$and": [
+                {"chromosome": chrom},
+                {"end_chrom": {"$ne": chrom}},
+                {"position": {"$gte": start}},
+                {"position": {"$lte": end}},
+            ]
+        },
+        # Case chromosome != end_chrom, position matching 'end_chrom'
+        {
+            "$and": [
+                {"chromosome": {"$ne": chrom}},
+                {"end_chrom": chrom},
+                {"end": {"$gte": start}},
+                {"end": {"$lte": end}},
+            ]
+        },
+    ]
 
-    assert mongo_query["$and"] == [{"$and": [chrom_part, coordinates_part]}]
+    assert mongo_query["$and"] == [{"$or": coordinates_part}]
 
 
 def test_build_ngi_sv(adapter):

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -1,6 +1,7 @@
 import re
 
 from pymongo import ReturnDocument
+
 from scout.constants import CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
 
 

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -834,6 +834,41 @@ def test_query_svs_by_coordinates(real_populated_database, sv_variant_objs, case
     assert list(results)[0] == variant_obj
 
 
+def test_query_svs_by_coordinates_bnds(adapter, case_obj):
+    """Test retrieving BND variants using variants query."""
+
+    # WHEN adding a SV variant with chromosome != end_chrom
+    variant_obj = {
+        "chromosome": "2",
+        "end_chrom": "7",
+        "position": 65000,
+        "end": 22000,
+        "category": "sv",
+        "sub_category": "bnd",
+        "case_id": case_obj["_id"],
+        "variant_type": "clinical",
+    }
+    adapter.load_variant(variant_obj)
+
+    # A coordinate search using chromosome should return the variant
+    query = {
+        "chrom": "2",
+        "start": 64000,
+        "end": 66000,
+    }
+    results = adapter.variants(case_obj["_id"], query=query, category="sv")
+    assert list(results)
+
+    # Same should happen also when searching for coordinates matching end_chrom
+    query = {
+        "chrom": "7",
+        "start": 21000,
+        "end": 23000,
+    }
+    results = adapter.variants(case_obj["_id"], query=query, category="sv")
+    assert list(results)
+
+
 def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, sv_variant_obj):
     """Test function that finds SVs overlapping to a given SNV"""
 

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -833,26 +833,6 @@ def test_query_svs_by_coordinates(real_populated_database, sv_variant_objs, case
     # THEN the same variant should be returned
     assert list(results)[0] == variant_obj
 
-    # Query should return also BND variants that have end chromosome on another chromosome than chromomsome
-    assert variant_obj["chromosome"] != "6"
-
-    updated_variant = adapter.variant_collection.find_one_and_update(
-        {"_id": variant_obj["_id"]},
-        {"$set": {"end_chrom": "6"}},
-        return_document=ReturnDocument.AFTER,
-    )
-    assert updated_variant["end_chrom"] == "6"
-
-    query = {
-        "chrom": "6",
-        "start": variant_obj["position"] + 10,
-        "end": variant_obj["end"] - 10,
-    }
-    # THEN using the filter in a variant query
-    results = adapter.variants(case_obj["_id"], query=query, category="sv")
-    # The same variant should be returned
-    assert list(results)[0] == updated_variant
-
 
 def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, sv_variant_obj):
     """Test function that finds SVs overlapping to a given SNV"""


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Tentative fix #5127

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test on this variants list: https://scout-stage.scilifelab.se/cust110/F0055865-TN-re/cancer/sv-variants, by looking for variants on chr14, start: 106032600, stop: 106032700
2. This branch should return the exact BND

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by automatic tests, CR
