### PR TITLE
Fix #5214 - parse SV freq only for SVs, accept `.` as missing value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
+- Don't parse SV frequencies for SNVs even if the name matches. Also accept "." as missing value for SV frequencies.
 
 ## [4.96]
 ### Added

--- a/scout/parse/variant/frequency.py
+++ b/scout/parse/variant/frequency.py
@@ -152,11 +152,14 @@ def parse_sv_frequency(variant, info_key):
     These have to be treated separately since some of them are not actually frequencies(float) but
     occurences(int)
     """
-    value = variant.INFO.get(info_key, 0)
-    if any([float_str in info_key.upper() for float_str in ["AF", "FRQ"]]):
-        value = float(value)
+    raw_value = variant.INFO.get(info_key, 0)
+    if raw_value in [".", "-1", -1, 0, "0"]:
+        return None
+
+    if any(float_str in info_key.upper() for float_str in ["AF", "FRQ"]):
+        value = float(raw_value)
     else:
-        value = int(value)
+        value = int(raw_value)
     if value > 0:
         return value
     return None

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -145,6 +145,7 @@ def parse_variant(
     parsed_variant["azqual"] = call_safe(float, variant.INFO.get("AZQUAL"))
 
     # STR variant info
+
     set_str_info(variant, parsed_variant)
     # STR source dict with display string, source type and entry id
     set_str_source(parsed_variant, variant)
@@ -241,14 +242,16 @@ def parse_variant(
     set_rank_result(parsed_variant, variant, rank_results_header)
 
     ###################### Add SV specific annotations ######################
-    sv_frequencies = parse_sv_frequencies(variant)
-    for key in sv_frequencies:
-        parsed_variant["frequencies"][key] = sv_frequencies[key]
+    if parsed_variant.get("category") in ["sv", "cancer_sv"]:
+        sv_frequencies = parse_sv_frequencies(variant)
+        for key in sv_frequencies:
+            parsed_variant["frequencies"][key] = sv_frequencies[key]
 
     ###################### Add MEI specific annotations #####################
-    mei_frequencies = parse_mei_frequencies(variant)
-    for key in mei_frequencies:
-        parsed_variant["frequencies"][key] = mei_frequencies[key]
+    if parsed_variant.get("category") in ["mei"]:
+        mei_frequencies = parse_mei_frequencies(variant)
+        for key in mei_frequencies:
+            parsed_variant["frequencies"][key] = mei_frequencies[key]
 
     ###################### Add Cancer specific annotations ######################
     # MSK_MVL indicates if variants are in the MSK managed variant list


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5214 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
