### PR TITLE
Fix general report to show all dismissed variants (not pinned or causatives) only among the dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Button with link to cancerhotspots.org on variant page for cancer cases (#5359)
 - Link to ClinGen ACMG CSPEC Criteria Specification Registry from ACMG classification page (#5364)
-- Documentation on how to export data from the scout database using the command line
-- Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive.
+- Documentation on how to export data from the scout database using the command line (#5373)
+- Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive (#5367)
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
-- Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
-- Gene panels open in new tabs from case panels and display case name on the top of the page
-- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
-- On case general report, when a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants.
+- Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples (#5368)
+- Gene panels open in new tabs from case panels and display case name on the top of the page (#5369)
+- When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8 (#5370)
+- On case general report, when a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants (#5377)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
 - Gene panels open in new tabs from case panels and display case name on the top of the page
 - When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
+- On case general report. When a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants.
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
 - Gene panels open in new tabs from case panels and display case name on the top of the page
 - When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
-- On case general report. When a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants.
+- On case general report, when a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants.
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -383,7 +383,7 @@
     {% set duplicated_variants = [] %}
     {% if variants.classified_detailed %}
       {% for variant in variants.classified_detailed|sort(attribute='variant_rank') %}
-        {% if variant['_id'] not in printed_vars %}
+        {% if variant['_id'] not in printed_vars and variant not in variants.dismissed_detailed %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
           <br>
@@ -395,7 +395,7 @@
       No ACMG-classified variants available for this case
     {% endif %}
     {% if variants.classified_detailed and duplicated_variants|length == variants.classified_detailed|length %}
-      All ACMG-classified variants are already described in the previous views
+      All ACMG-classified variants are already described in the other panels
     {% endif %}
   </div>
 </div>
@@ -410,7 +410,7 @@
     {% set duplicated_variants = [] %}
     {% if variants.ccv_classified_detailed %}
       {% for variant in variants.ccv_classified_detailed|sort(attribute='variant_rank') %}
-        {% if variant['_id'] not in printed_vars %}
+        {% if variant['_id'] not in printed_vars and variant not in variants.dismissed_detailed %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
           <br>
@@ -422,7 +422,7 @@
       No ClinGen-CGC-VICC-classified variants available for this case
     {% endif %}
     {% if variants.ccv_classified_detailed and duplicated_variants|length == variants.ccv_classified_detailed|length %}
-      All ClinGen-CGC-VICC-classified variants are already described in the previous views
+      All ClinGen-CGC-VICC-classified variants are already described in the other panels
     {% endif %}
   </div>
 </div>
@@ -437,7 +437,7 @@
     {% set duplicated_variants = [] %}
     {% if variants.tagged_detailed %}
       {% for variant in variants.tagged_detailed|sort(attribute='variant_rank') %}
-        {% if variant['_id'] not in printed_vars %}
+        {% if variant['_id'] not in printed_vars and variant not in variants.dismissed_detailed %}
           {% do printed_vars.append(variant['_id']) %}
           {{ variant_content(variant, loop.index) }}
           <br>
@@ -461,7 +461,7 @@
       No tagged variants for this case
     {% endif %}
     {% if (variants.tagged_detailed or variants.tier_detailed) and duplicated_variants|length == (variants.tagged_detailed|length+variants.tier_detailed|length) %}
-      All tagged variants are already described in the previous views
+      All tagged variants are already described in the other panels
     {% endif %}
   </div>
 </div>
@@ -500,7 +500,7 @@
     {% set duplicated_variants = [] %}
     {% if variants.commented_detailed %}
       {% for variant in variants.commented_detailed|sort(attribute='variant_rank') %}
-        {% if variant['_id'] not in printed_vars %}
+        {% if variant['_id'] not in printed_vars and variant not in variants.dismissed_detailed %}
           {% do printed_vars.append(variant['_id']) %}
           {% if variant.category == 'snv' %}
             {{ sn_variant_content(variant, loop.index) }}
@@ -520,7 +520,7 @@
       No commented variants for this case
     {% endif %}
     {% if variants.commented_detailed and duplicated_variants|length == variants.commented_detailed|length %}
-      All commented variants are already described in the previous views
+      All commented variants are already described in the other panels
     {% endif %}
   </div>
 </div>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -845,7 +845,8 @@
                 <th class="w-5"></th>
                 <th class="w-25"><strong>Variant</strong></th>
                 <th class="w-5"><strong>Category</strong></th>
-  	            <th class="w-25"><strong>Genes</strong></th>
+  	            <th class="w-20"><strong>Genes</strong></th>
+                <th class="w-5"><strong>Classification</strong></th>
                 <th class="w-45"><strong>Dismissed description</strong></th>
             </tr>
           </thead>
@@ -867,7 +868,14 @@
               <td style="width:15%;"
                 {{ dismissed_gene_list(variant) }}
               </td>
-
+              <td>
+                {% if variant.acmg_classification %}
+                  <span class="badge rounded-pill bg-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>
+                {% endif %}
+                {% if variant.ccv_classification %}
+                  <span class="badge rounded-pill bg-{{variant.ccv_classification['color'] if variant.ccv_classification['color'] else 'secondary'}}" title="{{variant.ccv_classification['code']}}">{{variant.ccv_classification['short'] }}</span>
+                {% endif %}
+              </td>
               <td rowspan="2">
                 <ul>
                   {% for reason in variant.dismiss_variant if not reason == "Select a tag"  %}
@@ -1531,7 +1539,11 @@
   <td>
     {% if variant.acmg_classification %}
       <span class="badge rounded-pill bg-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['code']}}">{{variant.acmg_classification['short'] }}</span>
-    {% elif variant.manual_rank %}
+    {% endif %}
+    {% if variant.ccv_classification%}
+      <span class="badge rounded-pill bg-{{variant.ccv_classification['color'] if variant.ccv_classification['color'] else 'secondary'}}" title="{{variant.ccv_classification['code']}}">{{variant.ccv_classification['short'] }}</span>
+    {% endif%}
+    {% if variant.manual_rank %}
       <span class="badge rounded-pill bg-secondary" title="Manual rank">{{ manual_rank_options[variant.manual_rank]['label'] }}</span>
     {% else %}
       -


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5374
 
<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
