### PR TITLE
Remove successfully processed submissions from ClinVar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Button to directly remove accepted submissions from ClinVar
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -363,9 +363,6 @@ def update_clinvar_submission_status(request_obj, institute_id, submission_id):
             f"Removed {deleted_objects} objects and {deleted_submissions} submission from database",
             "info",
         )
-    if update_status == "clinvar-delete":
-        submitter_key = request_obj.form.get("apiKey")
-        flash(submitter_key)
 
     if update_status == "submit":
         submitter_key = request_obj.form.get("apiKey")

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -363,6 +363,10 @@ def update_clinvar_submission_status(request_obj, institute_id, submission_id):
             f"Removed {deleted_objects} objects and {deleted_submissions} submission from database",
             "info",
         )
+    if update_status == "clinvar-delete":
+        submitter_key = request_obj.form.get("apiKey")
+        flash(submitter_key)
+
     if update_status == "submit":
         submitter_key = request_obj.form.get("apiKey")
         send_api_submission(institute_id, submission_id, submitter_key)

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -77,7 +77,6 @@
               {% if subm_obj.status != 'submitted' %}
                 <li class="breadcrumb-item"><button type="submit" name="update_submission" value="submitted" class="btn btn-success btn-xs">Mark as submitted</button></li>
               {% endif %}
-
                 <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission from Scout</button></li>
             </ol>
           </nav>
@@ -101,8 +100,12 @@
               {% endif %}
               {% if subm_obj.status == 'submitted' %} <!--Submission status query -->
                  <form id="statusApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_submission_status', submission_id=subm_obj.clinvar_subm_id) }}" method="POST">
-                   {{ status_modal(subm_obj._id) }}
+                   {{ action_modal("status", subm_obj._id) }}
                    <td style="width: 20%"><button type="button" class="btn btn-sm btn-secondary form-control" name="status_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#statusModal_{{subm_obj._id}}">Submission status enquiry</button></td>
+                 </form>
+                <form id="deleteApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_submission_delete', submission_id=subm_obj.clinvar_subm_id) }}" method="POST">
+                   {{ action_modal("remove", subm_obj._id) }}
+                   <td style="width: 20%"><button type="button" class="btn btn-sm btn-danger form-control" name="_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#removeModal_{{subm_obj._id}}">Delete submission from ClinVar</button></td>
                  </form>
               {% endif %}
             </tr>
@@ -246,12 +249,12 @@
 </div>
 {% endmacro %}
 
-{% macro status_modal(subm_id) %}
-<div class="modal fade" id="statusModal_{{subm_id}}" tabindex="-1">
+{% macro action_modal(action_type, subm_id) %}
+<div class="modal fade" id="{{action_type}}Modal_{{subm_id}}" tabindex="-1">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Submission status</h5>
+        <h5 class="modal-title">Submission {{action_type}}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
@@ -260,7 +263,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <button type="submit" name="show_status" value="status" class="btn btn-primary">Submission status enquiry</button>
+        <button type="submit" name="{{action_type}}" value="{{action_type}}" class="btn btn-primary">Submission {{action_type}} enquiry</button>
       </div>
     </div>
   </div>

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -78,7 +78,7 @@
                 <li class="breadcrumb-item"><button type="submit" name="update_submission" value="submitted" class="btn btn-success btn-xs">Mark as submitted</button></li>
               {% endif %}
 
-                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission</button></li>
+                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission from Scout</button></li>
             </ol>
           </nav>
           </form>

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -4,10 +4,22 @@ from json import dumps
 from tempfile import NamedTemporaryFile
 from typing import List
 
-from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_login import current_user
 
-from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, GERMLINE_CLASSIF_TERMS
+from scout.constants.clinvar import (
+    CASEDATA_HEADER,
+    CLINVAR_HEADER,
+    GERMLINE_CLASSIF_TERMS,
+)
 from scout.server.extensions import clinvar_api, store
 from scout.server.utils import institute_and_case
 
