### PR TITLE
Fix #5194 - display STR variant filter status on variantS page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Severity predictions on general case report for SNVs and cancer SNVs
 - Variant functional annotation on general case report for SNVs and cancer SNVs
 - Version of Scout used when the case was loaded is displayed on case page and general report now
+- Display STR variant filter status on corresponding variantS page
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -100,8 +100,8 @@
             <td>{{ str_status(variant) }}</td>
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}
-                    <div class="float-start">{{ sample.display_name }}</div>
-                    <div class="float-end">{{ sample.genotype_call }}</div>
+                    <div class="row"><div class="col-8">{{ sample.display_name }}</div>
+                    <div class="col-4">{{ sample.genotype_call }}</div></div>
                   {% endif %}
                 {% endfor %}
             </td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -100,8 +100,10 @@
             <td>{{ str_status(variant) }}</td>
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}
-                    <div class="row"><div class="col-8">{{ sample.display_name }}</div>
-                    <div class="col-4">{{ sample.genotype_call }}</div></div>
+                    <div class="row">
+                      <div class="col-8">{{ sample.display_name }}</div>
+                      <div class="col-4 text-end">{{ sample.genotype_call }}</div>
+                    </div>
                   {% endif %}
                 {% endfor %}
             </td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -89,7 +89,7 @@
           {% elif variant.str_status == 'pre_mutation' %}
               <tr class="bg-warning">
 	        {% else %}
-	            <td>
+	            <tr>
 	        {% endif %}
             <td class="str-link">{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
             <td class="str-link">{{ str_locus_info(variant) }}</td>

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -3,7 +3,7 @@
 {% from "variant/buttons.html" import reviewer_button%}
 {% from "variant/gene_disease_relations.html" import inheritance_badge %}
 {% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general %}
-{% from "variants/utils.html" import cell_rank, dismiss_variants_block, filter_form_footer, update_stash_filter_button_status, pagination_footer, pagination_hidden_div, str_filters, filter_script_main %}
+{% from "variants/utils.html" import callers_cell, cell_rank, dismiss_variants_block, filter_form_footer, update_stash_filter_button_status, pagination_footer, pagination_hidden_div, str_filters, filter_script_main %}
 
 
 {% block title %}
@@ -60,13 +60,14 @@
       <thead class="thead table-light">
         <tr>
           <th style="width:8%" title="Index">Index</th>
-          <th title="Repeat ID">Repeat locus</th>
-          <th title="Repeat unit">Reference repeat unit</th>
-          <th title="ALT">Estimated size</th>
-          <th title="ReferenceSize">Reference size</th>
+          <th title="Repeat locus ID">Repeat locus</th>
+          <th title="Reference repeat unit">Reference RU</th>
+          <th style="width:6%" title="ALT">Est size</th>
+          <th style="width:6%" title="ReferenceSize">Ref size</th>
+          <th style="width:8%" title="Caller and call filter status">Qual</th>
           <th title="Status">Status</th>
           <th title="GT">Genotype</th>
-          <th title="Chromosome" style="width:6%">Chr.</th>
+          <th style="width:6%" title="Chromosome" style="width:6%">Chr.</th>
           <th title="Position" style="width:20%">Position</th>
         </tr>
       </thead>
@@ -88,13 +89,14 @@
           {% elif variant.str_status == 'pre_mutation' %}
               <tr class="bg-warning">
 	        {% else %}
-	            <tr>
+	            <td>
 	        {% endif %}
             <td class="str-link">{{ cell_rank(variant, institute, case, form, manual_rank_options) }}</td>
             <td class="str-link">{{ str_locus_info(variant) }}</td>
 	          <td class="text-end">{{ variant.str_display_ru or variant.str_ru or variant.reference }}</td>
             <td class="text-end"><b><span data-bs-toggle="tooltip" title="{{ variant.alternative }}">{{ variant.str_mc }}</span></b></td>
             <td class="text-end"><span data-bs-toggle="tooltip" title="{{ variant.reference }}">{{ variant.str_ref or "." }}</span></td>
+            <td>{{ callers_cell(variant) }}</td>
             <td>{{ str_status(variant) }}</td>
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -61,11 +61,11 @@
         <tr>
           <th style="width:8%" title="Index">Index</th>
           <th title="Repeat locus ID">Repeat locus</th>
-          <th title="Reference repeat unit">Reference RU</th>
+          <th style="width:8%" title="Reference repeat unit">Ref RU</th>
           <th style="width:6%" title="ALT">Est size</th>
           <th style="width:6%" title="ReferenceSize">Ref size</th>
           <th style="width:8%" title="Caller and call filter status">Qual</th>
-          <th title="Status">Status</th>
+          <th style="width:8%" title="Status">Status</th>
           <th title="GT">Genotype</th>
           <th style="width:6%" title="Chromosome" style="width:6%">Chr.</th>
           <th title="Position" style="width:20%">Position</th>
@@ -101,7 +101,7 @@
             <td>{% for sample in variant.samples %}
                   {% if sample.genotype_call != "./." %}
                     <div class="float-start">{{ sample.display_name }}</div>
-                    <div class="float-end">{{ sample.genotype_call }}</div><br>
+                    <div class="float-end">{{ sample.genotype_call }}</div>
                   {% endif %}
                 {% endfor %}
             </td>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5194 

![Screenshot 2025-01-27 at 09 24 36](https://github.com/user-attachments/assets/e180b789-c043-43df-8ba6-e34d5e2db12d)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, CR
 