### PR TITLE
Simple ACMG classification for SVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Quick ACMG classification link on SV variant page
+
 ## [4.94.1]
 ### Fixed
 - Temporary directory generation for MT reports and pedigree file for case general report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Added
-- Quick ACMG classification link on SV variant page
+- ACMG SNV classification form also accessible from SV variant page
 ### Fixed
 - ACMG temperature on case general report should respect term modifiers
 - Missing inheritance, constraint info for genes with symbols matching other genes previous aliases with some lower case letters

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -38,9 +38,13 @@
   <li class="list-group-item {{ 'list-group-item-info' if current_variant }}">
     <div class="d-flex">
       <span>
-        <a href="{{ url_for('variant.evaluation', evaluation_id=data._id) }}">
+        {% if variant.category in ["snv", "cancer_snv"] %}
+          <a href="{{ url_for('variant.evaluation', evaluation_id=data._id) }}">
+            {{ data.classification.label }}
+          </a>
+        {% else %}
           {{ data.classification.label }}
-        </a>
+        {% endif %}
         <span class="badge bg-info">{{ data.classification.short }}</span>
       </span>
       <span>
@@ -133,7 +137,6 @@
 {% endmacro %}
 
 {% macro acmg_form(institute, case, variant, ACMG_OPTIONS, selected=None) %}
-  <label class="mt-3" data-bs-toggle="tooltip" title="Richards et al 2015"><a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf"  rel="noopener noreferrer" target="_blank" style="color: inherit;  text-decoration: inherit;">ACMG classification</a></label>
   <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
     <div class="d-flex justify-content-between">
       {% for option in ACMG_OPTIONS %}
@@ -168,7 +171,7 @@
           <form action="{{ url_for('variant.ccv_evaluation', evaluation_id=data._id) }}" method="POST" style="display: inline-block;">
             <button class="btn btn-xs btn-link" >Delete</button>
           </form>
-          {% if data.ccv_criteria %} 
+          {% if data.ccv_criteria %}
             <a class="btn btn-xs btn-link" href="{{ url_for('variant.ccv_evaluation', evaluation_id=data._id, edit=True) }}" data-bs-toggle="tooltip" title="Editing this classification will result in a new classification">Edit</a>
           {% endif %}
       {% endif %}
@@ -191,6 +194,22 @@
   </form>
 {% endmacro %}
 
+{% macro panel_classify_sv(variant, institute, case, ACMG_OPTIONS, evaluations) %}
+  <div class="mt-3">
+    ACMG classification <a href="https://pubmed.ncbi.nlm.nih.gov/31690835/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guidelines</a> & <a href="https://cnvcalc.clinicalgenome.org/cnvcalc/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guide</a>.
+  </div>
+  <div>
+    {{ acmg_form(institute, case, variant, ACMG_OPTIONS, variant.acmg_classification.code if variant.acmg_classification) }}
+  </div>
+  {% if evaluations %} <!-- scrollable previous ACMG evaluations div-->
+    <div class="list-group mt-3" style="max-height:200px;overflow-y: scroll;">
+      {% for evaluation in evaluations %}
+        {{ acmg_classification_item(variant, evaluation) }}
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% macro panel_classify(variant, institute, case, ACMG_OPTIONS, CCV_OPTIONS, manual_rank_options, cancer_tier_options, dismiss_variant_options, mosaic_variant_options, evaluations, ccv_evaluations) %}
   <div class="card panel-default">
     <div class="panel-heading">Classify</div>
@@ -203,6 +222,7 @@
       {% if case.track != "cancer" %}
         {{ mosaic_variant_button(variant, institute, case, mosaic_variant_options) }}
       {% endif %}
+      <label class="mt-3" data-bs-toggle="tooltip" title="Richards et al 2015"><a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf"  rel="noopener noreferrer" target="_blank" style="color: inherit;  text-decoration: inherit;">ACMG classification</a></label>
       {{ acmg_form(institute, case, variant, ACMG_OPTIONS, variant.acmg_classification.code if variant.acmg_classification) }}
       <div class="mt-3">
         <a href="{{ url_for('variant.variant_acmg', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" class="btn btn-outline-secondary form-control">Classify</a>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -196,7 +196,7 @@
 
 {% macro panel_classify_sv(variant, institute, case, ACMG_OPTIONS, evaluations) %}
   <div class="mt-3">
-    ACMG classification <a href="https://pubmed.ncbi.nlm.nih.gov/31690835/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guidelines</a> & <a href="https://cnvcalc.clinicalgenome.org/cnvcalc/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guide</a>.
+    ACMG (INDEL) classification<label class="mt-3" data-bs-toggle="tooltip" title="Richards et al 2015"><a href="https://www.acmg.net/docs/standards_guidelines_for_the_interpretation_of_sequence_variants.pdf"  rel="noopener noreferrer" target="_blank" style="color: inherit;  text-decoration: inherit;">(Richards et al 2015)</a></label>.
   </div>
   <div>
     {{ acmg_form(institute, case, variant, ACMG_OPTIONS, variant.acmg_classification.code if variant.acmg_classification) }}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -201,6 +201,9 @@
   <div>
     {{ acmg_form(institute, case, variant, ACMG_OPTIONS, variant.acmg_classification.code if variant.acmg_classification) }}
   </div>
