### PR TITLE
Fix #5258 - stop clinical filter HPO when dynamic gene panel is emptied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Downloading and parsing of genes from Ensembl (including MT-TP)
 - Don't parse SV frequencies for SNVs even if the name matches. Also accept "." as missing value for SV frequencies.
 - HPO search on WTS Outliers page
+- Stop using dynamic gene panel (HPO generated list) for clinical filter when the last gene is removed from the dynamic gene panel
 
 ## [4.96]
 ### Added

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1088,11 +1088,12 @@ def update_default_panels(store, current_user, institute_id, case_name, panel_id
     store.update_default_panels(institute_obj, case_obj, user_obj, link, panel_objs)
 
 
-def update_clinical_filter_hpo(store, current_user, institute_id, case_name, hpo_clinical_filter):
+def update_clinical_filter_hpo(store, current_user, institute_obj, case_obj, hpo_clinical_filter):
     """Update HPO clinical filter use for a case."""
-    institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     user_obj = store.user(current_user.email)
-    link = url_for("cases.case", institute_id=institute_id, case_name=case_name)
+    link = url_for(
+        "cases.case", institute_id=institute_obj["_id"], case_name=case_obj["display_name"]
+    )
     store.update_clinical_filter_hpo(institute_obj, case_obj, user_obj, link, hpo_clinical_filter)
 
 
@@ -1495,7 +1496,7 @@ def add_link_for_disease(case_obj: dict):
             diagnosis.update({"disease_link": disease_link(disease_id=diagnosis["disease_id"])})
 
 
-def remove_dynamic_genes(store: dict, case_obj: dict, request_form: dict):
+def remove_dynamic_genes(store: dict, case_obj: dict, institute_obj: dict, request_form: dict):
     """Remove one or more genes from the dynamic gene list. If there are no more
     genes on the list, also stop using the HPO panel for clinical filter."""
     case_dynamic_genes = [dyn_gene["hgnc_id"] for dyn_gene in case_obj.get("dynamic_gene_list")]
@@ -1507,4 +1508,8 @@ def remove_dynamic_genes(store: dict, case_obj: dict, request_form: dict):
         delete_only=True,
     )
     if not hgnc_ids:
-        case_obj["hpo_clinical_filter"] = False
+        hpo_clinical_filter = False
+        case_obj["hpo_clinical_filter"] = hpo_clinical_filter
+        update_clinical_filter_hpo(
+            store, current_user, institute_obj, case_obj, hpo_clinical_filter
+        )

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1493,3 +1493,18 @@ def add_link_for_disease(case_obj: dict):
         for diagnosis in case_diagnoses:
             #: Add link
             diagnosis.update({"disease_link": disease_link(disease_id=diagnosis["disease_id"])})
+
+
+def remove_dynamic_genes(store: dict, case_obj: dict, request_form: dict):
+    """Remove one or more genes from the dynamic gene list. If there are no more
+    genes on the list, also stop using the HPO panel for clinical filter."""
+    case_dynamic_genes = [dyn_gene["hgnc_id"] for dyn_gene in case_obj.get("dynamic_gene_list")]
+    genes_to_remove = [int(gene_id) for gene_id in request_form.getlist("dynamicGene")]
+    hgnc_ids = list(set(case_dynamic_genes) - set(genes_to_remove))
+    store.update_dynamic_gene_list(
+        case_obj,
+        hgnc_ids=hgnc_ids,
+        delete_only=True,
+    )
+    if not hgnc_ids:
+        case_obj["hpo_clinical_filter"] = False

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -118,7 +118,7 @@
       </div>
 
       <div>
-        {% if case.track == 'rare' %} %}
+        {% if case.track == 'rare' %}
         <div class="row"> <!-- Show variants in dynamic gene list -->
           <form action="{{ url_for('cases.update_clinical_filter_hpo', institute_id=institute._id, case_name=case.display_name)+'#hpo_clinical_filter' }}" method="POST">
             <div class="form-check form-switch">

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -79,8 +79,7 @@
           <span class="mr-3" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ case.dynamic_panel_phenotypes|join(', ') }}">
               {{ case.dynamic_panel_phenotypes|length }} phenotypes
           </span>
-        {% endif %}
-        )
+        {% endif %})
         {% if case.dynamic_gene_list_edited %} <span class="text-danger ml-3"> (edited) </span> {% endif %}
       </h6>
     </div>
@@ -119,6 +118,7 @@
       </div>
 
       <div>
