### PR TITLE
Fix #5356 - move de novo and paraphase tracks to own sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Refactored the liftover functionality to avoid using the old Ensembl REST API (#5326)
 - Downloading of Ensembl resources by fixing the URL to the schug server, pointing to the production instance instead of the staging one (#5348)
 - Missing MT genes from the IGV track (#5339)
+- Paraphase and de novo assembly tracks could mismatch alignment sample labels - refactor to case specific tracks (#5357)
 
 ## [4.98]
 ### Added

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -124,6 +124,8 @@ HUMAN_GENES_38 = {
 }
 
 CASE_SPECIFIC_TRACKS = {
+    "paraphase_alignments": "Paraphase Alignment",
+    "assembly_alignments": "de novo Assembly Alignment",
     "rhocall_beds": "Rhocall Zygosity",
     "rhocall_wigs": "Rhocall Regions",
     "tiddit_coverage_wigs": "TIDDIT Coverage",

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -41,6 +41,8 @@ samples:
         'vcf': 'scout/demo/REViewer_test_data/justhusky_exphun_hugelymodelbat.vcf'
         'catalog': 'scout/demo/REViewer_test_data/catalog_test.json'
     omics_sample_id: RNA1059A2
+    assembly_alignment_path: scout/demo/reduced_mt.bam
+    paraphase_alignment_path: scout/demo/reduced_mt.bam
     rna_alignment_path: scout/demo/reduced_mt.bam
     rna_coverage_bigwig: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered.bigWig
     splice_junctions_bed: scout/demo/ACC5963A1_lanes_1234_star_sorted_sj_filtered_sorted.bed.gz

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -271,7 +271,11 @@ def set_tracks(name_list, file_list):
     for name, track in zip(name_list, file_list):
         if track == "missing":
             continue
-        track_list.append({"name": name, "url": track, "min": 0.0, "max": 30.0})
+        track_config = {"name": name, "url": track, "min": 0.0, "max": 30.0}
+        index = find_index(track)
+        if index:
+            track_config["index"] = index
+        track_list.append(track_config)
     return track_list
 
 
@@ -355,6 +359,7 @@ def set_case_specific_tracks(display_obj, case_obj):
 
         labels = [f"{label} - {sample}" for sample in case_obj.get("sample_names")]
 
+        set_tracks(labels, case_obj.get(track))
         track_info = set_tracks(labels, case_obj.get(track))
         display_obj[track] = track_info
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -86,6 +86,30 @@
                           {% endif %}
                         },
                       {% endfor %}
+                      {% for ptrack in paraphase_alignments %}
+                      {
+                        type: "{{ ptrack.type }}",
+                        name: "{{ ptrack.name }}",
+                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url) }}',
+                        format: 'bw',
+                         indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL)  }}',
+                        min: '{{ ptrack.min }}',
+                        max: '{{ ptrack.max }}',
+                        sourceType: 'file'
+                      },
+                      {% endfor %}
+                      {% for atrack in assembly_alignments %}
+                      {
+                        type: "{{ atrack.type }}",
+                        name: "{{ atrack.name }}",
+                        url: '{{ url_for("alignviewers.remote_static", file=atrack.url) }}',
+                        format: 'bw',
+                         indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL)  }}',
+                        min: '{{ atrack.min }}',
+                        max: '{{ atrack.max }}',
+                        sourceType: 'file'
+                      },
+                      {% endfor %}
                       {% for wtrack in rhocall_wigs %}
                       {
                         type: "wig",
@@ -96,7 +120,7 @@
                         color: "rgb(60, 37, 17)",
                         min: '{{ wtrack.min }}',
                         max: '{{ wtrack.max }}',
-                        sourceType: 'file'
+                        sourceType: 'file',
                       },
                       {% endfor %}
                       {% for btrack in rhocall_beds %}

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -309,12 +309,19 @@ def case_append_alignments(case_obj: dict):
     """Deconvolute information about files to case_obj.
 
     This function prepares bam/cram files and their indexes for easy access in templates.
+
+    index is set only if it is expected as a separate key on the indiviudal: an
+    attempt at discovery is still made for files with index: None.
     """
     unwrap_settings = [
         {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
-        {"path": "assembly_alignment_path", "append_to": "bam_files", "index": "bai_files"},
+        {"path": "assembly_alignment_path", "append_to": "assembly_alignments", "index": None},
         {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
-        {"path": "paraphase_alignment_path", "append_to": "bam_files", "index": "bai_files"},
+        {
+            "path": "paraphase_alignment_path",
+            "append_to": "paraphase_alignments",
+            "index": None,
+        },
         {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
         {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
         {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
