### PR TITLE
Filter cancer SNVs by oncogenicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
+- Filter cancer SNV by ClinVar oncogenicity
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
 - Documentation on how to export data from the scout database using the command line
-- Filter cancer SNVs by ClinVar oncogenicity
+- Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive.
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
 - Documentation on how to export data from the scout database using the command line
-- Filter cancer SNV by ClinVar oncogenicity
+- Filter cancer SNVs by ClinVar oncogenicity
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -387,6 +387,7 @@ class QueryHandler(object):
             else:
                 mongo_query["$and"] = coordinate_query
 
+        LOG.warning(mongo_query)
         return mongo_query
 
     def soft_filters_query(self, query: dict, mongo_query: dict):
@@ -861,7 +862,7 @@ class QueryHandler(object):
                         {
                             "$or": [
                                 {
-                                    "clinsig_onc": {"$not": elem_match["value"]}
+                                    "clnsig_onc": {"$not": elem_match["value"]}
                                 },  # Exclude values in `elem_match`
                                 CLNSIG_ONC_NOT_EXISTS,  # Field does not exist
                                 CLNSIG_ONC_NULL,  # Field is null
@@ -869,7 +870,7 @@ class QueryHandler(object):
                         }
                     )
                 else:
-                    mongo_secondary_query.append({"clinsig_onc": elem_match})
+                    mongo_secondary_query.append({"clnsig_onc": elem_match})
 
         return mongo_secondary_query
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -387,7 +387,6 @@ class QueryHandler(object):
             else:
                 mongo_query["$and"] = coordinate_query
 
-        LOG.warning(mongo_query)
         return mongo_query
 
     def soft_filters_query(self, query: dict, mongo_query: dict):

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -13,7 +13,9 @@ from scout.constants import (
 )
 
 CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
+CLNSIG_ONC_NOT_EXISTS = {"clnsig_onc": {"$exists": False}}
 CLNSIG_NULL = {"clnsig": {"$eq": None}}
+CLNSIG_ONC_NULL = {"clnsig_onc": {"$eq": None}}
 CRITERION_EXCLUDE_OPERATOR = {False: "$in", True: "$nin"}
 EXISTS = {"$exists": True}
 NOT_EXISTS = {"$exists": False}
@@ -849,6 +851,25 @@ class QueryHandler(object):
                 for caller in query.get("fusion_caller", []):
                     fusion_caller_query.append({caller: "Pass"})
                 mongo_secondary_query.append({"$or": fusion_caller_query})
+
+            if criterion == "clinsig_onc":
+
+                elem_match = {"value": re.compile("|".join(query.get("clinsig_onc")))}
+
+                if query.get("clinsig_onc_exclude"):
+                    mongo_secondary_query.append(
+                        {
+                            "$or": [
+                                {
+                                    "clinsig_onc": {"$not": elem_match["value"]}
+                                },  # Exclude values in `elem_match`
+                                CLNSIG_ONC_NOT_EXISTS,  # Field does not exist
+                                CLNSIG_ONC_NULL,  # Field is null
+                            ]
+                        }
+                    )
+                else:
+                    mongo_secondary_query.append({"clinsig_onc": elem_match})
 
         return mongo_secondary_query
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -855,14 +855,14 @@ class QueryHandler(object):
 
             if criterion == "clinsig_onc":
 
