### PR TITLE
Display also soft filters on institute's filters page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Documentation on how to delete variants for one or more cases
 - Document the option to collect green genes from any panel when updating the PanelApp green genes panel
+- On institute's filters page, display also eventual soft filters applied to institute's variants
 
 ## [4.97]
 ### Added

--- a/scout/server/blueprints/institutes/templates/overview/filters.html
+++ b/scout/server/blueprints/institutes/templates/overview/filters.html
@@ -34,8 +34,21 @@
   <div class="row" id="body-row"> <!--sidebar and main container are on the same row-->
     {{ institute_actionbar(institute) }} <!-- This is the sidebar -->
     <div class="col">
+
       <div class="card">
-        <div class="card-header"><b>Filters created for institute on variants pages</b></div>
+        <div class="card-header"><b>Soft filters created by an admin on the institute's settings</b></div>
+        <div class="card-body">
+          {% for filter_tag in institute.soft_filters %}
+            <span class="badge bg-secondary">{{filter_tag}}</span>
+          {% else%}
+            No soft filters available
+          {% endfor %}
+
+        </div>
+      </div>
+
+      <div class="card mt-3">
+        <div class="card-header"><b>Custom filters created for institute on variants pages</b></div>
         <div class="card-body">
           <ul class="list-group">
            <li class="list-group-item list-group-item-heading">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5277 

<img width="789" alt="image" src="https://github.com/user-attachments/assets/db159a20-301e-4228-a4cf-9907ec160bdf" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
