### PR TITLE
sv overlaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - De novo assembly alignment file load and display (#5284)
 - Paraphase bam-let alignment file load and display (#5284)
 - Parsing and showing ClinVar somatic oncogenicity anontations, when available (#5304)
+- Gene overlapping variants (superset of compounds) for SVs (#5332)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parsing and showing ClinVar somatic oncogenicity anontations, when available (#5304)
 - Gene overlapping variants (superset of compounds) for SVs (#5332)
 - Gene overlapping variants for MEIs (#5332)
+- Gene overlapping variants for cancer (and cancer_sv) (#5332)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Paraphase bam-let alignment file load and display (#5284)
 - Parsing and showing ClinVar somatic oncogenicity anontations, when available (#5304)
 - Gene overlapping variants (superset of compounds) for SVs (#5332)
+- Gene overlapping variants for MEIs (#5332)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -689,13 +689,14 @@ class VariantHandler(VariantLoader):
         result = self.variant_collection.delete_many(query)
         LOG.info("{0} variants deleted".format(result.deleted_count))
 
-    def overlapping(self, variant_obj, limit=30):
+    def hgnc_overlapping(self, variant_obj, limit=30):
         """Return overlapping variants.
 
         Look at the genes that a variant overlaps to.
         Then return all variants that overlap these genes.
 
-        If variant_obj is sv it will return the overlapping snvs and oposite
+        If variant_obj is an SV it will return the hgnc_id matching SVs and SNVs, but
+        for SNVs we will only return the SVs
         There is a problem when SVs are huge since there are to many overlapping variants.
 
         Args:
@@ -705,7 +706,8 @@ class VariantHandler(VariantLoader):
             variants(iterable(dict))
         """
         # This is the category of the variants that we want to collect
-        category = "snv" if variant_obj["category"] == "sv" else "sv"
+
+        category = '{"$in": ["sv", "snv"]}' if variant_obj["category"] == "sv" else "sv"
         variant_type = variant_obj.get("variant_type", "clinical")
         hgnc_ids = variant_obj["hgnc_ids"]
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -718,6 +718,7 @@ class VariantHandler(VariantLoader):
                 {"category": category},
                 {"variant_type": variant_type},
                 {"hgnc_ids": {"$in": hgnc_ids}},
+                {"variant_id": {"$ne": variant_obj["variant_id"]}},
             ]
         }
         sort_key = [("rank_score", pymongo.DESCENDING)]

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -706,7 +706,7 @@ class VariantHandler(VariantLoader):
         category = (
             {"$in": ["sv", "mei"]}
             if variant_obj["category"] == "snv"
-            else {"$in": ["sv", "snv", "mei"]}
+            else {"$in": ["sv", "snv", "mei", "cancer", "cancer_sv"]}
         )
 
         variant_type = variant_obj.get("variant_type", "clinical")

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -698,6 +698,8 @@ class VariantHandler(VariantLoader):
         If variant_obj is an SV it will return the hgnc_id matching SVs, SNVs, and MEIs but
         for SNVs we will only return the SVs and MEIs since the genmod compounds are way better.
 
+        Do not return the present variant as matching.
+
         limit: A maximum count of returned variants is introduced: mainly this is a problem when SVs are huge since there can be many genes and overlapping variants.
                We sort to offer the LIMIT most severe overlapping variants.
         """

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -325,21 +325,21 @@
 
   {% if variant.category in ("mei", "str", "snv", "cancer") %}
     {% if variant.category == "cancer" %}
-    <a href="{{ url_for('variant.cancer_variant',
+    <a href='{{ url_for('variant.cancer_variant',
                    institute_id=variant.institute,
                    case_name=case.display_name,
-                   variant_id=variant._id) }}" target="_blank">
+                   variant_id=variant._id) }}' target='_blank'>
     {% else %}
-    <a href="{{ url_for('variant.variant',
+    <a href='{{ url_for('variant.variant',
                    institute_id=variant.institute,
                    case_name=case.display_name,
-                   variant_id=variant._id) }}" target="_blank">
+                   variant_id=variant._id) }}' target='_blank'>
     {% endif %}
   {% else %} <!-- structural variants -->
-    <a href="{{ url_for('variant.sv_variant',
+    <a href='{{ url_for('variant.sv_variant',
                               institute_id=variant.institute,
                               case_name=case.display_name,
-                              variant_id=variant._id) }}" target="_blank">
+                              variant_id=variant._id) }}' target='_blank'>
   {% endif %}
     {{ pretty_variant(variant) }}
   </a>

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -369,7 +369,7 @@ def variant(
 
     overlapping_vars = []
     if get_overlapping:
-        for var in store.overlapping(variant_obj):
+        for var in store.hgnc_overlapping(variant_obj):
             var.update(predictions(var.get("genes", [])))
             overlapping_vars.append(var)
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -119,9 +119,9 @@
 {% macro overlapping_panel(variant, overlapping_vars, case, institute) %}
   <div class="card panel-default">
     {% if variant.category == 'sv' %}
-      <div class="panel-heading">Overlapping SNVs</div>
+      <div class="panel-heading">Gene overlapping SNVs and SVs</div>
     {% else %}
-      <div class="panel-heading">Overlapping SVs</div>
+      <div class="panel-heading">Gene overlapping SVs</div>
     {% endif %}
     <div class="card-body">
       <div class="table-responsive">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -118,10 +118,10 @@
 
 {% macro overlapping_panel(variant, overlapping_vars, case, institute) %}
   <div class="card panel-default">
-    {% if variant.category == 'sv' %}
+    {% if variant.category != "snv" %}
       <div class="panel-heading">Gene overlapping variants</div>
     {% else %}
-      <div class="panel-heading">Gene overlapping SVs</div>
+      <div class="panel-heading">Gene overlapping non-SNVs</div>
     {% endif %}
     <div class="card-body">
       <div class="table-responsive">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -119,7 +119,7 @@
 {% macro overlapping_panel(variant, overlapping_vars, case, institute) %}
   <div class="card panel-default">
     {% if variant.category == 'sv' %}
-      <div class="panel-heading">Gene overlapping SNVs and SVs</div>
+      <div class="panel-heading">Gene overlapping variants</div>
     {% else %}
       <div class="panel-heading">Gene overlapping SVs</div>
     {% endif %}

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -137,7 +137,7 @@ def variants(
 
     variants = []
     for variant_obj in variant_res:
-        overlapping_svs = list(store.overlapping(variant_obj))
+        overlapping_svs = list(store.hgnc_overlapping(variant_obj))
         variant_obj["overlapping"] = overlapping_svs or None
 
         evaluations = []

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1454,6 +1454,9 @@ def cancer_variants(store, institute_id, case_name, variants_query, variant_coun
         variant_obj["second_rep_gene"] = secondary_gene
         variant_obj["clinical_assessments"] = get_manual_assessments(variant_obj)
 
+        overlapping = list(store.hgnc_overlapping(variant_obj))
+        variant_obj["overlapping"] = overlapping or None
+
         evaluations = []
         # Get previous ClinGen-CGC-VIGG evaluations of the variant from other cases
         for evaluation_obj in store.get_ccv_evaluations(variant_obj):

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -282,6 +282,9 @@ def mei_variants(
     case_dismissed_vars = store.case_dismissed_variants(institute_obj, case_obj)
 
     for variant_obj in variants_query.skip(skip_count).limit(per_page):
+        overlapping = list(store.hgnc_overlapping(variant_obj))
+        variant_obj["overlapping"] = overlapping or None
+
         # show previous classifications for research variants
         clinical_var_obj = variant_obj
         if variant_obj["variant_type"] == "research":

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -233,6 +233,9 @@ def sv_variants(store, institute_obj, case_obj, variants_query, variant_count, p
     case_dismissed_vars = store.case_dismissed_variants(institute_obj, case_obj)
 
     for variant_obj in variants_query.skip(skip_count).limit(per_page):
+        overlapping_svs = list(store.hgnc_overlapping(variant_obj))
+        variant_obj["overlapping"] = overlapping_svs or None
+
         # show previous classifications for research variants
         clinical_var_obj = variant_obj
         if variant_obj["variant_type"] == "research":

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -439,11 +439,11 @@
   <a href="#" class="badge bg-warning" data-bs-toggle="popover" data-bs-placement="left"
     data-bs-html="true" data-bs-trigger="hover click"
     {% if variant.category == "SNV" %}
-      data-bs-content="<div>Gene overlapping SVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlapping SVs</a>
+      data-bs-content="<div>Gene overlapping non-SNVs</div>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlapping</a>
     {% else %}
-      data-bs-content="<div>Gene overlapping SNVs and SVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlapping SNVs and SVs</a>
+      data-bs-content="<div>Gene overlapping variants</div>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlapping</a>
     {% endif %}
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -1,4 +1,5 @@
 {% from "variant/gene_disease_relations.html" import inheritance_badge %}
+{% from "variants/utils.html" import compounds_table, overlapping_tooltip_table %}
 
 {% macro variant_gene_symbols_cell(variant, inherit_palette) %}
   <div class="d-flex justify-content-between align-items-center">
@@ -417,5 +418,32 @@
     <small class="text-body">{% if 'alt_depth' in allele and allele.alt_depth >= 0 %}{{ allele.alt_depth }}{% else %}.{% endif %}|{% if 'ref_depth' in allele and allele.ref_depth >= 0 %}{{ allele.ref_depth }}{% else %}.{% endif %}</small>
   {% else %}
     <span class="text-body">N/A</span>
+  {% endif %}
+{% endmacro %}
+
+
+{% macro overlapping_cell(variant, institute, case) %}
+  {% if variant.compounds %}
+    {% set ns=namespace(show_compounds=false) %}
+    {% for compound in variant.compounds if not compound.is_dismissed %}
+      {% set ns.show_compounds = true %}
+    {% endfor %}
+    {% if ns.show_compounds %}
+      <a href="#" class="badge bg-primary text-white" data-bs-toggle="popover" data-bs-placement="left"
+        data-bs-html="true" data-bs-trigger="hover click"
+        data-bs-content="{{ compounds_table(institute, case, variant.compounds[:20], is_popover=true) }}">Compounds</a>
+    {% endif %}
+  {% endif %}
+
+  {% if variant.overlapping %}
+  <a href="#" class="badge bg-warning" data-bs-toggle="popover" data-bs-placement="left"
+    data-bs-html="true" data-bs-trigger="hover click"
+    {% if variant.category == "SNV" %}
+      data-bs-content="<div>Gene overlapping SVs</div>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlapping SVs</a>
+    {% else %}
+      data-bs-content="<div>Gene overlapping SNVs and SVs</div>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlapping SNVs and SVs</a>
+    {% endif %}
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/mei-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/mei-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import mei_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, overlapping_cell, variant_gene_symbols_cell, variant_funct_anno_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - Mobile Element Insertion variants
@@ -57,16 +57,17 @@ onsubmit="return validateForm()">
           <thead class="table-light thead">
             <tr>
               <th style="width:3%"></th>
-              <th>Rank</th>
-              <th>Score</th>
+              <th title="Rank position">Rank</th>
+              <th title="Rank score">Score</th>
               <th>Type</th>
               <th style="width:18%">Element</th>
-              <th>Chr</th>
+              <th title="Chromosome">Chr</th>
               <th style="width:9%">Start loc</th>
               <th>Frequency</th>
               <th>Gene(s)</th>
-              <th>Function</th>
-            </tr>
+              <th title="Functional annotation">Function</th>
+              <th title="Gene overlapping variants">Overlap</th>
+          </tr>
           </thead>
           <tbody>
             {% for variant in variants %}
@@ -113,6 +114,7 @@ onsubmit="return validateForm()">
     <td style="word-wrap:break-word;">
       {{ variant_funct_anno_cell(variant) }}
     </td>
+    <td>{{ overlapping_cell(variant, institute, case) }}</td>
   </tr>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "variants/utils.html" import sv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status, callers_cell %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, observed_cell_general, variant_gene_symbols_cell, variant_funct_anno_cell %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, observed_cell_general, overlapping_cell, variant_gene_symbols_cell, variant_funct_anno_cell %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - SV variants
@@ -57,18 +57,19 @@ onsubmit="return validateForm()">
         <thead class="table-light thead">
           <tr>
             <th style="width:3%"></th>
-            <th>Rank</th>
-            <th>Score</th>
+            <th title="Rank position">Rank</th>
+            <th title="Rank score">Score</th>
             <th>Callers</th>
             <th>Type</th>
-            <th>Chr</th>
+            <th title="Chromosome">Chr</th>
             <th>Start</th>
             <th>End</th>
             <th>Length</th>
-            <th>Pop Freq</th>
-            <th>Observed</th>
+            <th title="Population Frequency">Pop Freq</th>
+            <th title="Observed database matches">Observed</th>
             <th>Gene(s)</th>
-            <th>Function</th>
+            <th title="Functional annotation">Function</th>
+            <th title="Gene overlapping variants">Overlap</th>
           </tr>
         </thead>
         <tbody>
@@ -121,6 +122,7 @@ onsubmit="return validateForm()">
     <td style="word-wrap:break-word;">
       {{ variant_funct_anno_cell(variant) }}
     </td>
+    <td>{{ overlapping_cell(variant, institute, case) }}</td>
   </tr>
 {% endmacro %}
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1,5 +1,6 @@
 {% import "bootstrap/wtf.html" as wtf %}
 {% from "utils.html" import comments_table %}
+{% from "cases/utils.html" import pretty_link_variant %}
 {% from "variants/indicators.html" import pin_indicator, causative_badge, clinical_assessments_badge, comments_badge, dismissals_badge, evaluations_badge, group_assessments_badge, matching_manual_rank, research_assessments_badge %}
 
 {% macro filter_script_main(cytobands) %}
@@ -225,30 +226,25 @@
   </table>
 {% endmacro %}
 
-{% macro svs_table(institute, case, overlapping) %}
+{% macro overlapping_tooltip_table(institute, case, overlapping) %}
   <table class='table table-bordered table-hover table-condensed'>
     <thead>
       <tr>
-        <th>Region</th>
+        <th>Pos</th>
         <th>Type</th>
         <th>Length</th>
         <th>Rank score</th>
       </tr>
     </thead>
     <tbody>
-      {% for sv in overlapping %}
+      {% for variant in overlapping %}
         <tr>
           <td>
-              <a href='{{ url_for("variant.sv_variant",
-                                 institute_id=institute._id,
-                                 case_name=case.display_name,
-                                 variant_id=sv._id) }}'>
-                {{ sv.chromosome }}{{ sv.cytoband_start }}
-              </a>
+            {{ pretty_link_variant(variant, case) }}
           </td>
-          <td class='text-end'>{{ sv.sub_category }}</td>
-          <td class='text-end'>{{ sv.length if sv.length < 100000000000 else "-" }}</td>
-          <td class='text-end'>{{ sv.rank_score }}</td>
+          <td class='text-end'>{{ variant.sub_category }}</td>
+          <td class='text-end'>{{ variant.length if variant.length < 100000000000 else '-' }}</td>
+          <td class='text-end'>{{ variant.rank_score }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
-{% from "variants/utils.html" import compounds_table, svs_table, snv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status, mark_heteroplasmic_mt %}
-{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, gene_cell, observed_cell_general  %}
+{% from "variants/utils.html" import snv_filters, cell_rank, pagination_footer, pagination_hidden_div, dismiss_variants_block, filter_form_footer, filter_script_main, update_stash_filter_button_status, mark_heteroplasmic_mt %}
+{% from "variants/components.html" import external_scripts, external_stylesheets, frequency_cell_general, gene_cell, observed_cell_general, overlapping_cell  %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - {{ case.display_name }} - {{ form.variant_type.data|capitalize }} variants
@@ -59,7 +59,7 @@
               <th style="width:5%" title="Rank score">Score</th>
               <th style="width:4%" title="Chromosome">Chr.</th>
               <th style="width:12%" title="HGNC symbols">Gene</th>
-              <th style="width:6%" title="Pop Freq">Pop Freq</th>
+              <th style="width:6%" title="Population Frequency">Pop Freq</th>
               <th style="width:10%" title="Observed database matches">Observed</th>
               <th style="width:5%" title="CADD score">CADD</th>
               <th style="width:18%" title="Functional annotation">Function</th>
@@ -93,7 +93,7 @@
                   {{ functional_annotation_cell(variant) }}
                 </td>
                 <td>{{ cell_models(variant) }}</td>
-                <td>{{ overlapping_cell(variant) }}</td>
+                <td>{{ overlapping_cell(variant, institute, case) }}</td>
               </tr>
             {% else %}
               <tr>
@@ -156,27 +156,6 @@
 
   {% if variant.mosaic_tags %}
     <span class="badge bg-warning">mosaic</span>
-  {% endif %}
-{% endmacro %}
-
-{% macro overlapping_cell(variant) %}
-
-  {% if variant.compounds %}
-    {% set ns=namespace(show_compounds=false) %}
-    {% for compound in variant.compounds if not compound.is_dismissed %}
-      {% set ns.show_compounds = true %}
-    {% endfor %}
-    {% if ns.show_compounds %}
-      <a href="#" class="badge bg-primary text-white" data-bs-toggle="popover" data-bs-placement="left"
-        data-bs-html="true" data-bs-trigger="hover click"
-        data-bs-content="{{ compounds_table(institute, case, variant.compounds[:20], is_popover=true) }}">Compounds</a>
-    {% endif %}
-  {% endif %}
-
-  {% if variant.overlapping %}
-  <a href="#" class="badge bg-warning" data-bs-toggle="popover" data-bs-placement="left"
-    data-bs-html="true" data-bs-trigger="hover click"
-    data-bs-content="{{ svs_table(institute, case, variant.overlapping[:20]) }}">Overlapping SVs</a>
   {% endif %}
 {% endmacro %}
 

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -944,7 +944,7 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
     )
 
     # THEN the function that finds overlapping variants to the snv_variant
-    results = adapter.overlapping(updated_snv_variant, limit=10000)
+    results = adapter.hgnc_overlapping(updated_snv_variant, limit=10000)
     for res in results:
         # SHOULD return the SV variant
         assert res["category"] == "sv"
@@ -952,6 +952,6 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
 
     # The function should also work the other way around:
     # and return snv variants that overlaps with sv variants
-    result_vars = list(adapter.overlapping(updated_sv_variant, limit=10000))
+    result_vars = list(adapter.hgnc_overlapping(updated_sv_variant, limit=10000))
     result_ids = [result_var["_id"] for result_var in result_vars]
     assert updated_snv_variant["_id"] in result_ids


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5252 - add gene overlapping for SVs
- Fix #3955 (and eg dupe #4132) - add gene overlapping for MEIs
- Fix #2195 - actually partially fix; a genmod 2hit model, similar to the inheritance aware compounds will be great eventually.

Feels really nice on demo. Caveat would likely be the aggregated query time. This is one of those things that we could start doing somewhat asynchronously - ie when someone hovers over, we could fetch the tooltip contents via api. For proper compounds, especially with compound filters active, we would need to be rid of the button, but for most variant types and genes we would now some kind of second match, no? There is surely at least some SV covering the whole chr... 🙄 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. check some cases variantS page for gene overlaps, especially MEI, SV(to SV).
2. check variant pages for the same overlaps, here also available for cancer and cancer_sv
![Screenshot 2025-03-18 at 16 57 48](https://github.com/user-attachments/assets/3cd3a76f-7b54-41ae-a823-9c0449938376)
![Screenshot 2025-03-18 at 17 03 00](https://github.com/user-attachments/assets/57fc42ab-cd86-4d8a-bdf8-e31c12542cda)
![Screenshot 2025-03-18 at 17 01 31](https://github.com/user-attachments/assets/6864abc1-033d-4117-a0e2-af5f74456eee)
![Screenshot 2025-03-18 at 17 00 57](https://github.com/user-attachments/assets/6ca11679-0c0a-4c99-b167-a74cb6eef026)
![Screenshot 2025-03-18 at 17 00 43](https://github.com/user-attachments/assets/dc9268e0-f3c7-4625-8b4d-e58b33344ac1)
![Screenshot 2025-03-18 at 16 58 20](https://github.com/user-attachments/assets/cf1b9bb5-7632-47d3-bfc4-f129a37163df)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
