### PR TITLE
Fix #1386 - reenable tracks after track security improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
 ### Fixed
-- Re-enable display of case and individual specific tracks (coverage, UPD, zygosity)
+- Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
 
 ## [4.98]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Paraphase bam-let alignment file load and display
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
+### Fixed
+- Re-enable display of case and individual specific tracks (coverage, UPD, zygosity)
 
 ## [4.98]
 ### Added

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -124,11 +124,11 @@ HUMAN_GENES_38 = {
 }
 
 CASE_SPECIFIC_TRACKS = {
-    "rhocall_bed": "Rhocall Zygosity",
-    "rhocall_wig": "Rhocall Regions",
-    "tiddit_coverage_wig": "TIDDIT Coverage",
-    "upd_regions_bed": "UPD regions",
-    "upd_sites_bed": "UPD sites",
+    "rhocall_beds": "Rhocall Zygosity",
+    "rhocall_wigs": "Rhocall Regions",
+    "tiddit_coverage_wigs": "TIDDIT Coverage",
+    "upd_regions_beds": "UPD regions",
+    "upd_sites_beds": "UPD sites",
 }
 
 HUMAN_REFERENCE = {"37": HUMAN_REFERENCE_37, "38": HUMAN_REFERENCE_38}

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -50,10 +50,6 @@ samples:
         'coverage': 'scout/demo/images/chromograph_demo/coverage'
         'upd_regions': 'scout/demo/images/chromograph_demo/upd_regions'
         'upd_sites': 'scout/demo/images/chromograph_demo/upd_sites'
-    rhocall_wig: /Users/dannil/project/upd_tracks/justhusky_gatkcomb_rhocall_norm_af_rhoviz.hugelymodelbat.bw
-    tiddit_coverage_wig: /Users/dannil/project/upd_tracks/hugelymodelbat_lanes_1_fastp_sorted_md_tcov.bw
-    upd_regions_bed: /Users/dannil/project/upd_tracks/hugelymodelbat_gatkcomb_rhocall_norm_af_upd.regions.bb
-    upd_sites_bed: /Users/dannil/project/upd_tracks/hugelymodelbat_gatkcomb_rhocall_norm_af_upd.sites.bb
   - analysis_type: wes
     sample_id: ADM1059A1
     capture_kit: Agilent_SureSelectCRE.V1

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -29,6 +29,7 @@ samples:
     expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/hugelymodelbat_lanes_1_sorted_md_mitodel.txt
+    mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A2.test.cgh
     d4_file: scout/demo/ADM1059A2.d4
     bionano_access:
@@ -48,7 +49,7 @@ samples:
         'coverage': 'scout/demo/images/chromograph_demo/coverage'
         'upd_regions': 'scout/demo/images/chromograph_demo/upd_regions'
         'upd_sites': 'scout/demo/images/chromograph_demo/upd_sites'
-    
+
   - analysis_type: wes
     sample_id: ADM1059A1
     capture_kit: Agilent_SureSelectCRE.V1

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -29,7 +29,6 @@ samples:
     expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/hugelymodelbat_lanes_1_sorted_md_mitodel.txt
-    alignment_path: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A2.test.cgh
     d4_file: scout/demo/ADM1059A2.d4
     bionano_access:
@@ -49,6 +48,7 @@ samples:
         'coverage': 'scout/demo/images/chromograph_demo/coverage'
         'upd_regions': 'scout/demo/images/chromograph_demo/upd_regions'
         'upd_sites': 'scout/demo/images/chromograph_demo/upd_sites'
+    
   - analysis_type: wes
     sample_id: ADM1059A1
     capture_kit: Agilent_SureSelectCRE.V1

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -29,6 +29,7 @@ samples:
     expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/hugelymodelbat_lanes_1_sorted_md_mitodel.txt
+    alignment_path: scout/demo/reduced_mt.bam
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A2.test.cgh
     d4_file: scout/demo/ADM1059A2.d4
@@ -49,7 +50,10 @@ samples:
         'coverage': 'scout/demo/images/chromograph_demo/coverage'
         'upd_regions': 'scout/demo/images/chromograph_demo/upd_regions'
         'upd_sites': 'scout/demo/images/chromograph_demo/upd_sites'
-
+    rhocall_wig: /Users/dannil/project/upd_tracks/justhusky_gatkcomb_rhocall_norm_af_rhoviz.hugelymodelbat.bw
+    tiddit_coverage_wig: /Users/dannil/project/upd_tracks/hugelymodelbat_lanes_1_fastp_sorted_md_tcov.bw
+    upd_regions_bed: /Users/dannil/project/upd_tracks/hugelymodelbat_gatkcomb_rhocall_norm_af_upd.regions.bb
+    upd_sites_bed: /Users/dannil/project/upd_tracks/hugelymodelbat_gatkcomb_rhocall_norm_af_upd.sites.bb
   - analysis_type: wes
     sample_id: ADM1059A1
     capture_kit: Agilent_SureSelectCRE.V1

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -30,7 +30,6 @@ samples:
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/hugelymodelbat_lanes_1_sorted_md_mitodel.txt
     alignment_path: scout/demo/reduced_mt.bam
-    mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A2.test.cgh
     d4_file: scout/demo/ADM1059A2.d4
     bionano_access:

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -265,10 +265,10 @@ def make_locus_from_gene(variant_obj: Dict, case_obj: Dict, build: str) -> str:
     return f"{chrom}:{locus_start}-{locus_end}"
 
 
-def set_tracks(name, file_list):
+def set_tracks(name_list, file_list):
     """Return a dict according to IGV track format."""
     track_list = []