+        {% if case.track == 'rare' %} %}
         <div class="row"> <!-- Show variants in dynamic gene list -->
           <form action="{{ url_for('cases.update_clinical_filter_hpo', institute_id=institute._id, case_name=case.display_name)+'#hpo_clinical_filter' }}" method="POST">
             <div class="form-check form-switch">
@@ -128,6 +128,7 @@
             </div>
           </form>
         </div>
+        {% endif %}
         <div class="row mt-3">
           <div class="btn-group btn-group-sm">
           {% if case.track == 'cancer' %}

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -513,7 +513,7 @@ def phenotypes_actions(institute_id, case_name):
             store.update_dynamic_gene_list(case_obj, hgnc_ids=list(hgnc_ids), add_only=True)
 
         case "REMOVEGENES":
-            controllers.remove_dynamic_genes(store, case_obj, request.form)
+            controllers.remove_dynamic_genes(store, case_obj, institute_obj, request.form)
 
         case "GENES":
             hgnc_symbols = parse_raw_gene_symbols(request.form.getlist("genes"))
@@ -923,9 +923,10 @@ def default_panels(institute_id, case_name):
 @cases_bp.route("/<institute_id>/<case_name>/update-clinical-filter-hpo", methods=["POST"])
 def update_clinical_filter_hpo(institute_id, case_name):
     """Update default panels for a case."""
+    institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     hpo_clinical_filter = request.form.get("hpo_clinical_filter")
     controllers.update_clinical_filter_hpo(
-        store, current_user, institute_id, case_name, hpo_clinical_filter
+        store, current_user, institute_obj, case_obj, hpo_clinical_filter
     )
     return redirect(request.referrer)
 

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -486,45 +486,45 @@ def phenotypes_actions(institute_id, case_name):
     hpo_ids = request.form.getlist("hpo_id")
     user_obj = store.user(current_user.email)
 
-    match action:
-        case "PHENOMIZER":
-            diseases = controllers.phenomizer_diseases(hpo_ids, case_obj)
-            if diseases:
-                return render_template(
-                    "cases/diseases.html",
-                    diseases=diseases,
-                    institute=institute_obj,
-                    case=case_obj,
-                )
+    ### match action for 3.10
+    if action == "PHENOMIZER":
+        diseases = controllers.phenomizer_diseases(hpo_ids, case_obj)
+        if diseases:
+            return render_template(
+                "cases/diseases.html",
+                diseases=diseases,
+                institute=institute_obj,
+                case=case_obj,
+            )
 
-        case "DELETE":
-            for hpo_id in hpo_ids:
-                # DELETE a phenotype from the list
-                store.remove_phenotype(institute_obj, case_obj, user_obj, case_url, hpo_id)
+    if action == "DELETE":
+        for hpo_id in hpo_ids:
+            # DELETE a phenotype from the list
+            store.remove_phenotype(institute_obj, case_obj, user_obj, case_url, hpo_id)
 
-        case "ADDGENE":
-            try:
-                hgnc_ids = parse_raw_gene_ids(request.form.getlist("genes"))
-            except ValueError:
-                flash(
-                    "Provided gene info could not be parsed!. Please allow autocompletion to finish.",
-                    "warning",
-                )
-            store.update_dynamic_gene_list(case_obj, hgnc_ids=list(hgnc_ids), add_only=True)
+    if action == "ADDGENE":
+        try:
+            hgnc_ids = parse_raw_gene_ids(request.form.getlist("genes"))
+        except ValueError:
+            flash(
+                "Provided gene info could not be parsed!. Please allow autocompletion to finish.",
+                "warning",
+            )
+        store.update_dynamic_gene_list(case_obj, hgnc_ids=list(hgnc_ids), add_only=True)
 
-        case "REMOVEGENES":
-            controllers.remove_dynamic_genes(store, case_obj, institute_obj, request.form)
+    if action == "REMOVEGENES":
+        controllers.remove_dynamic_genes(store, case_obj, institute_obj, request.form)
 
-        case "GENES":
-            hgnc_symbols = parse_raw_gene_symbols(request.form.getlist("genes"))
-            store.update_dynamic_gene_list(case_obj, hgnc_symbols=list(hgnc_symbols))
+    if action == "GENES":
+        hgnc_symbols = parse_raw_gene_symbols(request.form.getlist("genes"))
+        store.update_dynamic_gene_list(case_obj, hgnc_symbols=list(hgnc_symbols))
 
