### PR TITLE
preserve saved filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO search on WTS Outliers page
 - Stop using dynamic gene panel (HPO generated list) for clinical filter when the last gene is removed from the dynamic gene panel
 - Return only variants with ClinVar annotation when `ClinVar hits` checkbox is checked on variants search form
+- Legacy variant filter option `clinsig_confident_always_returned` on saved filters is remapped as `prioritised_clivar` and `clinvar_trusted_revstat`
+
 
 ## [4.96]
 ### Added

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -264,16 +264,31 @@ class FilterHandler(object):
         return filters_res
 
     def set_legacy_options(self, filter_obj):
-        """Update any remaining legacy filter options,
+        """Update remaining legacy filter options,
         i e filter controls that changed names or functionality.
-
-        clinsig_confident_always_returned was split into two different
+        In particular, clinsig_confident_always_returned was split into two different
         options.
         """
-        if "clinsig_confident_always_returned" in filter_obj:
-            filter_obj["clinvar_trusted_revstat"] = filter_obj.get(
-                "clinsig_confident_always_returned", ["True"]
-            )
-            filter_obj["prioritise_clinvar"] = filter_obj.get(
-                "clinsig_confident_always_returned", ["True"]
-            )
+        if "clinsig_confident_always_returned" not in filter_obj:
+            return
+
+        filter_obj["clinvar_trusted_revstat"] = filter_obj.get(
+            "clinsig_confident_always_returned", ["True"]
+        )
+        filter_obj["prioritise_clinvar"] = filter_obj.get(
+            "clinsig_confident_always_returned", ["True"]
+        )
+        del filter_obj["clinsig_confident_always_returned"]
+
+        self.filter_collection.find_one_and_update(
+            {"_id": filter_obj["_id"]},
+            {
+                "$set": {
+                    "clinvar_trusted_revstat": filter_obj["clinvar_trusted_revstat"],
+                    "prioritise_clinvar": filter_obj["prioritise_clinvar"],
+                },
+                "$unset": {
+                    "clinsig_confident_always_returned": "",
+                },
+            },
+        )

--- a/scout/adapter/mongo/filter.py
+++ b/scout/adapter/mongo/filter.py
@@ -25,7 +25,9 @@ class FilterHandler(object):
             filter_obj(dict)
         """
         filter_obj = self.filter_collection.find_one({"_id": ObjectId(filter_id)})
+
         if filter_obj is not None:
+            self.set_legacy_options(filter_obj)
             # use _id to preselect the currently loaded filter, and drop it while we are at it
             filter_obj.update([("filters", filter_obj.pop("_id", None))])
         return filter_obj
@@ -260,3 +262,18 @@ class FilterHandler(object):
         )
 
         return filters_res
+
+    def set_legacy_options(self, filter_obj):
+        """Update any remaining legacy filter options,
+        i e filter controls that changed names or functionality.
+
+        clinsig_confident_always_returned was split into two different
+        options.
+        """
+        if "clinsig_confident_always_returned" in filter_obj:
+            filter_obj["clinvar_trusted_revstat"] = filter_obj.get(
+                "clinsig_confident_always_returned", ["True"]
+            )
+            filter_obj["prioritise_clinvar"] = filter_obj.get(
+                "clinsig_confident_always_returned", ["True"]
+            )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
