### PR TITLE
Variants filter by size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display pLI score and LOEUF on rare diseases and cancer SNV pages
 - Preselect MANE SELECT transcripts in the multi-step ClinVar variant add to submission process
 - Allow updating case with WTS Fraser and Outrider research files
+- Enhanced SNV and SV filtering for cancer and rare disease cases, now supporting size thresholds (≥ or < a specified base pair length)
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 - Set case as research case if it contains any type of research variants

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -765,22 +765,7 @@ class QueryHandler(object):
                 size = query["size"]
                 size_selector = query.get("size_selector")
 
-                size_query = (
-                    {
-                        "$or": [
-                            {"length": {size_selector: size}},
-                            {"length": {size_selector: -size}},
-                            {"length": {"$exists": False}},
-                        ]
-                    }
-                    if size_selector == "$lt"
-                    else {
-                        "$or": [
-                            {"length": {size_selector: size}},
-                            {"length": {size_selector: -size}},
-                        ]
-                    }
-                )
+                size_query = {"$expr": {size_selector: [{"$abs": "$length"}, size]}}
 
                 mongo_secondary_query.append(size_query)
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -227,6 +227,7 @@ class QueryHandler(object):
             mongo_query : A dictionary in the mongo query format
 
         """
+        LOG.warning(query)
         query = query or {}
         mongo_query = {}
         coordinate_query = None
@@ -366,7 +367,6 @@ class QueryHandler(object):
             else:
                 mongo_query["$and"] = coordinate_query
 
-        LOG.warning(mongo_query)
         return mongo_query
 
     def affected_inds_query(self, mongo_query, case_id, gt_query):
@@ -764,11 +764,11 @@ class QueryHandler(object):
 
             if criterion == "size":
                 size = query["size"]
-                size_query = {"length": {"$gte": int(size)}}
-                if query.get("size_selector") == "$lt" or query.get("size_shorter"):
+                size_query = {"length": {query["size_selector"]: size}}
+                if query.get("size_selector") == "$lt":
                     size_query = {
                         "$or": [
-                            {"length": {"$lt": int(size)}},
+                            {"length": {"$lt": size}},
                             {"length": {"$exists": False}},
                         ]
                     }

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -765,7 +765,14 @@ class QueryHandler(object):
                 size = query["size"]
                 size_selector = query.get("size_selector")
 
-                size_query = {"$expr": {size_selector: [{"$abs": "$length"}, size]}}
+                size_query = {
+                    "$or": [
+                        {"$expr": {size_selector: [{"$abs": "$length"}, size]}},
+                        {
+                            "length": {"$exists": False}
+                        },  # Include documents where 'length' is missing
+                    ]
+                }
 
                 mongo_secondary_query.append(size_query)
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -227,7 +227,6 @@ class QueryHandler(object):
             mongo_query : A dictionary in the mongo query format
 
         """
-        LOG.warning(query)
         query = query or {}
         mongo_query = {}
         coordinate_query = None

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -763,14 +763,14 @@ class QueryHandler(object):
 
             if criterion == "size":
                 size = query["size"]
-                size_query = {"length": {query["size_selector"]: size}}
-                if query.get("size_selector") == "$lt":
-                    size_query = {
-                        "$or": [
-                            {"length": {"$lt": size}},
-                            {"length": {"$exists": False}},
-                        ]
-                    }
+                size_selector = query.get("size_selector")
+
+                size_query = (
+                    {"$or": [{"length": {size_selector: size}}, {"length": {"$exists": False}}]}
+                    if size_selector == "$lt"
+                    else {"length": {size_selector: size}}
+                )
+
                 mongo_secondary_query.append(size_query)
 
             if criterion == "svtype":

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -769,7 +769,7 @@ class QueryHandler(object):
                     {
                         "$or": [
                             {"length": {size_selector: size}},
-                            {"length": {size_selector: -size}},  # Add the negative condition
+                            {"length": {size_selector: -size}},
                             {"length": {"$exists": False}},
                         ]
                     }
