### PR TITLE
Skip calling rank function for the demo case without ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
-
+- Avoid recurrent error by removing variant ranking settings in unranked demo case
 
 ## [4.95]
 ### Added

--- a/docs/admin-guide/loading-case.md
+++ b/docs/admin-guide/loading-case.md
@@ -55,7 +55,7 @@ madeline: scout/demo/madeline.xml
 default_gene_panels: [panel1]
 gene_panels: [panel1]
 
-# meta data
+# metadata
 rank_model_version: '1.12'
 sv_rank_model_version: '1.5'
 rank_score_threshold: -100

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -44,10 +44,7 @@ delivery_report: scout/demo/delivery_report.html
 cnv_report: scout/demo/cancer_cnv_report.pdf
 coverage_qc_report: scout/demo/cancer_coverage_qc_report.html
 
-
-# meta data
-rank_model_version: '1.1'
-rank_score_threshold: -100
+# metadata
 analysis_date: 2018-10-12 14:00:46
 human_genome_build: '37'
 track: cancer

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -45,6 +45,7 @@ cnv_report: scout/demo/cancer_cnv_report.pdf
 coverage_qc_report: scout/demo/cancer_coverage_qc_report.html
 
 # metadata
+rank_score_threshold: -100
 analysis_date: 2018-10-12 14:00:46
 human_genome_build: '37'
 track: cancer


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5184 - Avoid calling ranking function for a case without ranking.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
