### PR TITLE
Discontinue ClinVar submissions via CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Severity predictions on general case report for SNVs and cancer SNVs
 - Variant functional annotation on general case report for SNVs and cancer SNVs
 - Version of Scout used when the case was loaded is displayed on case page and general report now
+### Changed
+- Discontinue ClinVar submissions via CSV files and support only submission via API: removed buttons for downloading ClinVar submission objects as CSV files.
 ### Fixed
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -58,13 +58,6 @@
           <nav aria-label="breadcrumb">
             <ol class="breadcrumb align-items-center">
               <li class="breadcrumb-item">
-                <!-- Download the Variant data CSV file -->
-                <a href="{{ url_for('clinvar.clinvar_download_csv', submission=subm_obj._id, csv_type='variant_data', clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
-                  Download variants csv file
-                </a>
-                <a href=" {{ url_for('clinvar.clinvar_download_csv', submission=subm_obj._id, csv_type='case_data', clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
-                  Download casedata csv file
-                </a>
                 <a id="download_clinvar_json" href="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
                   Download submission json file
                 </a>

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -1,4 +1,3 @@
-import csv
 import logging
 from json import dumps
 from tempfile import NamedTemporaryFile

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -104,33 +104,6 @@ def clinvar_update_submission(institute_id, submission):
     return redirect(request.referrer)
 
 
-@clinvar_bp.route("/<submission>/download/csv/<csv_type>/<clinvar_id>", methods=["GET"])
-def clinvar_download_csv(submission, csv_type, clinvar_id):
-    """Download a csv (Variant file or CaseData file) for a clinVar submission"""
-
-    clinvar_file_data = controllers.clinvar_submission_file(submission, csv_type, clinvar_id)
-
-    if clinvar_file_data is None:
-        return redirect(request.referrer)
-
-    # Write temp CSV file and serve it in response
-    tmp_csv = NamedTemporaryFile(
-        mode="a+", prefix=clinvar_file_data[0].split(".")[0], suffix=".csv"
-    )
-    writes = csv.writer(tmp_csv, delimiter=",", quoting=csv.QUOTE_ALL)
-    writes.writerow(clinvar_file_data[1])  # Write header
-    writes.writerows(clinvar_file_data[2])  # Write lines
-    tmp_csv.flush()
-    tmp_csv.seek(0)
-
-    return send_file(
-        tmp_csv.name,
-        download_name=clinvar_file_data[0],
-        mimetype="text/csv",
-        as_attachment=True,
-    )
-
-
 @clinvar_bp.route("/<submission>/download/json/<clinvar_id>", methods=["GET"])
 def clinvar_download_json(submission, clinvar_id):
     """Download a json for a clinVar submission"""

--- a/tests/server/blueprints/clinvar/test_clinvar_views.py
+++ b/tests/server/blueprints/clinvar/test_clinvar_views.py
@@ -256,50 +256,6 @@ def test_clinvar_update_submission(app, institute_obj, case_obj, clinvar_form):
         assert store.clinvar_submission_collection.find_one() is None
 
 
-def test_clinvar_download_csv(app, institute_obj, case_obj, clinvar_form):
-    """Test downloading the Variant and CaseData .CSV files from the ClinVar submissions page"""
-
-    # GIVEN an initialized app
-    with app.test_client() as client:
-        # WITH a logged user
-        client.get(url_for("auto_login"))
-
-        # GIVEN that institute has one ClinVar submission
-        client.post(
-            url_for(
-                SAVE_ENDPOINT,
-                institute_id=institute_obj["internal_id"],
-                case_name=case_obj["display_name"],
-            ),
-            data=clinvar_form,
-        )
-        subm_obj = store.clinvar_submission_collection.find_one()
-
-        # It should be possible to download the Variant .CSV file
-        resp = client.get(
-            url_for(
-                "clinvar.clinvar_download_csv",
-                submission=subm_obj["_id"],
-                csv_type="variant_data",
-                clinvar_id="SUB000",
-            )
-        )
-        assert resp.status_code == 200
-        assert resp.mimetype == "text/csv"
-
-        # AND a a CaseData .CSV file
-        resp = client.get(
-            url_for(
-                "clinvar.clinvar_download_csv",
-                submission=subm_obj["_id"],
-                csv_type="case_data",
-                clinvar_id="SUB000",
-            )
-        )
-        assert resp.status_code == 200
-        assert resp.mimetype == "text/csv"
-
-
 @responses.activate
 def test_clinvar_api_status(app):
     """Test the endpoint used to check the status of a ClinVar submission."""


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Discontinue ClinVar submissions via CSV files and support only submission via API: removed buttons for downloading ClinVar submission objects as CSV files. (closes #5196)


### Main branch

<img width="905" alt="image" src="https://github.com/user-attachments/assets/690dcf73-f763-4940-870a-4f1eacd42822" />


### This branch

<img width="851" alt="image" src="https://github.com/user-attachments/assets/c6f13038-1f2e-4774-a3de-450bd785a889" />



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