-        case "GENERATE":
-            results = store.generate_hpo_gene_list(*hpo_ids)
-            # determine how many HPO terms each gene must match
-            hpo_count = int(request.form.get("min_match") or 1)
-            hgnc_ids = [result[0] for result in results if result[1] >= hpo_count]
-            store.update_dynamic_gene_list(case_obj, hgnc_ids=hgnc_ids, phenotype_ids=hpo_ids)
+    if action == "GENERATE":
+        results = store.generate_hpo_gene_list(*hpo_ids)
+        # determine how many HPO terms each gene must match
+        hpo_count = int(request.form.get("min_match") or 1)
+        hgnc_ids = [result[0] for result in results if result[1] >= hpo_count]
+        store.update_dynamic_gene_list(case_obj, hgnc_ids=hgnc_ids, phenotype_ids=hpo_ids)
 
     return redirect("#".join([case_url, "phenotypes_panel"]))
 

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -12,6 +12,7 @@ from scout.server.blueprints.variants.controllers import (
     populate_chrom_choices,
     populate_filters_form,
     populate_persistent_filters_choices,
+    set_hpo_clinical_filter,
     update_form_hgnc_symbols,
 )
 from scout.server.blueprints.variants.forms import OutlierFiltersForm
@@ -45,8 +46,7 @@ def outliers(institute_id, case_name):
         variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
+    set_hpo_clinical_filter(case_obj, request.form)
 
     # update status of case if visited for the first time
     activate_case(store, institute_obj, case_obj, current_user)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -49,12 +49,7 @@ from scout.server.utils import (
     user_institutes,
 )
 
-from .forms import (
-    FILTERSFORMCLASS,
-    CancerSvFiltersForm,
-    FusionFiltersForm,
-    SvFiltersForm,
-)
+from .forms import FILTERSFORMCLASS, CancerSvFiltersForm, FusionFiltersForm, SvFiltersForm
 from .utils import update_case_panels
 
 NUM = re.compile(r"\d+")
@@ -2108,3 +2103,9 @@ def get_show_dismiss_block():
         session["show_dismiss_block"] = show_dismiss_block
 
     return show_dismiss_block
+
+
+def set_hpo_clinical_filter(case_obj: dict, request_form: dict):
+    """Set HPO clinical filter on case if requested through the form."""
+    if request_form.get("hpo_clinical_filter"):
+        case_obj["hpo_clinical_filter"] = True

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -67,8 +67,7 @@ def variants(institute_id, case_name):
 
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
+    controllers.set_hpo_clinical_filter(case_obj, request.form)
 
     user_obj = store.user(current_user.email)
     if request.method == "POST":
@@ -275,8 +274,7 @@ def sv_variants(institute_id, case_name):
         variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
+    controllers.set_hpo_clinical_filter(case_obj, request.form)
 
     if "dismiss_submit" in request.form:  # dismiss a list of variants
         controllers.dismiss_variant_list(
@@ -350,8 +348,7 @@ def mei_variants(institute_id, case_name):
     )
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
+    controllers.set_hpo_clinical_filter(case_obj, request.form)
 
     if "dismiss_submit" in request.form:  # dismiss a list of variants
         controllers.dismiss_variant_list(
@@ -555,9 +552,6 @@ def cancer_sv_variants(institute_id, case_name):
         variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
 
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
-
     if "dismiss_submit" in request.form:  # dismiss a list of variants
         controllers.dismiss_variant_list(
             store,
@@ -636,9 +630,6 @@ def fusion_variants(institute_id, case_name):
     if variant_type not in ["clinical", "research"]:
         variant_type = "clinical"
     variants_stats = store.case_variants_count(case_obj["_id"], institute_id, variant_type, False)
-
-    if request.form.get("hpo_clinical_filter"):
-        case_obj["hpo_clinical_filter"] = True
 
     if "dismiss_submit" in request.form:  # dismiss a list of variants
         controllers.dismiss_variant_list(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5258 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Go to the case page
2. Create an HPO panel
3. Toggle "Use HPO list for clinical filter"
4. Delete the HPO panel (delete all genes from the panel)
5. Note how the "Use HPO.." toggle disappears, but on the case obj and hence variantS page, HPO is still set for use in clincal filter, potentially confusing the analyst
6. Rinse and repeat with patch and note the HPO clinical filter being disabled, visible as an event and on the variantS page as clinical filter not defaulting to the HPO panel

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
