### PR TITLE
Clearer case panels tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
-- Gene panels open in new tabs from case panels and display case name on top
+- Gene panels open in new tabs from case panels and display case name on the top of the page
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
+- Gene panels open in new tabs from case panels and display case name on top
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -18,7 +18,7 @@
           {% for panel in case.panels %}
             <tr {% if panel.is_default %} class="bg-info" {% endif %}>
               <td>
-                <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}" target="_blank" rel="noopener"
+                <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}" target="_blank" rel="noopener">
                   {{ panel.display_name|truncate(30, True) }}
                 </a>
                 {% if panel.removed %}

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -18,7 +18,7 @@
           {% for panel in case.panels %}
             <tr {% if panel.is_default %} class="bg-info" {% endif %}>
               <td>
-                <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}">
+                <a {% if panel.is_default %} class="text-white" {% endif %} href="{{ url_for('panels.panel', panel_id=panel.panel_id, case_id=case._id, institute_id=institute._id) }}" target="_blank" rel="noopener"
                   {{ panel.display_name|truncate(30, True) }}
                 </a>
                 {% if panel.removed %}

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -10,11 +10,21 @@
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
   </li>
+  {% if case %}
+    <li class="nav-item">
+      <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">
+        {{ institute.display_name }}
+      </a>
+    </li>
+    <li class="nav-item active d-flex align-items-center">
+      <span class="navbar-text">{{ case.display_name }}</span>
+    </li>
+  {% endif %}
   <li class="nav-item">
     <a class="nav-link" href="{{ url_for('panels.panels') }}">Gene Panels</a>
   </li>
   <li class="nav-item active d-flex align-items-center">
-    <span class="navbar-text">{{ panel.display_name }} {{ panel.version }}</span>
+    <span class="navbar-text">{{ panel.display_name }} {{ panel.version }} {% if case%} ({{case.display_name}}) {% endif %}</span>
   </li>
 {% endblock %}
 

--- a/scout/server/blueprints/panels/templates/panels/panel.html
+++ b/scout/server/blueprints/panels/templates/panels/panel.html
@@ -16,16 +16,19 @@
         {{ institute.display_name }}
       </a>
     </li>
-    <li class="nav-item active d-flex align-items-center">
-      <span class="navbar-text">{{ case.display_name }}</span>
+    <li class="nav-item d-flex align-items-center">
+      <a class="nav-link" href="{{ url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
+        {{ case.display_name }}
+      </a>
+    </li>
+  {% else %}
+    <li class="nav-item">
+      <a class="nav-link" href="{{ url_for('panels.panels') }}">Gene Panels</a>
     </li>
   {% endif %}
-  <li class="nav-item">
-    <a class="nav-link" href="{{ url_for('panels.panels') }}">Gene Panels</a>
-  </li>
-  <li class="nav-item active d-flex align-items-center">
-    <span class="navbar-text">{{ panel.display_name }} {{ panel.version }} {% if case%} ({{case.display_name}}) {% endif %}</span>
-  </li>
+    <li class="nav-item active d-flex align-items-center">
+      <span class="navbar-text">{{ panel.display_name }} {{ panel.version }}</span>
+    </li>
 {% endblock %}
 
 {% block content_main %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4893 - chanjo2 reports already open in new tabs, but case gene panels don't

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Click on the name of a gene panel from case page and notice the difference between this branch and main

<img width="257" alt="image" src="https://github.com/user-attachments/assets/c4d31c3d-9e00-4ee8-be4e-dc930b40ca63" />


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
