### PR TITLE
Partially fix #4048 - add links to cspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
-- Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5361)
+- Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
+- Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5361)
 ### Changed
-- Allow matching compounded subcategories from SV callers e.g. DUP:INV (#4057)
+- Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 
@@ -23,7 +26,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Documentation on Keycloak login system integration (#5342)
 - Integrity check for genes/transcripts/exons files downloaded from Ensembl (#5353)
 - Options for custom ID/display name for PanelApp Green updates (#5355)
-- Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 ### Changed
 - Allow ACMG criteria strength modification to Very strong/Stand-alone (#5297)
 - Mocked the Ensembl liftover service in igv tracks tests (#5319)

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -653,6 +653,12 @@ def variant_acmg(store: MongoAdapter, institute_id: str, case_name: str, variant
         store, variant_obj, institute_id, case_name
     )
 
+    genome_build = str(case_obj.get("genome_build", "37"))
+    if genome_build not in ["37", "38"]:
+        genome_build = "37"
+
+    add_gene_info(store, variant_obj, genome_build=genome_build)
+
     return dict(
         institute=institute_obj,
         case=case_obj,

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -105,6 +105,14 @@
           </div>
         {% endfor %}
       </div>
+    <!-- external links -->
+    <div class="card panel-default mt-3">
+      <div class="card-body">
+        {% for gene in variant.genes %}
+          <a href="{{ gene.cspec_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Search {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }} ClinGen CSPEC</a>
+        {% endfor %}
+      </div>
+    </div>
     <!-- classification preview in the footer-->
       <div class="mt-3 fixed-bottom bg-light border">
         <div class="row">

--- a/scout/server/blueprints/variant/templates/variant/acmg.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg.html
@@ -108,8 +108,9 @@
     <!-- external links -->
     <div class="card panel-default mt-3">
       <div class="card-body">
+        Search ClinGen Criteria Specifications (CSPEC):
         {% for gene in variant.genes %}
-          <a href="{{ gene.cspec_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">Search {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }} ClinGen CSPEC</a>
+          <a href="{{ gene.cspec_link }}" class="btn btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank">{{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}</a>
         {% endfor %}
       </div>
     </div>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -54,6 +54,7 @@ def add_gene_links(
     gene_obj["string_link"] = string(ensembl_id)
     gene_obj["reactome_link"] = reactome(ensembl_id)
     gene_obj["clingen_link"] = clingen(hgnc_id)
+    gene_obj["cspec_link"] = clingen_cspec(hgnc_id)
     gene_obj["gencc_link"] = gencc(hgnc_id)
     gene_obj["expression_atlas_link"] = expression_atlas(ensembl_id)
     gene_obj["exac_link"] = exac(ensembl_id)
@@ -252,6 +253,13 @@ def reactome(ensembl_id):
 
 def clingen(hgnc_id):
     link = "https://search.clinicalgenome.org/kb/genes/HGNC:{}"
+    if not hgnc_id:
+        return None
+    return link.format(hgnc_id)
+
+
+def clingen_cspec(hgnc_id):
+    link = "https://cspec.genome.network/cspec/ui/svi/?search=HGNC:{}"
     if not hgnc_id:
         return None
     return link.format(hgnc_id)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Partially fix #4048 - add link to CSPEC. They do have JSONs for retrieval and use in adapting the whole ACMG page, but that is a big project, which will need to be revamped considerably when ACMG v4 goes live: it is in an early pilot stage right now.
 
![Screenshot 2025-03-28 at 14 04 37](https://github.com/user-attachments/assets/d9e248a1-f4ba-4dab-a6b6-c2bc526f2498)

![Screenshot 2025-03-28 at 14 14 17](https://github.com/user-attachments/assets/24f7336f-71e6-40c6-8b0c-d4bf0a327f8c)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
