### PR TITLE
fix docs for PanelApp green genes cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Documentation on how to delete variants for one or more cases
+- Document the option to collect green genes from any panel when updating the PanelApp green genes panel
 
 ## [4.97]
 ### Added

--- a/docs/admin-guide/panelapp_panels.md
+++ b/docs/admin-guide/panelapp_panels.md
@@ -68,9 +68,13 @@ At the time of writing, the following panel types are available:
 12. **Research**
 13. **Submitted List**
 14. **Superpanel**
+15. **all** - all types above
 
 #### Default Behavior
 If no panel type is selected (i.e., the user presses Enter without input), Green Genes will be selected from the following default panel types: `3`, `4`, `6`, `7`, `8`, `9`, `10`.
+
+### Include all available panels
+By typing `all` at the prompt, green genes will be collected from any panel available in PanelApp
 
 #### Important Note
 The `--force` or (`-f`) parameter is required to create a new version of the gene panel if the number of green genes retrieved from the PanelApp server is lower than the number of genes in the older version of the panel. This ensures the panel is updated despite the reduction in gene count.


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Document the option to collect green genes from any panel when updating the PanelApp green genes panel

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Automatic tests

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