-                elem_match = {"value": re.compile("|".join(query.get("clinsig_onc")))}
+                elem_match = re.compile("|".join(query.get("clinsig_onc")))
 
                 if query.get("clinsig_onc_exclude"):
                     mongo_secondary_query.append(
                         {
                             "$or": [
                                 {
-                                    "clnsig_onc": {"$not": elem_match["value"]}
+                                    "clnsig_onc.value": {"$not": elem_match}
                                 },  # Exclude values in `elem_match`
                                 CLNSIG_ONC_NOT_EXISTS,  # Field does not exist
                                 CLNSIG_ONC_NULL,  # Field is null
@@ -870,7 +870,7 @@ class QueryHandler(object):
                         }
                     )
                 else:
-                    mongo_secondary_query.append({"clnsig_onc": elem_match})
+                    mongo_secondary_query.append({"clnsig_onc.value": elem_match})
 
         return mongo_secondary_query
 

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -37,7 +37,7 @@ from .clinvar import (
     GERMLINE_CLASSIF_TERMS,
     MULTIPLE_CONDITION_EXPLANATION,
 )
-from .clnsig import CLINSIG_MAP, REV_CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
+from .clnsig import CLINSIG_MAP, ONC_CLNSIG, REV_CLINSIG_MAP, TRUSTED_REVSTAT_LEVEL
 from .disease_parsing import (
     DISEASE_INHERITANCE_TERMS,
     ENTRY_PATTERN,
@@ -68,7 +68,12 @@ from .gene_tags import (
     PANEL_GENE_INFO_TRANSCRIPTS,
     UPDATE_GENES_RESOURCES,
 )
-from .igv_tracks import CASE_SPECIFIC_TRACKS, HUMAN_REFERENCE, IGV_TRACKS, USER_DEFAULT_TRACKS
+from .igv_tracks import (
+    CASE_SPECIFIC_TRACKS,
+    HUMAN_REFERENCE,
+    IGV_TRACKS,
+    USER_DEFAULT_TRACKS,
+)
 from .indexes import ID_PROJECTION, INDEXES
 from .panels import PANELAPP_CONFIDENCE_EXCLUDE
 from .phenotype import (

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -62,4 +62,5 @@ SECONDARY_CRITERIA = [
     "split_reads",
     "fusion_caller",
     "rank_score",
+    "clinsig_onc",
 ]

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -39,7 +39,7 @@ from scout.constants import (
 LOG = logging.getLogger(__name__)
 
 CLINSIG_OPTIONS = list(CLINSIG_MAP.items())
-ONC_CLNSIG_OPTIONS = [(term, term.lower) for term in ONC_CLNSIG]
+ONC_CLNSIG_OPTIONS = [(term.lower().replace(" ", "_"), term) for term in ONC_CLNSIG]
 FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
 REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
 SV_TYPE_CHOICES = [(term, term.replace("_", " ").upper()) for term in SV_TYPES]
@@ -114,7 +114,7 @@ class VariantFiltersForm(FlaskForm):
     compound_rank_score = IntegerField("Compound rank score")
     compound_follow_filter = BooleanField("Compounds follow filter")
     cadd_inclusive = BooleanField("CADD inclusive")
-    clinsig = NonValidatingSelectMultipleField("ClinVar CLINSIG", choices=CLINSIG_OPTIONS)
+    clinsig = NonValidatingSelectMultipleField("ClinVar significance", choices=CLINSIG_OPTIONS)
     clinsig_exclude = BooleanField("Exclude")
     clinvar_tag = BooleanField("ClinVar hits only")
     prioritise_clinvar = BooleanField("Prioritise ClinVar")

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -28,6 +28,7 @@ from scout.constants import (
     CLINSIG_MAP,
     FEATURE_TYPES,
     GENETIC_MODELS,
+    ONC_CLNSIG,
     OUTLIER_TYPES,
     SO_TERMS,
     SPIDEX_LEVELS,
@@ -38,6 +39,7 @@ from scout.constants import (
 LOG = logging.getLogger(__name__)
 
 CLINSIG_OPTIONS = list(CLINSIG_MAP.items())
+ONC_CLNSIG_OPTIONS = [(term, term.lower) for term in ONC_CLNSIG]
 FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
 REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
 SV_TYPE_CHOICES = [(term, term.replace("_", " ").upper()) for term in SV_TYPES]
@@ -114,6 +116,7 @@ class VariantFiltersForm(FlaskForm):
     cadd_inclusive = BooleanField("CADD inclusive")
     clinsig = NonValidatingSelectMultipleField("ClinVar CLINSIG", choices=CLINSIG_OPTIONS)
     clinsig_exclude = BooleanField("Exclude")
+    clinvar_tag = BooleanField("ClinVar hits only")
     prioritise_clinvar = BooleanField("Prioritise ClinVar")
 
     gnomad_frequency = BetterDecimalField("gnomadAF", validators=[validators.Optional()])
@@ -183,7 +186,6 @@ class FiltersForm(VariantFiltersForm):
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
     clinical_filter = SubmitField(label="Clinical filter")
-    clinvar_tag = BooleanField("ClinVar hits only")
 
     # polymorphic constant base for clinical filter
     clinical_filter_base = CLINICAL_FILTER_BASE
@@ -196,8 +198,11 @@ class CancerFiltersForm(VariantFiltersForm):
     alt_count = IntegerField("Min alt count", validators=[validators.Optional()])
     control_frequency = BetterDecimalField("Normal alt AF <", validators=[validators.Optional()])
     tumor_frequency = BetterDecimalField("Tumor alt AF >", validators=[validators.Optional()])
-    clinvar_tag = BooleanField("ClinVar hits only")
     cosmic_tag = BooleanField("Cosmic hits")
+    clinsig_onc = NonValidatingSelectMultipleField(
+        "ClinVar oncogenicity", choices=ONC_CLNSIG_OPTIONS
+    )
+    clinsig_onc_exclude = BooleanField("Exclude")
     mvl_tag = BooleanField("Managed Variants hits")
     local_obs_cancer_somatic_old = IntegerField(
         "Local somatic obs. (archive)", validators=[validators.Optional()]

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -727,21 +727,12 @@
         {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
       </div>
       <div class="col-2">
-        <div class="form-check d-flex justify-content-start">
-          {{ form.mvl_tag(class="form-check-input",type="checkbox") }}
-          {{ form.mvl_tag.label(class="ms-2 form-check-label") }}
-        </div>
-        <div class="form-check d-flex justify-content-start">
-          {{ form.clinvar_tag(class="form-check-input",type="checkbox") }}
-          {{ form.clinvar_tag.label(class="ms-2 form-check-label") }}
-        </div>
-        <div class="form-check d-flex justify-content-start">
-          {{ form.cosmic_tag(class="form-check-input",type="checkbox") }}
-          {{ form.cosmic_tag.label(class="ms-2 form-check-label") }}
-        </div>
+        <span>{{ form.clinsig_onc.label(class="control-label") }}</span>
+        <span style="float:right;">{{ form.clinsig_onc_exclude.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Exclude variants with oncogenicity among the selected categories.") }} {{form.clinsig_onc_exclude}}</span>
+        {{ form.clinsig_onc(class="selectpicker", data_style="btn-secondary") }}
       </div>
     </div>
-    <div class="row">
+    <div class="row mt-2">
       <div class="col-4">
         {{ form.hgnc_symbols.label(class="control-label") }}
         {{ form.hgnc_symbols(class="form-control") }}
@@ -762,13 +753,27 @@
         {{ form.alt_count.label(class="control-label") }}
         {{ form.alt_count(class="form-control") }}
       </div>
-      <div class="col-2">
+      <div class="col-1">
         {{ form.tumor_frequency.label(class="control-label") }}
         {{ form.tumor_frequency(class="form-control", min="0", max=1) }}
       </div>
-      <div class="col-2">
+      <div class="col-1">
         {{ form.control_frequency.label(class="control-label") }}
         {{ form.control_frequency(class="form-control", min="0", max=1) }}
+      </div>
+      <div class="col-2">
+        <div class="form-check d-flex justify-content-start">
+          {{ form.mvl_tag(class="form-check-input",type="checkbox") }}
+          {{ form.mvl_tag.label(class="ms-2 form-check-label") }}
+        </div>
+        <div class="form-check d-flex justify-content-start">
+          {{ form.clinvar_tag(class="form-check-input",type="checkbox") }}
+          {{ form.clinvar_tag.label(class="ms-2 form-check-label") }}
+        </div>
+        <div class="form-check d-flex justify-content-start">
+          {{ form.cosmic_tag(class="form-check-input",type="checkbox") }}
+          {{ form.cosmic_tag.label(class="ms-2 form-check-label") }}
+        </div>
       </div>
     </div>
     <div class="form" id="chromosome_search">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -727,7 +727,7 @@
         {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
       </div>
       <div class="col-2">
-        <span>{{ form.clinsig_onc.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Oncogenicity annotations are still sparse in ClinVar, so relying solely on them could be too restrictive.") }}</span>
+        <span>{{ form.clinsig_onc.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="ClinVar oncogenicity criteria will be applied alongside the other search criteria, not as an alternative. Oncogenicity annotations are still sparse in ClinVar, so relying solely on them could be too restrictive.") }}</span>
         <span style="float:right;">{{ form.clinsig_onc_exclude.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Exclude variants with oncogenicity among the selected categories.") }} {{form.clinsig_onc_exclude}}</span>
         {{ form.clinsig_onc(class="selectpicker", data_style="btn-secondary") }}
       </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -218,7 +218,7 @@
           <td>
             {% for annotation in compound.functional_annotations %}
               {{ annotation }}<br>
-            {% endfor %}
+            {% endfor %}x
           </td>
         </tr>
       {% endfor %}
@@ -332,7 +332,7 @@
       {{ form.spidex_human(class="selectpicker", data_style="btn-secondary") }}
     </div>
     <div class="col-2">
-      <span>{{ form.clinsig.label(class="control-label") }}</span>
+      <span>{{ form.clinsig.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Germline classification criteria.") }}</span>
       <span style="float:right;">{{ form.clinsig_exclude.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Exclude variants with clinical significance among the selected categories.") }} {{form.clinsig_exclude}}</span>
       {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
     </div>
@@ -621,7 +621,7 @@
     </div>
   </div>
   <div class="col-2">
-    {{ form.clinsig.label(class="control-label") }}
+    {{ form.clinsig.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Germline classification criteria.") }}
     {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
   </div>
   <div class="col-1">
@@ -722,12 +722,12 @@
         {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
       </div>
       <div class="col-2">
-        <span>{{ form.clinsig.label(class="control-label") }}</span>
+        <span>{{ form.clinsig.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Germline classification criteria.") }}</span>
         <span style="float:right;">{{ form.clinsig_exclude.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Exclude variants with clinical significance among the selected categories.") }} {{form.clinsig_exclude}}</span>
         {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
       </div>
       <div class="col-2">
-        <span>{{ form.clinsig_onc.label(class="control-label") }}</span>
+        <span>{{ form.clinsig_onc.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Oncogenicity annotations are still sparse in ClinVar, so relying solely on them could be too restrictive.") }}</span>
         <span style="float:right;">{{ form.clinsig_onc_exclude.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Exclude variants with oncogenicity among the selected categories.") }} {{form.clinsig_onc_exclude}}</span>
         {{ form.clinsig_onc(class="selectpicker", data_style="btn-secondary") }}
       </div>
@@ -866,7 +866,7 @@
         {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
       </div>
       <div class="col-2">
-        {{ form.clinsig.label(class="control-label") }}
+        {{ form.clinsig.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="left", title="Germline classification criteria.") }}
         {{ form.clinsig(class="selectpicker", data_style="btn-secondary") }}
       </div>
     </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5305 

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/6686d431-1e24-46ce-952b-cb9125721a7e" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test on stage with [this case](https://scout-stage.scilifelab.se/cust090/829728fam14)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by CR
