### PR TITLE
Mock Ensembl liftover in igv tracks tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parsing and showing ClinVar somatic oncogenicity anontations, when available
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
+- Mocked the Enseml liftover service in igv tracks tests
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
 - Disable 2-color mode in IGV.js by default, since it obscures variant proportion of reads. Can be manually enabled.
-
 
 ## [4.98]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parsing and showing ClinVar somatic oncogenicity anontations, when available
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone
-- Mocked the Enseml liftover service in igv tracks tests
+- Mocked the Ensembl liftover service in igv tracks tests
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity)
 - Disable 2-color mode in IGV.js by default, since it obscures variant proportion of reads. Can be manually enabled.

--- a/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_controllers.py
@@ -7,8 +7,21 @@ from scout.server.blueprints.alignviewers import controllers
 from scout.server.extensions import config_igv_tracks, store
 
 
-def test_make_sashimi_tracks_variant_38(app, case_obj):
+@responses.activate
+def test_make_sashimi_tracks_variant_38(app, case_obj, ensembl_liftover_response):
     """Test function that creates splice junction tracks for a variant with genome build 38"""
+
+    # WHEN the gene splice junction track is created for any variant in a gene
+    test_variant = store.variant_collection.find_one({"hgnc_symbols": ["POT1"]})
+
+    # GIVEN a patched response from Ensembl liftover API
+    url = f'https://grch37.rest.ensembl.org/map/human/GRCh37/{test_variant["chromosome"]}:{test_variant["position"]}..{test_variant["end"]}/GRCh38?content-type=application/json'
+    responses.add(
+        responses.GET,
+        url,
+        json=ensembl_liftover_response,
+        status=200,
+    )
 
     # GIVEN a case with genome build 38
     store.case_collection.find_one_and_update(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5317


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by DN
- [x] tests executed by automatic tests
