### PR TITLE
Re-raise on load rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Release docs to include instructions for upgrading dependencies
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages
 - Avoid recurrent error by removing variant ranking settings in unranked demo case
+- Actually re-raise exception after load aborts and has rolled back variant insertion
+
 
 ## [4.95]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -998,6 +998,10 @@ class CaseHandler(object):
         except (IntegrityError, ValueError, ConfigError, KeyError) as error:
             LOG.exception(error)
             raise error
+        else:
+            if not existing_case:
+                LOG.info("Loading case %s into database", case_obj["display_name"])
+                self.add_case(case_obj, institute_obj)
         finally:
             if existing_case:
                 self.update_case_data_sharing(old_case=existing_case, new_case=case_obj)
@@ -1017,10 +1021,6 @@ class CaseHandler(object):
 
                 if keep_actions and old_evaluated_variants:
                     self.update_variant_actions(institute_obj, case_obj, old_evaluated_variants)
-
-            else:
-                LOG.info("Loading case %s into database", case_obj["display_name"])
-                self.add_case(case_obj, institute_obj)
 
         return case_obj
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -982,7 +982,6 @@ class CaseHandler(object):
                         variant_type=variant_type,
                         category=category,
                     )
-                # add variants
                 self.load_variants(
                     case_obj=case_obj,
                     variant_type=variant_type,
@@ -994,11 +993,11 @@ class CaseHandler(object):
                     ),
                 )
 
+                self._load_omics_variants(case_obj, build=genome_build, update=update)
+
         except (IntegrityError, ValueError, ConfigError, KeyError) as error:
             LOG.exception(error)
             raise error
-        else:
-            self._load_omics_variants(case_obj, build=genome_build, update=update)
         finally:
             if existing_case:
                 self.update_case_data_sharing(old_case=existing_case, new_case=case_obj)

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -27,12 +27,19 @@ from scout.server.blueprints.variant.controllers import (
     check_reset_variant_classification,
 )
 from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
-from scout.server.blueprints.variant.controllers import observations, str_variant_reviewer
+from scout.server.blueprints.variant.controllers import (
+    observations,
+    str_variant_reviewer,
+)
 from scout.server.blueprints.variant.controllers import variant as variant_controller
 from scout.server.blueprints.variant.controllers import variant_acmg as acmg_controller
-from scout.server.blueprints.variant.controllers import variant_acmg_post
+from scout.server.blueprints.variant.controllers import (
+    variant_acmg_post,
+)
 from scout.server.blueprints.variant.controllers import variant_ccv as ccv_controller
-from scout.server.blueprints.variant.controllers import variant_ccv_post
+from scout.server.blueprints.variant.controllers import (
+    variant_ccv_post,
+)
 from scout.server.blueprints.variant.verification_controllers import (
     MissingVerificationRecipientError,
     variant_verification,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5178

Before:
<img width="726" alt="Screenshot 2025-01-27 at 15 26 18" src="https://github.com/user-attachments/assets/63976b4d-43e7-49f6-8298-050eea255668" />
After:
<img width="1189" alt="Screenshot 2025-01-27 at 16 06 52" src="https://github.com/user-attachments/assets/13f53e00-09ba-4931-a231-2c5a86eb125e" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. garble a variant file, e.g. change the name of one individual in the case STR VCF
2. try updating or loading
3. notice the exception being (re-)raised, but caught by the next except and converted to a warning and exit status set to 0
4. apply patch, try again
5. note exception once more re-raised, and exit status now properly non-zero

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