+  <div class="mt-3">
+    ACMG SV classification <a href="https://pubmed.ncbi.nlm.nih.gov/31690835/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guidelines</a> & <a href="https://cnvcalc.clinicalgenome.org/cnvcalc/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guide</a>.
+  </div>
   {% if evaluations %} <!-- scrollable previous ACMG evaluations div-->
     <div class="list-group mt-3" style="max-height:200px;overflow-y: scroll;">
       {% for evaluation in evaluations %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% from "utils.html" import activity_panel, comments_panel, pedigree_panel %}
 {% from "variant/variant_details.html" import old_observations %}
-{% from "variant/components.html" import external_scripts, external_stylesheets, matching_variants, variant_scripts %}
+{% from "variant/components.html" import external_scripts, external_stylesheets, matching_variants, panel_classify_sv, variant_scripts %}
 {% from "variant/utils.html" import causative_button, genes_panel, igv_track_selection, modal_causative, overlapping_panel, sv_alignments, pin_button, transcripts_panel, custom_annotations, gene_panels %}
 {% from "variant/rank_score_results.html" import rankscore_panel %}
 {% from "variant/gene_disease_relations.html" import orpha_omim_phenotypes %}
@@ -196,7 +196,7 @@
             {{ variant_tag_button(variant, institute, case, manual_rank_options) }}
           </div>
           <div>
-            ACMG classification <a href="https://pubmed.ncbi.nlm.nih.gov/31690835/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guidelines</a> & <a href="https://cnvcalc.clinicalgenome.org/cnvcalc/" target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">guide</a>.
+            {{ panel_classify_sv(variant, institute, case, ACMG_OPTIONS, evaluations) }}
           </div>
         </div>
         <div class="list-group mt-3">

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -21,20 +21,13 @@ from scout.constants import (
     CCV_MAP,
     CCV_OPTIONS,
 )
-from scout.server.blueprints.variant.controllers import (
-    ccv_evaluation as ccv_evaluation_controller,
-)
+from scout.server.blueprints.variant.controllers import ccv_evaluation as ccv_evaluation_controller
 from scout.server.blueprints.variant.controllers import (
     check_reset_variant_ccv_classification,
     check_reset_variant_classification,
 )
-from scout.server.blueprints.variant.controllers import (
-    evaluation as evaluation_controller,
-)
-from scout.server.blueprints.variant.controllers import (
-    observations,
-    str_variant_reviewer,
-)
+from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
+from scout.server.blueprints.variant.controllers import observations, str_variant_reviewer
 from scout.server.blueprints.variant.controllers import variant as variant_controller
 from scout.server.blueprints.variant.controllers import variant_acmg as acmg_controller
 from scout.server.blueprints.variant.controllers import variant_acmg_post

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -21,13 +21,20 @@ from scout.constants import (
     CCV_MAP,
     CCV_OPTIONS,
 )
-from scout.server.blueprints.variant.controllers import ccv_evaluation as ccv_evaluation_controller
+from scout.server.blueprints.variant.controllers import (
+    ccv_evaluation as ccv_evaluation_controller,
+)
 from scout.server.blueprints.variant.controllers import (
     check_reset_variant_ccv_classification,
     check_reset_variant_classification,
 )
-from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
-from scout.server.blueprints.variant.controllers import observations, str_variant_reviewer
+from scout.server.blueprints.variant.controllers import (
+    evaluation as evaluation_controller,
+)
+from scout.server.blueprints.variant.controllers import (
+    observations,
+    str_variant_reviewer,
+)
 from scout.server.blueprints.variant.controllers import variant as variant_controller
 from scout.server.blueprints.variant.controllers import variant_acmg as acmg_controller
 from scout.server.blueprints.variant.controllers import variant_acmg_post
@@ -374,7 +381,6 @@ def variant_update(institute_id, case_name, variant_id):
 @templated("variant/acmg.html")
 def evaluation(evaluation_id):
     """Show, edit or delete an ACMG evaluation."""
-
     evaluation_obj = store.get_evaluation(evaluation_id)
     if evaluation_obj is None:
         flash("Evaluation was not found in database", "warning")
@@ -392,7 +398,7 @@ def evaluation(evaluation_id):
         if check_reset_variant_classification(store, evaluation_obj, link):
             flash("Cleared ACMG classification.", "info")
 
-        return redirect(link)
+        return redirect(request.referrer)
 
     return dict(
         evaluation=evaluation_obj,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug:
- Adds a link to assign a quick ACMG classification to SV variants (SVs and cancer SVs) - Closes #5074

### Before:

<img width="925" alt="image" src="https://github.com/user-attachments/assets/70006817-3555-4f28-bd2a-dbd2b9d732ae" />


### After:

<img width="896" alt="image" src="https://github.com/user-attachments/assets/2aabcb9c-e047-449c-a524-090779aa0d97" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