@@ -29,10 +41,21 @@ def clinvar_submission_status(submission_id):
     """Sends a request to ClinVar to retrieve and display the status of a submission."""
 
     # flash a message with current submission status for a ClinVar submission
-    clinvar_api.show_submission_status(
+    flash(
+        f'Response from ClinVar: {clinvar_api.json_submission_status( submission_id=submission_id, api_key=request.form.get("apiKey"))}',
+        "primary",
+    )
+    return redirect(request.referrer)
+
+
+@clinvar_bp.route("/clinvar/delete-enquiry/<submission_id>", methods=["POST"])
+def clinvar_submission_delete(submission_id):
+    """Sends a request to ClinVar to delete a successfully processed submission."""
+
+    # Retrieve the actual submission status:
+    clinvar_api.delete_clinvar_submission(
         submission_id=submission_id, api_key=request.form.get("apiKey")
     )
-
     return redirect(request.referrer)
 
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -4,22 +4,10 @@ from json import dumps
 from tempfile import NamedTemporaryFile
 from typing import List
 
-from flask import (
-    Blueprint,
-    flash,
-    redirect,
-    render_template,
-    request,
-    send_file,
-    url_for,
-)
+from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user
 
-from scout.constants.clinvar import (
-    CASEDATA_HEADER,
-    CLINVAR_HEADER,
-    GERMLINE_CLASSIF_TERMS,
-)
+from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, GERMLINE_CLASSIF_TERMS
 from scout.server.extensions import clinvar_api, store
 from scout.server.utils import institute_and_case
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -2,7 +2,7 @@ import csv
 import logging
 from json import dumps
 from tempfile import NamedTemporaryFile
-from typing import List
+from typing import List, Tuple
 
 from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -44,7 +44,8 @@ def clinvar_submission_delete(submission_id):
         submission_id=submission_id, api_key=request.form.get("apiKey")
     )
     flash(
-        f"ClinVar response: {str(delete_res[1])}", "success" if delete_res[0] == 201 else "warning"
+        f"ClinVar response: { str(delete_res[1]) }",
+        "success" if delete_res[0] == 201 else "warning",
     )
     return redirect(request.referrer)
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -41,8 +41,11 @@ def clinvar_submission_delete(submission_id):
     """Sends a request to ClinVar to delete a successfully processed submission."""
 
     # Retrieve the actual submission status:
-    clinvar_api.delete_clinvar_submission(
+    delete_res: Tuple[int, dict] = clinvar_api.delete_clinvar_submission(
         submission_id=submission_id, api_key=request.form.get("apiKey")
+    )
+    flash(
+        f"ClinVar response: {str(delete_res[1])}", "success" if delete_res[0] == 201 else "warning"
     )
     return redirect(request.referrer)
 

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import tempfile
+from io import StringIO
 from typing import Optional, Tuple
 
 import requests
@@ -94,15 +94,10 @@ class ClinVarApi:
         response = requests.get(url)
         response.raise_for_status()  # Raise an error if the request failed
 
-        # Create a temporary file to save the JSON content
-        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=True) as temp_file:
-            # Write the JSON content to the temporary file
-            temp_file.write(response.text)
-            temp_file.flush()  # Ensure content is written to disk
+        # Use an in-memory file-like object to hold the JSON content
+        with StringIO(response.text) as memory_file:
 
-            # Read and parse the JSON content from the file
-            temp_file.seek(0)  # Reset file pointer to the beginning
-            json_data = json.load(temp_file)
+            json_data = json.load(memory_file)
 
             submission_data: dict = json_data["submissions"][0]
             processing_status: str = submission_data["processingStatus"]

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -88,7 +88,7 @@ class ClinVarApi:
         actions_resp: requests.models.Response = requests.get(actions_url, headers=header)
         return actions_resp.json()
 
