### PR TITLE
Skip variant genotype matching check when matching causative is found in case with one sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Simplify updating of the PanelApp Green panel from all source types in the command line interactive session
 ### Changed
 - Clearer link to `Richards 2015` on ACMG classification section on SVs and SVs variants pages
+- Skip variant genotype matching check and just return True when matching causative is found in a case with only one individual/sample
 ### Fixed
 - ACMG temperature on case general report should respect term modifiers
 - Missing inheritance, constraint info for genes with symbols matching other genes previous aliases with some lower case letters

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -495,7 +495,7 @@ class VariantHandler(VariantLoader):
             {"samples": {"$size": 1}},  # Condition for samples with exactly one element
             {
                 "samples": {
-                    "$elemMatch": {  # Condition for samples with more than one element: GT should be carrier
+                    "$elemMatch": {  # Condition for samples with more than one element: individual/sample should be carrier
                         "sample_id": {"$in": affected_ids},
                         "genotype_call": {"$regex": CARRIER},
                     }

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -491,12 +491,17 @@ class VariantHandler(VariantLoader):
         if len(affected_ids) == 0:
             return []
         filters["case_id"] = case_obj["_id"]
-        filters["samples"] = {
-            "$elemMatch": {
-                "sample_id": {"$in": affected_ids},
-                "genotype_call": {"$regex": CARRIER},
-            }
-        }
+        filters["$or"] = [
+            {"samples": {"$size": 1}},  # Condition for samples with exactly one element
+            {
+                "samples": {
+                    "$elemMatch": {  # Condition for samples with more than one element: GT should be carrier
+                        "sample_id": {"$in": affected_ids},
+                        "genotype_call": {"$regex": CARRIER},
+                    }
+                }
+            },
+        ]
 
         if limit_genes:
             filters["genes.hgnc_id"] = {"$in": limit_genes}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5152

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
