### PR TITLE
Refactor and follow up on #5128 fix also for SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On variant page, RefSeq transcripts panel, truncate very long protein change descriptions
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
 - On variantS pages, display chromosome directly on start and end chromosome if different
-- Use same macro for cancer alleles for SNV and SV
+- On cancer variantS pages, display allele counts and frequency the same way for SNVs and SVs (refactor macro)
 ### Fixed
 - UCSC hg38 links are updated
 - Variants page tooltip errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On variant page, RefSeq transcripts panel, truncate very long protein change descriptions
 - Build system changed to uv/hatchling, remove setuptools, add project toml and associated files
 - On variantS pages, display chromosome directly on start and end chromosome if different
+- Use same macro for cancer alleles for SNV and SV
 ### Fixed
 - UCSC hg38 links are updated
 - Variants page tooltip errors

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -111,8 +111,8 @@
       {{ variant.sub_category|upper }}
     </td>
     <td>{{ variant.chromosome if variant.chromosome == variant.end_chrom else variant.chromosome+'-'+variant.end_chrom }}</td>
-<td class="col-2">{% if variant.chromosome != variant.end_chrom %}<span class="text-body"></span><b>{{ variant.chromosome }}</b>:</span>{% endif %}<span class="text-body" style="white-space: nowrap;">{{ variant.position|human_longint|safe }}</span></td>
-<td class="col-2">{% if variant.chromosome != variant.end_chrom %}<span class="text-body"><b>{{ variant.end_chrom }}</b>:</span>{% endif %}<span style="white-space: nowrap;">{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint|safe }}</span></td>
+    <td class="col-2">{% if variant.chromosome != variant.end_chrom %}<span class="text-body"></span><b>{{ variant.chromosome }}</b>:</span>{% endif %}<span class="text-body" style="white-space: nowrap;">{{ variant.position|human_longint|safe }}</span></td>
+    <td class="col-2">{% if variant.chromosome != variant.end_chrom %}<span class="text-body"><b>{{ variant.end_chrom }}</b>:</span>{% endif %}<span style="white-space: nowrap;">{{ 'inf' if variant.end == 100000000000 else variant.end|human_longint|safe }}</span></td>
     <td class="col-2"><span style="white-space: nowrap;">{{ '-' if variant.length == 100000000000 else variant.length|human_longint|safe }}</span></td>
     <td class="text-end">{{ frequency_cell_general(variant) }}</td>
     <td>{{observed_cell_general(variant)}}</td>
@@ -125,20 +125,6 @@
     <td>{{ allele_cell(variant.tumor or {}) }}{% if variant.somatic_score %}<small class="text-muted">[{{ variant.somatic_score }}]</small>{% endif %}</td>
     <td>{{ allele_cell(variant.normal or {}) }}</td>
   </tr>
