### PR TITLE
Preselect MANE SELECT transcripts in the ClinVar multistep form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Software version and link to the relative release on GitHub on the top left dropdown menu
 - Option to sort WTS outliers by p_value, Δψ, ψ value, zscore or l2fc
 - Display pLI score on rare diseases and cancer SNV pages
+- Preselect MANE SELECT transcripts in the multi-step ClinVar variant add to submission process
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 - Set case as research case if it contains any type of research variants
@@ -18,7 +19,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
 - Downloading and parsing of genes from Ensembl (including MT-TP)
-
 
 ## [4.96]
 ### Added

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -2,7 +2,7 @@ import csv
 import logging
 from datetime import datetime
 from tempfile import NamedTemporaryFile
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from flask import flash
 from flask_login import current_user
@@ -26,14 +26,9 @@ from .form import CaseDataForm, SNVariantForm, SVariantForm
 LOG = logging.getLogger(__name__)
 
 
-def _get_var_tx_hgvs(case_obj, variant_obj):
-    """Retrieve all transcripts / hgvs for a given variant
-    Args:
-        case_obj(scout.models.Case)
-        variant_obj(scout.models.Variant)
-    Returns:
-        list of tuples. example: [("NM_002340.6:c.1840C>T", "NM_002340.6:c.1840C>T (validated)" ), ("NM_001145436.2:c.1840C>T", "NM_001145436.2:c.1840C>T"), .. ]
-    """
+def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]:
+    """Retrieve all transcripts / hgvs for a given variant."""
+
     build = str(case_obj.get("genome_build", "37"))
     tx_hgvs_list = [("", "Do not specify")]
     for gene in variant_obj.get("genes", []):

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -38,6 +38,7 @@ def _get_var_tx_hgvs(case_obj, variant_obj):
     tx_hgvs_list = [("", "Do not specify")]
     for gene in variant_obj.get("genes", []):
         for tx in gene.get("transcripts", []):
+            mane_select = tx.get("mane_select")
             if all([tx.get("refseq_id"), tx.get("coding_sequence_name")]):
                 for refseq in tx.get("refseq_identifiers"):
                     refseq_version = fetch_refseq_version(refseq)  # adds version to a refseq ID
@@ -48,10 +49,11 @@ def _get_var_tx_hgvs(case_obj, variant_obj):
 
                     label = hgvs_simple
                     if validated:
-                        label += " (validated)"
+                        label += "_validated_"
+                    if mane_select and mane_select == refseq_version:
+                        label += "_mane-select_"
 
                     tx_hgvs_list.append((hgvs_simple, label))
-
     return tx_hgvs_list
 
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -17,6 +17,7 @@ from scout.constants.clinvar import (
 )
 from scout.constants.variant_tags import MANUAL_RANK_OPTIONS
 from scout.models.clinvar import clinvar_variant
+from scout.server.blueprints.variant.utils import add_gene_info
 from scout.server.extensions import clinvar_api, store
 from scout.utils.hgvs import validate_hgvs
 from scout.utils.scout_requests import fetch_refseq_version
@@ -31,9 +32,10 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
     build = str(case_obj.get("genome_build", "37"))
     tx_hgvs_list = [("", "Do not specify")]
+    add_gene_info(store, variant_obj, genome_build=build)
     for gene in variant_obj.get("genes", []):
         for tx in gene.get("transcripts", []):
-            mane_select = tx.get("mane_select")
+            mane_select = tx.get("mane_select_transcript")
             if all([tx.get("refseq_id"), tx.get("coding_sequence_name")]):
                 for refseq in tx.get("refseq_identifiers"):
                     refseq_version = fetch_refseq_version(refseq)  # adds version to a refseq ID
@@ -45,6 +47,7 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
                     label = hgvs_simple
                     if validated:
                         label += "_validated_"
+
                     if mane_select and mane_select == refseq_version:
                         label += "_mane-select_"
 

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -110,25 +110,33 @@
                     <table style="width:100%; table-layout: auto; border-collapse: collapse;">
                       <caption></caption>
                       <tr><th></th></tr>
-                    {% set ns = namespace(label='', validated=false) %}
                     {% for item_row in variant_data.var_form.tx_hgvs | batch(3) %}
                       <tr>
                       {% for item in item_row %}
-                        <td style="width: 3%; text-align: right; vertical-align: baseline;">{{item}}</td>
+                        {% set ns = namespace(label='', validated=false, mane_select=false) %}
 
-                        {% if "(validated)" in item.label.text %}
+                        {% if "_validated_" in item.label.text %}
                           {% set ns.validated = true %}
-                        {% else %}
-                          {% set ns.validated = false %}
                         {% endif %}
-                        {% set ns.label = item.label.text | replace(" (validated)", "") %}
+                        {% if "_mane-select_" in item.label.text %}
+                          {% set ns.mane_select = true %}
+                        {% endif %}
+                        {% set ns.label = item.label.text | replace("_validated_", "") | replace("_mane-select_", "")  %}
+
+                        <td style="width: 3%; text-align: right; vertical-align: baseline;">
+                          <input type="radio" name="tx_hgvs" value="{{ ns.label }}"
+                            {% if ns.mane_select %}checked{% endif %}>
+                        </td>
 
                         <td style="width: 30%; text-align: left; ">
                           <p class="text-dark"
-                          {% if ns.label|length > 25 %}
+                          {% if ns.label|length > 50 %}
                            data-bs-toggle="tooltip" title="{{ns.label}}">{{ ns.label|truncate(25,true,'..') }}
                           {% else %}
                             >{{ ns.label }}
+                          {% endif %}
+                          {% if ns.mane_select %}
+                            <span class='badge bg-dark'>MANE SELECT</span>
                           {% endif %}
                           {% if ns.validated %}
                             <em class="fa fa-check text-success" aria-hidden="true" data-bs-toggle="tooltip" title="Verified by VariantValidator"></em>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5231

### Before

<img width="1095" alt="image" src="https://github.com/user-attachments/assets/a6ce47a1-a228-4464-9e1a-3ee15ef6515c" />

### After 

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/9d588048-1a33-4121-8e9e-81464124feaf" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Using a case with genome build 38, add to a ClinVar submission object a variant which has a MANE select transcript.

**Expected outcome**:
- In the ClinVar multistep form, the transcripts with MANE SELECT should be preselected

**Review:**
- [ ] code approved by
- [ ] tests executed by Jakob37
