### PR TITLE
Fix #5316 - RF and other default color tags hard to see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
+- Updated color scheme for variant assessment badges that were hard to see in light mode, notably Risk Factor
 
 ## [4.98]
 ### Added

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -244,7 +244,7 @@ CANCER_TIER_OPTIONS = {
     "4": {
         "label": "Tier IV",
         "description": "Observed at high frequency in the population. No published evidence.",
-        "label_class": "default",
+        "label_class": "success",
     },
 }
 
@@ -334,7 +334,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "VUS",
                 "name": "Unknown Significance",
                 "description": "Variant of unknown significance",
-                "label_class": "default",
+                "label_class": "primary",
             },
         ),
         (
@@ -361,7 +361,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "RF",
                 "name": "Risk Factor",
                 "description": "Established risk allele - strong evidence for a small risk increase",
-                "label_class": "default",
+                "label_class": "dark",
             },
         ),
         (
@@ -370,7 +370,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "LRF",
                 "name": "Likely Risk Factor",
                 "description": "Likely risk allele - some evidence for a small risk increase",
-                "label_class": "default",
+                "label_class": "dark",
             },
         ),
         (
@@ -379,7 +379,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "URF",
                 "name": "Uncertain Risk Factor",
                 "description": "Uncertain risk allele - uncertain evidence for a small risk increase",
-                "label_class": "default",
+                "label_class": "dark",
             },
         ),
         (
@@ -388,7 +388,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "O",
                 "name": "Other",
                 "description": "Other, phenotype not related to disease",
-                "label_class": "default",
+                "label_class": "primary",
             },
         ),
     ]

--- a/scout/constants/variant_tags.py
+++ b/scout/constants/variant_tags.py
@@ -388,7 +388,7 @@ MANUAL_RANK_OPTIONS = OrderedDict(
                 "label": "O",
                 "name": "Other",
                 "description": "Other, phenotype not related to disease",
-                "label_class": "primary",
+                "label_class": "dark",
             },
         ),
     ]

--- a/tests/adapter/mongo/test_variant_events.py
+++ b/tests/adapter/mongo/test_variant_events.py
@@ -67,7 +67,7 @@ def test_matching_manual_rank(
     assert matching_ranked == {
         10: {
             "description": "Established risk allele - strong evidence for a small risk increase",
-            "label_class": "default",
+            "label_class": "dark",
             "label": "RF",
             "links": {"link"},
         }


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5316

![Screenshot 2025-03-13 at 13 57 56](https://github.com/user-attachments/assets/0115d70d-39b5-4c19-a290-c048b37e55a8)
![Screenshot 2025-03-13 at 13 57 44](https://github.com/user-attachments/assets/d87654d3-e0ca-451d-b5b6-1013e7ba50d5)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by CR
- [ ] tests executed by
