### PR TITLE
Additional LRS alns: paraphase and de novo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- De novo assembly alignment file load and display
+- Paraphase bam-let alignment file load and display
+
 ## [4.98]
 ### Added
 - Documentation on how to delete variants for one or more cases

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -51,6 +51,7 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **samples** _List_ List of samples included in the case:
     - **alignment_path** _String_ Path to BAM/CRAM file to view alignments.
     - **analysis_type** _String_ Specifies the analysis type for the sample. Options: {wgs, wes, panel, unknown, external}.
+    - **assembly_alignment_path** _String_ Path to BAM/CRAM file to view de novo assembly alignments.
     - **bam_file** _String_ Path to BAM/CRAM file to view alignments **WARNING:** Soon to be deprecated, use *alignment_path*.
     - **bam_path** _String_ Path to BAM/CRAM file to view alignments **WARNING:** Soon to be deprecated, use *alignment_path*.
     - **capture_kit** _String_ Exome specifies the capture kit.
@@ -70,6 +71,7 @@ Below are available configuration parameters for a Scout case. Names marked with
     - **mother** _String/Int_ Sample ID for mother or 0.
     - **msi** _Int_ Microsatellite instability [0-60].
     - **mt_bam** _String_ Path to the reduced mitochondrial BAM/CRAM alignment file.
+    - **paraphase_alignment_path** _String_ Path to BAM/CRAM file to view Paraphase alignments.
     - **phenotype(*)** _String_ Specifies the affection status {affected, unaffected, unknown}.
     - **reviewer** _List_ [Reference][srs]
       - **alignment** _String_ Path to BAM/CRAM file to view STR alignments

