### PR TITLE
Complete coverage indicator chanjo2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display pLI score and LOEUF on rare diseases and cancer SNV pages
 - Preselect MANE SELECT transcripts in the multi-step ClinVar variant add to submission process
 - Allow updating case with WTS Fraser and Outrider research files
+- Chanjo2 gene coverage report and completeness indicator
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 - Set case as research case if it contains any type of research variants

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Preselect MANE SELECT transcripts in the multi-step ClinVar variant add to submission process
 - Allow updating case with WTS Fraser and Outrider research files
 - Load research WTS outliers using the `scout load variants --outliers-research` command
-- Chanjo2 gene coverage report and completeness indicator
+- Chanjo2 gene coverage completeness indicator and report from variant page, summary card
 ### Changed
 - Do not show overlapping gene panels badge on variants from cases runned without gene panels
 - Set case as research case if it contains any type of research variants

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -40,7 +40,7 @@
     {% if panel_name == "HPO Panel" %}
       <button type="submit" class="btn btn-secondary btn-sm text-white"> Coverage {{report_type}} (Chanjo2) </button>
     {% else %}
-      <a class={{ link_class }} onclick="this.closest('form').submit();return false;">{{link_text}}</a>
+      <a class="{{ link_class }}" onclick="this.closest('form').submit();return false;">{{link_text}}</a>
     {% endif %}
   </form>
 

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -1,4 +1,4 @@
-{% macro chanjo2_report_form(institute_obj, case_obj, panel_name, report_type, hgnc_ids, link_text) %}
+{% macro chanjo2_report_form(institute_obj, case_obj, panel_name, report_type, hgnc_ids, link_text, link_class = "link-primary") %}
 
   {% set form_name = "chanjo2_"+panel_name+"_"+report_type %}
   {% set form_action = config.CHANJO2_URL+"/"+report_type %}
@@ -40,7 +40,7 @@
     {% if panel_name == "HPO Panel" %}
       <button type="submit" class="btn btn-secondary btn-sm text-white"> Coverage {{report_type}} (Chanjo2) </button>
     {% else %}
-      <a class="link-primary" onclick="this.closest('form').submit();return false;">{{link_text}}</a>
+      <a class=link_class onclick="this.closest('form').submit();return false;">{{link_text}}</a>
     {% endif %}
   </form>
 

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -40,7 +40,7 @@
     {% if panel_name == "HPO Panel" %}
       <button type="submit" class="btn btn-secondary btn-sm text-white"> Coverage {{report_type}} (Chanjo2) </button>
     {% else %}
