### PR TITLE
Avoid HGVS validations in CLinVar form for non-MANE transcripts for variants in build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Paraphase bam-let alignment file load and display
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
+### Fixed
+- Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts when variant contains more 50 HGVS descriptors
 
 ## [4.98]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
 ### Fixed
-- Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts when variant contains more 50 HGVS descriptors
+- Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts when variant contains more than 50 HGVS descriptors
 
 ## [4.98]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
 - Disable 2-color mode in IGV.js by default, since it obscures variant proportion of reads. Can be manually enabled.
-- Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts when variant contains more than 50 HGVS descriptors
-
+- Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts from variants in build 38
 
 ## [4.98]
 ### Added

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -32,6 +32,7 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
     build = str(case_obj.get("genome_build", "37"))
     tx_hgvs_list = [("", "Do not specify")]
+    case_has_build_37 = "37" in case_obj.get("genome_buil", "37")
 
     add_gene_info(store, variant_obj, genome_build=build)
 
@@ -53,7 +54,9 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
                 # Transcript is validate only when conditions are met
                 validated = (
-                    validate_hgvs(build, hgvs_simple) if (mane_select or mane_plus_clinical) else ""
+                    validate_hgvs(build, hgvs_simple)
+                    if (case_has_build_37 or mane_select or mane_plus_clinical)
+                    else ""
                 )
 
                 label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if mane_select == refseq_version else ''}{'_mane-plus-clinical_' if mane_plus_clinical == refseq_version else ''}"

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -32,7 +32,7 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
     build = str(case_obj.get("genome_build", "37"))
     tx_hgvs_list = [("", "Do not specify")]
-    case_has_build_37 = "37" in case_obj.get("genome_buil", "37")
+    case_has_build_37 = "37" in case_obj.get("genome_build", "37")
 
     add_gene_info(store, variant_obj, genome_build=build)
 
@@ -40,6 +40,7 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
         transcripts = gene.get("transcripts", [])
 
         for tx in transcripts:
+
             refseq_id = tx.get("refseq_id")
             coding_seq_name = tx.get("coding_sequence_name")
             if not (refseq_id and coding_seq_name):
@@ -52,14 +53,19 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
                 refseq_version = fetch_refseq_version(refseq)  # Adds version to a RefSeq ID
                 hgvs_simple = f"{refseq_version}:{coding_seq_name}"
 
+                refseq_is_mane_select = mane_select == refseq_version
+                refseq_is_mane_plus_clinical = mane_plus_clinical == refseq_version
+
                 # Transcript is validate only when conditions are met
                 validated = (
                     validate_hgvs(build, hgvs_simple)
-                    if (case_has_build_37 or mane_select or mane_plus_clinical)
+                    if (case_has_build_37 or refseq_is_mane_select or refseq_is_mane_plus_clinical)
                     else ""
                 )
 
-                label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if mane_select == refseq_version else ''}{'_mane-plus-clinical_' if mane_plus_clinical == refseq_version else ''}"
+                label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if refseq_is_mane_select else ''}{'_mane-plus-clinical_' if refseq_is_mane_plus_clinical else ''}"
+
+                print(label)
                 tx_hgvs_list.append((hgvs_simple, label))
 
     return tx_hgvs_list

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -65,7 +65,6 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
                 label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if refseq_is_mane_select else ''}{'_mane-plus-clinical_' if refseq_is_mane_plus_clinical else ''}"
 
-                print(label)
                 tx_hgvs_list.append((hgvs_simple, label))
 
     return tx_hgvs_list

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -25,7 +25,6 @@ from scout.utils.scout_requests import fetch_refseq_version
 from .form import CaseDataForm, SNVariantForm, SVariantForm
 
 LOG = logging.getLogger(__name__)
-MAX_VALIDATED_HGVS = 10
 
 
 def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]:
@@ -38,7 +37,6 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
     for gene in variant_obj.get("genes", []):
         transcripts = gene.get("transcripts", [])