--- a/docs/admin-guide/updating-individuals.md
+++ b/docs/admin-guide/updating-individuals.md
@@ -22,11 +22,13 @@ Options:
   --help              Show this message and exit.
 ```
 And the tracks that can be updated are the following:
+- assembly_alignment_path
 - bam_file
 - d4_file
 - rna_alignment_path
 - mt_bam
 - vcf2cytosure
+- paraphase_alignment_path
 - rhocall_bed
 - rhocall_wig
 - tiddit_coverage_wig

--- a/scout/build/individual.py
+++ b/scout/build/individual.py
@@ -6,9 +6,11 @@ from scout.exceptions import PedigreeError
 
 log = logging.getLogger(__name__)
 BUILD_INDIVIDUAL_FILES = [
+    "assembly_alignment_path",
     "bam_file",
     "d4_file",
     "mt_bam",
+    "paraphase_alignment_path",
     "rhocall_bed",
     "rhocall_wig",
     "rna_alignment_path",

--- a/scout/commands/update/individual.py
+++ b/scout/commands/update/individual.py
@@ -7,6 +7,7 @@ import click
 from scout.server.extensions import store
 
 UPDATE_DICT = {
+    "assembly_alignment_path": "path",
     "bam_file": "path",
     "bionano_access.sample": "str",
     "bionano_access.project": "str",
@@ -16,6 +17,7 @@ UPDATE_DICT = {
     "chromograph_images.upd_regions": "str",
     "chromograph_images.upd_sites": "str",
     "mt_bam": "path",
+    "paraphase_alignment_path": "path",
     "reviewer.alignment": "path",
     "reviewer.alignment_index": "path",
     "reviewer.vcf": "path",

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -25,9 +25,11 @@ LOG = logging.getLogger(__name__)
 REPID = "{REPID}"
 
 SAMPLES_FILE_PATH_CHECKS = [
+    "assembly_alignment_path",
     "bam_file",
     "d4_file",
     "mitodel_file",
+    "paraphase_alignment_path",
     "rhocall_bed",
     "rhocall_wig",
     "rna_alignment_path",
@@ -201,6 +203,7 @@ class REViewer(BaseModel):
 
 class SampleLoader(BaseModel):
     alignment_path: Optional[str] = None
+    assembly_alignment_path: Optional[str] = None
     analysis_type: Literal[ANALYSIS_TYPES] = None
     bam_file: Optional[str] = ""
     bam_path: Optional[str] = None
@@ -221,6 +224,7 @@ class SampleLoader(BaseModel):
     mother: Optional[str] = None
     msi: Optional[str] = None
     mt_bam: Optional[str] = None
+    paraphase_alignment_path: Optional[str] = None
     phenotype: Literal["affected", "unaffected", "unknown"]
     predicted_ancestry: Optional[str] = None
     reviewer: Optional[REViewer] = REViewer()

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -312,9 +312,9 @@ def case_append_alignments(case_obj: dict):
     """
     unwrap_settings = [
         {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
-        {"path": "assembly_alignment_file", "append_to": "bam_files", "index": "bai_files"},
+        {"path": "assembly_alignment_path", "append_to": "bam_files", "index": "bai_files"},
         {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
-        {"path": "paraphase_alignment_file", "append_to": "bam_files", "index": "bai_files"},
+        {"path": "paraphase_alignment_path", "append_to": "bam_files", "index": "bai_files"},
         {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
         {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
         {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -304,7 +304,9 @@ def case_append_alignments(case_obj: dict):
     """
     unwrap_settings = [
         {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
+        {"path": "assembly_alignment_file", "append_to": "bam_files", "index": "bai_files"},
         {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
+        {"path": "paraphase_alignment_file", "append_to": "bam_files", "index": "bai_files"},
         {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
         {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
         {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -244,15 +244,23 @@ def case_has_chanjo2_coverage(case_obj: dict):
 def case_has_alignments(case_obj: dict):
     """Add info on bam/cram files availability to a case dictionary
 
+    This sets the availability of alignments for autosomal chromosomes.
+    If paraphase or de novo assembly alignments, this is also sufficient to set
+    alignment availability.
     Args:
         case_obj(scout.models.Case)
     """
-    case_obj["bam_files"] = False  # Availability of alignments for autosomal chromosomes
+    case_obj["bam_files"] = False
     for ind in case_obj.get("individuals"):
-        bam_path = ind.get("bam_file")
-        if bam_path and os.path.exists(bam_path):
-            case_obj["bam_files"] = True
-            return
+        for alignment_path_key in [
+            "bam_file",
+            "assembly_alignment_path",
+            "paraphase_alignment_path",
+        ]:
+            bam_path = ind.get(alignment_path_key)
+            if bam_path and os.path.exists(bam_path):
+                case_obj["bam_files"] = True
+                return
 
 
 def case_has_mt_alignments(case_obj: dict):

--- a/tests/build/test_build_individual.py
+++ b/tests/build/test_build_individual.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from scout.build import build_individual
 from scout.exceptions import PedigreeError
-import pytest
 
 
 def test_build_individual():
@@ -14,6 +15,8 @@ def test_build_individual():
         "sex": "male",
         "phenotype": "affected",
         "bam_file": "scout/demo/reduced_mt.bam",
+        "paraphase_alignment_path": "scout/demo/reduced_mt.bam",
+        "assembly_alignment_path": "scout/demo/reduced_mt.bam",
         "capture_kits": ["Agilent"],
     }
 
@@ -28,6 +31,8 @@ def test_build_individual():
     assert ind_obj["sex"] == "1"
     assert ind_obj["phenotype"] == 2
     assert ind_obj["bam_file"].endswith(ind_info["bam_file"])
+    assert ind_obj["paraphase_alignment_path"].endswith(ind_info["bam_file"])
+    assert ind_obj["assembly_alignment_path"].endswith(ind_info["bam_file"])
     assert ind_obj["analysis_type"] == "unknown"
 
 

--- a/tests/parse/test_parse_case.py
+++ b/tests/parse/test_parse_case.py
@@ -396,7 +396,9 @@ def test_parse_individual_files(scout_config, custom_temp_file):
 
     # GIVEN that the samples contained in the scout load config file have a path associated to each possible file
     for sample_config in scout_config["samples"]:
+        sample_config["assembly_alignment_path"] = str(custom_temp_file(".bam"))
         sample_config["bam_path"] = str(custom_temp_file(".cram"))
+        sample_config["paraphase_alignment_path"] = str(custom_temp_file(".bam"))
         sample_config["rhocall_bed"] = str(custom_temp_file(".bed"))
         sample_config["rhocall_wig"] = str(custom_temp_file(".wig"))
         sample_config["tiddit_coverage_wig"] = str(custom_temp_file(".wig"))


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

I dunno, we could consider only showing these on particular endpoints (e.g. paraphase from the SMN view etc) but they do lend information where they exist. The aln tracks could perhaps be shrunk down to fewer (250-300?) px by default, but we could also take this as is without adding more complexity, and adjust later if it becomes an issue.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. add paraphase and assembly alignment files to an individual, load and note them visible on DNA alignment views.

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