-      <a class=link_class onclick="this.closest('form').submit();return false;">{{link_text}}</a>
+      <a class={{ link_class }} onclick="this.closest('form').submit();return false;">{{link_text}}</a>
     {% endif %}
   </form>
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -265,7 +265,10 @@ def variant(
     if case_obj.get("chanjo2_coverage"):
         gene_ids = [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
         gene_has_full_coverage: bool = chanjo2.get_gene_complete_coverage(
-            genes=gene_ids, threshold=15, build=genome_build
+            genes=gene_ids,
+            threshold=15,
+            individuals=case_obj.get("individuals"),
+            build=genome_build,
         )
 
     # Collect all the events for the variant

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -423,15 +423,18 @@ def get_gene_has_full_coverage(
     Query chanjo2, if configured and d4 files are available for this case,
     for coverage completeness on the genes touching this variant.
     """
-    gene_has_full_coverage = {}
-    if case_obj.get("chanjo2_coverage"):
-        for hgnc_id in [gene.get("hgnc_id") for gene in variant_obj.get("genes")]:
-            gene_has_full_coverage[hgnc_id]: bool = chanjo2.get_gene_complete_coverage(
-                hgnc_id=hgnc_id,
-                threshold=institute_obj.get("coverage_cutoff") or 15,
-                individuals=case_obj.get("individuals"),
-                build=genome_build,
-            )
+    if not case_obj.get("chanjo2_coverage"):
+        return {}
+
+    gene_has_full_coverage: dict = {
+        hgnc_id: chanjo2.get_gene_complete_coverage(
+            hgnc_id=hgnc_id,
+            threshold=institute_obj.get("coverage_cutoff") or 15,
+            individuals=case_obj.get("individuals"),
+            build=genome_build,
+        )
+        for hgnc_id in [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
+    }
     return gene_has_full_coverage
 
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -36,8 +36,8 @@ from scout.server.extensions import LoqusDB, config_igv_tracks, gens
 from scout.server.links import disease_link, get_variant_links
 from scout.server.utils import (
     case_has_alignments,
-    case_has_chanjo_coverage,
     case_has_chanjo2_coverage,
+    case_has_chanjo_coverage,
     case_has_mt_alignments,
     case_has_rna_tracks,
     user_institutes,

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -36,6 +36,8 @@ from scout.server.extensions import LoqusDB, config_igv_tracks, gens
 from scout.server.links import disease_link, get_variant_links
 from scout.server.utils import (
     case_has_alignments,
+    case_has_chanjo_coverage,
+    case_has_chanjo2_coverage,
     case_has_mt_alignments,
     case_has_rna_tracks,
     user_institutes,
@@ -257,6 +259,8 @@ def variant(
     # Provide basic info on alignment files availability for this case
     case_has_alignments(case_obj)
     case_has_mt_alignments(case_obj)
+    case_has_chanjo_coverage(case_obj)
+    case_has_chanjo2_coverage(case_obj)
 
     # Collect all the events for the variant
     events = list(store.events(institute_obj, case=case_obj, variant_id=variant_id))

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -32,7 +32,7 @@ from scout.server.blueprints.variant.utils import (
     update_variant_case_panels,
 )
 from scout.server.blueprints.variants.utils import update_case_panels
-from scout.server.extensions import LoqusDB, config_igv_tracks, gens
+from scout.server.extensions import LoqusDB, chanjo2, config_igv_tracks, gens
 from scout.server.links import disease_link, get_variant_links
 from scout.server.utils import (
     case_has_alignments,
@@ -261,6 +261,12 @@ def variant(
     case_has_mt_alignments(case_obj)
     case_has_chanjo_coverage(case_obj)
     case_has_chanjo2_coverage(case_obj)
+
+    if case_obj.get("chanjo2_coverage"):
+        gene_ids = [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
+        gene_has_full_coverage: bool = chanjo2.get_gene_complete_coverage(
+            genes=gene_ids, threshold=15, build=genome_build
+        )
 
     # Collect all the events for the variant
     events = list(store.events(institute_obj, case=case_obj, variant_id=variant_id))

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -424,7 +424,7 @@ def get_gene_has_full_coverage(case_obj, variant_obj, genome_build) -> Dict[int,
         gene_ids = [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
         for gene in gene_ids:
             gene_has_full_coverage[gene]: bool = chanjo2.get_gene_complete_coverage(
-                genes=gene,
+                gene=gene,
                 threshold=15,
                 individuals=case_obj.get("individuals"),
                 build=genome_build,

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -406,7 +406,9 @@ def variant(
         "inherit_palette": INHERITANCE_PALETTE,
         "igv_tracks": get_igv_tracks("38" if variant_obj["is_mitochondrial"] else genome_build),
         "has_rna_tracks": case_has_rna_tracks(case_obj),
-        "gene_has_full_coverage": get_gene_has_full_coverage(case_obj, variant_obj, genome_build),
+        "gene_has_full_coverage": get_gene_has_full_coverage(
+            institute_obj, case_obj, variant_obj, genome_build
+        ),
         "gens_info": gens.connection_settings(genome_build),
         "evaluations": evaluations,
         "ccv_evaluations": ccv_evaluations,
@@ -414,7 +416,9 @@ def variant(
     }
 
 
-def get_gene_has_full_coverage(case_obj, variant_obj, genome_build) -> Dict[int, bool]:
+def get_gene_has_full_coverage(
+    institute_obj, case_obj, variant_obj, genome_build
+) -> Dict[int, bool]:
     """
     Query chanjo2, if configured and d4 files are available for this case,
     for coverage completeness on the genes touching this variant.
@@ -425,7 +429,7 @@ def get_gene_has_full_coverage(case_obj, variant_obj, genome_build) -> Dict[int,
         for gene in gene_ids:
             gene_has_full_coverage[gene]: bool = chanjo2.get_gene_complete_coverage(
                 gene=gene,
-                threshold=15,
+                threshold=institute_obj.get("coverage_cutoff") or 15,
                 individuals=case_obj.get("individuals"),
                 build=genome_build,
             )

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -425,9 +425,8 @@ def get_gene_has_full_coverage(
     """
     gene_has_full_coverage = {}
     if case_obj.get("chanjo2_coverage"):
-        gene_ids = [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
-        for hgnc_id in gene_ids:
-            gene_has_full_coverage[gene]: bool = chanjo2.get_gene_complete_coverage(
+        for hgnc_id in [gene.get("hgnc_id") for gene in variant_obj.get("genes")]:
+            gene_has_full_coverage[hgnc_id]: bool = chanjo2.get_gene_complete_coverage(
                 hgnc_id=hgnc_id,
                 threshold=institute_obj.get("coverage_cutoff") or 15,
                 individuals=case_obj.get("individuals"),

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -426,9 +426,9 @@ def get_gene_has_full_coverage(
     gene_has_full_coverage = {}
     if case_obj.get("chanjo2_coverage"):
         gene_ids = [gene.get("hgnc_id") for gene in variant_obj.get("genes")]
-        for gene in gene_ids:
+        for hgnc_id in gene_ids:
             gene_has_full_coverage[gene]: bool = chanjo2.get_gene_complete_coverage(
-                gene=gene,
+                hgnc_id=hgnc_id,
                 threshold=institute_obj.get("coverage_cutoff") or 15,
                 individuals=case_obj.get("individuals"),
                 build=genome_build,

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -141,10 +141,7 @@
   {% if case.chanjo2_coverage %}
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}
-        <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}" data-bs-toggle="tooltip" title="Chanjo2 coverage report">
-          Gene coverage {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-
-        </a>
+        {{ chanjo2_report_form(panel.institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id)) }} <!--chanjo2 genes overview -->
         {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
           <span class="bg-success fa-solid fa-circle-check"></span>
         {% else %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -118,7 +118,7 @@
         {% endif %}
         </div>
       {% endfor %}
-      {{ gene_coverage(variant, case, config) }}
+      {{ gene_coverage(institute, variant, case, config) }}
     </li>
     <li class="list-group-item">
       <div>
@@ -128,7 +128,7 @@
   </ul>
 {% endmacro %}
 
-{% macro gene_coverage(variant, case, config) %}
+{% macro gene_coverage(institute, variant, case, config) %}
   {% if case.chanjo_coverage and config.chanjo_report %}
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}
@@ -141,7 +141,7 @@
   {% if case.chanjo2_coverage %}
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}
-        {{ chanjo2_report_form(panel.institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id)) }} <!--chanjo2 genes overview -->
+        {{ chanjo2_report_form(institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id)) }} <!--chanjo2 genes overview -->
         {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
           <span class="bg-success fa-solid fa-circle-check"></span>
         {% else %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -140,13 +140,13 @@
     </div>
   {% endif %}
   {% if case.chanjo2_coverage %}
-    <div class="d-flex flex-wrap ms-1">
+    <div class="d-flex flex-wrap ms-1" data-bs-toggle="tooltip" title="Chanjo2 coverage reports">
       {% for gene in variant.genes %}
         {{ chanjo2_report_form(institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id), "btn btn-sm btn-secondary text-white") }} <!--chanjo2 genes overview -->
         {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
-          <span class="bg-success fa-solid fa-circle-check"></span>
+          <span class="bg-success fa-solid fa-circle-check" data-bs-toggle="tooltip" title="Chanjo2 coverage is at 100% completeness."></span>
         {% else %}
-          <span class="bg-warning fa-solid fa-triangle-exclamation"></span>
+          <span class="bg-warning fa-solid fa-triangle-exclamation" data-bs-toggle="tooltip" title="Note that Chanjo2 coverage is below 100% completeness."></span>
         {% endif %}
       {% endfor %}
     </div>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -118,15 +118,7 @@
         {% endif %}
         </div>
       {% endfor %}
-      {% if config.chanjo_report %}
-        <div class="d-flex flex-wrap ms-1">
-          {% for gene in variant.genes %}
-            <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}">
-              Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-            </a>
-          {% endfor %}
-        </div>
-      {% endif %}
+      {{ gene_coverage(variant, case) }}
     </li>
     <li class="list-group-item">
       <div>
@@ -134,6 +126,27 @@
       </div>
     </li>
   </ul>
+{% endmacro %}
+
+{% macro gene_coverage(variant, case) %}
+  {% if case.chanjo_coverage and config.chanjo_report %}
+    <div class="d-flex flex-wrap ms-1">
+      {% for gene in variant.genes %}
+        <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}" data-bs-toggle="tooltip" title="Chanjo coverage report">
+          Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+        </a>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% if case.chanjo2_coverage %}
+    <div class="d-flex flex-wrap ms-1">
+      {% for gene in variant.genes %}
+        <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}" data-bs-toggle="tooltip" title="Chanjo2 coverage report">
+          Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+        </a>
+      {% endfor %}
+    </div>
+  {% endif %}
 {% endmacro %}
 
 {% macro acmg_form(institute, case, variant, ACMG_OPTIONS, selected=None) %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -142,7 +142,7 @@
   {% if case.chanjo2_coverage %}
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}
-        {{ chanjo2_report_form(institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id)) }} <!--chanjo2 genes overview -->
+        {{ chanjo2_report_form(institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id), "btn btn-sm btn-secondary text-white") }} <!--chanjo2 genes overview -->
         {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
           <span class="bg-success fa-solid fa-circle-check"></span>
         {% else %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -142,7 +142,12 @@
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}
         <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}" data-bs-toggle="tooltip" title="Chanjo2 coverage report">
-          Gene coverage: {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+          Gene coverage {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+          {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
+            <span class="bg-success fa-solid fa-circle-check"></span>
+          {% else %}
+            <span class="bg-warning fa-solid fa-circle-check"></span>
+          {% endif %}
         </a>
       {% endfor %}
     </div>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -143,12 +143,13 @@
       {% for gene in variant.genes %}
         <a class="btn btn-sm btn-secondary text-white" rel="noopener noreferrer" target="_blank" href="{{ url_for('report.gene', gene_id=gene.hgnc_id, sample_id=variant.samples|map(attribute='sample_id')|list) }}" data-bs-toggle="tooltip" title="Chanjo2 coverage report">
           Gene coverage {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
-          {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
-            <span class="bg-success fa-solid fa-circle-check"></span>
-          {% else %}
-            <span class="bg-warning fa-solid fa-circle-check"></span>
-          {% endif %}
+
         </a>
+        {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
+          <span class="bg-success fa-solid fa-circle-check"></span>
+        {% else %}
+          <span class="bg-warning fa-solid fa-triangle-exclamation"></span>
+        {% endif %}
       {% endfor %}
     </div>
   {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -144,9 +144,9 @@
       {% for gene in variant.genes %}
         {{ chanjo2_report_form(institute, case, gene.hgnc_symbol, 'overview', gene.hgnc_id, "Gene coverage " + (gene.common.hgnc_symbol if gene.common else gene.hgnc_id), "btn btn-sm btn-secondary text-white") }} <!--chanjo2 genes overview -->
         {% if gene.common.hgnc_id in gene_has_full_coverage and gene.common.hgnc_id[gene.common.hgnc_id] %}
-          <span class="bg-success fa-solid fa-circle-check" data-bs-toggle="tooltip" title="Chanjo2 coverage is at 100% completeness."></span>
+          <span class="bg-success fa-solid fa-circle-check" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Chanjo2 coverage is at 100% completeness."></span>
         {% else %}
-          <span class="bg-warning fa-solid fa-triangle-exclamation" data-bs-toggle="tooltip" title="Note that Chanjo2 coverage is below 100% completeness."></span>
+          <span class="bg-warning fa-solid fa-triangle-exclamation" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Note that Chanjo2 coverage is below 100% completeness."></span>
         {% endif %}
       {% endfor %}
     </div>

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -1,3 +1,4 @@
+{% from "cases/chanjo2_form.html" import chanjo2_report_form %}
 {% from "variant/buttons.html" import variant_tag_button, variant_tier_button, dismiss_variant_button, mosaic_variant_button %}
 {% from "variants/utils.html" import compounds_table %}
 {% from "variant/variant_details.html" import severity_list %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -118,7 +118,7 @@
         {% endif %}
         </div>
       {% endfor %}
-      {{ gene_coverage(variant, case) }}
+      {{ gene_coverage(variant, case, config) }}
     </li>
     <li class="list-group-item">
       <div>
@@ -128,7 +128,7 @@
   </ul>
 {% endmacro %}
 
-{% macro gene_coverage(variant, case) %}
+{% macro gene_coverage(variant, case, config) %}
   {% if case.chanjo_coverage and config.chanjo_report %}
     <div class="d-flex flex-wrap ms-1">
       {% for gene in variant.genes %}

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -49,7 +49,7 @@ class Chanjo2Client:
         return coverage_stats
 
     def get_gene_complete_coverage(
-        self, gene: int, threshold: int = 15, individuals: dict = {}, build: str = "38"
+        self, hgnc_id: int, threshold: int = 15, individuals: dict = {}, build: str = "38"
     ) -> bool:
         """
         Return complete coverage for hgnc_id at a coverage threshold.
@@ -62,7 +62,7 @@ class Chanjo2Client:
         gene_cov_query = {
             "build": chanjo_build,
             "coverage_threshold": threshold,
-            "hgnc_gene_ids": [gene],
+            "hgnc_gene_ids": [hgnc_id],
             "interval_type": "genes",
             "samples": [],
         }

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -49,24 +49,20 @@ class Chanjo2Client:
         return coverage_stats
 
     def get_gene_complete_coverage(
-        self, genes: List[int], threshold: int = 15, build: str = "38"
+        self, genes: List[int], threshold: int = 15, individuals: dict = {}, build: str = "38"
     ) -> dict:
         """
         Return complete coverage for hgnc_id at a coverage threshold.
         """
-        if "37" in build:
-            chanjo_build = CHANJO_BUILD_37
-        else:
-            chanjo_build = CHANJO_BUILD_38
-
+        chanjo_build = CHANJO_BUILD_37 if "37" in build else CHANJO_BUILD_38
         chanjo2_gene_cov_url: str = "/".join(
             [current_app.config.get("CHANJO2_URL"), "coverage/d4/genes/summary"]
         )
-        coverage_stats = {}
+
         gene_cov_query = {
             "build": chanjo_build,
             "coverage_threshold": threshold,
-            "hgnc_gene_ids": [gene],
+            "hgnc_gene_ids": genes,
             "interval_type": "genes",
         }
         for ind in individuals:
@@ -80,11 +76,9 @@ class Chanjo2Client:
         resp = requests.post(chanjo2_gene_cov_url, json=gene_cov_query)
         gene_cov = resp.json()
 
-        print(gene_cov)
-
         full_coverage = bool(gene_cov)
-        for sample in keys(gene_cov):
-            if gene_cov[sample]["coverage_completeness_percent"] < 99:
+        for sample in gene_cov.keys():
+            if gene_cov[sample]["coverage_completeness_percent"] < 100:
                 full_coverage = False
 
         return full_coverage

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -64,6 +64,7 @@ class Chanjo2Client:
             "coverage_threshold": threshold,
             "hgnc_gene_ids": [gene],
             "interval_type": "genes",
+            "samples": [],
         }
         for ind in individuals:
             if not ind.get("d4_file"):

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -49,8 +49,8 @@ class Chanjo2Client:
         return coverage_stats
 
     def get_gene_complete_coverage(
-        self, genes: List[int], threshold: int = 15, individuals: dict = {}, build: str = "38"
-    ) -> dict:
+        self, gene: int, threshold: int = 15, individuals: dict = {}, build: str = "38"
+    ) -> bool:
         """
         Return complete coverage for hgnc_id at a coverage threshold.
         """
@@ -62,7 +62,7 @@ class Chanjo2Client:
         gene_cov_query = {
             "build": chanjo_build,
             "coverage_threshold": threshold,
-            "hgnc_gene_ids": genes,
+            "hgnc_gene_ids": [gene],
             "interval_type": "genes",
         }
         for ind in individuals:

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -44,3 +44,10 @@ class Chanjo2Client:
             coverage_stats[ind["individual_id"]] = coverage_info
 
         return coverage_stats
+
+    def get_gene_complete_coverage(self, gene: int, threshold: int) -> dict:
+        """
+        Return complete coverage for hgnc_id at a coverage threshold.
+        """
+
+        return

--- a/scout/server/extensions/chanjo2_extension.py
+++ b/scout/server/extensions/chanjo2_extension.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict
+from typing import Dict, List
 
 import requests
 from flask import current_app
@@ -7,6 +7,9 @@ from flask import current_app
 REF_CHROM = "14"
 MT_CHROM = "MT"
 LOG = logging.getLogger(__name__)
+
+CHANJO_BUILD_37 = "GRCh37"
+CHANJO_BUILD_38 = "GRCh38"
 
 
 class Chanjo2Client:
@@ -45,9 +48,43 @@ class Chanjo2Client:
 
         return coverage_stats
 
-    def get_gene_complete_coverage(self, gene: int, threshold: int) -> dict:
+    def get_gene_complete_coverage(
+        self, genes: List[int], threshold: int = 15, build: str = "38"
+    ) -> dict:
         """
         Return complete coverage for hgnc_id at a coverage threshold.
         """
+        if "37" in build:
+            chanjo_build = CHANJO_BUILD_37
+        else:
+            chanjo_build = CHANJO_BUILD_38
 
-        return
+        chanjo2_gene_cov_url: str = "/".join(
+            [current_app.config.get("CHANJO2_URL"), "coverage/d4/genes/summary"]
+        )
+        coverage_stats = {}
+        gene_cov_query = {
+            "build": chanjo_build,
+            "coverage_threshold": threshold,
+            "hgnc_gene_ids": [gene],
+            "interval_type": "genes",
+        }
+        for ind in individuals:
+            if not ind.get("d4_file"):
+                continue
+
+            gene_cov_query["samples"].append(
+                {"coverage_file_path": ind["d4_file"], "name": ind["individual_id"]}
+            )
+
+        resp = requests.post(chanjo2_gene_cov_url, json=gene_cov_query)
+        gene_cov = resp.json()
+
+        print(gene_cov)
+
+        full_coverage = bool(gene_cov)
+        for sample in keys(gene_cov):
+            if gene_cov[sample]["coverage_completeness_percent"] < 99:
+                full_coverage = False
+
+        return full_coverage

--- a/tests/server/extensions/test_chanjo2_extension.py
+++ b/tests/server/extensions/test_chanjo2_extension.py
@@ -37,3 +37,41 @@ def test_chanjo2_mt_coverage_stats(case_obj):
             assert isinstance(coverage_stats[ind_id]["autosome_cov"], int)
             assert isinstance(coverage_stats[ind_id]["mt_coverage"], int)
             assert isinstance(coverage_stats[ind_id]["mt_copy_number"], float)
+
+
+@responses.activate
+def test_chanjo2_get_complete_coverage(case_obj):
+    """Test the function that sends requests to Chanjo2 to get MT vs autosomal coverage stats"""
+
+    # GIVEN a case with individuals containing d4 files
+    for ind in case_obj["individuals"]:
+        assert ind["d4_file"]
+
+    # GIVEN a response that is ok for each individual
+    json_response = {}
+    for ind in case_obj["individuals"]:
+        json_response[ind["individual_id"]] = {
+            "mean_coverage": 30,
+            "coverage_completeness_percent": 100,
+        }
+
+    # GIVEN a patched chanjo2 instance
+    # GIVEN a mocked Chanjo2 server dataset add endpoint
+    url = f"{CHANJO2_BASE_URL}/coverage/d4/genes/summary"
+    responses.add(
+        responses.POST,
+        url,
+        json=json_response,
+        status=200,
+    )
+
+    # WHEN app is created and contains the CHANJO2_URL param
+    test_app = create_app(config=dict(TESTING=True, CHANJO2_URL=CHANJO2_BASE_URL))
+
+    with test_app.app_context():
+        # WHEN POST requests are sent to chanjo2 to retrieve MT vs autosomal coverage stats
+        full_coverage = chanjo2.get_gene_complete_coverage(
+            gene=17284, threshold=10, individuals=case_obj["individuals"]
+        )
+
+        assert full_coverage

--- a/tests/server/extensions/test_chanjo2_extension.py
+++ b/tests/server/extensions/test_chanjo2_extension.py
@@ -71,7 +71,7 @@ def test_chanjo2_get_complete_coverage(case_obj):
     with test_app.app_context():
         # WHEN POST requests are sent to chanjo2 to retrieve MT vs autosomal coverage stats
         full_coverage = chanjo2.get_gene_complete_coverage(
-            gene=17284, threshold=10, individuals=case_obj["individuals"]
+            hgnc_id=17284, threshold=10, individuals=case_obj["individuals"]
         )
 
         assert full_coverage


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix  #4955
- Fix #376 

So far, so good:
![Screenshot 2025-02-14 at 12 24 25](https://github.com/user-attachments/assets/fd15a67d-4207-4b5a-8c18-05afa13f99e9)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