-    def get_clinvar_scv_accesssion(self, url: str) -> Optional[str]:
+    def get_clinvar_scv_accession(self, url: str) -> Optional[str]:
         """Downloads a submission summary from the given URL into a temporary file and parses this file to retrieve a SCV accession, if available."""
         # Send a GET request to download the file
         response = requests.get(url)
@@ -133,7 +133,7 @@ class ClinVarApi:
 
             # retrieve ClinVar SCV accession (SCVxxxxxxxx) from file url returned by subm_response
             subm_summary_url: str = subm_response["files"][0]["url"]
-            scv_accession: Optional(str) = self.get_clinvar_scv_accesssion(url=subm_summary_url)
+            scv_accession: Optional(str) = self.get_clinvar_scv_accession(url=subm_summary_url)
 
             # Remove ClinVar submission using preClinVar's 'delete' endpoint
             resp = requests.post(

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -77,10 +77,22 @@ class ClinVarApi:
         except Exception as ex:
             return self.submit_service_url, None, ex
 
-    def show_submission_status(self, submission_id: str, api_key=None):
+    def json_submission_status(self, submission_id: str, api_key=None) -> dict:
         """Retrieve the status of a ClinVar submission using the https://submit.ncbi.nlm.nih.gov/api/v1/submissions/SUBnnnnnn/actions/ endpoint."""
 
         header: dict = self.set_header(api_key)
         actions_url = f"{self.submit_service_url}{submission_id}/actions/"
         actions_resp: requests.models.Response = requests.get(actions_url, headers=header)
-        flash(f"Response from ClinVar: {actions_resp.json()}", "primary")
+        return actions_resp.json()
+
+    def delete_clinvar_submission(self, submission_id: str, api_key=None) -> None:
+        """Remove s successfully processed submission from ClinVar."""
+
+        submission_status_doc: dict = self.json_submission_status(
+            submission_id=submission_id, api_key=api_key
+        )
+        try:
+            submission_status = submission_status_doc["actions"][0]["responses"][0]["status"]
+        except Exception as ex:
+            flash(ex)
+            return

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -112,8 +112,7 @@ class ClinVarApi:
                     "warning",
                 )
                 return
-
-            return submission_data["processingStatus"]["identifiers"]["clinvarAccession"]
+            return submission_data["identifiers"]["clinvarAccession"]
 
     def delete_clinvar_submission(self, submission_id: str, api_key=None) -> None:
         """Remove s successfully processed submission from ClinVar."""

--- a/scout/server/extensions/clinvar_extension.py
+++ b/scout/server/extensions/clinvar_extension.py
@@ -109,9 +109,7 @@ class ClinVarApi:
                 return
             return submission_data["identifiers"]["clinvarAccession"]
 
-    def delete_clinvar_submission(
-        self, submission_id: str, api_key=None
-    ) -> Optional[Tuple[int, dict]]:
+    def delete_clinvar_submission(self, submission_id: str, api_key=None) -> Tuple[int, dict]:
         """Remove a successfully processed submission from ClinVar."""
 
         try:
@@ -123,11 +121,10 @@ class ClinVarApi:
             submission_status = subm_response["status"]
 
             if submission_status != "processed":
