### PR TITLE
Sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Software version and link to the relative release on GitHub on the top left dropdown menu
+- Option to sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 ### Fixed

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -188,7 +188,7 @@ class OmicsVariantHandler:
         if query.get("sort_by") and query.get("sort_order"):
             return (
                 self.omics_variant_collection.find(variants_query, projection)
-                .sort([(query.get("sort_by"), SORTING_ORDER[query.get("sort_order")])])
+                .sort([(query.get("sort_by"), SORT_ORDER[query.get("sort_order")])])
                 .skip(skip)
                 .limit(nr_of_variants)
             )

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -188,11 +188,9 @@ class OmicsVariantHandler:
         if query.get("sort_by") and query.get("sort_order"):
             return (
                 self.omics_variant_collection.find(variants_query, projection)
-                .sort(
-                    [(query.get("sort_by"), SORTING_ORDER[query.get("sort_order")])]
-                )  # Sorting first
-                .skip(skip)  # Skipping next
-                .limit(nr_of_variants)  # Limiting last
+                .sort([(query.get("sort_by"), SORTING_ORDER[query.get("sort_order")])])
+                .skip(skip)
+                .limit(nr_of_variants)
             )
 
         return self.omics_variant_collection.find(

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -8,7 +8,7 @@ from scout.models.omics_variant import OmicsVariantLoader
 from scout.parse.omics_variant import parse_omics_file
 
 LOG = logging.getLogger(__name__)
-SORTING_ORDER = {"asc": ASCENDING, "desc": DESCENDING}
+SORT_ORDER = {"asc": ASCENDING, "desc": DESCENDING}
 
 
 class OmicsVariantHandler:

--- a/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
+++ b/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
@@ -59,7 +59,7 @@
               <tr>
                 <th style="width:14%" title="HGNC symbols">Gene</th>
                 <th style="width:7%" title="Sub-category">Type</th>
-                <th style="width:7%" title="Value - delta Psi or l2fc ">Value</th>
+                <th style="width:7%" title="Value - delta Psi or l2fc">Value</th>
                 <th title="Functional annotation">Func. annotation</th>
                 <th style="width:7%" title="P-value">P-value</th>
                 <th style="width:10%" title="Individual">Ind</th>
@@ -178,6 +178,29 @@
       })
     })
 
+    document.addEventListener('DOMContentLoaded', function() {
+    // Find all buttons inside elements with the class "sort-btn"
+    const sortButtons = document.querySelectorAll('.sort-btn button[data-sort]');
+
+    sortButtons.forEach(function(button) {
+        button.addEventListener('click', function(event) {
+            event.preventDefault();  // Prevent default button behavior
+
+            // Toggle the sort direction
+            let sortDir = button.dataset.sort === 'asc' ? 'desc' : 'asc';
+            button.dataset.sort = sortDir;  // Set the new sort direction
+
+            // Update the icon class based on the new sort direction
+            const icon = button.querySelector('.fa');
+            if (icon) {
+                icon.className = 'fa fa-sort-' + sortDir;  // Update the icon class (e.g., fa-sort-asc or fa-sort-desc)
+            }
+
+            // Call your sorting function here (e.g., sortDesc() or sortAsc)
+        });
+      });
+    });
+
   </script>
 
 {% endblock %}
@@ -246,6 +269,13 @@
   <div class="col-6">
     {{ stash_filter_buttons(form, institute, case) }}
   </div>
+
+  <div class="col-2 offset-2">
+      <div class="btn-group">
+        {{ form.sort_by(class="form-select btn btn-primary", style="width: auto;") }}
+        {{ form.sort_order(class="form-select btn btn-primary", style="width: auto;") }}
+      </div>
+    </div>
 </div>
 {% endmacro %}
 
@@ -266,7 +296,7 @@
     <div class="col-4 d-flex justify-content-center">
       Filter returns {{result_size}} / {{ total_variants }} variants.
     </div>
-    <div class="col-4 d-flex flex-column justify-content-end">
+    <div class="col-4 d-flex justify-content-end">
       <div class="d-flex justify-content-end">Showing {%if more_variants %}page {{page}}{%else%}last page{% endif %} with {{nvars}} variants.</div>
     </div>
   </div>

--- a/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
+++ b/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
@@ -178,29 +178,6 @@
       })
     })
 
-    document.addEventListener('DOMContentLoaded', function() {
-    // Find all buttons inside elements with the class "sort-btn"
-    const sortButtons = document.querySelectorAll('.sort-btn button[data-sort]');
-
-    sortButtons.forEach(function(button) {
-        button.addEventListener('click', function(event) {
-            event.preventDefault();  // Prevent default button behavior
-
-            // Toggle the sort direction
-            let sortDir = button.dataset.sort === 'asc' ? 'desc' : 'asc';
-            button.dataset.sort = sortDir;  // Set the new sort direction
-
-            // Update the icon class based on the new sort direction
-            const icon = button.querySelector('.fa');
-            if (icon) {
-                icon.className = 'fa fa-sort-' + sortDir;  // Update the icon class (e.g., fa-sort-asc or fa-sort-desc)
-            }
-
-            // Call your sorting function here (e.g., sortDesc() or sortAsc)
-        });
-      });
-    });
-
   </script>
 
 {% endblock %}

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -32,6 +32,8 @@ omics_variants_bp = Blueprint(
 def outliers(institute_id, case_name):
     """Display a list of outlier omics variants."""
 
+    print(request.form)
+
     page = get_variants_page(request.form)
     category = "outlier"
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -32,8 +32,6 @@ omics_variants_bp = Blueprint(
 def outliers(institute_id, case_name):
     """Display a list of outlier omics variants."""
 
-    print(request.form)
-
     page = get_variants_page(request.form)
     category = "outlier"
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -305,7 +305,14 @@ class OutlierFiltersForm(FlaskForm):
     show_unaffected = BooleanField("Show also variants present only in unaffected", default=False)
 
     sort_by = NonValidatingSelectField(
-        choices=[("", "Sort by"), ("value", "Sort by Value"), ("p_value", "Sort by P-value")],
+        choices=[
+            ("", "Sort by"),
+            ("p_value", "Sort by P-value"),
+            ("delta_psi", "Sort by Δψ"),
+            ("psi_value", "Sort by ψ value"),
+            ("zscore", "Sort by zscore"),
+            ("l2fc", "Sort by l2fc"),
+        ],
         validators=[validators.Optional()],
     )
     sort_order = NonValidatingSelectField(

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -304,6 +304,15 @@ class OutlierFiltersForm(FlaskForm):
 
     show_unaffected = BooleanField("Show also variants present only in unaffected", default=False)
 
+    sort_by = NonValidatingSelectField(
+        choices=[("", "Sort by"), ("value", "Sort by Value"), ("p_value", "Sort by P-value")],
+        validators=[validators.Optional()],
+    )
+    sort_order = NonValidatingSelectField(
+        choices=[("", "Sort order"), ("asc", "asc"), ("desc", "desc")],
+        validators=[validators.Optional()],
+    )
+
 
 FILTERSFORMCLASS = {
     "snv": FiltersForm,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Option to sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc (closes #4989)


<img width="1110" alt="image" src="https://github.com/user-attachments/assets/ef3d0c55-0398-49f3-816b-7a0abe2b4773" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
