### PR TITLE
Add software version and link to the GitHub release on the top left dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Added
-- Software version and link to the relative release on GitHub in the top left dropdown menu
+- Software version and link to the relative release on GitHub on the top left dropdown menu
 
 ## [4.96]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Software version and link to the relative release on GitHub in the top left dropdown menu
+
 ## [4.96]
 ### Added
 - Support case status assignment upon loading (by providing case status in the case config file)
@@ -23,7 +27,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Truncated long HGVS descriptions on cancer SNV and SNVs pages
 - Avoid recurrent error by removing variant ranking settings in unranked demo case
 - Actually re-raise exception after load aborts and has rolled back variant insertion
-
 
 ## [4.95]
 ### Added

--- a/scout/commands/update/individual.py
+++ b/scout/commands/update/individual.py
@@ -1,5 +1,4 @@
-"""Code for updating information on individuals
-"""
+"""Code for updating information on individuals"""
 
 from pathlib import Path
 

--- a/scout/exceptions/database.py
+++ b/scout/exceptions/database.py
@@ -1,5 +1,5 @@
 """The following exceptions follow PEP249:
-    https://www.python.org/dev/peps/pep-0249
+https://www.python.org/dev/peps/pep-0249
 """
 
 

--- a/scout/models/managed_variant.py
+++ b/scout/models/managed_variant.py
@@ -1,7 +1,7 @@
-""" Managed variant
+"""Managed variant
 
-    For potentially causative variants that are not yet in ClinVar
-    and have yet not been marked causative in any existing case.
+For potentially causative variants that are not yet in ClinVar
+and have yet not been marked causative in any existing case.
 
 """
 

--- a/scout/models/omics_variant.py
+++ b/scout/models/omics_variant.py
@@ -1,7 +1,7 @@
-""" OMICS variant
+"""OMICS variant
 
-    For potentially causative variants that are not yet in ClinVar
-    and have yet not been marked causative in any existing case.
+For potentially causative variants that are not yet in ClinVar
+and have yet not been marked causative in any existing case.
 
 """
 

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -484,7 +484,7 @@ def set_fusion_info(variant: Variant, parsed_variant: Dict[str, Any]):
 
 
 def add_gene_and_transcript_info_for_fusions(
-    parsed_variant: Dict[str, Any]
+    parsed_variant: Dict[str, Any],
 ) -> List[Optional[Dict]]:
     """Add gene and transcript info for fusions. Return list of parsed
     transcripts for later use in parsing.

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -49,7 +49,7 @@ def create_app(config_file=None, config=None):
     app = Flask(__name__)
     CORS(app)
     app.jinja_env.add_extension("jinja2.ext.do")
-    app.jinja_env.globals['SCOUT_VERSION'] = __version__
+    app.jinja_env.globals["SCOUT_VERSION"] = __version__
 
     app.config.from_pyfile("config.py")  # Load default config file
     if (

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -13,9 +13,9 @@ from flask_login import current_user
 from markdown import markdown as python_markdown
 from markupsafe import Markup
 
+from scout import __version__
 from scout.constants import SPIDEX_HUMAN
 from scout.log import init_log
-from scout import __version__
 
 from . import extensions
 from .blueprints import (

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -15,6 +15,7 @@ from markupsafe import Markup
 
 from scout.constants import SPIDEX_HUMAN
 from scout.log import init_log
+from scout import __version__
 
 from . import extensions
 from .blueprints import (
@@ -48,6 +49,7 @@ def create_app(config_file=None, config=None):
     app = Flask(__name__)
     CORS(app)
     app.jinja_env.add_extension("jinja2.ext.do")
+    app.jinja_env.globals['SCOUT_VERSION'] = __version__
 
     app.config.from_pyfile("config.py")  # Load default config file
     if (

--- a/scout/server/extensions/beacon_extension.py
+++ b/scout/server/extensions/beacon_extension.py
@@ -1,5 +1,5 @@
 """Scout supports integration with the Clinical Genomics SciLifeLab Beacon
-   cgbeacon2: https://github.com/Clinical-Genomics/cgbeacon2
+cgbeacon2: https://github.com/Clinical-Genomics/cgbeacon2
 """
 
 import datetime

--- a/scout/server/extensions/bionano_extension.py
+++ b/scout/server/extensions/bionano_extension.py
@@ -1,10 +1,10 @@
 """
-    Connect to BioNano Access server via its API.
+Connect to BioNano Access server via its API.
 
