### PR TITLE
Fix #5153 - general report ACMG temperature respects criteria term modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- ACMG temperature on case general report should respect term modifiers
+
 ## [4.94.1]
 ### Fixed
 - Temporary directory generation for MT reports and pedigree file for case general report


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5153 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. classify a variant with ACMG criteria modifiers
2. note the ACMG (VUS) temperature differ between report and classification form
3. apply patch
4. note the temperatures equal

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.
On classification page (correct ✅ ):
![Screenshot 2025-01-07 at 18 40 04](https://github.com/user-attachments/assets/4b28fe31-f6dd-4c43-abd9-2ec1eed9dcae)
On report, main/4.94.1 branch ❌:
![Screenshot 2025-01-07 at 18 41 26](https://github.com/user-attachments/assets/b80c8393-d1c8-460d-a788-a2b9b339054d)
On report, with this patch ✅ 
![Screenshot 2025-01-07 at 18 41 06](https://github.com/user-attachments/assets/9910dc4e-bcd2-4801-b0df-9b139bcb4249)


**Review:**
- [x] code approved by CR
- [x] tests executed by DN
