### PR TITLE
Respect case rank score threshold when uploading research variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
 - Gene panels open in new tabs from case panels and display case name on the top of the page
-- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use a default threshold of 8
+- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
 - Gene panels open in new tabs from case panels and display case name on the top of the page
+- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use a default threshold of 8
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -10,6 +10,7 @@ from scout.adapter import MongoAdapter
 from scout.constants import ORDERED_FILE_TYPE_MAP
 from scout.server.extensions import store
 
+DEFAULT_RANK_THRESHOLD = 8
 LOG = logging.getLogger(__name__)
 
 
@@ -85,7 +86,6 @@ def research(case_id, institute, force):
         # Fetch all cases that have requested research
         case_objs = adapter.cases(research_requested=True)
 
-    default_threshold = 8
     files = False
     raise_file_not_found = False
     for case_obj in case_objs:
@@ -107,7 +107,7 @@ def research(case_id, institute, force):
                     case_obj=case_obj,
                     variant_type="research",
                     category=ORDERED_FILE_TYPE_MAP[file_type]["category"],
-                    rank_treshold=default_threshold,
+                    rank_treshold=case_obj.get("rank_score_threshold", DEFAULT_RANK_THRESHOLD),
                 )
 
         if not files:


### PR DESCRIPTION
This PR adds a functionlity or fixes a bug.
- Closes #5216


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