@@ -777,7 +777,7 @@ class QueryHandler(object):
                     else {
                         "$or": [
                             {"length": {size_selector: size}},
-                            {"length": {size_selector: -size}},  # Add the negative condition
+                            {"length": {size_selector: -size}},
                         ]
                     }
                 )

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -766,9 +766,20 @@ class QueryHandler(object):
                 size_selector = query.get("size_selector")
 
                 size_query = (
-                    {"$or": [{"length": {size_selector: size}}, {"length": {"$exists": False}}]}
+                    {
+                        "$or": [
+                            {"length": {size_selector: size}},
+                            {"length": {size_selector: -size}},  # Add the negative condition
+                            {"length": {"$exists": False}},
+                        ]
+                    }
                     if size_selector == "$lt"
-                    else {"length": {size_selector: size}}
+                    else {
+                        "$or": [
+                            {"length": {size_selector: size}},
+                            {"length": {size_selector: -size}},  # Add the negative condition
+                        ]
+                    }
                 )
 
                 mongo_secondary_query.append(size_query)

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -366,6 +366,7 @@ class QueryHandler(object):
             else:
                 mongo_query["$and"] = coordinate_query
 
+        LOG.warning(mongo_query)
         return mongo_query
 
     def affected_inds_query(self, mongo_query, case_id, gt_query):
@@ -763,16 +764,14 @@ class QueryHandler(object):
 
             if criterion == "size":
                 size = query["size"]
-                size_query = {"length": {"$gt": int(size)}}
-
-                if query.get("size_shorter"):
+                size_query = {"length": {"$gte": int(size)}}
+                if query.get("size_selector") == "$lt" or query.get("size_shorter"):
                     size_query = {
                         "$or": [
                             {"length": {"$lt": int(size)}},
                             {"length": {"$exists": False}},
                         ]
                     }
-
                 mongo_secondary_query.append(size_query)
 
             if criterion == "svtype":

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -151,6 +151,18 @@ class VariantFiltersForm(FlaskForm):
     cytoband_start = NonValidatingSelectField("Cytoband start", choices=[])
     cytoband_end = NonValidatingSelectField("Cytoband end", choices=[])
 
+    size_selector = NonValidatingSelectField(
+        "Variant size in bp", choices=[("$gte", ">="), ("$lt", "<")]
+    )
+    size = IntegerField(
+        "",
+        [
+            validators.Optional(),
+            validators.NumberRange(min=0, message="Number of bases must be 1 or greater."),
+        ],
+        widget=NumberInput(min=1),
+    )
+
     hide_dismissed = BooleanField("Hide dismissed", default=False)
     filter_variants = SubmitField(label="Filter variants")
     export = SubmitField(label="Filter and export")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -224,8 +224,6 @@ class StrFiltersForm(VariantFiltersForm):
 class SvFiltersForm(VariantFiltersForm):
     """Extends FiltersForm for structural variants"""
 
-    size = StringField("Length")
-    size_shorter = BooleanField("Length shorter than")
     svtype = SelectMultipleField("SVType", choices=SV_TYPE_CHOICES)
     decipher = BooleanField("Decipher")
     clingen_ngi = IntegerField("ClinGen NGI obs")
@@ -254,8 +252,6 @@ class CancerSvFiltersForm(SvFiltersForm):
 class FusionFiltersForm(VariantFiltersForm):
     """Extends FiltersForm for fusion variants"""
 
-    size = StringField("Length")
-    size_shorter = BooleanField("Length shorter than")
     decipher = BooleanField("Decipher")
     clinical_filter = SubmitField(label="Clinical filter")
     fusion_score = BetterDecimalField("Fusion score >=", validators=[validators.Optional()])

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -275,6 +275,16 @@
 </div>
 {% endmacro %}
 
