### PR TITLE
Add severity predictions and functional annotation on case report for SNVs and cancer SNVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Severity predictions on general case report for SNVs and cancer SNVs
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Severity predictions on general case report for SNVs and cancer SNVs
+- Variant functional annotation on general case report for SNVs and cancer SNVs
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -13,6 +13,7 @@ from flask_login import current_user
 from markdown import markdown as python_markdown
 from markupsafe import Markup
 
+from scout.constants import SPIDEX_HUMAN
 from scout.log import init_log
 
 from . import extensions
@@ -198,6 +199,17 @@ def register_filters(app):
         if value.isnumeric():
             return "{:,}".format(int(value)).replace(",", "&thinsp;")
         return value
+
+    @app.template_filter()
+    def spidex_human(spidex):
+        """Translate SPIDEX annotation to human readable string."""
+        if spidex is None:
+            return "not_reported"
+        if abs(spidex) < SPIDEX_HUMAN["low"]["pos"][1]:
+            return "low"
+        if abs(spidex) < SPIDEX_HUMAN["medium"]["pos"][1]:
+            return "medium"
+        return "high"
 
     @app.template_filter()
     def human_decimal(number, ndigits=4):

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -746,6 +746,27 @@
           </tr>
         </tbody>
       </table>
+      <table id="severity-table" class="table table-sm" style="background-color: transparent">
+        <thead>
+          <tr>
+            <th>SIFT</th>
+            <th>REVEL score</th>
+            <th>REVEL rank score</th>
+            <th>Polyphen</th>
+            <th>SPIDEX</th>
+            <th>SpliceAI DS max</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{ variant.sift_predictions|join(', ') or '-'}}</td>
+            <td>{{ variant.revel or '-' }}</td>
+            <td>{{ variant.revel_score or '-' }}</td>
+            <td>{{ variant.polyphen_predictions|join(', ') or '-' }}</td>
+            <td>{{ variant.spidex or none|spidex_human }}</td>
+            <td>{{ variant.spliceai_scores|join(', ') or '-' }}</td>
+          </tr>
+        </tbody>
+      </table>
       <table id="panel-table" class="table table-sm" style="background-color: transparent">
         <thead>
           <tr>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -773,6 +773,7 @@
             <th>Affected gene(s)</th>
             <th>Description</th>
             <th>Region annotation</th>
+            <th>Consequence</th>
             <th>Transcript - HGVS - Protein</th>
             <th>Diagnoses [inheritance]</th>
           </tr>
@@ -788,6 +789,7 @@
                 </td>
                 <td>{{gene.description|title}}</td>
                 <td>{{gene.region_annotation}}</td>
+                <td>{{gene.functional_annotation.replace("_"," ")|truncate(20, True)}}</td>
                 <td>
                   {{ variant_transcripts(gene) }}
                 </td>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -762,7 +762,7 @@
             <td>{{ variant.revel or '-' }}</td>
             <td>{{ variant.revel_score or '-' }}</td>
             <td>{{ variant.polyphen_predictions|join(', ') or '-' }}</td>
-            <td>{{ variant.spidex or none|spidex_human }}</td>
+            <td>{{ variant.spidex|spidex_human if variant.spidex else none|spidex_human }}</td>
             <td>{{ variant.spliceai_scores|join(', ') or '-' }}</td>
           </tr>
         </tbody>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -375,7 +375,7 @@
         </li>
         <li class="list-group-item">
           SPIDEX
-          <span class="float-end">{{ variant.spidex or none|spidex_human }}</span>
+          <span class="float-end">{{ variant.spidex|spidex_human if variant.spidex else none|spidex_human }}</span>
         </li>
         <li class="list-group-item">
           <a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -375,7 +375,7 @@
         </li>
         <li class="list-group-item">
           SPIDEX
-          <span class="float-end">{{ variant.spidex_human }}</span>
+          <span class="float-end">{{ variant.spidex or none|spidex_human }}</span>
         </li>
         <li class="list-group-item">
           <a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -3,7 +3,6 @@ from urllib.parse import quote
 
 from flask import current_app
 
-from scout.constants import SPIDEX_HUMAN
 from scout.utils.convert import amino_acid_residue_change_3_to_1
 
 SHALLOW_REFERENCE_STR_LOCI = ["ARX", "HOXA13"]
@@ -486,7 +485,6 @@ def get_variant_links(institute_obj: dict, variant_obj: dict, build: int = None)
         ensembl_link=ensembl_link(variant_obj, build),
         mitomap_link=mitomap_link(variant_obj),
         hmtvar_link=hmtvar_link(variant_obj),
-        spidex_human=spidex_human(variant_obj),
         spliceai_link=spliceai_link(variant_obj, build),
         str_source_link=str_source_link(variant_obj),
         snp_links=snp_links(variant_obj),
@@ -906,18 +904,6 @@ def hmtvar_link(variant_obj):
     """Compose a link to a variant in HmtVar"""
     url_template = "https://www.hmtvar.uniba.it/varCard/{id}"
     return url_template.format(id=variant_obj.get("hmtvar_variant_id"))
-
-
-def spidex_human(variant_obj):
-    """Translate SPIDEX annotation to human readable string."""
-    if variant_obj.get("spidex") is None:
-        return "not_reported"
-    if abs(variant_obj["spidex"]) < SPIDEX_HUMAN["low"]["pos"][1]:
-        return "low"
-    if abs(variant_obj["spidex"]) < SPIDEX_HUMAN["medium"]["pos"][1]:
-        return "medium"
-
-    return "high"
 
 
 def external_primer_order_link(variant_obj, build=None):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Including some additional info for SNVs and cancer SNVs - closes #5003

### Main branch

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/f03be5e2-de6e-40c2-92bb-2351c9764039" />

### This branch

<img width="1139" alt="image" src="https://github.com/user-attachments/assets/172de398-c729-4594-9dd8-b31d41fa09bc" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