-                flash(
+                return (
+                    500,
                     f"Clinvar submission status should be 'processed' and in order to attempt data deletion. Submission status is '{submission_status}'.",
-                    "warning",
                 )
-                return
 
             # retrieve ClinVar SCV accession (SCVxxxxxxxx) from file url returned by subm_response
             subm_summary_url: str = subm_response["files"][0]["url"]
@@ -140,5 +137,4 @@ class ClinVarApi:
             return resp.status_code, resp.json()
 
         except Exception as ex:
-            flash(str(ex))
-            return
+            return 500, str(ex)

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -7,7 +7,6 @@ from scout.server.extensions import store
 SAVE_ENDPOINT = "clinvar.clinvar_save"
 UPDATE_ENDPOINT = "clinvar.clinvar_update_submission"
 STATUS_ENDPOINT = "clinvar.clinvar_submission_status"
-DELETE_ENDPOINT = "clinvar.clinvar_submission_delete"
 VALIDATE_ENDPOINT = "clinvar.clinvar_validate"
 API_CSV_2_JSON_URL = "/".join([PRECLINVAR_URL, "csv_2_json"])
 API_VALIDATE_ENDPOINT = "/".join([PRECLINVAR_URL, "validate"])
@@ -339,48 +338,6 @@ def test_clinvar_api_status(app):
 
         # THEN the response should redirect
         assert response.status_code == 302
-
-
-@responses.activate
-def test_delete_processed(app):
-    """Test the endpoint that deletes a successfully processed submission using the API."""
-
-    """
-    DEMO_SUBMISSION_ID = "SUB12345678"
-    DEMO_API_KEY = "test_key"
-
-    # GIVEN a mocked submitted response from ClinVar:
-    actions: list[dict] = [
-        {
-            "id": f"{DEMO_SUBMISSION_ID}-1",
-            "responses": [],
-            "status": "processed",
-            "targetDb": "clinvar",
-            "updated": "2024-01-21T13:39:24.384085Z",
-            "responses": [
-                {
-                    "status": "processed",
-                    "message": {
-                        "errorCode": null,
-                        "severity": "info",
-                        "text": "Your ClinVar submission processing status is \"Success\". Please find the details in the file referenced by actions[0].responses[0].files[0].url."
-                    },
-                    "files": [
-                        {
-                            "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/xxxxxxxx/sub999999-summary-report.json/?format=attachment"
-                        }
-                    ],
-                    "objects": []
-                }
-            ]
-        }
-    ]
-
-    # GIVEN an initialized app
-    with app.test_client() as client:
-        # WITH a logged user
-        client.get(url_for("auto_login"))
-    """
 
 
 @responses.activate

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -7,6 +7,7 @@ from scout.server.extensions import store
 SAVE_ENDPOINT = "clinvar.clinvar_save"
 UPDATE_ENDPOINT = "clinvar.clinvar_update_submission"
 STATUS_ENDPOINT = "clinvar.clinvar_submission_status"
+DELETE_ENDPOINT = "clinvar.clinvar_submission_delete"
 VALIDATE_ENDPOINT = "clinvar.clinvar_validate"
 API_CSV_2_JSON_URL = "/".join([PRECLINVAR_URL, "csv_2_json"])
 API_VALIDATE_ENDPOINT = "/".join([PRECLINVAR_URL, "validate"])
@@ -338,6 +339,48 @@ def test_clinvar_api_status(app):
 
         # THEN the response should redirect
         assert response.status_code == 302
+
+
+@responses.activate
+def test_delete_processed(app):
+    """Test the endpoint that deletes a successfully processed submission using the API."""
+
+    """
+    DEMO_SUBMISSION_ID = "SUB12345678"
+    DEMO_API_KEY = "test_key"
+
+    # GIVEN a mocked submitted response from ClinVar:
+    actions: list[dict] = [
+        {
+            "id": f"{DEMO_SUBMISSION_ID}-1",
+            "responses": [],
+            "status": "processed",
+            "targetDb": "clinvar",
+            "updated": "2024-01-21T13:39:24.384085Z",
+            "responses": [
+                {
+                    "status": "processed",
+                    "message": {
+                        "errorCode": null,
+                        "severity": "info",
+                        "text": "Your ClinVar submission processing status is \"Success\". Please find the details in the file referenced by actions[0].responses[0].files[0].url."
+                    },
+                    "files": [
+                        {
+                            "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/xxxxxxxx/sub999999-summary-report.json/?format=attachment"
+                        }
+                    ],
+                    "objects": []
+                }
+            ]
+        }
+    ]
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # WITH a logged user
+        client.get(url_for("auto_login"))
+    """
 
 
 @responses.activate

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -573,6 +573,40 @@ def sv_var_obj():
 #############################################################
 ##################### Clinvar fixtures ######################
 #############################################################
+@pytest.fixture
+def processed_submission():
+    """Mocks a dictionary corresponding to a processed submission coming from ClinVar.
+    Copied from the ClinVar howto pages: https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
+    """
+
+    return {
+        "actions": [
+            {
+                "id": "SUB999999-1",
+                "responses": [
+                    {
+                        "status": "processed",
+                        "message": {
+                            "errorCode": None,
+                            "severity": "info",
+                            "text": 'Your ClinVar submission processing status is "Success". Please find the details in the file referenced by actions[0].responses[0].files[0].url.',
+                        },
+                        "files": [
+                            {
+                                "url": "https://submit.ncbi.nlm.nih.gov/api/2.0/files/xxxxxxxx/sub999999-summary-report.json/?format=attachment"
+                            }
+                        ],
+                        "objects": [],
+                    }
+                ],
+                "status": "processed",
+                "targetDb": "clinvar",
+                "updated": "2021-03-24T04:22:04.101297Z",
+            }
+        ]
+    }
+
+
 @pytest.fixture(scope="function")
 def clinvar_form(request):
     """Mocks a ClinVar form compiled by the user. Contains Variant and CaseData input data"""

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -574,7 +574,7 @@ def sv_var_obj():
 ##################### Clinvar fixtures ######################
 #############################################################
 @pytest.fixture
-def processed_submission():
+def processed_submission() -> dict:
     """Mocks a dictionary corresponding to a processed submission coming from ClinVar.
     Copied from the ClinVar howto pages: https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
     """
@@ -604,6 +604,35 @@ def processed_submission():
                 "updated": "2021-03-24T04:22:04.101297Z",
             }
         ]