+{% macro variant_size_filter(form) %}
+<div class="col-2">
+  {{ form.size_selector.label(class="control-label") }}
+  <div class="input-group">
+    {{ form.size_selector(class="form-select") }}
+    {{ form.size(class="form-control") }}
+  </div>
+</div>
+{% endmacro %}
+
 {% macro snv_filters(form, institute, case, filters)%}
 <input type="hidden" name="variant_type" value="{{ form.variant_type.data }}">
   {{ variants_common_filters(form, "snv") }}
@@ -348,13 +358,7 @@
     <div class="col-2">
       {{ wtf.form_field(form.cytoband_end) }}
     </div>
-    <div class="col-2">
-      {{ form.size_selector.label(class="control-label") }}
-      <div class="input-group">
-        {{ form.size_selector(class="form-select") }}
-        {{ form.size(class="form-control") }}
-      </div>
-    </div>
+     {{ variant_size_filter(form) }}
   </div>
   <div class="row">
     <div class="col-2">
@@ -631,13 +635,7 @@
   <div class="col-1">
     {{ wtf.form_field(form.cytoband_end) }}
   </div>
-  <div class="col-2">
-    {{ form.size_selector.label(class="control-label") }}
-    <div class="input-group">
-      {{ form.size_selector(class="form-select") }}
-      {{ form.size(class="form-control") }}
-    </div>
-  </div>
+  {{ variant_size_filter(form) }}
 </div>
 <div class="row mb-3">
   <div class="col-2">
@@ -769,13 +767,7 @@
         <div class="col">
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
-        <div class="col-2">
-          {{ form.size_selector.label(class="control-label") }}
-          <div class="input-group">
-            {{ form.size_selector(class="form-select") }}
-            {{ form.size(class="form-control") }}
-          </div>
-      </div>
+        {{ variant_size_filter(form) }}
       </div>
       <div class="row" style="margin-top:10px;">
         <div class="col-2">
@@ -889,13 +881,7 @@
         <div class="col">
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
-        <div class="col-2">
-          {{ form.size_selector.label(class="control-label") }}
-          <div class="input-group">
-            {{ form.size_selector(class="form-select") }}
-            {{ form.size(class="form-control") }}
-          </div>
-        </div>
+        {{ variant_size_filter(form) }}
       </div>
       <div class="row" style="margin-top:10px;">
         <div class="col-2">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -584,10 +584,6 @@
         gene_panels=['hpo']) }}">HPO gene list</a>
     </div>
   </div>
-  <div class="col-2">
-    {{ form.size.label(class="control-label") }}
-    {{ form.size(class="form-control", type="number") }}
-  </div>
   <div class="col-1 d-flex align-items-end">
     <div class="mb-2 form-check">
       {{ form.decipher.label(class="form-check-label") }}
@@ -855,9 +851,7 @@
         {{ form.hgnc_symbols.label(class="control-label") }}
         {{ form.hgnc_symbols(class="form-control") }}
       </div>
