### PR TITLE
Fix parsing of entire Ensembl documents - including MT-TP gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
+- Downloading and parsing of genes from ensembl (including MT-TP)
 
 ## [4.96]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
-- Downloading and parsing of genes from ensembl (including MT-TP)
+- Downloading and parsing of genes from Ensembl (including MT-TP)
 
 ## [4.96]
 ### Added

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterator
 import requests
 
 LOG = logging.getLogger(__name__)
-SCHUG_BASE = "https://schug.scilifelab.se"
+SCHUG_BASE = "https://schug-stage.scilifelab.se"
 
 BUILDS: Dict[str, str] = {"37": "GRCh37", "38": "GRCh38"}
 
@@ -29,15 +29,6 @@ class EnsemblBiomartHandler:
     def stream_resource(self, interval_type: str) -> Iterator[str]:
         """Use schug web to fetch genes, transcripts or exons from a remote Ensembl biomart in the right genome build and save them to file."""
 
-        def yield_resource_lines(iterable) -> str:
-            """Removes the last element from an iterator."""
-            it = iter(iterable)
-            current = next(it)
-            for i in it:
-                yield current
-                current = i
-
         shug_url: str = f"{SCHUG_BASE}{SCHUG_RESOURCE_URL[interval_type]}{self.build}"
 
-        # return all lines except the last, which contains the "[success]" string
-        return yield_resource_lines(self.stream_get(shug_url))
+        return self.stream_get(shug_url)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix parsing of Ensembl resources. While working on #5204, I've realised that the only missing gene after the parsing is MT-TP - I'll include comments in the PR code, to explain why I think this happens

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Install the branch locally or on stage
2. Download all resources and update the database
3. Compare with the number of genes available on prod

**Expected outcome**:
- The only missing gene on prod is MT-TP!!

**Review:**
- [ ] code approved by
- [x] tests executed by CR
