### PR TITLE
pLI scores on SNV and cancer SNV pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Software version and link to the relative release on GitHub on the top left dropdown menu
+- Display pLI score on SNV variants page
 
 ## [4.96]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Software version and link to the relative release on GitHub on the top left dropdown menu
-- Display pLI score on SNV variants page
+- Display pLI score on rare diseases and cancer SNV pages
 
 ## [4.96]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -223,9 +223,28 @@
       {% if tmp_gene_info %}
         {% set primary_transcript = tmp_gene_info[1] %}
         {% set nr_genes = variant.genes | length %}
-        <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=primary_gene.hgnc_id) }}" data-bs-toggle="tooltip" title="Preferred gene for variant {% if nr_genes > 1 %} out of {{ nr_genes }} {% endif %}- shows conceptually highest impact change. See Severity card and Transcripts table below for more details."><h5 class="card-title">
-          {{ primary_gene.hgnc_symbol }}; {{ primary_gene.description }} {% if nr_genes > 1 %} <span class="badge bg-info">+ {{ nr_genes-1 }} genes</span>{% endif %}
-        </h5></a>
+        <table class="table table-bordered table-fixed table-sm">
+        <thead class="thead table-light border-top">
+          <tr class="active">
+            <th>Gene</th>
+            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
+            <th>Description</th>
+            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI</th>
+            {% if case.genome_build == "38" %}
+              <th id="MANE functional annotations">Consequence (MANE transcripts)</th>
+            {% endif %}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=primary_gene.hgnc_id) }}" data-bs-toggle="tooltip" title="Preferred gene for variant {% if nr_genes > 1 %} out of {{ nr_genes }} {% endif %}- shows conceptually highest impact change. See Severity card and Transcripts table below for more details.">{{ primary_gene.hgnc_symbol }}</a>
+              {% if nr_genes > 1 %} <span class="badge bg-info">+ {{ nr_genes-1 }} genes</span>{% endif %}
+            </td>
+            <td>{{primary_gene.description}}</td>
+            <td>{{primary_gene.pli_score}}</td>
+          </tr>
+        </tbody>
       {% endif %}
       <ul class="list-group list-group-flush" style="margin-bottom: 1rem">
         {% if primary_transcript %}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -224,23 +224,24 @@
         {% set primary_transcript = tmp_gene_info[1] %}
         {% set nr_genes = variant.genes | length %}
         <table class="table table-bordered table-fixed table-sm">
-        <thead class="thead table-light border-top">
-          <tr class="active">
-            <th>Gene</th>
-            <th>Description</th>
-            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=primary_gene.hgnc_id) }}" data-bs-toggle="tooltip" title="Preferred gene for variant {% if nr_genes > 1 %} out of {{ nr_genes }} {% endif %}- shows conceptually highest impact change. See Severity card and Transcripts table below for more details.">{{ primary_gene.hgnc_symbol }}</a>
-              {% if nr_genes > 1 %} <span class="badge bg-info">+ {{ nr_genes-1 }} genes</span>{% endif %}
-            </td>
-            <td>{{primary_gene.description}}</td>
-            <td>{{primary_gene.pli_score}}</td>
-          </tr>
-        </tbody>
+          <thead class="thead table-light border-top">
+            <tr class="active">
+              <th>Gene</th>
+              <th>Description</th>
+              <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <a target="_blank" href="{{ url_for('genes.gene', hgnc_id=primary_gene.hgnc_id) }}" data-bs-toggle="tooltip" title="Preferred gene for variant {% if nr_genes > 1 %} out of {{ nr_genes }} {% endif %}- shows conceptually highest impact change. See Severity card and Transcripts table below for more details.">{{ primary_gene.hgnc_symbol }}</a>
+                {% if nr_genes > 1 %} <span class="badge bg-info">+ {{ nr_genes-1 }} genes</span>{% endif %}
+              </td>
+              <td>{{primary_gene.description}}</td>
+              <td>{{primary_gene.pli_score}}</td>
+            </tr>
+          </tbody>
+        </table>
       {% endif %}
       <ul class="list-group list-group-flush" style="margin-bottom: 1rem">
         {% if primary_transcript %}

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -228,7 +228,7 @@
             <tr class="active">
               <th>Gene</th>
               <th>Description</th>
-              <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
+              <th data-bs-toggle="tooltip" title="Gene tolerance to a single copy of a truncating mutation (pLI) | Loss-of-function observed/expected upper bound fraction (LOEUF)">pLI score|LOEUF</th>
             </tr>
           </thead>
           <tbody>