-        nr_transcripts = len(transcripts)
 
         for tx in transcripts:
             refseq_id = tx.get("refseq_id")
@@ -55,13 +53,10 @@ def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]
 
                 # Transcript is validate only when conditions are met
                 validated = (
-                    validate_hgvs(build, hgvs_simple)
-                    if (nr_transcripts <= MAX_VALIDATED_HGVS or mane_select or mane_plus_clinical)
-                    else ""
+                    validate_hgvs(build, hgvs_simple) if (mane_select or mane_plus_clinical) else ""
                 )
 
                 label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if mane_select == refseq_version else ''}{'_mane-plus-clinical_' if mane_plus_clinical == refseq_version else ''}"
-
                 tx_hgvs_list.append((hgvs_simple, label))
 
     return tx_hgvs_list

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -25,33 +25,45 @@ from scout.utils.scout_requests import fetch_refseq_version
 from .form import CaseDataForm, SNVariantForm, SVariantForm
 
 LOG = logging.getLogger(__name__)
+MAX_VALIDATED_HGVS = 50
 
 
 def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]:
-    """Retrieve all transcripts / hgvs for a given variant."""
+    """Retrieve all transcripts / HGVS for a given variant."""
 
     build = str(case_obj.get("genome_build", "37"))
     tx_hgvs_list = [("", "Do not specify")]
+
     add_gene_info(store, variant_obj, genome_build=build)
+
     for gene in variant_obj.get("genes", []):
-        for tx in gene.get("transcripts", []):
+        transcripts = gene.get("transcripts", [])
+        nr_transcripts = len(transcripts)
+
+        for tx in transcripts:
+            refseq_id = tx.get("refseq_id")
+            coding_seq_name = tx.get("coding_sequence_name")
+            if not (refseq_id and coding_seq_name):
+                continue  # Skip transcripts missing required fields
+
             mane_select = tx.get("mane_select_transcript")
-            if all([tx.get("refseq_id"), tx.get("coding_sequence_name")]):
-                for refseq in tx.get("refseq_identifiers"):
-                    refseq_version = fetch_refseq_version(refseq)  # adds version to a refseq ID
-                    hgvs_simple = ":".join([refseq_version, tx["coding_sequence_name"]])
+            mane_plus_clinical = tx.get("mane_plus_clinical_transcript")
 
-                    # Validate descriptor using VariantValidator
-                    validated = validate_hgvs(build, hgvs_simple)
+            for refseq in tx.get("refseq_identifiers", []):
+                refseq_version = fetch_refseq_version(refseq)  # Adds version to a RefSeq ID
+                hgvs_simple = f"{refseq_version}:{coding_seq_name}"
 
-                    label = hgvs_simple
-                    if validated:
-                        label += "_validated_"
+                # Transcript is validate only when conditions are met
+                validated = (
+                    validate_hgvs(build, hgvs_simple)
+                    if (nr_transcripts <= MAX_VALIDATED_HGVS or mane_select or mane_plus_clinical)
+                    else ""
+                )
 
-                    if mane_select and mane_select == refseq_version:
-                        label += "_mane-select_"
+                label = f"{hgvs_simple}{'_validated_' if validated else ''}{'_mane-select_' if mane_select == refseq_version else ''}{'_mane-plus-clinical_' if mane_plus_clinical == refseq_version else ''}"
 
-                    tx_hgvs_list.append((hgvs_simple, label))
+                tx_hgvs_list.append((hgvs_simple, label))
+
     return tx_hgvs_list
 
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -25,7 +25,7 @@ from scout.utils.scout_requests import fetch_refseq_version
 from .form import CaseDataForm, SNVariantForm, SVariantForm
 
 LOG = logging.getLogger(__name__)
-MAX_VALIDATED_HGVS = 50
+MAX_VALIDATED_HGVS = 10
 
 
 def _get_var_tx_hgvs(case_obj: dict, variant_obj: dict) -> List[Tuple[str, str]]:

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -110,11 +110,10 @@
                     <table style="width:100%; table-layout: auto; border-collapse: collapse;">
                       <caption></caption>
                       <tr><th></th></tr>