+    }
+
+
+@pytest.fixture
+def successful_submission_summary_file_content() -> dict:
+    """Mocks the submission summary file which is downloadable from the ClinVar API. The submission contains the status 'Success'.
+    Based on the example collected from ClinVar API howto: https://www.ncbi.nlm.nih.gov/clinvar/docs/api_http/
+    """
+
+    return {
+        "submissionName": "SUB673156",
+        "submissionDate": "2021-03-25",
+        "batchProcessingStatus": "Success",
+        "batchReleaseStatus": "Not released",
+        "totalCount": 1,
+        "totalErrors": 0,
+        "totalSuccess": 1,
+        "totalPublic": 0,
+        "submissions": [
+            {
+                "identifiers": {
+                    "localID": "adefc5ed-7d59-4119-8b3d-07dcdc504c09_success1",
+                    "clinvarLocalKey": "adefc5ed-7d59-4119-8b3d-07dcdc504c09_success1",
+                    "localKey": "adefc5ed-7d59-4119-8b3d-07dcdc504c09_success1",
+                    "clinvarAccession": "SCV000839746",
+                },
+                "processingStatus": "Success",
+            },
+        ],
     }
 
 

--- a/tests/server/extensions/test_clinvar_extension.py
+++ b/tests/server/extensions/test_clinvar_extension.py
@@ -1,11 +1,15 @@
+import json
+
 import responses
 
 from scout.server.app import create_app
 from scout.server.extensions import clinvar_api
 
 CLINVAR_TEST_API_URL = "https://test.clinvar.api.submissions/"
+CLINVAR_TEST_SUBMISSION_SUMMARY_URL = "https://submit.ncbi.nlm.nih.gov/api/2.0/files/xxxxxxxx/sub999999-summary-report.json/?format=attachment"
 TEST_SUBMISSION_ID = "SUB1234567"
 TEST_API_KEY = "test_key"
+TEST_CLINVAR_ACCESSION = "SCV000839746"
 
 
 @responses.activate
@@ -20,7 +24,7 @@ def test_json_submission_status(processed_submission):
         status=200,
     )
 
-    # WHEN app is created and contains the CLINVAR_API_URL param
+    # WHEN an app is created and contains the CLINVAR_API_URL param
     test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
 
     with test_app.app_context():
