### PR TITLE
Fix exclude ClinVar + secondary filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO search on WTS Outliers page
 - Stop using dynamic gene panel (HPO generated list) for clinical filter when the last gene is removed from the dynamic gene panel
 - Return only variants with ClinVar annotation when `ClinVar hits` checkbox is checked on variants search form
-- Legacy variant filter option clinsig_confident_always_returned on saved filters is remapped as prioritised_clivar and clinvar_trusted_revstat
+- Legacy variant filter option `clinsig_confident_always_returned` on saved filters is remapped as `prioritised_clivar` and `clinvar_trusted_revstat`
 - Variants queries excluding ClinVar tags without `prioritise_clinvar` checkbox checked
 
 ## [4.96]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO search on WTS Outliers page
 - Stop using dynamic gene panel (HPO generated list) for clinical filter when the last gene is removed from the dynamic gene panel
 - Return only variants with ClinVar annotation when `ClinVar hits` checkbox is checked on variants search form
+- Variants queries excluding ClinVar tags without `prioritise_clinvar` checkbox checked
 
 ## [4.96]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - HPO search on WTS Outliers page
 - Stop using dynamic gene panel (HPO generated list) for clinical filter when the last gene is removed from the dynamic gene panel
 - Return only variants with ClinVar annotation when `ClinVar hits` checkbox is checked on variants search form
-- Legacy variant filter option `clinsig_confident_always_returned` on saved filters is remapped as `prioritised_clivar` and `clinvar_trusted_revstat`
+- Legacy variant filter option clinsig_confident_always_returned on saved filters is remapped as prioritised_clivar and clinvar_trusted_revstat
 - Variants queries excluding ClinVar tags without `prioritise_clinvar` checkbox checked
 
 ## [4.96]

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -13,8 +13,6 @@ from scout.constants import (
 )
 
 CRITERION_EXCLUDE_OPERATOR = {False: "$in", True: "$nin"}
-CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
-CLNSIG_NULL = {"clnsig": {"$eq": None}}
 EXISTS = {"$exists": True}
 NOT_EXISTS = {"$exists": False}
 EXISTS_NOT_NULL = {"$exists": True, "$ne": None}
@@ -336,6 +334,14 @@ class QueryHandler(object):
 
         if primary_terms is True:
             clinsign_filter: dict = self.set_and_get_clinsig_query(query, mongo_query)
+            if query.get("clinsig_exclude"):
+                clinsign_filter = {
+                    "$or": [
+                        clinsign_filter,
+                        {"clnsig": {"$exists": False}},
+                        {"clnsig": {"$eq": None}},
+                    ]
+                }
 
         # Secondary, excluding filter criteria will hide variants in general,
         # but can be overridden by an including, major filter criteria
@@ -357,26 +363,14 @@ class QueryHandler(object):
                         clinsign_filter,
                     ]
                 else:  # clinical_filter will be applied at the same level as the other secondary filters ("$and")
-                    if query.get("clinsig_exclude"):
-                        clinsign_filter = {
-                            "$or": [
-                                clinsign_filter,
-                                CLNSIG_NOT_EXISTS,
-                                CLNSIG_NULL,
-                            ]
-                        }
                     secondary_filter.append(clinsign_filter)
                     mongo_query["$and"] = secondary_filter
 
         elif primary_terms is True:  # clisig is provided without secondary terms query
-            if query.get("clinsig_exclude"):
-                mongo_query["$or"] = [
-                    clinsign_filter,
-                    CLNSIG_NOT_EXISTS,
-                    CLNSIG_NULL,
-                ]
-            else:
+            if clinsign_filter.get("clnsig"):
                 mongo_query["clnsig"] = clinsign_filter["clnsig"]
+            elif clinsign_filter.get("$or"):
+                mongo_query["$or"] = clinsign_filter["$or"]
 
         # if chromosome coordinates exist in query, add them as first element of the mongo_query['$and']
         if coordinate_query:

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -13,9 +13,12 @@ from scout.constants import (
 )
 
 CRITERION_EXCLUDE_OPERATOR = {False: "$in", True: "$nin"}
+CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
+CLNSIG_NULL = {"clnsig": {"$eq": None}}
 EXISTS = {"$exists": True}
 NOT_EXISTS = {"$exists": False}
 EXISTS_NOT_NULL = {"$exists": True, "$ne": None}
+
 LOG = logging.getLogger(__name__)
 
 
@@ -354,6 +357,14 @@ class QueryHandler(object):
                         clinsign_filter,
                     ]
                 else:  # clinical_filter will be applied at the same level as the other secondary filters ("$and")
+                    if query.get("clinsig_exclude"):
+                        clinsign_filter = {
+                            "$or": [
+                                clinsign_filter,
+                                CLNSIG_NOT_EXISTS,
+                                CLNSIG_NULL,
+                            ]
+                        }
                     secondary_filter.append(clinsign_filter)
                     mongo_query["$and"] = secondary_filter
 
@@ -361,8 +372,8 @@ class QueryHandler(object):
             if query.get("clinsig_exclude"):
                 mongo_query["$or"] = [
                     clinsign_filter,
-                    {"clnsig": {"$exists": False}},
-                    {"clnsig": {"$eq": None}},
+                    CLNSIG_NOT_EXISTS,
+                    CLNSIG_NULL,
                 ]
             else:
                 mongo_query["clnsig"] = clinsign_filter["clnsig"]

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -356,7 +356,7 @@
       <div class="row">
         <div class="class="form-check">
         {{ form.prioritise_clinvar(class="form-check-input") }}
-        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded using ClinVar tags might still be returned when found using the other search criteria.") }}
+        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded using ClinVar tags will still be returned when found using the other search criteria.") }}
       </div>
     </div>
   </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -356,7 +356,7 @@
       <div class="row">
         <div class="class="form-check">
         {{ form.prioritise_clinvar(class="form-check-input") }}
-        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search).") }}
+        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded usibg ClinVar tags might still be returned when found using the other search criteria.") }}
       </div>
     </div>
   </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -356,7 +356,7 @@
       <div class="row">
         <div class="class="form-check">
         {{ form.prioritise_clinvar(class="form-check-input") }}
-        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded usibg ClinVar tags might still be returned when found using the other search criteria.") }}
+        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded using ClinVar tags might still be returned when found using the other search criteria.") }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix variantS query when:
   -  Excluding ClinVar CLINSIG 
   - Prioritise ClinVar is NOT checked
   - Secondary search is on (for instance variants shorter than 2 bases)

### Example with demo data:

<img width="560" alt="image" src="https://github.com/user-attachments/assets/197898d3-c44c-40a6-9567-1fab94727bb5" />


### Main branch:

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/368da6e2-82c8-4a89-85de-4b2ca487b80d" />


### This branch:

<img width="1673" alt="image" src="https://github.com/user-attachments/assets/14d721da-30e7-4c61-88ca-b7efab6a925a" />





<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR, DN
