### PR TITLE
Display gene-matching WTS outliers on DNA variants pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
+- Include eventual gene-matching WTS outliers on variantS page (Overlap column) and variant page (Gene overlapping non-SNVs table)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
-- Documentation on how to export data from the scout database using the command line
-- Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive.
-- Include eventual gene-matching WTS outliers on variantS page (Overlap column) and variant page (Gene overlapping non-SNVs table)
+- Documentation on how to export data from the scout database using the command line (#5373)
+- Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive (#5367)
+- Include eventual gene-matching WTS outliers on variantS page (Overlap column) and variant page (Gene overlapping non-SNVs table) (#5371)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
-- Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
-- Gene panels open in new tabs from case panels and display case name on the top of the page
-- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
+- Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples (#5368)
+- Gene panels open in new tabs from case panels and display case name on the top of the page (#5369)
+- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8 (#5370)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -731,7 +731,7 @@ class VariantHandler(VariantLoader):
             sort_key = [("rank_score", pymongo.DESCENDING)]
             return self.variant_collection.find(query).sort(sort_key).limit(limit)
 
-        def wts_overlapping(hgnc_ids: List[int], variant_type: str) -> Iterable[Dict]:
+        def omics_overlapping(hgnc_ids: List[int], variant_type: str) -> Iterable[Dict]:
             """Return WTS outliers matching the genes of the DNA variant in question."""
             query = {
                 "$and": [
@@ -746,7 +746,7 @@ class VariantHandler(VariantLoader):
         variant_type = variant_obj.get("variant_type", "clinical")
         return dna_overlapping(
             hgnc_ids=hgnc_ids, variant_type=variant_type, limit=limit
-        ), wts_overlapping(hgnc_ids=hgnc_ids, variant_type=variant_type)
+        ), omics_overlapping(hgnc_ids=hgnc_ids, variant_type=variant_type)
 
     def evaluated_variant_ids_from_events(self, case_id, institute_id):
         """Returns variant ids for variants that have been evaluated

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -371,8 +371,8 @@ def variant(
     if get_overlapping:
         overlapping_dna, overlapping_wts = map(list, store.hgnc_overlapping(variant_obj))
 
-    for var in overlapping_dna:
-        var.update(predictions(var.get("genes", [])))
+        for var in overlapping_dna:
+            var.update(predictions(var.get("genes", [])))
 
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -367,7 +367,9 @@ def variant(
     if variant_id in case_clinvars:
         variant_obj["clinvar_clinsig"] = case_clinvars.get(variant_id)["clinsig"]
 
-    overlapping_dna, overlapping_wts = map(list, store.hgnc_overlapping(variant_obj))
+    overlapping_dna, overlapping_wts = [], []
+    if get_overlapping:
+        overlapping_dna, overlapping_wts = map(list, store.hgnc_overlapping(variant_obj))
 
     for var in overlapping_dna:
         var.update(predictions(var.get("genes", [])))

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -367,11 +367,11 @@ def variant(
     if variant_id in case_clinvars:
         variant_obj["clinvar_clinsig"] = case_clinvars.get(variant_id)["clinsig"]
 
-    overlapping_vars = []
-    if get_overlapping:
-        for var in store.hgnc_overlapping(variant_obj):
-            var.update(predictions(var.get("genes", [])))
-            overlapping_vars.append(var)
+    overlapping_dna, overlapping_wts = map(list, store.hgnc_overlapping(variant_obj))
+
+    for var in overlapping_dna:
+        var.update(predictions(var.get("genes", [])))
+
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])
 
     dismiss_options = DISMISS_VARIANT_OPTIONS
@@ -395,7 +395,8 @@ def variant(
         "causatives": other_causatives,
         "managed_variant": managed_variant,
         "events": events,
-        "overlapping_vars": overlapping_vars,
+        "overlapping_vars": overlapping_dna,
+        "overlapping_wts": overlapping_wts,
         "manual_rank_options": MANUAL_RANK_OPTIONS,
         "cancer_tier_options": CANCER_TIER_OPTIONS,
         "dismiss_variant_options": dismiss_options,

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -104,7 +104,7 @@
     </div>
 
     <div class="row">
-      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, case, institute) }}</div>
+      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
       {% if rank_score_results %}
         <div class="col-12">{{ rankscore_panel(rank_score_results) }}</div>
       {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -122,7 +122,7 @@
   </div>
 
   <div class="row">
-    <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, case, institute) }}</div>
+    <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
   </div>
 
   <div class="mt-3 row">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -116,7 +116,7 @@
 </div>
 {% endmacro %}
 
-{% macro overlapping_panel(variant, overlapping_vars, case, institute) %}
+{% macro overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) %}
   <div class="card panel-default">
     {% if variant.category != "snv" %}
       <div class="panel-heading">Gene overlapping variants</div>
@@ -141,27 +141,38 @@
             </tr>
           </thead>
           <tbody>
-          {% for overlapping_variant in overlapping_vars %}
+          {% for overlapping_variant in overlapping_vars + overlapping_wts %}
             <tr>
               <td>
                 {% if overlapping_variant.category in ("sv", "cancer_sv") %}
                   <a href="{{url_for('variant.sv_variant', institute_id=institute._id,
                                    case_name=case.display_name, variant_id=overlapping_variant._id)}}" target="_blank">
-                    {{ overlapping_variant.display_name|truncate(20, True) }}
+                    {{ overlapping_variant.display_name|truncate(50, True) }}
                   </a>
-                {% else %}
+                {% elif overlapping_variant.category == "outlier" %}
+                  {{ overlapping_variant.display_name|truncate(50, True) }}
+                {% else  %}
                   <a href="{{url_for('variant.variant', institute_id=institute._id,
                                  case_name=case.display_name, variant_id=overlapping_variant._id)}}" target="_blank">
-                    {{ overlapping_variant.display_name|truncate(20, True) }}
+                    {{ overlapping_variant.display_name|truncate(50, True) }}
                   </a>
                 {% endif %}
               </td>
               <td>{{ overlapping_variant.hgnc_symbols|join(', ')|truncate(40, True) }}</td>
               <td>{{ overlapping_variant.sub_category|upper }}</td>
-	            <td class="text-end">{{ variant.rank_score + overlapping_variant.rank_score }}</td>
-              <td class="text-end">{{ overlapping_variant.rank_score }}</td>
+              {% if overlapping_variant.rank_score %}
+	              <td class="text-end">{{ variant.rank_score + overlapping_variant.rank_score }}</td>
+                <td class="text-end">{{ overlapping_variant.rank_score }}</td>
+              {% else %}
+                <td class="text-end">-</td>
+              {% endif %}
               <td class="text-end">{{ overlapping_variant.length }}</td>
-              <td>{{ overlapping_variant.region_annotations|join(', ')|truncate(40, True) }}</td>
+              <td>
+                {{ overlapping_variant.region_annotations|join(', ')|truncate(40, True) }}
+                {% if overlapping_variant.sub_category == "splicing" %}
+                  {{ overlapping_variant.potential_impact }} - fs {{ overlapping_variant.causes_frameshift }}
+                {% endif %}
+              </td>
               <td>{{ overlapping_variant.functional_annotations|join(', ')|truncate(40, True) }}</td>
             </tr>
           {% else %}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -152,7 +152,7 @@
     {% endif %}
     {{ rankscore_panel(rank_score_results) }}
     <div class="row">
-      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, case, institute) }}</div>
+      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
     </div>
     <div class="mt-3 row">
       <div class="col-12">

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -440,16 +440,16 @@
     data-bs-html="true" data-bs-trigger="hover click"
     {% if variant.category == "SNV" %}
       data-bs-content="<div>Gene overlapping non-SNVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">DNA gene matches</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlappings (DNA)</a>
     {% else %}
       data-bs-content="<div>Gene overlapping variants</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">DNA gene matches</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlappings (DNA)</a>
     {% endif %}
   {% endif %}
 
   {% if variant.overlapping_wts %}
     <a href="#" class="badge bg-success text-white" data-bs-toggle="popover" data-bs-placement="left"
     data-bs-html="true" data-bs-trigger="hover click" data-bs-content="<div>Gene overlapping WTS outliers</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">WTS Gene matches</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">Gene overlappings (WTS)</a>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -440,10 +440,16 @@
     data-bs-html="true" data-bs-trigger="hover click"
     {% if variant.category == "SNV" %}
       data-bs-content="<div>Gene overlapping non-SNVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlapping</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">DNA Gene matches</a>
     {% else %}
       data-bs-content="<div>Gene overlapping variants</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlapping</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">DNA Gene matches</a>
     {% endif %}
+  {% endif %}
+
+  {% if variant.overlapping_wts %}
+    <a href="#" class="badge bg-success text-white" data-bs-toggle="popover" data-bs-placement="left"
+    data-bs-html="true" data-bs-trigger="hover click" data-bs-content="<div>Gene overlapping WTS outliers</div>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">WTS Gene matches</a>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -440,10 +440,10 @@
     data-bs-html="true" data-bs-trigger="hover click"
     {% if variant.category == "SNV" %}
       data-bs-content="<div>Gene overlapping non-SNVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">DNA Gene matches</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">DNA gene matches</a>
     {% else %}
       data-bs-content="<div>Gene overlapping variants</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">DNA Gene matches</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">DNA gene matches</a>
     {% endif %}
   {% endif %}
 

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -440,16 +440,16 @@
     data-bs-html="true" data-bs-trigger="hover click"
     {% if variant.category == "SNV" %}
       data-bs-content="<div>Gene overlapping non-SNVs</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlappings (DNA)</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:20]) }}">Gene overlapping (DNA)</a>
     {% else %}
       data-bs-content="<div>Gene overlapping variants</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlappings (DNA)</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping[:40]) }}">Gene overlapping (DNA)</a>
     {% endif %}
   {% endif %}
 
   {% if variant.overlapping_wts %}
     <a href="#" class="badge bg-success text-white" data-bs-toggle="popover" data-bs-placement="left"
     data-bs-html="true" data-bs-trigger="hover click" data-bs-content="<div>Gene overlapping WTS outliers</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">Gene overlappings (WTS)</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">Gene overlapping (WTS)</a>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -243,7 +243,7 @@
             {{ pretty_link_variant(variant, case) }}
           </td>
           <td class='text-end'>{{ variant.sub_category }}</td>
-          <td class='text-end'>{{ variant.length if variant.length < 100000000000 else '-' }}</td>
+          <td class='text-end'>{{ variant.length if variant.length and variant.length < 100000000000 else '-' }}</td>
           <td class='text-end'>{{ variant.rank_score }}</td>
         </tr>
       {% endfor %}

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -944,7 +944,7 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
     )
 
     # THEN the function that finds overlapping variants to the snv_variant
-    results = adapter.hgnc_overlapping(updated_snv_variant, limit=10000)
+    results, _ = adapter.hgnc_overlapping(updated_snv_variant, limit=10000)
     for res in results:
         # SHOULD return the SV variant
         assert res["category"] == "sv"
@@ -952,6 +952,6 @@ def test_get_overlapping_variant(real_variant_database, case_obj, variant_obj, s
 
     # The function should also work the other way around:
     # and return snv variants that overlaps with sv variants
-    result_vars = list(adapter.hgnc_overlapping(updated_sv_variant, limit=10000))
+    result_vars, _ = list(adapter.hgnc_overlapping(updated_sv_variant, limit=10000))
     result_ids = [result_var["_id"] for result_var in result_vars]
     assert updated_snv_variant["_id"] in result_ids


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4796

Display gene-matching WTS ouliers on variantS pages:

<img width="1677" alt="image" src="https://github.com/user-attachments/assets/6d033b4b-eb49-4f71-83bf-e76947f2cc74" />


And on variant page:

<img width="1655" alt="image" src="https://github.com/user-attachments/assets/698b43a7-5e9b-4c45-a504-32d261efc5a8" />



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On stage, with [this case](https://scout-stage.scilifelab.se/cust002/F0044127)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