+                    {% set ns = namespace(label='', validated=false, mane_select=false, mane_plus_clinical=false) %}
                     {% for item_row in variant_data.var_form.tx_hgvs | batch(3) %}
                       <tr>
                       {% for item in item_row %}
-                        {% set ns = namespace(label='', validated=false, mane_select=false) %}
-
                         {% if "_validated_" in item.label.text %}
                           {% set ns.validated = true %}
                         {% endif %}
@@ -155,8 +154,8 @@
                     {% endfor %}
                     </table>
 
-                    {% if variant_data.var_form.tx_hgvs.choices |length > max_validated_hgvs+1 %} <!-- +1 because there is also the option to leave HGVS blank -->
-                      <span class="text-danger">HGVS validations were skipped because the variant contains more than {{max_validated_hgvs}} HGVS entries. Validating a large number of HGVS entries may cause a page timeout. Please perform a manual validation using the VariantValidator link above.</span>
+                    {% if ns.mane_select or ns.mane_plus_clinical %} <!-- Only those HGVS have been validated -->
+                      <span class="text-danger">HGVS validation was only performed on MANE Select and MANE Plus Clinical transcripts. For any other available HGVS present in this list, manual validation can be performed using the VariantValidator link above.</span>
                     {% endif %}
 
                     <br><br>

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -110,10 +110,10 @@
                     <table style="width:100%; table-layout: auto; border-collapse: collapse;">
                       <caption></caption>
                       <tr><th></th></tr>
-                    {% set ns = namespace(label='', validated=false, mane_select=false, mane_plus_clinical=false) %}
                     {% for item_row in variant_data.var_form.tx_hgvs | batch(3) %}
                       <tr>
                       {% for item in item_row %}
+                        {% set ns = namespace(label='', validated=false, mane_select=false, mane_plus_clinical=false) %}
                         {% if "_validated_" in item.label.text %}
                           {% set ns.validated = true %}
                         {% endif %}
@@ -154,9 +154,7 @@
                     {% endfor %}
                     </table>
 
-                    {% if ns.mane_select or ns.mane_plus_clinical %} <!-- Only those HGVS have been validated -->
-                      <span class="text-danger">HGVS validation was only performed on MANE Select and MANE Plus Clinical transcripts. For any other available HGVS present in this list, manual validation can be performed using the VariantValidator link above.</span>
-                    {% endif %}
+                    <span class="text-danger">HGVS validation is performed only for variants in build GRCh37 or MANE Select and MANE Plus Clinical transcripts. For any other available HGVS present in this list, manual validation can be performed using the VariantValidator link above.</span>
 
                     <br><br>
                     <!-- dbSNP identifier -->

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -92,7 +92,7 @@
                   {% if var_category == 'snv' %}
                     <br><br>
                     <!-- Transcripts & HGVS:(optional) -->
-                    {{variant_data.var_form.tx_hgvs.label(class="fw-bold, text-dark")}}
+                    {{ variant_data.var_form.tx_hgvs.label(class="fw-bold, text-dark") }}
 
                     <span class="text-danger" data-bs-toggle='tooltip' title="If you do not provide any HGVS expression, chromosome coordinates will be used to describe this variant instead (automatic). HGVS expressions were validated using VariantValidator"><strong>?</strong></span>
                     <span class="badge bg-primary float-end"><a class="text-white" href="https://variantvalidator.org/service/validate/" target="_blank" rel="noopener">VariantValidator</a></span>
@@ -121,6 +121,10 @@
                         {% if "_mane-select_" in item.label.text %}
                           {% set ns.mane_select = true %}
                         {% endif %}
+                        {% if "_mane-plus-clinical_" in item.label.text %}
+                           {% set ns.mane_plus_clinical = true %}
+                        {% endif %}
+
                         {% set ns.label = item.label.text | replace("_validated_", "") | replace("_mane-select_", "")  %}
 
                         <td style="width: 3%; text-align: right; vertical-align: baseline;">