-    for track in file_list:
+    for name, track in zip(name_list, file_list):
         if track == "missing":
             continue
         track_list.append({"name": name, "url": track, "min": 0.0, "max": 30.0})
@@ -342,16 +342,20 @@ def set_sample_tracks(display_obj: dict, case_groups: list, chromosome: str):
 
 
 def set_case_specific_tracks(display_obj, case_obj):
-    """Set up tracks from files that might be present or not at the case level
+    """Set up tracks from files that might be present for the focus case samples,
+        not fetched for all samples in the case group.
         (rhocall files, tiddit coverage files, upd regions and sites files)
     Args:
         display_obj(dict) dictionary containing all tracks info
         form(dict) flask request form dictionary
     """
     for track, label in CASE_SPECIFIC_TRACKS.items():
-        if case_obj.get(track) is None:
+        if None in [case_obj.get(track), case_obj.get("sample_names")]:
             continue
-        track_info = set_tracks(label, case_obj.get(track))
+
+        labels = [f"{label} - {sample}" for sample in case_obj.get("sample_names")]
+
+        track_info = set_tracks(labels, case_obj.get(track))
         display_obj[track] = track_info
 
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -43,7 +43,9 @@ def set_session_tracks(display_obj: dict):
 
     session_tracks = list(display_obj.get("reference_track", {}).values())
     for key, track_items in display_obj.items():
-        if key not in ["tracks", "custom_tracks", "sample_tracks", "config_custom_tracks"]:
+        if key not in ["tracks", "custom_tracks", "sample_tracks", "config_custom_tracks"] + list(
+            CASE_SPECIFIC_TRACKS.keys()
+        ):
             continue
         for track_item in track_items:
             session_tracks += list(track_item.values())
@@ -267,6 +269,8 @@ def set_tracks(name, file_list):
     """Return a dict according to IGV track format."""
     track_list = []
     for track in file_list:
+        if track == "missing":
+            continue
         track_list.append({"name": name, "url": track, "min": 0.0, "max": 30.0})
     return track_list
 
@@ -347,7 +351,7 @@ def set_case_specific_tracks(display_obj, case_obj):
     for track, label in CASE_SPECIFIC_TRACKS.items():
         if case_obj.get(track) is None:
             continue
-        track_info = set_tracks(label, case_obj.get(track).split(","))
+        track_info = set_tracks(label, case_obj.get(track))
         display_obj[track] = track_info
 
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -86,12 +86,12 @@
                           {% endif %}
                         },
                       {% endfor %}
-                      {% for wtrack in rhocall_wig %}
+                      {% for wtrack in rhocall_wigs %}
                       {
                         type: "wig",
                         name: '{{ wtrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=wtrack.url) }}',
-                        format: 'wig',
+                        format: 'bw',
                         {# indexURL: '{{ url_for("alignviewers.remote_static", file=wtrack.url)  }}', #}
                         color: "rgb(60, 37, 17)",
                         min: '{{ wtrack.min }}',
@@ -99,12 +99,12 @@
                         sourceType: 'file'
                       },
                       {% endfor %}
-                      {% for btrack in rhocall_bed %}
+                      {% for btrack in rhocall_beds %}
                       {
                         type: "bed",
                         name: '{{ btrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=btrack.url) }}',
-                        format: 'bed',
+                        format: 'bb',
                         color: "rgb(65, 31, 30)",
                         sourceType: 'file'
                       },
@@ -123,27 +123,30 @@
                         height: "{{track.height}}"
                       },
                       {% endfor %}
-                      {% for ttrack in tiddit_coverage_wig %}
+                      {% for ttrack in tiddit_coverage_wigs %}
                       {
                         type: "wig",
+                        format: 'bw',
                         name: '{{ ttrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=ttrack.url) }}',
                         color: "rgb(40, 0, 13)",
                         sourceType: 'file'
                       },
                       {% endfor %}
-                      {% for rtrack in upd_regions_bed %}
+                      {% for rtrack in upd_regions_beds %}
                       {
-                        type: "bed",
+                        type: 'bed',
+                        format: 'bb',
                         name: '{{ rtrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=rtrack.url) }}',
                         color: "rgb(0, 204, 102)",
                         sourceType: 'file'
                       },
                       {% endfor %}
-                      {% for strack in upd_sites_bed %}
+                      {% for strack in upd_sites_beds %}
                       {
                         type: "bed",
+                        format: 'bb',
                         name: '{{ strack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=strack.url) }}',
                         color: "rgb(25, 61, 4)",

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -101,7 +101,7 @@
                       {% endfor %}
                       {% for btrack in rhocall_beds %}
                       {
-                        type: "bed",
+                        type: "annotation",
                         name: '{{ btrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=btrack.url) }}',
                         format: 'bb',
@@ -135,7 +135,7 @@
                       {% endfor %}
                       {% for rtrack in upd_regions_beds %}
                       {
-                        type: 'bed',
+                        type: 'annotation',
                         format: 'bb',
                         name: '{{ rtrack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=rtrack.url) }}',
@@ -145,7 +145,7 @@
                       {% endfor %}
                       {% for strack in upd_sites_beds %}
                       {
-                        type: "bed",
+                        type: "annotation",
                         format: 'bb',
                         name: '{{ strack.name }}',
                         url: '{{ url_for("alignviewers.remote_static", file=strack.url) }}',


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

![Screenshot 2025-03-07 at 16 23 46](https://github.com/user-attachments/assets/c48ff864-3396-4f17-958c-652669d77f1e)

I especially like the coverage one, since it gives a Quick Look at larger deletions etc and a bit more context when zooming in and around, without having to jump back and forth between IGV and gens when evaluating more complex SVs.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
