### PR TITLE
Version 4.98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [4.98]
 ### Added
 - Documentation on how to delete variants for one or more cases
 - Document the option to collect green genes from any panel when updating the PanelApp green genes panel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.97.0"
+version = "4.98.0"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Mans Magnuson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}


### PR DESCRIPTION
## [4.98]
### Added
- [x] Documentation on how to delete variants for one or more cases
- [x] Document the option to collect green genes from any panel when updating the PanelApp green genes panel
- [x] On the institute's filters page, display also any soft filters applied to institute's variants
### Fixed
- [x] Case page patch for research cases without WTS outliers



**Review:**
- [x] code approved by DN
- [x] tests executed by CR
