### PR TITLE
Fix #5380 - add genome build on general case report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples
 - Gene panels open in new tabs from case panels and display case name on the top of the page
 - When uploading research variants, use rank threshold defined in case settings, if available, otherwise use the default threshold of 8
+- Display genome build version on case general report
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -63,7 +63,7 @@
 </nav>
 
 <div id="container" class="container">
-  <h4>Scout case analysis report</h4> - created on:&nbsp;<strong>{{report_created_at}}</strong> using <strong>Scout v.{{current_scout_version}}</strong><br><br>
+  <h4>Scout case analysis report</h4> - created on:&nbsp;<strong>{{report_created_at}}</strong> using <strong>Scout v{{current_scout_version}}</strong> for genome build <strong>{{case.genome_build }}</strong>.<br><br>
    {{ phenotype_panel() }}
    {{ gene_panels_panel()}}
    {{ causatives_panel()}}
@@ -104,7 +104,7 @@
                 <td>Case created: <strong>{{case.created_at.strftime('%Y-%m-%d')}}</strong></td>
 	              <td>Last updated: <strong>{{case.updated_at.strftime('%Y-%m-%d') if case.updated_at else "n.a." }}</strong></td>
                 {% if case.scout_load_version %}
-                  <td> Loaded with <strong>Scout v.{{case.scout_load_version}}</strong></td>
+                  <td> Loaded with <strong>Scout v{{case.scout_load_version}}</strong></td>
                 {% endif %}
 	            </tr>
 	          </table>

--- a/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
+++ b/scout/server/blueprints/cases/templates/cases/collapsible_actionbar.html
@@ -196,7 +196,7 @@
   <div href="#" class="bg-dark list-group-item text-white" data-bs-toggle="tooltip" title="Scout version used for loading the case" data-bs-placement="right">
     <div class="d-flex w-100 justify-content-start align-items-center">
       <span class="fa fa-gear fa-fw me-3"></span>
-      <span class="menu-collapsed">v.{{ case.scout_load_version }}</span>
+      <span class="menu-collapsed">v{{ case.scout_load_version }}</span>
     </div>
   </div>
 {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout.target`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