@@ -238,7 +238,7 @@
                 {% if nr_genes > 1 %} <span class="badge bg-info">+ {{ nr_genes-1 }} genes</span>{% endif %}
               </td>
               <td>{{primary_gene.description}}</td>
-              <td>{{primary_gene.pli_score}}</td>
+              <td>{{primary_gene.pli_score|round(2) if primary_gene.pli_score else "n.a."}} | {{primary_gene.loeuf|round(2) if primary_gene.loeuf else "n.a."}}</td>
             </tr>
           </tbody>
         </table>

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -227,12 +227,8 @@
         <thead class="thead table-light border-top">
           <tr class="active">
             <th>Gene</th>
-            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
             <th>Description</th>
-            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI</th>
-            {% if case.genome_build == "38" %}
-              <th id="MANE functional annotations">Consequence (MANE transcripts)</th>
-            {% endif %}
+            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
           </tr>
         </thead>
         <tbody>

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -339,7 +339,7 @@
         <thead class="thead table-light border-top">
           <tr class="active">
             <th>Gene</th>
-            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
+            <th data-bs-toggle="tooltip" title="Gene tolerance to a single copy of a truncating mutation (pLI) | Loss-of-function observed/expected upper bound fraction (LOEUF)">pLI score | LOEUF</th>
             <th>Region</th>
             <th>Consequence</th>
             {% if case.genome_build == "38" %}
@@ -355,7 +355,7 @@
                   {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
               </td>
-              <td>{{gene.pli_score}}</td>
+              <td>{{gene.pli_score|round(2) if gene.pli_score else "n.a."}} | {{gene.loeuf|round(2) if gene.loeuf else "n.a."}}</td>
               <td>{{ gene.region_annotation }}</td>
               <td>{{ gene.functional_annotation|truncate(20, True) }}</td>
               {% if case.genome_build == "38" %} <!-- Display eventual functional annotations associated to MANE transcripts -->

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -339,6 +339,7 @@
         <thead class="thead table-light border-top">
           <tr class="active">
             <th>Gene</th>
+            <th data-bs-toggle="tooltip" title="Quantifies the likelihood that this gene is intolerant to a mutation that produces LoF in the protein product">pLI score</th>
             <th>Region</th>
             <th>Consequence</th>
             {% if case.genome_build == "38" %}
@@ -349,11 +350,12 @@
         <tbody>
           {% for gene in variant.genes %}
             <tr>
-              <th>
+              <td>
                 <a href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
                   {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
                 </a>
-              </th>
+              </td>
+              <td>{{gene.pli_score}}</td>
               <td>{{ gene.region_annotation }}</td>
               <td>{{ gene.functional_annotation|truncate(20, True) }}</td>
               {% if case.genome_build == "38" %} <!-- Display eventual functional annotations associated to MANE transcripts -->

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -339,7 +339,7 @@
         <thead class="thead table-light border-top">
           <tr class="active">
             <th>Gene</th>
-            <th data-bs-toggle="tooltip" title="Gene tolerance to a single copy of a truncating mutation (pLI) | Loss-of-function observed/expected upper bound fraction (LOEUF)">pLI score | LOEUF</th>
+            <th data-bs-toggle="tooltip" title="Gene tolerance to a single copy of a truncating mutation (pLI) | Loss-of-function observed/expected upper bound fraction (LOEUF)">pLI score|LOEUF</th>
             <th>Region</th>
             <th>Consequence</th>
             {% if case.genome_build == "38" %}

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -283,6 +283,7 @@ def add_gene_info(
 
             all_models.update(set(variant_gene["manual_inheritance"]))
             variant_gene["pli_score"] = hgnc_gene.get("pli_score")
+            variant_gene["loeuf"] = hgnc_gene.get("constraint_lof_oe_ci_upper")
 
             update_inheritance_model(variant_gene, all_models, disease_terms)
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -282,6 +282,7 @@ def add_gene_info(
             )
 
             all_models.update(set(variant_gene["manual_inheritance"]))
+            variant_gene["pli_score"] = hgnc_gene.get("pli_score")
 
             update_inheritance_model(variant_gene, all_models, disease_terms)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes https://github.com/Clinical-Genomics/scout/issues/4991
- Adds pLI scores on SNV and cancer SNV pages

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