@@ -32,3 +36,30 @@ def test_json_submission_status(processed_submission):
 
         # THEN the extension function should return the expected json document
         assert submission_status_json == processed_submission
+
+
+@responses.activate
+def test_get_clinvar_scv_accession(successful_submission_summary_file_content):
+    """Tests the ClinVar extension function that collects the ClinVar accession ID (SCV) after downloading a submission summary file."""
+
+    # GIVEN a downloadable submission summary from ClinVar
+    file_content = json.dumps(successful_submission_summary_file_content).encode("utf-8")
+
+    # GIVEN a patched response from ClinVar
+    responses.add(
+        method=responses.GET,
+        url=CLINVAR_TEST_SUBMISSION_SUMMARY_URL,
+        body=file_content,
+        status=200,
+        stream=True,
+        content_type="application/json",
+    )
+
+    # WHEN an app is created and contains the CLINVAR_API_URL param
+    test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
+
+    with test_app.app_context():
+        clinvar_accession = clinvar_api.get_clinvar_scv_accession(
+            url=CLINVAR_TEST_SUBMISSION_SUMMARY_URL
+        )
+        assert clinvar_accession == TEST_CLINVAR_ACCESSION

--- a/tests/server/extensions/test_clinvar_extension.py
+++ b/tests/server/extensions/test_clinvar_extension.py
@@ -2,6 +2,7 @@ import json
 
 import responses
 
+from scout.constants.clinvar import PRECLINVAR_URL
 from scout.server.app import create_app
 from scout.server.extensions import clinvar_api
 
@@ -59,7 +60,39 @@ def test_get_clinvar_scv_accession(successful_submission_summary_file_content):
     test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
 
     with test_app.app_context():
+
+        # THEN the extension function should return the expected ClinVar accession ID
         clinvar_accession = clinvar_api.get_clinvar_scv_accession(
             url=CLINVAR_TEST_SUBMISSION_SUMMARY_URL
         )
         assert clinvar_accession == TEST_CLINVAR_ACCESSION
+
+
+@responses.activate
+def test_delete_clinvar_submission(mocker, processed_submission):
+    """Test the extension function responsible for deleting a successful submission from ClinVar."""
+
+    # GIVEN a patched response from ClinVar
+    responses.post(
+        url="/".join([PRECLINVAR_URL, "delete"]), json={"id": TEST_SUBMISSION_ID}, status=201
+    )
+
+    # GIVEN a patched clinvar_extension.json_submission_status
+    mocker.patch.object(clinvar_api, "json_submission_status", return_value=processed_submission)
+
+    # GIVEN a patched clinvar_extension.get_clinvar_scv_accession
+    mocker.patch.object(
+        clinvar_api, "get_clinvar_scv_accession", return_value=TEST_CLINVAR_ACCESSION
+    )
+
+    # WHEN an app is created and contains the CLINVAR_API_URL param
+    test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
+
+    with test_app.test_request_context():
+
+        # THEN the extension function should return the expected values
+        result: tuple = clinvar_api.delete_clinvar_submission(
+            submission_id=TEST_SUBMISSION_ID, api_key=TEST_API_KEY
+        )
+
+        assert result == (201, {"id": TEST_SUBMISSION_ID})

--- a/tests/server/extensions/test_clinvar_extension.py
+++ b/tests/server/extensions/test_clinvar_extension.py
@@ -1,0 +1,31 @@
+from scout.constants.clinvar import CLINVAR_API_URL_DEFAULT
+from scout.server.app import create_app
+
+CLINVAR_TEST_API_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions/"
+TEST_SUBMISSION_ID = "SUB1234567"
+TEST_API_KEY = "test_key"
+
+
+@responses.activate
+def test_json_submission_status(processed_submission):
+    """Test the function that retrieves the status of a submission to ClinVar."""
+
+    # GIVEN a mocked submitted response from ClinVar:
+    actions: list[dict] = [
+        {
+            "id": f"{CLINVAR_TEST_API_URL}-1",
+            "responses": [],
+            "status": "submitted",
+            "targetDb": "clinvar",
+            "updated": "2024-04-29T13:39:24.384085Z",
+        }
+    ]
+
+    responses.add(
+        responses.GET,
+        f"{CLINVAR_API_URL_DEFAULT}{CLINVAR_TEST_API_URL}/actions/",
+        json=processed_submission,
+        status=200,
+    )
+
+    test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))

