### PR TITLE
Fix odd hgnc gene inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Gene aliases with lower case letters mixed would not match gene symbols when adding inheritance, constraint etc
+
 ## [4.94.1]
 ### Fixed
 - Temporary directory generation for MT reports and pedigree file for case general report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- Gene aliases with lower case letters mixed would not match gene symbols when adding inheritance, constraint etc
+- Missing inheritance, constraint info for genes with symbols matching other genes previous aliases with some lower case letters
 
 ## [4.94.1]
 ### Fixed

--- a/scout/parse/omim.py
+++ b/scout/parse/omim.py
@@ -311,7 +311,6 @@ def get_mim_genes(genemap_lines, mim2gene_lines):
         mim_number = entry["mim_number"]
         inheritance = entry["inheritance"]
         phenotype_info = entry["phenotypes"]
-        hgnc_symbol = entry["hgnc_symbol"]
         hgnc_symbols = entry["hgnc_symbols"]
         if mim_number in genes:
             genes[mim_number]["inheritance"] = inheritance
@@ -354,11 +353,11 @@ def get_mim_disease(genemap_lines: Iterable[str]) -> Dict[str, Any]:
     """
     diseases_found = {}
 
-    # Genemap is a file with one entry per gene.
-    # Each line hold a lot of information and in specific it
-    # has information about the phenotypes that a gene is associated with
-    # From this source we collect inheritane patterns and what hgnc symbols
-    # a disease is associated with
+    # Genemap2 is a file with one entry per gene.
+    # Each line hold a lot of information and in particular it
+    # has information about the phenotypes that a gene is associated with.
+    # From this source we collect inheritance patterns and what hgnc symbols
+    # a disease is associated with.
     for entry in parse_genemap2(genemap_lines):
         hgnc_symbol = entry["hgnc_symbol"]
         for disease in entry["phenotypes"]:

--- a/scout/utils/link.py
+++ b/scout/utils/link.py
@@ -36,15 +36,16 @@ def genes_by_alias(hgnc_genes):
         hgnc_symbol = gene["hgnc_symbol"]
 
         for alias in gene["previous_symbols"]:
+            alias = alias.upper()
             true_id = None
             if alias == hgnc_symbol:
                 true_id = hgnc_id
             if alias in alias_genes:
-                alias_genes[alias.upper()]["ids"].add(hgnc_id)
+                alias_genes[alias]["ids"].add(hgnc_id)
                 if true_id:
-                    alias_genes[alias.upper()]["true"] = hgnc_id
+                    alias_genes[alias]["true"] = hgnc_id
             else:
-                alias_genes[alias.upper()] = {"true": true_id, "ids": set([hgnc_id])}
+                alias_genes[alias] = {"true": true_id, "ids": set([hgnc_id])}
 
     return alias_genes
 

--- a/uv.lock
+++ b/uv.lock
@@ -2340,7 +2340,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.94"
+version = "4.94.1"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

It's not easy when it's not easy I guess. But I'm tempted to say "trivial" post hoc. Old aliases could contain lower case letters in the HGNC `previous_symbols`, which would then not match gene symbols (that are now mandated to be upper case).
❌  Before:
![Screenshot 2025-01-08 at 11 47 12](https://github.com/user-attachments/assets/fdddd9b2-f4aa-4cbd-9a9f-8a41ff2a6f3d)

✅ After:
![Screenshot 2025-01-08 at 14 33 48](https://github.com/user-attachments/assets/d145a207-934a-4e1e-b2b1-986dae416219)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. check the entries for eg gene 714 (*ARSB*) and 18746 (*SLURP1*) and perhaps verify that ARSB variants show no inheritance badges, pLi constraints etc.
2. apply patch
3. `scout update genes`
4. check the same entries and variants, noticing good content for both

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
