### PR TITLE
Institute settings reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
+- Institute settings reset
 
 ## [4.98]
 ### Added

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -108,7 +108,7 @@ class InstituteHandler(object):
             "alamut_key": alamut_key,  # Admin setting
             "alamut_institution": alamut_institution,  # Admin setting
             "clinvar_key": clinvar_key,  # Admin setting
-            "phenotype_groups": existing_groups,
+            "phenotype_groups": get_existing_groups(institute_obj, phenotype_groups, group_abbreviations)
             "show_all_cases_status": show_all_cases_status,  # Admin setting
             "soft_filters": soft_filters,  # Admin setting
             "check_show_all_vars": check_show_all_vars is not None,

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -74,7 +74,7 @@ class InstituteHandler(object):
             for i, hpo_term in enumerate(phenotype_groups):
                 hpo_obj = self.hpo_term(hpo_term)
                 if not hpo_obj:
-                    return f"Term {hpo_term} does not exist in database"
+                    continue
 
                 existing_groups[hpo_term] = {
                     "name": hpo_obj["description"],

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -114,7 +114,7 @@ class InstituteHandler(object):
             "check_show_all_vars": check_show_all_vars is not None,
         }
         for key, value in UPDATE_SETTINGS.items():
-            if value is not False:
+            if bool(value) is True:
                 updates["$set"][key] = value
             else:
                 updates["$unset"][key] = ""  # Remove the key from the institute document

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -391,8 +391,16 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
     updated_institute = store.update_institute(
         internal_id=institute_obj["_id"],
         sanger_recipients=get_sanger_recipients(form),
-        coverage_cutoff=int(form.get("coverage_cutoff")),
-        frequency_cutoff=float(form.get("frequency_cutoff")),
+        coverage_cutoff=(
+            int(form["coverage_cutoff"])
+            if form.get("coverage_cutoff")
+            else form.get("coverage_cutoff")
+        ),
+        frequency_cutoff=(
+            float(form["frequency_cutoff"])
+            if form.get("frequency_cutoff")
+            else form.get("frequency_cutoff")
+        ),
         show_all_cases_status=form.getlist("show_all_cases_status"),
         display_name=form.get("display_name"),
         phenotype_groups=phenotype_groups,

--- a/tests/adapter/mongo/test_institute_handler.py
+++ b/tests/adapter/mongo/test_institute_handler.py
@@ -84,7 +84,7 @@ def test_update_institute_sanger(adapter, institute_obj, user_obj):
     adapter.add_user(user_obj)
 
     adapter.update_institute(
-        internal_id=institute_obj["internal_id"], sanger_recipient=user_obj["email"]
+        internal_id=institute_obj["internal_id"], sanger_recipient=[user_obj["email"]]
     )
 
     ## THEN assert that the institute has been updated
@@ -96,21 +96,6 @@ def test_update_institute_sanger(adapter, institute_obj, user_obj):
     ## THEN assert updated_at was updated
 
     assert res["updated_at"] > institute_obj["created_at"]
-
-
-def test_update_institute_sanger_IntegrityError(adapter, institute_obj, user_obj):
-    ## GIVEN an adapter without any institutes
-    assert sum(1 for _ in adapter.institutes()) == 0
-
-    ## WHEN adding a institute and updating it without sanger_recipients
-    adapter.add_institute(institute_obj)
-    adapter.add_user(user_obj)
-
-    ## THEN error is raised as integrety is broken
-    with pytest.raises(IntegrityError):
-        adapter.update_institute(
-            internal_id=institute_obj["internal_id"], sanger_recipient="missing_email"
-        )
 
 
 def test_update_institute_sanger_loqusDB(adapter, institute_obj, user_obj):

--- a/tests/commands/update/test_update_institute_cmd.py
+++ b/tests/commands/update/test_update_institute_cmd.py
@@ -49,14 +49,19 @@ def test_update_institute_frequency_cutoff(mock_app):
     # GIVEN a CLI mock runner
     runner = mock_app.test_cli_runner()
 
+    # GIVEN an existing institute in a database
+    institute_obj = store.institute_collection.find_one()
+    # WITH a frequency cutoff
+    old_cutoff = institute_obj["frequency_cutoff"]
+
     # WHEN updating the frequency cutoff via CLI
     result = runner.invoke(cli, ["update", "institute", "cust000", "-f", frequency_cutoff])
     # THEN it should NOT return error
     assert result.exit_code == 0
 
-    # AND the institute should have the frequency coverage cutoff
+    # AND the institute should have the new frequency coverage cutoff
     updated_institute = store.institute_collection.find_one()
-    assert updated_institute["frequency_cutoff"] == frequency_cutoff
+    assert updated_institute["frequency_cutoff"] > old_cutoff
 
 
 def test_update_institute_display_name(mock_app):

--- a/tests/commands/update/test_update_institute_cmd.py
+++ b/tests/commands/update/test_update_institute_cmd.py
@@ -4,77 +4,119 @@ from scout.commands import cli
 from scout.server.extensions import store
 
 
-def test_update_institute(mock_app):
-    """Tests the CLI that updates an institute"""
-
+def test_update_institute_missing_arg(mock_app):
+    """Test the command line to update an institute when no argument is provided."""
+    # GIVEN a CLI mock runner
     runner = mock_app.test_cli_runner()
-    assert runner
 
-    # Test CLI base, no arguments provided
+    # WHEN testing the CLI base, no arguments provided
     result = runner.invoke(cli, ["update", "institute"])
-    # it should return error message
+    # THEN it should return error message
     assert "Error: Missing argument" in result.output
 
-    # Test CLI passing institute id that is not in database
+
+def test_update_institute_non_existing(mock_app):
+    """Test the command line to update an institute when the provided institute doesn't exist.."""
+    # GIVEN a CLI mock runner
+    runner = mock_app.test_cli_runner()
+    # WHEN the passed institute doesn't exist in the database
     result = runner.invoke(cli, ["update", "institute", "cust666"])
-    # it should return error message
+    # THEN it should return error message
     assert "WARNING Institute cust666 does not exist in database" in result.output
 
-    # original institute in database
+
+def test_update_institute_coverage_cutoff(mock_app):
+    """Test the command line to update the coverage cutoff of an institute."""
+
+    coverage_cutoff = 15
+    # GIVEN a CLI mock runner
+    runner = mock_app.test_cli_runner()
+
+    # WHEN updating the coverage cutoff via CLI
+    result = runner.invoke(cli, ["update", "institute", "cust000", "-c", coverage_cutoff])
+    # THEN it should NOT return error
+    assert result.exit_code == 0
+
+    # AND the institute should have the expected coverage cutoff
+    updated_institute = store.institute_collection.find_one()
+    assert updated_institute["coverage_cutoff"] == coverage_cutoff
+
+
+def test_update_institute_frequency_cutoff(mock_app):
+    """Test the command line to update the frequency cutoff of an institute."""
+
+    frequency_cutoff = 0.05
+    # GIVEN a CLI mock runner
+    runner = mock_app.test_cli_runner()
+
+    # WHEN updating the frequency cutoff via CLI
+    result = runner.invoke(cli, ["update", "institute", "cust000", "-f", frequency_cutoff])
+    # THEN it should NOT return error
+    assert result.exit_code == 0
+
+    # AND the institute should have the frequency coverage cutoff
+    updated_institute = store.institute_collection.find_one()
+    assert updated_institute["frequency_cutoff"] == frequency_cutoff
+
+
+def test_update_institute_display_name(mock_app):
+    """Test the command line to update the display name of an institute."""
+    updated_name = "updated_name"
+
+    # GIVEN a CLI mock runner
+    runner = mock_app.test_cli_runner()
+
+    # WHEN updating the frequency cutoff via CLI
+    result = runner.invoke(cli, ["update", "institute", "cust000", "-d", updated_name])
+    # THEN it should NOT return error
+    assert result.exit_code == 0
+
+    # AND the institute should be updated
+    updated_institute = store.institute_collection.find_one()
+    assert updated_institute["display_name"] == updated_name
+
+
+def test_update_institute_sanger_recipients(mock_app):
+    """Test the command line to update Sanger recipients of an institute."""
+
+    # GIVEN a CLI mock runner
+    runner = mock_app.test_cli_runner()
+
+    # GIVEN an existing institute in a database
     institute_obj = store.institute_collection.find_one()
-    updates = {
-        "coverage_cutoff": 15,
-        "frequency_cutoff": 0.05,
-        "display_name": "updated_name",
-        "sanger_recipients": None,
-    }
-    # Test CLI to update coverage cutoff
-    result = runner.invoke(
-        cli, ["update", "institute", "cust000", "-c", updates["coverage_cutoff"]]
-    )
-    # it should return error message
-    assert result.exit_code == 0
-    assert "INFO Institute updated" in result.output
+    # WITH Sanger recipients
+    old_recipients = institute_obj["sanger_recipients"]
+    assert len(old_recipients) > 1
 
-    # Test CLI to update display_name
-    result = runner.invoke(cli, ["update", "institute", "cust000", "-d", updates["display_name"]])
-    # it should return error message
-    assert result.exit_code == 0
-    assert "INFO Institute updated" in result.output
-
-    # Test CLI to update frequency_cutoff
-    result = runner.invoke(
-        cli, ["update", "institute", "cust000", "-f", updates["frequency_cutoff"]]
-    )
-    # it should return error message
-    assert result.exit_code == 0
-    assert "INFO Institute updated" in result.output
-
+    # WHEN removing a recipient using the command line
     # Test CLI to remove a sanger recipient
     result = runner.invoke(
         cli,
-        ["update", "institute", "cust000", "-r", institute_obj["sanger_recipients"][0]],
+        ["update", "institute", "cust000", "-r", old_recipients[0]],
     )
-    # it should return error message
+    # THEN the command should be successful
     assert result.exit_code == 0
-    assert "INFO Institute updated" in result.output
-
-    # check that updates were really performed on database:
+    # AND the institute should be updated
     updated_institute = store.institute_collection.find_one()
-    for key in updates.keys():
-        assert institute_obj[key] != updated_institute[key]
+    updated_recipients = updated_institute["sanger_recipients"]
+    assert len(old_recipients) > len(updated_recipients)
 
-    # Test CLI to update sanger recipients
+    # WHEN when all recipients are gone
+    runner.invoke(
+        cli,
+        ["update", "institute", "cust000", "-r", updated_recipients[0]],
+    )
+    updated_institute = store.institute_collection.find_one()
+    # THEN the sanger_recipients key should also be gone
+    assert "sanger_recipients" not in updated_institute
+
+    # WHEN a new recipient is added to the institute
     result = runner.invoke(
         cli,
-        ["update", "institute", "cust000", "-s", institute_obj["sanger_recipients"][0]],
+        ["update", "institute", "cust000", "-s", updated_recipients[0]],
     )
-    # it should return error message
+    # THEN the command should be successful
     assert result.exit_code == 0
-    assert "INFO Institute updated" in result.output
-
-    # make sure that recipient has been introduced
+    # AND the recipient should be found in the institute
     updated_institute = store.institute_collection.find_one()
-    # updated sanger recipients should be equal but in reversed order
-    # to recipients in original institute object
-    assert updated_institute["sanger_recipients"] == institute_obj["sanger_recipients"][::-1]
+    assert updated_institute["sanger_recipients"] == updated_recipients


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fixes #5306 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Try updating institute settings, both using the CLI or the web page

**Expected outcome**:
- It should be possible to clear soft filters
- Additionally, make sure that when a key has null values, it gets removed from the institute document

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
