### PR TITLE
Fix query by coordinates - start coordinate must be >=1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Loading of all PanelApp panels from command line
 - Saving gene inheritance models when loading/updating specific/all PanelApp panels (doesn't apply to the `PanelApp Green Genes panel`)
 - Save also complete penetrance status (in addition to incomplete) if available when loading specific/all PanelApp panels (does not apply to the `PanelApp Green Genes panel`)
-- Variants query by coordinates that was returning all variants in the chromosome if start position was 0
+- Variants and managed variants query by coordinates, which was returning all variants in the chromosome if start position was 0
 
 ## [4.94.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ACMG temperature on case general report should respect term modifiers
 - Missing inheritance, constraint info for genes with symbols matching other genes previous aliases with some lower case letters
 - Loading of all PanelApp panels from command line
+- Variants query by coordinates that was returning all variants in the chromosome if start position was 0
 
 ## [4.94.1]
 ### Fixed

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -180,10 +180,12 @@ class ManagedVariantHandler(object):
                 }
 
             if "position" in query_options:
-                query["end"] = {"$gte": int(query_options["position"])}
+                position = max(int(query_options["position"]), 1)
+                query["end"] = {"$gte": position}
 
             if "end" in query_options:
-                query["position"] = {"$lte": int(query_options["end"])}
+                end = max(int(query_options["end"]), 1)
+                query["position"] = {"$lte": end}
 
             if "sub_category" in query_options:
                 query["sub_category"] = {"$in": query_options["sub_category"]}

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -469,8 +469,10 @@ class QueryHandler(object):
             mongo_query(dict): returned object contains coordinate filters
 
         """
-        mongo_query["position"] = {"$lte": int(query["end"])}
-        mongo_query["end"] = {"$gte": int(query["start"])}
+        start_pos = int(query["start"]) if query["start"] >= 1 else 1
+        end_pos = int(query["end"]) if query["end"] >= 1 else 1
+        mongo_query["position"] = {"$lte": end_pos}
+        mongo_query["end"] = {"$gte": start_pos}
 
         return mongo_query
 
@@ -559,8 +561,8 @@ class QueryHandler(object):
             query.get("start") is not None and query.get("end") is not None
         ):  # query contains full coordinates
             chrom = query["chrom"]
-            start = int(query["start"])
-            end = int(query["end"])
+            start = int(query["start"]) if query["start"] >= 1 else 1
+            end = int(query["end"]) if query["end"] >= 1 else 1
             coordinate_query = self.get_position_query(chrom=chrom, start=start, end=end)
         else:  # query contains only chromosome info
             coordinate_query = {

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -469,8 +469,8 @@ class QueryHandler(object):
             mongo_query(dict): returned object contains coordinate filters
 
         """
-        start_pos = int(query["start"]) if query["start"] >= 1 else 1
-        end_pos = int(query["end"]) if query["end"] >= 1 else 1
+        start_pos = max(int(query["start"]), 1)
+        end_pos = max(int(query["end"]), 1)
         mongo_query["position"] = {"$lte": end_pos}
         mongo_query["end"] = {"$gte": start_pos}
 
@@ -561,8 +561,8 @@ class QueryHandler(object):
             query.get("start") is not None and query.get("end") is not None
         ):  # query contains full coordinates
             chrom = query["chrom"]
-            start = int(query["start"]) if query["start"] >= 1 else 1
-            end = int(query["end"]) if query["end"] >= 1 else 1
+            start = max(int(query["start"]), 1)
+            end = max(int(query["end"]), 1)
             coordinate_query = self.get_position_query(chrom=chrom, start=start, end=end)
         else:  # query contains only chromosome info
             coordinate_query = {

--- a/scout/server/blueprints/managed_variants/forms.py
+++ b/scout/server/blueprints/managed_variants/forms.py
@@ -10,6 +10,7 @@ from wtforms import (
     SubmitField,
     validators,
 )
+from wtforms.widgets import NumberInput
 
 from scout.constants import CHROMOSOMES, SV_TYPES
 
@@ -24,8 +25,22 @@ CATEGORY_CHOICES = [
 
 
 class ManagedVariantForm(FlaskForm):
-    position = IntegerField("Start position", [validators.Optional()])
-    end = IntegerField("End position", [validators.Optional()])
+    position = IntegerField(
+        "Start position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=0, message="Start position must be 1 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
+    end = IntegerField(
+        "End position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=0, message="End position must be 1 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
     cytoband_start = SelectField("Cytoband start", choices=[])
     cytoband_end = SelectField("Cytoband end", choices=[])
     description = StringField(label="Description")

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -212,8 +212,8 @@
     <tbody>
       <tr>
       <td>{{ add_form.chromosome(class_="form-control") }}</td>
-      <td><input type="number" name="position" id="position" class="form-control" required></td>
-      <td><input type="number" name="end" id="end" class="form-control"></td>
+      <td><input type="number" name="position" id="position" class="form-control" required min="1"></td>
+      <td><input type="number" name="end" id="end" class="form-control" min="1"></td>
       <td><input type="text" name="reference" id="reference" class="form-control" required></td>
       <td><input type="text" name="alternative" id="alternative" class="form-control" required></td>
       <td>{{ add_form.category(class_="form-control", onchange="populateSubTypeSelect('add_variant')") }}</td>

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -144,7 +144,7 @@ class VariantFiltersForm(FlaskForm):
         "End position",
         [
             validators.Optional(),
-            validators.NumberRange(min=0, message="Start position must be 1 or greater."),
+            validators.NumberRange(min=0, message="End position must be 1 or greater."),
         ],
         widget=NumberInput(min=1),
     )
@@ -290,7 +290,7 @@ class OutlierFiltersForm(FlaskForm):
         "End position",
         [
             validators.Optional(),
-            validators.NumberRange(min=1, message="Start position must be 0 or greater."),
+            validators.NumberRange(min=1, message="End position must be 0 or greater."),
         ],
         widget=NumberInput(min=1),
     )

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -16,7 +16,7 @@ from wtforms import (
     SubmitField,
     validators,
 )
-from wtforms.widgets import TextInput
+from wtforms.widgets import NumberInput, TextInput
 
 from scout.constants import (
     CALLERS,
@@ -132,8 +132,22 @@ class VariantFiltersForm(FlaskForm):
     )
 
     chrom = NonValidatingSelectMultipleField("Chromosome", choices=[], default="")
-    start = IntegerField("Start position", [validators.Optional()])
-    end = IntegerField("End position", [validators.Optional()])
+    start = IntegerField(
+        "Start position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=0, message="Start position must be 1 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
+    end = IntegerField(
+        "End position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=0, message="Start position must be 1 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
     cytoband_start = NonValidatingSelectField("Cytoband start", choices=[])
     cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
 
@@ -264,8 +278,22 @@ class OutlierFiltersForm(FlaskForm):
     )
 
     chrom = NonValidatingSelectMultipleField("Chromosome", choices=[], default="")
-    start = IntegerField("Start position", [validators.Optional()])
-    end = IntegerField("End position", [validators.Optional()])
+    start = IntegerField(
+        "Start position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=1, message="Start position must be 0 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
+    end = IntegerField(
+        "End position",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=1, message="Start position must be 0 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
     cytoband_start = NonValidatingSelectField("Cytoband start", choices=[])
     cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5142

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
