### PR TITLE
Fix #5237 - enable HPO searches on WTS outlier page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Don't save any "-1", "." or "0" frequency values for SNVs - same as for SVs
 - Downloading and parsing of genes from Ensembl (including MT-TP)
 - Don't parse SV frequencies for SNVs even if the name matches. Also accept "." as missing value for SV frequencies.
+- HPO search on WTS Outliers page
 
 ## [4.96]
 ### Added

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -180,7 +180,12 @@
                Clinical HPO MEIs
              </a>
             {% endif %}
-           {% endif %}
+            {% if case.has_outliers %}
+              <a class="btn btn-secondary btn-sm text-white" href="{{ url_for('omics_variants.outliers',
+                institute_id=institute._id, case_name=case.display_name, variant_type='clinical',
+                gene_panels=['hpo']) }}" target="_blank" rel="noopener">Clinical HPO WTS</a>
+            {% endif %}
+          {% endif %}
           </div>
         </div>
         {% if case.chanjo_coverage or case.chanjo2_coverage and case.dynamic_gene_list|length > 0 %}

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -11,6 +11,7 @@ from scout.server.blueprints.variants.controllers import (
     get_variants_page,
     populate_chrom_choices,
     populate_filters_form,
+    update_form_hgnc_symbols,
 )
 from scout.server.blueprints.variants.forms import OutlierFiltersForm
 from scout.server.extensions import store
@@ -78,7 +79,7 @@ def outliers(institute_id, case_name):
     genome_build = "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
     cytobands = store.cytoband_by_chrom(genome_build)
 
-    # controllers.update_form_hgnc_symbols(store, case_obj, form)
+    update_form_hgnc_symbols(store, case_obj, form)
     variants_query = store.omics_variants(
         case_obj["_id"], query=form.data, category=category, build=genome_build
     )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5237 

Looks good on local:
![Screenshot 2025-02-12 at 09 33 24](https://github.com/user-attachments/assets/51a5aa25-c5c8-4f14-a4bd-f59159042834)

Added shortcut for clinical filter HPO WTS on case page.
![Screenshot 2025-02-12 at 09 45 56](https://github.com/user-attachments/assets/11965dc6-4a43-48ee-ab29-b9ccd53d2376)

Looks ok also for narrow pages.
![Screenshot 2025-02-12 at 09 46 18](https://github.com/user-attachments/assets/d868280a-893a-44bd-8c79-46633dcdcbb4)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. add an hpo term that will match a clinical WTS outlier for the case, e.g. neoplasm for POT1 on demo.
2. test clicking clinical HPO filter from case page
3. test enabling HPO search with clinical filter, and then clicking clinical filter on outliers page
4. test searching with HPO panel selected from variants page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
