### PR TITLE
Custom ID/name for PanelApp updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Support for login using Keycloak (#5337)
 - Documentation on Keycloak login system integration (#5342)
 - Integrity check for genes/transcripts/exons file downloaded from Ensembl
-- Options for custom ID/display name for PanelApp Green updates
+- Options for custom ID/display name for PanelApp Green updates (#5355)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Support for login using Keycloak (#5337)
 - Documentation on Keycloak login system integration (#5342)
 - Integrity check for genes/transcripts/exons file downloaded from Ensembl
+- Options for custom ID/display name for PanelApp Green updates
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -34,7 +34,7 @@ LOG = logging.getLogger(__name__)
 @click.option("--panel-id", help="Panel ID", default="PANELAPP-GREEN", show_default=True)
 @click.option(
     "--panel-display-name",
-    help="Use a custom display name",
+    help="Panel display name",
     default="PanelApp Green Genes",
     show_default=True,
 )

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Force update even if updated panel contains less genes",
 )
-@click.option("--panel-id", help="Use a custom ID", default="PANELAPP-GREEN", show_default=True)
+@click.option("--panel-id", help="Panel ID", default="PANELAPP-GREEN", show_default=True)
 @click.option(
     "--panel-display-name",
     help="Use a custom display name",

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -31,8 +31,10 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Force update even if updated panel contains less genes",
 )
+@click.option("--panel-id", help="Use a custom ID")
+@click.option("--panel-display-name", help="Use a custom display name")
 @with_appcontext
-def panelapp_green(institute, force, signed_off):
+def panelapp_green(institute, force, signed_off, panel_id, panel_display_name):
     """
     Update the automatically generated PanelApp Green Genes panel in the database.
     """
@@ -47,7 +49,12 @@ def panelapp_green(institute, force, signed_off):
 
     try:
         load_panelapp_green_panel(
-            adapter=store, institute=institute, force=force, signed_off=signed_off
+            adapter=store,
+            institute=institute,
+            force=force,
+            signed_off=signed_off,
+            custom_id=panel_id,
+            custom_display_name=panel_display_name,
         )
     except Exception as err:
         LOG.error(err)

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -31,8 +31,8 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Force update even if updated panel contains less genes",
 )
-@click.option("--panel-id", help="Use a custom ID")
-@click.option("--panel-display-name", help="Use a custom display name")
+@click.option("--panel-id", help="Use a custom ID", default="PANELAPP-GREEN", show_default=True)
+@click.option("--panel-display-name", help="Use a custom display name", default="PanelApp Green Genes", show_default=True)
 @with_appcontext
 def panelapp_green(institute, force, signed_off, panel_id, panel_display_name):
     """

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -58,8 +58,8 @@ def panelapp_green(institute, force, signed_off, panel_id, panel_display_name):
             institute=institute,
             force=force,
             signed_off=signed_off,
-            custom_id=panel_id,
-            custom_display_name=panel_display_name,
+            panel_id=panel_id,
+            panel_display_name=panel_display_name,
         )
     except Exception as err:
         LOG.error(err)

--- a/scout/commands/update/panelapp.py
+++ b/scout/commands/update/panelapp.py
@@ -5,6 +5,7 @@ import logging
 import click
 from flask.cli import current_app, with_appcontext
 
+from scout.constants.panels import PANELAPPGREEN_DISPLAY_NAME, PANELAPPGREEN_NAME
 from scout.load.panelapp import load_panelapp_green_panel
 from scout.server.extensions import store
 
@@ -31,11 +32,11 @@ LOG = logging.getLogger(__name__)
     is_flag=True,
     help="Force update even if updated panel contains less genes",
 )
-@click.option("--panel-id", help="Panel ID", default="PANELAPP-GREEN", show_default=True)
+@click.option("--panel-id", help="Panel ID", default=PANELAPPGREEN_NAME, show_default=True)
 @click.option(
     "--panel-display-name",
     help="Panel display name",
-    default="PanelApp Green Genes",
+    default=PANELAPPGREEN_DISPLAY_NAME,
     show_default=True,
 )
 @with_appcontext

--- a/scout/constants/panels.py
+++ b/scout/constants/panels.py
@@ -25,3 +25,6 @@ PRESELECTED_PANELAPP_PANEL_TYPE_SLUGS = [
     "gms-signed-off",
     "rare-disease-100k",
 ]
+
+PANELAPPGREEN_NAME = "PANELAPP-GREEN"
+PANELAPPGREEN_DISPLAY_NAME = "PanelApp Green Genes"

--- a/scout/load/panelapp.py
+++ b/scout/load/panelapp.py
@@ -11,7 +11,6 @@ from scout.parse.panelapp import parse_panelapp_panel
 from scout.server.extensions import panelapp
 
 LOG = logging.getLogger(__name__)
-PANEL_NAME = "PANELAPP-GREEN"
 
 
 def load_panelapp_panel(

--- a/scout/load/panelapp.py
+++ b/scout/load/panelapp.py
@@ -72,7 +72,14 @@ def get_panelapp_genes(
     return genes
 
 
-def load_panelapp_green_panel(adapter: MongoAdapter, institute: str, force: bool, signed_off: bool):
+def load_panelapp_green_panel(
+    adapter: MongoAdapter,
+    institute: str,
+    force: bool,
+    signed_off: bool,
+    custom_id: str | None,
+    custom_display_name: str | None,
+):
     """Load/Update the panel containing all Panelapp Green genes."""
 
     def parse_types_filter(types_filter: str, available_types: List[str]) -> List[str]:
@@ -85,10 +92,15 @@ def load_panelapp_green_panel(adapter: MongoAdapter, institute: str, force: bool
         return [available_types[i] for i in index_list]
 
     # check and set panel version
-    old_panel = adapter.gene_panel(panel_id=PANEL_NAME)
+    panel_id = custom_id if custom_id is not None else PANEL_NAME
+    panel_display_name = (
+        custom_display_name if custom_display_name is not None else "PanelApp Green Genes"
+    )
+
+    old_panel = adapter.gene_panel(panel_id=panel_id)
     green_panel = {
-        "panel_name": PANEL_NAME,
-        "display_name": "PanelApp Green Genes",
+        "panel_name": panel_id,
+        "display_name": panel_display_name,
         "institute": institute,
         "version": float(math.floor(old_panel["version"]) + 1) if old_panel else 1.0,
         "date": datetime.now(),

--- a/scout/load/panelapp.py
+++ b/scout/load/panelapp.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from datetime import datetime
-from typing import List, Optional, Set
+from typing import List, Set
 
 from click import progressbar
 

--- a/scout/load/panelapp.py
+++ b/scout/load/panelapp.py
@@ -77,8 +77,8 @@ def load_panelapp_green_panel(
     institute: str,
     force: bool,
     signed_off: bool,
-    custom_id: Optional[str],
-    custom_display_name: Optional[str],
+    panel_id: str,
+    panel_display_name: str,
 ):
     """Load/Update the panel containing all Panelapp Green genes."""
 
@@ -92,11 +92,6 @@ def load_panelapp_green_panel(
         return [available_types[i] for i in index_list]
 
     # check and set panel version
-    panel_id = custom_id if custom_id is not None else PANEL_NAME
-    panel_display_name = (
-        custom_display_name if custom_display_name is not None else "PanelApp Green Genes"
-    )
-
     old_panel = adapter.gene_panel(panel_id=panel_id)
     green_panel = {
         "panel_name": panel_id,

--- a/scout/load/panelapp.py
+++ b/scout/load/panelapp.py
@@ -1,7 +1,7 @@
 import logging
 import math
 from datetime import datetime
-from typing import List, Set
+from typing import List, Optional, Set
 
 from click import progressbar
 
@@ -77,8 +77,8 @@ def load_panelapp_green_panel(
     institute: str,
     force: bool,
     signed_off: bool,
-    custom_id: str | None,
-    custom_display_name: str | None,
+    custom_id: Optional[str],
+    custom_display_name: Optional[str],
 ):
     """Load/Update the panel containing all Panelapp Green genes."""
 

--- a/tests/commands/update/test_update_panelapp_green.py
+++ b/tests/commands/update/test_update_panelapp_green.py
@@ -6,13 +6,12 @@ import responses
 
 from scout.commands import cli
 from scout.demo import panelapp_panel_path, panelapp_panels_reduced_path
-from scout.load.panelapp import PANEL_NAME
 from scout.server.extensions import store
 from scout.server.extensions.panelapp_extension import API_PANELS_URL
 
 DEMO_PANEL = "522"
 PANELAPP_GET_PANEL_URL = f"{API_PANELS_URL}{DEMO_PANEL}"
-
+PANEL_NAME = "PANELAPP-GREEN"
 
 def test_update_panelapp_green_non_existing_institute(empty_mock_app):
     """Tests the CLI that updates PANELAPP-GREEN panel in database, when provided institute id doesn't exist"""

--- a/tests/commands/update/test_update_panelapp_green.py
+++ b/tests/commands/update/test_update_panelapp_green.py
@@ -5,13 +5,13 @@ import json
 import responses
 
 from scout.commands import cli
+from scout.constants.panels import PANELAPPGREEN_NAME
 from scout.demo import panelapp_panel_path, panelapp_panels_reduced_path
 from scout.server.extensions import store
 from scout.server.extensions.panelapp_extension import API_PANELS_URL
 
 DEMO_PANEL = "522"
 PANELAPP_GET_PANEL_URL = f"{API_PANELS_URL}{DEMO_PANEL}"
-PANEL_NAME = "PANELAPP-GREEN"
 
 
 def test_update_panelapp_green_non_existing_institute(empty_mock_app):
@@ -36,7 +36,7 @@ def test_update_green_panel(mock_app):
     """Tests the CLI that creates/updates PANELAPP-GREEN panel in database"""
 
     # GIVEN that no PANELAPP-GREEN panel exists in database:
-    assert store.gene_panel(panel_id=PANEL_NAME) is None
+    assert store.gene_panel(panel_id=PANELAPPGREEN_NAME) is None
 
     # GIVEN a mocked response from PanelApp list_panels endpoint
     with open(panelapp_panels_reduced_path) as f:
@@ -71,22 +71,22 @@ def test_update_green_panel(mock_app):
     assert result.exit_code == 0
 
     # AND the panel should have been saved in database
-    green_panel = store.gene_panel(panel_id=PANEL_NAME)
+    green_panel = store.gene_panel(panel_id=PANELAPPGREEN_NAME)
 
     # GIVEN that the old saved panel contains one extra gene
     extra_gene = {"hgnc_id": 7227, "symbol": "MRAS"}
     store.panel_collection.find_one_and_update(
-        {"panel_name": PANEL_NAME}, {"$push": {"genes": extra_gene}}
+        {"panel_name": PANELAPPGREEN_NAME}, {"$push": {"genes": extra_gene}}
     )
 
     # WHEN panel is updated without the force flag
     runner.invoke(cli, ["update", "panelapp-green", "-i", "cust000"], input="1")
 
     # THEN PanelApp Green panel should NOT be updated
-    assert store.gene_panel(panel_id=PANEL_NAME)["version"] == green_panel["version"]
+    assert store.gene_panel(panel_id=PANELAPPGREEN_NAME)["version"] == green_panel["version"]
 
     # WHEN updating the panel with the force flag
     runner.invoke(cli, ["update", "panelapp-green", "-i", "cust000", "-f"], input="1")
 
     # THEN PanelApp Green panel should be updated
-    assert store.gene_panel(panel_id=PANEL_NAME)["version"] > green_panel["version"]
+    assert store.gene_panel(panel_id=PANELAPPGREEN_NAME)["version"] > green_panel["version"]

--- a/tests/commands/update/test_update_panelapp_green.py
+++ b/tests/commands/update/test_update_panelapp_green.py
@@ -13,6 +13,7 @@ DEMO_PANEL = "522"
 PANELAPP_GET_PANEL_URL = f"{API_PANELS_URL}{DEMO_PANEL}"
 PANEL_NAME = "PANELAPP-GREEN"
 
+
 def test_update_panelapp_green_non_existing_institute(empty_mock_app):
     """Tests the CLI that updates PANELAPP-GREEN panel in database, when provided institute id doesn't exist"""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

Close #5354

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