-{% endmacro %}
-
-{% macro allele_cell(allele) %}
-  {% if 'alt_freq' in allele %}
-    {% if allele.alt_freq == -1 %}
-      <span class="text-muted">.</span>
-    {% else %}
-      {{ allele.alt_freq|round(4) }}
-    {% endif %}
-    <br>
-    <small class="text-muted">{% if allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
-  {% else %}
-    <span class="text-muted">N/A</span>
-  {% endif %}
 {% endmacro %}
 
 

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import cancer_sv_filters,cell_rank, pagination_footer, pagination_hidden_div, filter_form_footer, filter_script_main, update_stash_filter_button_status, dismiss_variants_block, callers_cell %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, observed_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import allele_cell, external_scripts, external_stylesheets, frequency_cell_general, observed_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -122,7 +122,7 @@
     <td>
       {{ variant_funct_anno_cell(variant) }}
     </td>
-    <td>{{ allele_cell(variant.tumor or {}) }}{% if variant.somatic_score %}<small class="text-muted">[{{ variant.somatic_score }}]</small>{% endif %}</td>
+    <td>{{ allele_cell(variant.tumor or {}) }}{% if variant.somatic_score %}<small class="text-body" data-bs-toggle="tooltip" data-bs-placement="top" title="SV caller (Manta) somatic score">[{{ variant.somatic_score }}]</small>{% endif %}</td>
     <td>{{ allele_cell(variant.normal or {}) }}</td>
   </tr>
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 
-{% from "variants/components.html" import external_scripts, external_stylesheets, gene_cell, frequency_cell_general, observed_cell_general, variant_funct_anno_cell %}
+{% from "variants/components.html" import allele_cell, external_scripts, external_stylesheets, gene_cell, frequency_cell_general, observed_cell_general, variant_funct_anno_cell %}
 {% from "variants/utils.html" import cancer_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status, callers_cell %}
 {% from "variants/indicators.html" import pin_indicator, causative_badge, clinical_assessments_badge, comments_badge, dismissals_badge, evaluations_badge, ccv_evaluations_badge, group_assessments_badge, matching_manual_rank, other_tiered_variants, research_assessments_badge %}
 
@@ -176,16 +176,6 @@
 
 {% macro position_cell(variant) %}
   <span class="text-body"><b>{{ variant.chromosome }}</b>:{{ variant.position }}</span>
-{% endmacro %}
-
-{% macro allele_cell(allele) %}
-  {% if 'alt_freq' in allele %}
-    <span class="text-body"><b>{{ allele.alt_freq|round(4) }}</b></span>
-    <br>
-    <small class="text-body">{{ allele.alt_depth }} | {{ allele.ref_depth }}</small>
-  {% else %}
-    <span class="text-body">N/A</span>
-  {% endif %}
 {% endmacro %}
 
 {% block scripts %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -412,7 +412,7 @@
       <span class="text-body"><b>{{ allele.alt_freq|round(4) }}</b></span>
     {% endif %}
     <br>
-    <small class="text-body">{% if allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
+    <small class="text-body">{% if alt_depth in allele and allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if ref_depth in allele and allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
   {% else %}
     <span class="text-body">N/A</span>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -412,7 +412,7 @@
       <span class="text-body"><b>{{ allele.alt_freq|round(4) }}</b></span>
     {% endif %}
     <br>
-    <small class="text-body">{% if alt_depth in allele and allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if ref_depth in allele and allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
+    <small class="text-body">{% if 'alt_depth' in allele and allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if 'ref_depth' in allele and allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
   {% else %}
     <span class="text-body">N/A</span>
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -403,3 +403,17 @@
   <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
   <script src="https://cdn.datatables.net/1.12.0/js/dataTables.bootstrap5.min.js" integrity="sha512-nfoMMJ2SPcUdaoGdaRVA1XZpBVyDGhKQ/DCedW2k93MTRphPVXgaDoYV1M/AJQLCiw/cl2Nbf9pbISGqIEQRmQ==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
 {% endmacro %}
+
+{% macro allele_cell(allele) %}
+  {% if 'alt_freq' in allele %}
+    {% if allele.alt_freq == -1 %}
+      <span class="text-body">.</span>
+    {% else %}
+      <span class="text-body"><b>{{ allele.alt_freq|round(4) }}</b></span>
+    {% endif %}
+    <br>
+    <small class="text-body">{% if allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
+  {% else %}
+    <span class="text-body">N/A</span>
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
This PR refactors an existing functionality, and harmonises display between SNV and SV somatic variantS view alleles.

Also saw one more muted item on the cancer_sv variant line, the Manta SOMATICSCORE. Added a tooltip for those that have not been here since day 1 of that. 😊 

![Screenshot 2024-12-18 at 17 59 55](https://github.com/user-attachments/assets/2f829935-fa93-49e4-a2e7-19fc03887dfe)

![Screenshot 2024-12-18 at 17 58 52](https://github.com/user-attachments/assets/5b2b1532-99a9-44e1-8897-b276e0b8ac65)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