-    The server API we connect to is described in the following document:
-    https://bionano.com/wp-content/uploads/2023/01/30462-Bionano-Access-API-Guide-1.pdf
-    For further development, the server has a Swagger-like demo interface at https://bionano-access.scilifelab.se/Bnx/
-    which is useful for details, and for sniffing actual message content structure, required cookie variable names etc.
+The server API we connect to is described in the following document:
+https://bionano.com/wp-content/uploads/2023/01/30462-Bionano-Access-API-Guide-1.pdf
+For further development, the server has a Swagger-like demo interface at https://bionano-access.scilifelab.se/Bnx/
+which is useful for details, and for sniffing actual message content structure, required cookie variable names etc.
 """
 
 import json

--- a/scout/server/extensions/chanjo_extension.py
+++ b/scout/server/extensions/chanjo_extension.py
@@ -1,5 +1,5 @@
 """
-    Generate coverage reports using chanjo and chanjo-report. Documentation under -> `docs/admin-guide/chanjo_coverage_integration.md`
+Generate coverage reports using chanjo and chanjo-report. Documentation under -> `docs/admin-guide/chanjo_coverage_integration.md`
 """
 
 import json

--- a/scout/server/extensions/matchmaker_extension.py
+++ b/scout/server/extensions/matchmaker_extension.py
@@ -1,5 +1,5 @@
 """Code for MatchMaker Exchange integration
-   Tested with PatientMatcher: https://github.com/Clinical-Genomics/patientMatcher
+Tested with PatientMatcher: https://github.com/Clinical-Genomics/patientMatcher
 """
 
 import datetime

--- a/scout/server/templates/layout.html
+++ b/scout/server/templates/layout.html
@@ -43,7 +43,7 @@
                 <div class="dropdown-divider" ></div>
                 <a class="dropdown-item" href="https://clinical-genomics.github.io/scout" referrerpolicy="no-referrer" rel="noopener" target='_blank'>User guide</a>
                 <a class="dropdown-item" href="https://github.com/Clinical-Genomics/scout/issues" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Open issues</a>
-                <a class="dropdown-item mb-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Release note v{{SCOUT_VERSION}}</a>
+                <a class="dropdown-item mb-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Release notes v{{SCOUT_VERSION}}</a>
               </div>
             </li>
             {% block top_nav %}{% endblock %}

--- a/scout/server/templates/layout.html
+++ b/scout/server/templates/layout.html
@@ -43,7 +43,7 @@
                 <div class="dropdown-divider" ></div>
                 <a class="dropdown-item" href="https://clinical-genomics.github.io/scout" referrerpolicy="no-referrer" rel="noopener" target='_blank'>User guide</a>
                 <a class="dropdown-item" href="https://github.com/Clinical-Genomics/scout/issues" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Open issues</a>
-                <a class="dropdown-item ms-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Scout v.{{SCOUT_VERSION}}</a>
+                <a class="dropdown-item mb-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Scout v.{{SCOUT_VERSION}}</a>
               </div>
             </li>
             {% block top_nav %}{% endblock %}

--- a/scout/server/templates/layout.html
+++ b/scout/server/templates/layout.html
@@ -43,6 +43,7 @@
                 <div class="dropdown-divider" ></div>
                 <a class="dropdown-item" href="https://clinical-genomics.github.io/scout" referrerpolicy="no-referrer" rel="noopener" target='_blank'>User guide</a>
                 <a class="dropdown-item" href="https://github.com/Clinical-Genomics/scout/issues" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Open issues</a>
+                <a class="dropdown-item ms-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Scout v.{{SCOUT_VERSION}}</a>
               </div>
             </li>
             {% block top_nav %}{% endblock %}

--- a/scout/server/templates/layout.html
+++ b/scout/server/templates/layout.html
@@ -43,7 +43,7 @@
                 <div class="dropdown-divider" ></div>
                 <a class="dropdown-item" href="https://clinical-genomics.github.io/scout" referrerpolicy="no-referrer" rel="noopener" target='_blank'>User guide</a>
                 <a class="dropdown-item" href="https://github.com/Clinical-Genomics/scout/issues" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Open issues</a>
-                <a class="dropdown-item mb-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Scout v.{{SCOUT_VERSION}}</a>
+                <a class="dropdown-item mb-1" href="https://github.com/Clinical-Genomics/scout/releases/tag/v{{ SCOUT_VERSION[:-2] if SCOUT_VERSION.endswith('.0') and SCOUT_VERSION.count('.') > 1 else SCOUT_VERSION }}" referrerpolicy="no-referrer" rel="noopener" target='_blank'>Release note v{{SCOUT_VERSION}}</a>
               </div>
             </li>
             {% block top_nav %}{% endblock %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Close #5193 ? - Could be expanded later, this is a very simple fix.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
