### PR TITLE
Fix tests by pulling mongo image from ecr.aws instead of Docker Hub

### DIFF
--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -37,7 +37,7 @@ jobs:
         mongodb-version: ['7']
     steps:
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.10.0
+        uses: supercharge/mongodb-github-action@1.12.0
         with:
          mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -38,8 +38,8 @@ jobs:
     steps:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
-        mongodb-image: 'clinicalgenomics/mongo:7.0.16'
         with:
+         mongodb-image: 'public.ecr.aws/docker/library/mongo'
          mongodb-version: ${{ matrix.mongodb-version }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -38,6 +38,7 @@ jobs:
     steps:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
+        mongodb-image: 'public.ecr.aws/docker/library/mongo'
         with:
          mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
-        mongodb-image: 'public.ecr.aws/docker/library/mongo'
+        mongodb-image: 'clinicalgenomics/mongo:7.0.16'
         with:
          mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         group: [1, 2, 3, 4, 5, 6, 7, 8]
-        mongodb-version: ['7']
+        mongodb-version: ['7.0.16']
     steps:
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
+- Updated the GitHub MongoDB action to version to 1.12 in automatic tests workflow
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
-- Updated the GitHub MongoDB action to version to 1.12 in automatic tests workflow
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
+- In automatic tests, avoid the `toomanyrequests: You have reached your pull rate limit` error by pulling the MongoDB image from The Amazon Elastic Container Registry (ecr.aws) instead of Docker Hub.
 
 ## [4.96]
 ### Added


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5222 - Using a recent feature of the GitHub action, see [this PR](https://github.com/supercharge/mongodb-github-action/pull/64)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions
