### PR TITLE
Fix save PanelApp inheritance models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ACMG temperature on case general report should respect term modifiers
 - Missing inheritance, constraint info for genes with symbols matching other genes previous aliases with some lower case letters
 - Loading of all PanelApp panels from command line
+- Saving gene inheritance models when loading/updating specific/all PanelApp panels (doesn't apply to the `PanelApp Green Genes panel`)
 
 ## [4.94.1]
 ### Fixed

--- a/scout/constants/gene_tags.py
+++ b/scout/constants/gene_tags.py
@@ -36,17 +36,27 @@ INHERITANCE_PALETTE = {
 INCOMPLETE_PENETRANCE_MAP = {"unknown": None, "Complete": None, "Incomplete": True}
 
 MODELS_MAP = {
-    "monoallelic_not_imprinted": ["AD"],
-    "monoallelic_maternally_imprinted": ["AD"],
-    "monoallelic_paternally_imprinted": ["AD"],
-    "monoallelic": ["AD"],
-    "biallelic": ["AR"],
-    "monoallelic_and_biallelic": ["AD", "AR"],
-    "monoallelic_and_more_severe_biallelic": ["AD", "AR"],
-    "xlinked_biallelic": ["XR"],
-    "xlinked_monoallelic": ["XD"],
-    "mitochondrial": ["MT"],
-    "unknown": [],
+    "MONOALLELIC, autosomal or pseudoautosomal, NOT imprinted": ["AD"],
+    "MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown": ["AD"],
+    "MONOALLELIC, autosomal or pseudoautosomal, maternally imprinted (paternal allele expressed)": [
+        "AD"
+    ],
+    "MONOALLELIC, autosomal or pseudoautosomal, paternally imprinted (maternal allele expressed)": [
+        "AD"
+    ],
+    "BIALLELIC, autosomal or pseudoautosomal": ["AR"],
+    "BOTH monoallelic and biallelic, autosomal or pseudoautosomal": ["AD", "AR"],
+    "BOTH monoallelic and biallelic (but BIALLELIC mutations cause a more SEVERE disease form), autosomal or pseudoautosomal": [
+        "AD",
+        "AR",
+    ],
+    "X-LINKED: hemizygous mutation in males, biallelic mutations in females": ["XR"],
+    "X-LINKED: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)": [
+        "XD"
+    ],
+    "MITOCHONDRIAL": ["MT"],
+    "Other": [],
+    "Other - please specifiy in evaluation comments": [],
 }
 
 PANEL_GENE_INFO_TRANSCRIPTS = [

--- a/scout/parse/panelapp.py
+++ b/scout/parse/panelapp.py
@@ -33,11 +33,11 @@ def parse_panel_app_gene(
 
     gene_info["reduced_penetrance"] = INCOMPLETE_PENETRANCE_MAP.get(panelapp_gene["penetrance"])
 
-    inheritance_models = []
-    for model in MODELS_MAP.get(panelapp_gene["mode_of_inheritance"], []):
-        inheritance_models.append(model)
+    mode_of_inheritance = panelapp_gene.get("mode_of_inheritance")
+    if mode_of_inheritance not in MODELS_MAP:
+        LOG.warning(f"Mode of inheritance '{mode_of_inheritance}' not found in MODELS_MAP.")
 
-    gene_info["inheritance_models"] = inheritance_models
+    gene_info["inheritance_models"] = MODELS_MAP.get(mode_of_inheritance, [])
 
     return gene_info
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5170. This bug is likely happening because the inheritance models have a slightly different naming in the other PanelApp API

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Load one or more PanelApp panels, example: `scout --demo load panel --panel-app --panel-id 391`

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
