### PR TITLE
Version 4.99

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests for the Google login functionality (#5335)
 - Support for login using Keycloak (#5337)
 - Documentation on Keycloak login system integration (#5342)
-- Integrity check for genes/transcripts/exons file downloaded from Ensembl
+- Integrity check for genes/transcripts/exons files downloaded from Ensembl (#5353)
 - Options for custom ID/display name for PanelApp Green updates (#5355)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [4.99]
 ### Added
 - De novo assembly alignment file load and display (#5284)
 - Paraphase bam-let alignment file load and display (#5284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Updated color scheme for variant assessment badges that were hard to see in light mode, notably Risk Factor (#5318)
 - Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts from variants in build 38 (#5302)
 - Sashimi view page displaying an error message when Ensembl REST API (LiftOver) is not available (#5322)
-- Refactored the liftover functionality to avoid using the old Ensembl REST API (#5326)
+- Refactored the LiftOver functionality to avoid using the old Ensembl REST API (#5326)
 
 ## [4.98]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Gene overlapping variants (superset of compounds) for SVs (#5332)
 - Gene overlapping variants for MEIs (#5332)
 - Gene overlapping variants for cancer (and cancer_sv) (#5332)
-- Tests for the Google login functionality
+- Tests for the Google login functionality (#5335)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)
-- Refactored the login function into smaller functions, handling respectively: user consent, LDAP login, Google login, database login and user validation
+- Refactored the login function into smaller functions, handling respectively: user consent, LDAP login, Google login, database login and user validation (#5331)
 - Allow loading of mixed analysis type cases where some individuals are fully WTS and do not appear in DNA VCFs (#5327)
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity) (#5300)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.98.0"
+version = "4.99.0"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Mans Magnuson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}

--- a/uv.lock
+++ b/uv.lock
@@ -685,15 +685,6 @@ wheels = [
 ]
 
 [[package]]
-name = "enum34"
-version = "1.1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/c4/2da1f4952ba476677a42f25cd32ab8aaf0e1c0d0e00b89822b835c7e654c/enum34-1.1.10.tar.gz", hash = "sha256:cce6a7477ed816bd2542d03d53db9f0db935dd013b70f336a95c73979289f248", size = 28187 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/f6/ccb1c83687756aeabbf3ca0f213508fcfb03883ff200d201b3a4c60cedcc/enum34-1.1.10-py3-none-any.whl", hash = "sha256:c3858660960c984d6ab0ebad691265180da2b43f07e061c0f8dca9ef3cffd328", size = 11224 },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1586,18 +1577,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathlib2"
-version = "2.3.7.post1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/31/51/99caf463dc7c18eb18dad1fffe465a3cf3ee50ac3d1dccbd1781336fe9c7/pathlib2-2.3.7.post1.tar.gz", hash = "sha256:9fe0edad898b83c0c3e199c842b27ed216645d2e177757b2dd67384d4113c641", size = 211190 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/eb/4af4bcd5b8731366b676192675221c5324394a580dfae469d498313b5c4a/pathlib2-2.3.7.post1-py2.py3-none-any.whl", hash = "sha256:5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b", size = 18027 },
-]
-
-[[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2013,8 +1992,6 @@ name = "pyscss"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "enum34" },
-    { name = "pathlib2" },
     { name = "six" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/30/64c818fd317e03138f98ca67800edb6a916f59fc07b3d7e535e84c3c333a/pyScss-1.4.0.tar.gz", hash = "sha256:8f35521ffe36afa8b34c7d6f3195088a7057c185c2b8f15ee459ab19748669ff", size = 122100 }
@@ -2341,7 +2318,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.98.0"
+version = "4.99.0"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
This PR marks a new Scout release. We apply semantic versioning. This is a minor release since it adds features, fixes issues and changes code and behaviour in a backwards compatible manner.

## [unreleased]
## [4.99]
### Added
- [x] De novo assembly alignment file load and display (#5284)
- [x] Paraphase bam-let alignment file load and display (#5284)
- [x] Parsing and showing ClinVar somatic oncogenicity anontations, when available (#5304)
- [x] Gene overlapping variants (superset of compounds) for SVs (#5332)
- [x] Gene overlapping variants for MEIs (#5332)
- [x] Gene overlapping variants for cancer (and cancer_sv) (#5332)
- [x] Tests for the Google login functionality (#5335)
- [x] Support for login using Keycloak (#5337) _- Tested on local instances only_
- [x] Documentation on Keycloak login system integration (#5342)
- [x] Integrity check for genes/transcripts/exons files downloaded from Ensembl (#5353)
- [x] Options for custom ID/display name for PanelApp Green updates (#5355)
### Changed
- [x] Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
- [x] Mocked the Ensembl liftover service in igv tracks tests (#5319)
- [x] Refactored the login function into smaller functions, handling respectively: user consent, LDAP login, Google login, database login and user validation (#5331)
- [x] Allow loading of mixed analysis type cases where some individuals are fully WTS and do not appear in DNA VCFs (#5327)
- [x] Documentation available in dark mode, and expanded installation instructions (#5343)
### Fixed
- [x] Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity) (#5300)
- [x] Disable 2-color mode in IGV.js by default, since it obscures variant proportion of reads. Can be manually enabled (#5311)
- [x] Institute settings reset (#5309)
- [x] Updated color scheme for variant assessment badges that were hard to see in light mode, notably Risk Factor (#5318)
- [x] Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts from variants in build 38 (#5302) _Tested by collaborators_
- [x] Sashimi view page displaying an error message when Ensembl REST API (LiftOver) is not available (#5322)
- [x] Refactored the LiftOver functionality to avoid using the old Ensembl REST API (#5326)
- [x] Downloading of Ensembl resources by fixing the URL to the schug server, pointing to the production instance instead of the staging one (#5348)
- [x] Missing MT genes from the IGV track (#5339)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
