### PR TITLE
Fix #5100 - allow ACMG modifiers with very strong ie PVS and BA level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - De novo assembly alignment file load and display
 - Paraphase bam-let alignment file load and display
+### Changed
+- Allow ACMG criteria strength modification to Very strong/Stand-alone
 
 ## [4.98]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -79,7 +79,11 @@
                       <div class="row">
                         <select {{ 'disabled' if evaluation and edit is false}} id="modifier-{{ criterion_code }}" name="modifier-{{ criterion_code }}" class="form-control form-select">
                           <option value="" {% if not modifier %}selected{% endif %}>Strength modifier...</option>
-                          {% for level in "Strong", "Moderate", "Supporting" %}
+                          {% set sa_level = "Stand-alone" %}
+                          {% if category == "pathogenicity" %}
+                            {% set sa_level = "Very Strong" %}
+                          {% endif %}
+                          {% for level in sa_level, "Strong", "Moderate", "Supporting" %}
                             {% if(level != evidence) %}
                               <option id="{{ criterion_code }}-{{ level }}" value="{{ level }}" {% if modifier == level %}selected{% endif %}>{{ level }}</option>
                             {% endif %}
@@ -148,7 +152,7 @@
 
     function update_classification() {
       var criteria = $(':checked').map(function(idx, elem) {
-        const modifiers = ["Strong", "Moderate", "Supporting"];
+        const modifiers = ["Stand-alone", "Very Strong", "Strong", "Moderate", "Supporting"];
         for (possible_modifier of modifiers) {
           var modifier_option;
           if(elem.value !== null && elem.value !== '') {

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -27,19 +27,12 @@ from scout.server.blueprints.variant.controllers import (
     check_reset_variant_classification,
 )
 from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
-from scout.server.blueprints.variant.controllers import (
-    observations,
-    str_variant_reviewer,
-)
+from scout.server.blueprints.variant.controllers import observations, str_variant_reviewer
 from scout.server.blueprints.variant.controllers import variant as variant_controller
 from scout.server.blueprints.variant.controllers import variant_acmg as acmg_controller
-from scout.server.blueprints.variant.controllers import (
-    variant_acmg_post,
-)
+from scout.server.blueprints.variant.controllers import variant_acmg_post
 from scout.server.blueprints.variant.controllers import variant_ccv as ccv_controller
-from scout.server.blueprints.variant.controllers import (
-    variant_ccv_post,
-)
+from scout.server.blueprints.variant.controllers import variant_ccv_post
 from scout.server.blueprints.variant.verification_controllers import (
     MissingVerificationRecipientError,
     variant_verification,

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -21,7 +21,7 @@ def test_is_pathogenic_1():
 
     """
     # GIVEN values that fulfill the (a) criteria for pathogenic
-    pvs = True
+    pvs = ["PVS1"]
     ps_terms = ["PS1"]
     pm_terms = []
     pp_terms = []
@@ -39,7 +39,7 @@ def test_is_pathogenic_1():
     assert res
 
     # GIVEN values that fulfill the (b) criteria for pathogenic
-    pvs = True
+    pvs = ["PVS1"]
     ps_terms = []
     pm_terms = ["PM1", "PM2"]
     pp_terms = []
@@ -56,7 +56,7 @@ def test_is_pathogenic_1():
     assert not res
 
     # GIVEN values that fulfill the (c) criteria for pathogenic
-    pvs = True
+    pvs = ["PVS1"]
     ps_terms = []
     pm_terms = ["PM1"]
     pp_terms = ["PP1"]
@@ -66,7 +66,7 @@ def test_is_pathogenic_1():
     assert res
 
     # GIVEN values that fulfill the (d) criteria for pathogenic
-    pvs = True
+    pvs = ["PVS1"]
     ps_terms = []
     pm_terms = []
     pp_terms = ["PP1", "PP2"]
@@ -91,7 +91,7 @@ def test_is_pathogenic_2():
 
     """
     # GIVEN values that fulfill the (ii) criteria for pathogenic
-    pvs = False
+    pvs = []
     ps_terms = ["PS1", "PS2"]
     pm_terms = []
     pp_terms = []
@@ -119,7 +119,7 @@ def test_is_pathogenic_3():
 
     """
     # GIVEN values that fulfill the (a) criteria for pathogenic (iii)
-    pvs = False
+    pvs = []
     ps_terms = ["PS1"]
     pm_terms = ["PM1", "PM2", "PM3"]
     pp_terms = []
@@ -135,7 +135,7 @@ def test_is_pathogenic_3():
     assert not res
 
     # GIVEN values that fulfill the (b) criteria for pathogenic (iii)
-    pvs = False
+    pvs = []
     ps_terms = ["PS1"]
     pm_terms = ["PM1", "PM2"]
     pp_terms = ["PP1", "PP2"]
@@ -151,7 +151,7 @@ def test_is_pathogenic_3():
     assert not res
 
     # GIVEN values that fulfill the (c) criteria for pathogenic (iii)
-    pvs = False
+    pvs = []
     ps_terms = ["PS1"]
     pm_terms = ["PM1"]
     pp_terms = ["PP1", "PP2", "PP3", "PP4"]
@@ -175,7 +175,7 @@ def test_is_likely_pathogenic_1():
 
     """
     # GIVEN values that fulfill the (1) criteria for likely pathogenic
-    pvs = True
+    pvs = ["PVS1"]
     ps_terms = []
     pm_terms = ["PM1"]
     pp_terms = []
@@ -197,7 +197,7 @@ def test_is_likely_pathogenic_2():
 
     """
     # GIVEN values that fulfill the (1) criteria for likely pathogenic
-    pvs = False
+    pvs = []
     ps_terms = ["PS1"]
     pm_terms = ["PM1"]
     pp_terms = []
@@ -219,7 +219,7 @@ def test_is_likely_pathogenic_3():
 
     """
     # GIVEN values that fulfill the (1) criteria for likely pathogenic
-    pvs = False
+    pvs = []
     ps_terms = ["PS1"]
     pm_terms = []
     pp_terms = ["PP1", "PP2"]
@@ -241,7 +241,7 @@ def test_is_likely_pathogenic_4():
 
     """
     # GIVEN values that fulfill the (1) criteria for likely pathogenic
-    pvs = False
+    pvs = []
     ps_terms = []
     pm_terms = ["PM1", "PM2", "PM3"]
     pp_terms = []
@@ -263,7 +263,7 @@ def test_is_likely_pathogenic_5():
 
     """
     # GIVEN values that fulfill the (1) criteria for likely pathogenic
-    pvs = False
+    pvs = []
     ps_terms = []
     pm_terms = ["PM1", "PM2"]
     pp_terms = ["PP1", "PP2"]
@@ -285,7 +285,7 @@ def test_is_likely_pathogenic_6():
 
     """
     # GIVEN values that fulfill the (vi) criteria for likely pathogenic
-    pvs = False
+    pvs = []
     ps_terms = []
     pm_terms = ["PM1"]
     pp_terms = ["PP1", "PP2", "PP3", "PP4"]
@@ -307,14 +307,14 @@ def test_is_benign_1():
 
     """
     # GIVEN values that fulfill the (i) criteria for benign
-    ba = True
+    ba = ["BA1"]
     bs_terms = []
     ## WHEN performing the evaluation
     res = is_benign(ba, bs_terms)
     ## THEN assert the criterias are fullfilled
     assert res
 
-    ba = False
+    ba = []
     res = is_benign(ba, bs_terms)
     assert not res
 
@@ -327,7 +327,7 @@ def test_is_benign_2():
 
     """
     # GIVEN values that fulfill the (ii) criteria for benign
-    ba = False
+    ba = []
     bs_terms = ["BS1", "BS2"]
     ## WHEN performing the evaluation
     res = is_benign(ba, bs_terms)
@@ -454,6 +454,18 @@ def test_acmg_temperature():
     res = get_acmg_temperature(acmg_terms)
     assert res["points"] == 4
     assert res["temperature"] == "Warm"
+    assert res["point_classification"] == "VUS"
+
+    acmg_terms = {"PS1_Very Strong", "PP1_Moderate", "PP3", "BS1_Supporting"}
+    res = get_acmg_temperature(acmg_terms)
+    assert res["points"] == 10
+    assert res["temperature"] == "Pathogenic"
+    assert res["point_classification"] == "P"
+
+    acmg_terms = {"PS1_Very Strong", "PP1_Moderate", "PP3", "BS1_Supporting", "BS2_Stand-alone"}
+    res = get_acmg_temperature(acmg_terms)
+    assert res["points"] == 2
+    assert res["temperature"] == "Cold"
     assert res["point_classification"] == "VUS"
 
     acmg_terms = {"PVS1", "BS2", "BP1"}

--- a/uv.lock
+++ b/uv.lock
@@ -452,7 +452,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -1329,7 +1329,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
@@ -2341,7 +2341,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.97.0"
+version = "4.98.0"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
