### PR TITLE
Ensembl data integrity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests for the Google login functionality (#5335)
 - Support for login using Keycloak (#5337)
 - Documentation on Keycloak login system integration (#5342)
+- Integrity check for genes/transcripts/exons file downloaded from Ensembl
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/scout/commands/download/ensembl.py
+++ b/scout/commands/download/ensembl.py
@@ -18,9 +18,9 @@ LOG = logging.getLogger(__name__)
 def integrity_check(nr_chromosomes_in_file: int):
     if nr_chromosomes_in_file < NR_EXPECTED_CHROMS:
         raise BufferError(
-            f"Ensembl resource does not seem to be complete. Please retry downloading the file."
+            "Ensembl resource does not seem to be complete. Please retry downloading the file."
         )
-    LOG.info(f"Integrity check OK.")
+    LOG.info("Integrity check OK.")
 
 
 def print_ensembl(

--- a/scout/commands/download/ensembl.py
+++ b/scout/commands/download/ensembl.py
@@ -2,7 +2,6 @@
 
 import logging
 import pathlib
-import time
 from typing import List, Optional
 
 import click

--- a/scout/commands/download/ensembl.py
+++ b/scout/commands/download/ensembl.py
@@ -40,6 +40,8 @@ def print_ensembl(
 
         LOG.info(f"{file_name} file saved to disk")
 
+        ensembl_client.check_integrity(file_path)
+
 
 @click.command("ensembl", help="Download files with ensembl info")
 @click.option("-o", "--out-dir", default="./", show_default=True)

--- a/scout/commands/download/ensembl.py
+++ b/scout/commands/download/ensembl.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 def integrity_check(nr_chromosomes_in_file: int):
     if nr_chromosomes_in_file < NR_EXPECTED_CHROMS:
         raise BufferError(
-            "Ensembl resource does not seem to be complete. Please retry downloading the file."
+            "Ensembl resource does not seem to be complete. Please retry downloading genes/transcripts."
         )
     LOG.info("Integrity check OK.")
 

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -32,3 +32,19 @@ class EnsemblBiomartHandler:
         shug_url: str = f"{SCHUG_BASE}{SCHUG_RESOURCE_URL[interval_type]}{self.build}"
 
         return self.stream_get(shug_url)
+
+    def check_integrity(self, file_path: str):
+        """Counts the number of lines containing '[success]'. One such line per chromosome is expected for the file to be considered intact."""
+
+        def count_line_occurrences(file_path, target_line):
+            with open(file_path, "r", encoding="utf-8") as file:
+                return sum(1 for line in file if line.strip() == target_line)
+
+        nr_chromosomes_in_file = count_line_occurrences(file_path, "[success]")
+        nr_chromosomes = 24
+        if nr_chromosomes_in_file < nr_chromosomes:
+            raise BufferError(
+                f"Ensembl resource {file_path} does not seem to be complete. Please retry downloading the file."
+            )
+
+        LOG.info("Integrity check OK")

--- a/scout/utils/ensembl_biomart_clients.py
+++ b/scout/utils/ensembl_biomart_clients.py
@@ -32,19 +32,3 @@ class EnsemblBiomartHandler:
         shug_url: str = f"{SCHUG_BASE}{SCHUG_RESOURCE_URL[interval_type]}{self.build}"
 
         return self.stream_get(shug_url)
-
-    def check_integrity(self, file_path: str):
-        """Counts the number of lines containing '[success]'. One such line per chromosome is expected for the file to be considered intact."""
-
-        def count_line_occurrences(file_path, target_line):
-            with open(file_path, "r", encoding="utf-8") as file:
-                return sum(1 for line in file if line.strip() == target_line)
-
-        nr_chromosomes_in_file = count_line_occurrences(file_path, "[success]")
-        nr_chromosomes = 24
-        if nr_chromosomes_in_file < nr_chromosomes:
-            raise BufferError(
-                f"Ensembl resource {file_path} does not seem to be complete. Please retry downloading the file."
-            )
-
-        LOG.info("Integrity check OK")

--- a/tests/commands/download/test_download_ensembl_cmd.py
+++ b/tests/commands/download/test_download_ensembl_cmd.py
@@ -32,7 +32,7 @@ def test_print_ensembl_genes(mocker, genes37_handle):
     # GIVEN a patched call to schug
     # GIVEN a patched response from Ensembl Biomart, via schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=genes37_handle)
-    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
+    mocker.patch("scout.commands.download.ensembl.integrity_check")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -53,7 +53,7 @@ def test_print_ensembl_transcripts(mocker, transcripts_handle):
 
     # GIVEN a patched call to schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=transcripts_handle)
-    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
+    mocker.patch("scout.commands.download.ensembl.integrity_check")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -74,7 +74,7 @@ def test_print_ensembl_exons(mocker, exons_handle):
 
     # GIVEN a patched call to schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=exons_handle)
-    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
+    mocker.patch("scout.commands.download.ensembl.integrity_check")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()

--- a/tests/commands/download/test_download_ensembl_cmd.py
+++ b/tests/commands/download/test_download_ensembl_cmd.py
@@ -32,6 +32,7 @@ def test_print_ensembl_genes(mocker, genes37_handle):
     # GIVEN a patched call to schug
     # GIVEN a patched response from Ensembl Biomart, via schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=genes37_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -52,6 +53,7 @@ def test_print_ensembl_transcripts(mocker, transcripts_handle):
 
     # GIVEN a patched call to schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=transcripts_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()
@@ -72,6 +74,7 @@ def test_print_ensembl_exons(mocker, exons_handle):
 
     # GIVEN a patched call to schug
     mocker.patch.object(EnsemblBiomartHandler, "stream_get", return_value=exons_handle)
+    mocker.patch.object(EnsemblBiomartHandler, "check_integrity")
 
     # GIVEN a temporary directory where the ensembl genes will be saved
     dir_name = tempfile.TemporaryDirectory()


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5352 

Tested locally:
- Genes 37 🆗 
- Genes 38 🆗 
- Transcripts 37 🆗 
- Transcripts 38 ❌ - incomplete file

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/3d748364-c39d-4a39-9eb0-a5784c3599f5" />






<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