-      <div class="col-2">
-        {{ form.size.label(class="control-label") }}
-        {{ form.size(class="form-control", type="number") }}
+      <div class="col-1">
       </div>
       <div class="col-1">
         {{ form.somatic_score.label(class="control-label", data_toggle="tooltip", data_placement="top", title="Somatic score from SV caller. Filter away variants called with a score lower or equal to this value.") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -629,10 +629,10 @@
       </div>
     </div>
   </div>
-  <div class="col-2">
+  <div class="col-1">
     {{ wtf.form_field(form.start) }}
   </div>
-  <div class="col-2">
+  <div class="col-1">
     {{ wtf.form_field(form.end) }}
   </div>
   <div class="col-1">
@@ -640,6 +640,13 @@
   </div>
   <div class="col-1">
     {{ wtf.form_field(form.cytoband_end) }}
+  </div>
+  <div class="col-2">
+    {{ form.size_selector.label(class="control-label") }}
+    <div class="input-group">
+      {{ form.size_selector(class="form-select") }}
+      {{ form.size(class="form-control") }}
+    </div>
   </div>
 </div>
 <div class="row mb-3">
@@ -772,9 +779,15 @@
         <div class="col">
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
+        <div class="col-2">
+          {{ form.size_selector.label(class="control-label") }}
+          <div class="input-group">
+            {{ form.size_selector(class="form-select") }}
+            {{ form.size(class="form-control") }}
+          </div>
+      </div>
       </div>
       <div class="row" style="margin-top:10px;">
-        <div class="col-2"></div>
         <div class="col-2">
           <a class="btn btn-secondary btn-sm form-control" data-bs-toggle="collapse" href="#stringcoords" aria-expanded="false" aria-controls="stringcoords">
             String coordinates
@@ -896,9 +909,15 @@
         <div class="col">
           {{ wtf.form_field(form.cytoband_end) }}
         </div>
+        <div class="col-2">
+          {{ form.size_selector.label(class="control-label") }}
+          <div class="input-group">
+            {{ form.size_selector(class="form-select") }}
+            {{ form.size(class="form-control") }}
+          </div>
+        </div>
       </div>
       <div class="row" style="margin-top:10px;">
-        <div class="col-2"></div>
         <div class="col-2">
           <a class="btn btn-secondary btn-sm form-control" data-bs-toggle="collapse" href="#stringcoords" aria-expanded="false" aria-controls="stringcoords">
             String coordinates

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -588,12 +588,6 @@
     {{ form.size.label(class="control-label") }}
     {{ form.size(class="form-control", type="number") }}
   </div>
-  <div class="col-2 d-flex align-items-end">
-    <div class="mb-2 form-check">
-      {{ form.size_shorter.label(class="form-check-label") }}
-      {{ form.size_shorter(class="form-check-input",type="checkbox") }}
-    </div>
-  </div>
   <div class="col-1 d-flex align-items-end">
     <div class="mb-2 form-check">
       {{ form.decipher.label(class="form-check-label") }}
@@ -864,14 +858,6 @@
       <div class="col-2">
         {{ form.size.label(class="control-label") }}
         {{ form.size(class="form-control", type="number") }}
-      </div>
-      <div class="col-2 d-flex align-items-end">
-        <div class="form-check mb-2">
-          {{ form.size_shorter.label(class="form-check-label") }}
-          {{ form.size_shorter(class="form-check-input",type="checkbox") }}
-        </div>
-      </div>
-      <div class="col-1">
       </div>
       <div class="col-1">
         {{ form.somatic_score.label(class="control-label", data_toggle="tooltip", data_placement="top", title="Somatic score from SV caller. Filter away variants called with a score lower or equal to this value.") }}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -336,10 +336,10 @@
         </div>
       </div>
     </div>
-    <div class="col-2">
+    <div class="col-1">
       {{ wtf.form_field(form.start) }}
     </div>
-    <div class="col-2">
+    <div class="col-1">
       {{ wtf.form_field(form.end) }}
     </div>
     <div class="col-2">
@@ -347,6 +347,13 @@
     </div>
     <div class="col-2">
       {{ wtf.form_field(form.cytoband_end) }}
+    </div>
+    <div class="col-2">
+      {{ form.size_selector.label(class="control-label") }}
+      <div class="input-group">
+        {{ form.size_selector(class="form-select") }}
+        {{ form.size(class="form-control") }}
+      </div>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Improved SNVs and SVs filter (RD & cancer cases) - now supporting size thresholds (≥ or < a specified base pair length): fix #5223 

<img width="327" alt="image" src="https://github.com/user-attachments/assets/0986b4bc-0208-45bf-8d33-7579d68dafa4" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy locally or or stage
2. Make sure that the following pages display the new filter:
  - SNVs
  - cancer SNVs
  - SVs
  - cancer SVs
3. Make sure that the filtering works as expected  

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