@@ -138,6 +142,9 @@
                           {% if ns.mane_select %}
                             <span class='badge bg-dark'>MANE SELECT</span>
                           {% endif %}
+                          {% if ns.mane_plus_clinical %}
+                            <span class='badge bg-dark'>MANE PLUS CLINICAL</span>
+                          {% endif %}
                           {% if ns.validated %}
                             <em class="fa fa-check text-success" aria-hidden="true" data-bs-toggle="tooltip" title="Verified by VariantValidator"></em>
                           {% endif %}
@@ -147,6 +154,11 @@
                       </tr>
                     {% endfor %}
                     </table>
+
+                    {% if variant_data.var_form.tx_hgvs.choices |length > max_validated_hgvs+1 %} <!-- +1 because there is also the option to leave HGVS blank -->
+                      <span class="text-danger">HGVS validations were skipped because the variant contains more than {{max_validated_hgvs}} HGVS entries. Validating a large number of HGVS entries may cause a page timeout. Please perform a manual validation using the VariantValidator link above.</span>
+                    {% endif %}
+
                     <br><br>
                     <!-- dbSNP identifier -->
                     {{variant_data.var_form.variations_ids.label(class="fw-bold, text-dark")}}

--- a/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/multistep_add_variant.html
@@ -101,7 +101,7 @@
                     {% with messages = get_flashed_messages() %}
                       {% if messages %}
                         {% for message in messages %}
-                          <span class="ml-3" style="color:red">{{ message }}</span><br>
+                          <span class="ml-3">{{ message }}</span><br>
                         {% endfor %}
                         <br><br>
                       {% endif %}

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -70,7 +70,6 @@ def clinvar_add_variant(institute_id, case_name):
         "institute": institute_obj,
         "case": case_obj,
         "germline_classif_terms": GERMLINE_CLASSIF_TERMS,
-        "max_validated_hgvs": controllers.MAX_VALIDATED_HGVS,
     }
     controllers.set_clinvar_form(request.form.get("var_id"), data)
     return render_template("clinvar/multistep_add_variant.html", **data)

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -3,10 +3,22 @@ from json import dumps
 from tempfile import NamedTemporaryFile
 from typing import List, Tuple
 
-from flask import Blueprint, flash, redirect, render_template, request, send_file, url_for
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    url_for,
+)
 from flask_login import current_user
 
-from scout.constants.clinvar import CASEDATA_HEADER, CLINVAR_HEADER, GERMLINE_CLASSIF_TERMS
+from scout.constants.clinvar import (
+    CASEDATA_HEADER,
+    CLINVAR_HEADER,
+    GERMLINE_CLASSIF_TERMS,
+)
 from scout.server.extensions import clinvar_api, store
 from scout.server.utils import institute_and_case
 
@@ -58,6 +70,7 @@ def clinvar_add_variant(institute_id, case_name):
         "institute": institute_obj,
         "case": case_obj,
         "germline_classif_terms": GERMLINE_CLASSIF_TERMS,
+        "max_validated_hgvs": controllers.MAX_VALIDATED_HGVS,
     }
     controllers.set_clinvar_form(request.form.get("var_id"), data)
     return render_template("clinvar/multistep_add_variant.html", **data)

--- a/scout/utils/hgvs.py
+++ b/scout/utils/hgvs.py
@@ -6,7 +6,7 @@ LOG = logging.getLogger(__name__)
 VALIDATOR_URL = "https://rest.variantvalidator.org/VariantValidator/variantvalidator/{}/{}/select?content-type=application%2Fjson"
 
 
-def validate_hgvs(build, desc):
+def validate_hgvs(build: str, desc: str) -> bool:
     """Validates a simple hgvs descriptor using the VariantValidator API (https://rest.variantvalidator.org/)
 
     Args:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5299 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by Jakob37
- [x] tests executed by Jakob37, CR