--- a/tests/server/extensions/test_clinvar_extension.py
+++ b/tests/server/extensions/test_clinvar_extension.py
@@ -1,7 +1,9 @@
-from scout.constants.clinvar import CLINVAR_API_URL_DEFAULT
-from scout.server.app import create_app
+import responses
 
-CLINVAR_TEST_API_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions/"
+from scout.server.app import create_app
+from scout.server.extensions import clinvar_api
+
+CLINVAR_TEST_API_URL = "https://test.clinvar.api.submissions/"
 TEST_SUBMISSION_ID = "SUB1234567"
 TEST_API_KEY = "test_key"
 
@@ -10,22 +12,23 @@ TEST_API_KEY = "test_key"
 def test_json_submission_status(processed_submission):
     """Test the function that retrieves the status of a submission to ClinVar."""
 
-    # GIVEN a mocked submitted response from ClinVar:
-    actions: list[dict] = [
-        {
-            "id": f"{CLINVAR_TEST_API_URL}-1",
-            "responses": [],
-            "status": "submitted",
-            "targetDb": "clinvar",
-            "updated": "2024-04-29T13:39:24.384085Z",
-        }
-    ]
-
+    # GIVEN a patched ClinVar API instance
     responses.add(
         responses.GET,
-        f"{CLINVAR_API_URL_DEFAULT}{CLINVAR_TEST_API_URL}/actions/",
+        f"{CLINVAR_TEST_API_URL}{TEST_SUBMISSION_ID}/actions/",
         json=processed_submission,
         status=200,
     )
 
+    # WHEN app is created and contains the CHANJO2_URL param
     test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
+
+    with test_app.app_context():
+
+        # GIVEN a call to the json_submission_status function of the ClinVar extension
+        submission_status_json = clinvar_api.json_submission_status(
+            submission_id=TEST_SUBMISSION_ID, api_key=TEST_API_KEY
+        )
+
+        # THEN the extension function should return the expected json document
+        assert submission_status_json == processed_submission

--- a/tests/server/extensions/test_clinvar_extension.py
+++ b/tests/server/extensions/test_clinvar_extension.py
@@ -20,7 +20,7 @@ def test_json_submission_status(processed_submission):
         status=200,
     )
 
-    # WHEN app is created and contains the CHANJO2_URL param
+    # WHEN app is created and contains the CLINVAR_API_URL param
     test_app = create_app(config=dict(TESTING=True, CLINVAR_API_URL=CLINVAR_TEST_API_URL))
 
     with test_app.app_context():


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

How the feature works:

- Adds the possibility to delete an already processed submission, by clicking on a button. What happens then:
- scout calls the ClinVar API to retrieve the status of the submission, it the status is 'processed':
- Scout downloads a submission summary. if the status in this summary is "Success":
- Scout extracts the ClinVar accession number (SCVxxxxxxx)
- Sends a request to PreClinVar with the accession to send a request to the ClinVar API for removal
- Closes #5029

<img width="986" alt="image" src="https://github.com/user-attachments/assets/161016e1-8861-4a40-96b1-9e1406109655" />

### OBS I HAVEN'T TRIED THIS BECAUSE THEN I HAVE TO SUBMIT TO THE PROD CLINVAR API AND THEN REMOVE THE SUBMISSION FOR REAL, BUT IT IS BASED ON THE DATA COLLECTED WHEN I DID A SUBMISSION BY MISTAKE AND I DELETED IT USING THE API.


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by automatic tests
