### PR TITLE
Keycloak login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Gene overlapping variants for MEIs (#5332)
 - Gene overlapping variants for cancer (and cancer_sv) (#5332)
 - Tests for the Google login functionality (#5335)
-- Support for login using Keycloak
+- Support for login using Keycloak (#5337)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Gene overlapping variants (superset of compounds) for SVs (#5332)
 - Gene overlapping variants for MEIs (#5332)
 - Gene overlapping variants for cancer (and cancer_sv) (#5332)
-- Tests for the Google login functionality
+- Tests for the Google login functionality (#5335)
+- Support for login using Keycloak
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)
-- Refactored the login function into smaller functions, handling respectively: user consent, LDAP login, Google login, database login and user validation
+- Refactored the login function into smaller functions, handling respectively: user consent, LDAP login, Google login, database login and user validation (#5331)
 - Allow loading of mixed analysis type cases where some individuals are fully WTS and do not appear in DNA VCFs (#5327)
 ### Fixed
 - Re-enable display of case and individual specific tracks (pre-computed coverage, UPD, zygosity) (#5300)
@@ -26,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid page timeout by skipping HGVS validations in ClinVar multistep submission for non-MANE transcripts from variants in build 38 (#5302)
 - Sashimi view page displaying an error message when Ensembl REST API (LiftOver) is not available (#5322)
 - Refactored the liftover functionality to avoid using the old Ensembl REST API (#5326)
+
 
 ## [4.98]
 ### Added

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -165,7 +165,7 @@ def configure_extensions(app):
 
 
 def set_login_system(app):
-    """Initialize login system: LDAP, Google OAuth, Keycloak or simple database user search."""
+    """Initialize login system: LDAP, Google OAuth, Keycloak. If none of these is set, then simple database user matching is used."""
     if app.config.get("LDAP_HOST"):
         LOG.info("LDAP login enabled")
         extensions.ldap_manager.init_app(app)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -168,12 +168,10 @@ def set_login_system(app):
     """Initialize login system: LDAP, Google OAuth, Keycloak or simple database user search."""
     if app.config.get("LDAP_HOST"):
         LOG.info("LDAP login enabled")
-        # setup connection to server
         extensions.ldap_manager.init_app(app)
 
     if app.config.get("GOOGLE"):
         LOG.info("Google login enabled")
-        # setup connection to google oauth2
         configure_google_login(app)
 
     if app.config.get("KEYCLOAK"):

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -152,7 +152,7 @@ def perform_flask_login(user_dict: "LoginUser") -> Response:
 def logout_oidc_user(session, provider: str):
     """Log out a user from an OIDC login provider-"""
     logout_url = current_app.config[provider].get("logout_url")
-    if not logout_url:
+    if not logout_url or not session.get("token_response"):
         return
     refresh_token = session["token_response"]["refresh_token"]
     requests.post(

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -150,6 +150,7 @@ def perform_flask_login(user_dict: "LoginUser") -> Response:
 
 
 def logout_oidc_user(session, provider: str):
+    """Log out a user from an OIDC login provider-"""
     logout_url = current_app.config[provider].get("logout_url")
     if not logout_url:
         return

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -103,14 +103,9 @@ def authorized():
 @login_bp.route("/logout")
 def logout():
     logout_user()  # logs out user from scout
-    for client_type in ["GOOGLE", "KEYCLOAK"]:
-        if current_app.config.get(session, client_type):
-            controllers.logout_oidc_user(session, client_type)
-        controllers.logout_oidc_user(session, "GOOGLE")  # logs out user from Google OIDC provider
-    if current_app.config.get("KEYCLOAK"):
-        controllers.logout_oidc_user(
-            session, "KEYCLOAK"
-        )  # logs out user from Keycloak OIDC provider
+    for provider in ["GOOGLE", "KEYCLOAK"]:
+        if current_app.config.get(provider):
+            controllers.logout_oidc_user(session, provider)
     session.clear()
     flash("you logged out", "success")
     return redirect(url_for("public.index"))

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -73,7 +73,6 @@ def login() -> Response:
         if session.get("email"):
             user_mail = session["email"]
         else:
-            # Redirect to Google OAuth if not completed
             return controllers.keycloak_login()
 
     elif request.form.get("email"):

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -87,9 +87,7 @@ def authorized():
     """OIDC callback function."""
     if current_app.config.get("GOOGLE"):
         client = oauth_client.google
-        user = oauth_client.google.parse_id_token(token, None)
     if current_app.config.get("KEYCLOAK"):
-        token = oauth_client.keycloak.authorize_access_token()
         client = oauth_client.keycloak
     token = client.authorize_access_token()
     user = client.parse_id_token(token, None)

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -103,7 +103,9 @@ def authorized():
 @login_bp.route("/logout")
 def logout():
     logout_user()  # logs out user from scout
-    if current_app.config.get("GOOGLE"):
+    for client_type in ["GOOGLE", "KEYCLOAK"]:
+        if current_app.config.get(session, client_type):
+            controllers.logout_oidc_user(session, client_type)
         controllers.logout_oidc_user(session, "GOOGLE")  # logs out user from Google OIDC provider
     if current_app.config.get("KEYCLOAK"):
         controllers.logout_oidc_user(

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -86,7 +86,7 @@ def login() -> Response:
 def authorized():
     """OIDC callback function."""
     if current_app.config.get("GOOGLE"):
-        token = oauth_client.google.authorize_access_token()
+        client = oauth_client.google
         user = oauth_client.google.parse_id_token(token, None)
     if current_app.config.get("KEYCLOAK"):
         token = oauth_client.keycloak.authorize_access_token()

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -90,7 +90,9 @@ def authorized():
         user = oauth_client.google.parse_id_token(token, None)
     if current_app.config.get("KEYCLOAK"):
         token = oauth_client.keycloak.authorize_access_token()
-        user = oauth_client.keycloak.parse_id_token(token, None)
+        client = oauth_client.keycloak
+    token = client.authorize_access_token()
+    user = client.parse_id_token(token, None)
 
     session["email"] = user.get("email").lower()
     session["name"] = user.get("name")

--- a/scout/server/blueprints/public/templates/public/index.html
+++ b/scout/server/blueprints/public/templates/public/index.html
@@ -21,7 +21,11 @@
       </p>
     {% else %}
       <form class="row" method="POST" action="{{ url_for('login.login') }}">
-        {% if config.GOOGLE %}
+        {% if config.KEYCLOAK %}
+          <button name="googleLogin" class="btn btn-primary btn-lg text-white" href="{{ url_for('login.login') }}" type="submit">
+            Login with Keycloak
+          </button>
+        {% elif config.GOOGLE %}
           <button name="googleLogin" class="btn btn-primary btn-lg text-white" href="{{ url_for('login.login') }}" type="submit">
             Login with Google
           </button>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -39,12 +39,12 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # )
 
 # Parameters required for login with Keycloak
-KEYCLOAK = dict(
-    client_id="scout-client",
-    client_secret="3VFpvHLXUyiNMcCxGOKe5vld378yZLqd",
-    discovery_url=f"http://localhost:8080/realms/CG/.well-known/openid-configuration",
-    logout_url=f"http://localhost:8080/realms/CG/protocol/openid-connect/logout",
-)
+# KEYCLOAK = dict(
+#    client_id="<name_of_client>",
+#    client_secret="secret",
+#    discovery_url=f"http://localhost:8080/realms/<name_of_realm>/.well-known/openid-configuration",
+#    logout_url=f"http://localhost:8080/realms/<name_of_realm>/protocol/openid-connect/logout",
+# )
 
 # Chanjo database connection string - used by chanjo report to create coverage reports
 # SQLALCHEMY_DATABASE_URI = "mysql+pymysql://test_user:test_passwordw@127.0.0.1:3306/chanjo"

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -38,6 +38,14 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 #    discovery_url="https://accounts.google.com/.well-known/openid-configuration",
 # )
 
+# Parameters required for login with Keycloak
+KEYCLOAK = dict(
+    client_id="scout-client",
+    client_secret="3VFpvHLXUyiNMcCxGOKe5vld378yZLqd",
+    discovery_url=f"http://localhost:8080/realms/CG/.well-known/openid-configuration",
+    logout_url=f"http://localhost:8080/realms/CG/protocol/openid-connect/logout",
+)
+
 # Chanjo database connection string - used by chanjo report to create coverage reports
 # SQLALCHEMY_DATABASE_URI = "mysql+pymysql://test_user:test_passwordw@127.0.0.1:3306/chanjo"
 

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -42,8 +42,8 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # KEYCLOAK = dict(
 #    client_id="<name_of_client>",
 #    client_secret="secret",
-#    discovery_url=f"http://localhost:8080/realms/<name_of_realm>/.well-known/openid-configuration",
-#    logout_url=f"http://localhost:8080/realms/<name_of_realm>/protocol/openid-connect/logout",
+#    discovery_url="http://localhost:8080/realms/<name_of_realm>/.well-known/openid-configuration",
+#    logout_url="http://localhost:8080/realms/<name_of_realm>/protocol/openid-connect/logout",
 # )
 
 # Chanjo database connection string - used by chanjo report to create coverage reports

--- a/tests/server/blueprints/login/conftest.py
+++ b/tests/server/blueprints/login/conftest.py
@@ -15,7 +15,7 @@ def user_adapter(adapter, user_obj, institute_obj):
 
 @pytest.fixture
 def ldap_app(request):
-    """app ficture for testing LDAP connections."""
+    """app ficture for testing the LDAP login system."""
     config = {
         "TESTING": True,
         "DEBUG": True,
@@ -37,7 +37,7 @@ def ldap_app(request):
 
 @pytest.fixture
 def google_app(request):
-    """app ficture for testing LDAP connections."""
+    """app ficture for testing the Google login system."""
     config = {
         "TESTING": True,
         "DEBUG": True,
@@ -46,6 +46,32 @@ def google_app(request):
             "client_id": "test",
             "client_secret": "test",
             "discovery_url": "https://test.com",
+        },
+        "MONGO_DBNAME": "testdb",
+    }
+    app = create_app(config=config)
+    ctx = app.app_context()
+    ctx.push()
+
+    def teardown():
+        ctx.pop()
+
+    request.addfinalizer(teardown)
+    return app
+
+
+@pytest.fixture
+def keycloak_app(request):
+    """app ficture for testing the Keycloak login system."""
+    config = {
+        "TESTING": True,
+        "DEBUG": True,
+        "SERVER_NAME": "fakey.server.name",
+        "KEYCLOAK": {
+            "client_id": "test",
+            "client_secret": "test",
+            "discovery_url": "https://test.com",
+            "logout_url": "https://test.com/logout",
         },
         "MONGO_DBNAME": "testdb",
     }

--- a/tests/server/blueprints/login/conftest.py
+++ b/tests/server/blueprints/login/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 from scout.server.app import create_app
 
+SERVER_NAME = "test.server"
+
 
 @pytest.fixture
 def user_adapter(adapter, user_obj, institute_obj):
@@ -19,7 +21,7 @@ def ldap_app(request):
     config = {
         "TESTING": True,
         "DEBUG": True,
-        "SERVER_NAME": "fakey.server.name",
+        "SERVER_NAME": SERVER_NAME,
         "LDAP_HOST": "ldap://test_ldap_server",
         "WTF_CSRF_ENABLED": False,
         "MONGO_DBNAME": "testdb",
@@ -41,7 +43,7 @@ def google_app(request):
     config = {
         "TESTING": True,
         "DEBUG": True,
-        "SERVER_NAME": "fakey.server.name",
+        "SERVER_NAME": SERVER_NAME,
         "GOOGLE": {
             "client_id": "test",
             "client_secret": "test",
@@ -66,7 +68,7 @@ def keycloak_app(request):
     config = {
         "TESTING": True,
         "DEBUG": True,
-        "SERVER_NAME": "fakey.server.name",
+        "SERVER_NAME": SERVER_NAME,
         "KEYCLOAK": {
             "client_id": "test",
             "client_secret": "test",

--- a/tests/server/blueprints/login/test_views.py
+++ b/tests/server/blueprints/login/test_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import pytest
 from flask import redirect, url_for
 from flask_login import current_user
 
@@ -52,40 +53,49 @@ def test_ldap_login(ldap_app, user_obj, mocker):
         assert current_user.is_authenticated
 
 
-def test_google_login(google_app, user_obj, mocker):
-    """Test authentication using Google credentials."""
+@pytest.mark.parametrize(
+    "app_fixture, oauth_provider",
+    [
+        ("google_app", "google"),
+        ("keycloak_app", "keycloak"),
+    ],
+)
+def test_oauth_login(request, app_fixture, oauth_provider, user_obj, mocker):
+    """Test authentication using different providers (Google and Keycloak for now)."""
+
+    # Resolve the correct app fixture dynamically
+    app = request.getfixturevalue(app_fixture)
 
     # GIVEN a patched database containing the user
     mocker.patch("scout.server.blueprints.login.views.store.user", return_value=user_obj)
 
-    # GIVEN a set of patched responses from Google OAuth
+    # GIVEN a set of patched responses from the OAuth provider
     mock_redirect_to_auth = redirect(url_for("login.authorized"))
     mocker.patch(
-        "scout.server.blueprints.login.controllers.oauth_client.google.authorize_redirect",
+        f"scout.server.blueprints.login.controllers.oauth_client.{oauth_provider}.authorize_redirect",
         return_value=mock_redirect_to_auth,
     )
     mocker.patch(
-        "scout.server.blueprints.login.controllers.oauth_client.google.authorize_access_token",
+        f"scout.server.blueprints.login.controllers.oauth_client.{oauth_provider}.authorize_access_token",
         return_value={"access_token": "fake_access_token"},
     )
-    fake_google_user = {
+    fake_user = {
         "email": user_obj["email"],
         "name": user_obj["name"],
         "locale": "en",
     }
     mocker.patch(
-        "scout.server.blueprints.login.controllers.oauth_client.google.parse_id_token",
-        return_value=fake_google_user,
+        f"scout.server.blueprints.login.controllers.oauth_client.{oauth_provider}.parse_id_token",
+        return_value=fake_user,
     )
 
-    # GIVEN an initialized app with GOOGLE config params
-    with google_app.test_client() as client:
-
+    # GIVEN an initialized app with proper config
+    with app.test_client() as client:
         # GIVEN that session doesn't contain user data
         with client.session_transaction() as mock_session:
             assert "email" not in mock_session
 
-        with google_app.app_context():
+        with app.app_context():
             # THEN the login should be successful
             resp = client.post(url_for("login.login"), follow_redirects=True)
             assert resp.status_code == 200


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5315

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

**Prepare for testing**
- To launch and fix settings in Keycloak, follow the instructions provided in this document (until when you launch the app, which you do not need to do, since the test app now is scout) ---> https://github.com/northwestwitch/keycloak_flask_auth?tab=readme-ov-file#keycloak_flask_auth

**The only difference from that document that you should have these settings is this:
`Valid redirect URIs : http://localhost:5000/authorized`**
This way we can reuse the same redirect endpoint that is also used by the google login

**How to test**:
- [x] On stage, deploy this branch and make sure that the Google login still works
- [x] Locally, uncomment the new settings and fill in the specifics of your keycloak instance
- [x] Launch a scout web instance as usual and test that the connection goes thru Keycloak (localhost:5000)
- [x] Bonus test: logout and check that the active session is gone also from keycloak (under user):

<img width="1132" alt="image" src="https://github.com/user-attachments/assets/38219a3e-a125-470a-adf7-ec1168556789" />


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN
