### PR TITLE
Fix #5383 - scope of overlapping functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On case general report, when a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants (#5377)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
+- Scope of overlapping functions (#5384)
 
 ## [4.99]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On case general report, when a variant is classified (ACMG or CCV), tagged, commented and also dismissed, will only be displayed among the dismissed variants (#5377)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
-- Scope of overlapping functions (#5384)
+- Scope of overlapping functions (#5385)
 
 ## [4.99]
 ### Added

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Dict, Iterable, List, Optional
 
 from pymongo import ASCENDING, DESCENDING
 

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -216,7 +216,7 @@ class OmicsVariantHandler:
         query = self.build_query(
             case_id, query=query, variant_ids=variant_ids, category=category, build=build
         )
-        return self.get_omics_variant_collection.count_documents(query)
+        return self.omics_variant_collection.count_documents(query)
 
     def get_omics_variants_hgnc_overlapping(
         self, hgnc_ids: List[int], variant_type: str, variant_obj: dict

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -216,4 +216,17 @@ class OmicsVariantHandler:
         query = self.build_query(
             case_id, query=query, variant_ids=variant_ids, category=category, build=build
         )
-        return self.omics_variant_collection.count_documents(query)
+        return self.get_omics_variant_collection.count_documents(query)
+
+    def get_omics_variants_hgnc_overlapping(
+        self, hgnc_ids: List[int], variant_type: str, variant_obj: dict
+    ) -> Iterable[Dict]:
+        """Return WTS outliers matching the genes of the DNA variant in question."""
+        query = {
+            "$and": [
+                {"case_id": variant_obj["case_id"]},
+                {"variant_type": variant_type},
+                {"hgnc_ids": {"$in": hgnc_ids}},
+            ]
+        }
+        return self.omics_variant_collection.find(query)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -736,7 +736,7 @@ class VariantHandler(VariantLoader):
             self.get_variants_hgnc_overlapping(
                 hgnc_ids=hgnc_ids, variant_type=variant_type, limit=limit, variant_obj=variant_obj
             ),
-            self.get_omics_variants_hgvs_overlapping(
+            self.get_omics_variants_hgnc_overlapping(
                 hgnc_ids=hgnc_ids, variant_type=variant_type, variant_obj=variant_obj
             ),
         )

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -736,7 +736,7 @@ class VariantHandler(VariantLoader):
             self.get_variants_hgnc_overlapping(
                 hgnc_ids=hgnc_ids, variant_type=variant_type, limit=limit, variant_obj=variant_obj
             ),
-            self.get_omics_variants_hngs_overlapping(
+            self.get_omics_variants_hgvs_overlapping(
                 hgnc_ids=hgnc_ids, variant_type=variant_type, variant_obj=variant_obj
             ),
         )

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -689,6 +689,42 @@ class VariantHandler(VariantLoader):
         result = self.variant_collection.delete_many(query)
         LOG.info("{0} variants deleted".format(result.deleted_count))
 
+    def _dna_overlapping(
+        self, hgnc_ids: List[int], variant_type: str, limit: Optional[int]
+    ) -> Iterable[Dict]:
+        """Return DNA other categories of DNA variants matching the genes of the DNA variant in question."""
+        category = (
+            {"$in": ["sv", "mei"]}
+            if variant_obj["category"] == "snv"
+            else {"$in": ["sv", "snv", "mei", "cancer", "cancer_sv"]}
+        )
+
+        if not limit:
+            limit = 30 if variant_obj["category"] == "snv" else 45
+
+        query = {
+            "$and": [
+                {"case_id": variant_obj["case_id"]},
+                {"category": category},
+                {"variant_type": variant_type},
+                {"hgnc_ids": {"$in": hgnc_ids}},
+                {"variant_id": {"$ne": variant_obj["variant_id"]}},
+            ]
+        }
+        sort_key = [("rank_score", pymongo.DESCENDING)]
+        return self.variant_collection.find(query).sort(sort_key).limit(limit)
+
+    def _omics_overlapping(self, hgnc_ids: List[int], variant_type: str) -> Iterable[Dict]:
+        """Return WTS outliers matching the genes of the DNA variant in question."""
+        query = {
+            "$and": [
+                {"case_id": variant_obj["case_id"]},
+                {"variant_type": variant_type},
+                {"hgnc_ids": {"$in": hgnc_ids}},
+            ]
+        }
+        return self.omics_variant_collection.find(query)
+
     def hgnc_overlapping(
         self, variant_obj: dict, limit: int = None
     ) -> Tuple[Iterable[Dict], Iterable[Dict]]:
@@ -705,48 +741,11 @@ class VariantHandler(VariantLoader):
         limit: A maximum count of returned variants is introduced: mainly this is a problem when SVs are huge since there can be many genes and overlapping variants.
                We sort to offer the LIMIT most severe overlapping variants.
         """
-
-        def dna_overlapping(
-            hgnc_ids: List[int], variant_type: str, limit: Optional[int]
-        ) -> Iterable[Dict]:
-            """Return DNA other categories of DNA variants matching the genes of the DNA variant in question."""
-            category = (
-                {"$in": ["sv", "mei"]}
-                if variant_obj["category"] == "snv"
-                else {"$in": ["sv", "snv", "mei", "cancer", "cancer_sv"]}
-            )
-
-            if not limit:
-                limit = 30 if variant_obj["category"] == "snv" else 45
-
-            query = {
-                "$and": [
-                    {"case_id": variant_obj["case_id"]},
-                    {"category": category},
-                    {"variant_type": variant_type},
-                    {"hgnc_ids": {"$in": hgnc_ids}},
-                    {"variant_id": {"$ne": variant_obj["variant_id"]}},
-                ]
-            }
-            sort_key = [("rank_score", pymongo.DESCENDING)]
-            return self.variant_collection.find(query).sort(sort_key).limit(limit)
-
-        def omics_overlapping(hgnc_ids: List[int], variant_type: str) -> Iterable[Dict]:
-            """Return WTS outliers matching the genes of the DNA variant in question."""
-            query = {
-                "$and": [
-                    {"case_id": variant_obj["case_id"]},
-                    {"variant_type": variant_type},
-                    {"hgnc_ids": {"$in": hgnc_ids}},
-                ]
-            }
-            return self.omics_variant_collection.find(query)
-
         hgnc_ids = variant_obj.get("hgnc_ids", [])
         variant_type = variant_obj.get("variant_type", "clinical")
-        return dna_overlapping(
+        return self.dna_overlapping(
             hgnc_ids=hgnc_ids, variant_type=variant_type, limit=limit
-        ), omics_overlapping(hgnc_ids=hgnc_ids, variant_type=variant_type)
+        ), self.omics_overlapping(hgnc_ids=hgnc_ids, variant_type=variant_type)
 
     def evaluated_variant_ids_from_events(self, case_id, institute_id):
         """Returns variant ids for variants that have been evaluated

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -313,6 +313,22 @@
 
       {{ display_genes|join(", ") }}
 
+    {% elif variant.category == "outlier" %}
+      {{ variant.sub_category|upper }} - {% if variant.genes %}
+        {% for gene in variant.genes %}
+           {% if gene.hgnc_symbol %}
+             {{ gene.hgnc_symbol }}
+           {% else %}
+             {{gene.hgnc_id}}
+           {% endif %}
+        {% endfor %} - {%  if variant.sub_category == "splicing" %}
+          {{ variant.delta_psi }}&Delta;&psi;  {{ variant.potential_impact }} - fs {{ variant.causes_frameshift }}
+        {% else %}
+          {{ variant.l2fc }}{% if variant.l2fc > 0 %}&uarr;{% elif variant.l2fc < 0 %}&darr;{% endif %}
+        {% endif %}
+      {% else %}
+        {{ variant.gene_name_orig }}
+      {% endif %}
     {% else %} <!-- structural variants -->
       {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.end_chrom }}{{ variant.cytoband_end }})
     {% endif %}
@@ -335,6 +351,9 @@
                    case_name=case.display_name,
                    variant_id=variant._id) }}' target='_blank'>
     {% endif %}
+  {% elif variant.category == "outlier" %}
+    <a href='{{ url_for('omics_variants.outliers',
+       institute_id=variant.institute, case_name=case.display_name) }}' target='_blank'>
   {% else %} <!-- structural variants -->
     <a href='{{ url_for('variant.sv_variant',
                               institute_id=variant.institute,

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -367,11 +367,11 @@ def variant(
     if variant_id in case_clinvars:
         variant_obj["clinvar_clinsig"] = case_clinvars.get(variant_id)["clinsig"]
 
-    overlapping_dna, overlapping_wts = [], []
+    overlapping_variants, overlapping_outliers = [], []
     if get_overlapping:
-        overlapping_dna, overlapping_wts = map(list, store.hgnc_overlapping(variant_obj))
+        overlapping_variants, overlapping_outliers = map(list, store.hgnc_overlapping(variant_obj))
 
-        for var in overlapping_dna:
+        for var in overlapping_variants:
             var.update(predictions(var.get("genes", [])))
 
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])
@@ -397,8 +397,8 @@ def variant(
         "causatives": other_causatives,
         "managed_variant": managed_variant,
         "events": events,
-        "overlapping_vars": overlapping_dna,
-        "overlapping_wts": overlapping_wts,
+        "overlapping_vars": overlapping_variants,
+        "overlapping_outliers": overlapping_outliers,
         "manual_rank_options": MANUAL_RANK_OPTIONS,
         "cancer_tier_options": CANCER_TIER_OPTIONS,
         "dismiss_variant_options": dismiss_options,

--- a/scout/server/blueprints/variant/templates/variant/cancer-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/cancer-variant.html
@@ -104,7 +104,7 @@
     </div>
 
     <div class="row">
-      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
+      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_outliers, case, institute) }}</div>
       {% if rank_score_results %}
         <div class="col-12">{{ rankscore_panel(rank_score_results) }}</div>
       {% endif %}

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -122,7 +122,7 @@
   </div>
 
   <div class="row">
-    <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
+    <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_outliers, case, institute) }}</div>
   </div>
 
   <div class="mt-3 row">

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -116,7 +116,7 @@
 </div>
 {% endmacro %}
 
-{% macro overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) %}
+{% macro overlapping_panel(variant, overlapping_vars, overlapping_outliers, case, institute) %}
   <div class="card panel-default">
     {% if variant.category != "snv" %}
       <div class="panel-heading">Gene overlapping variants</div>
@@ -141,7 +141,7 @@
             </tr>
           </thead>
           <tbody>
-          {% for overlapping_variant in overlapping_vars + overlapping_wts %}
+          {% for overlapping_variant in overlapping_vars + overlapping_outliers %}
             <tr>
               <td>
                 {% if overlapping_variant.category in ("sv", "cancer_sv") %}

--- a/scout/server/blueprints/variant/templates/variant/utils.html
+++ b/scout/server/blueprints/variant/templates/variant/utils.html
@@ -164,8 +164,9 @@
 	              <td class="text-end">{{ variant.rank_score + overlapping_variant.rank_score }}</td>
                 <td class="text-end">{{ overlapping_variant.rank_score }}</td>
               {% else %}
-                <td class="text-end">-</td>
+                <td class="text-end">-</td><td class="text-end">-</td>
               {% endif %}
+
               <td class="text-end">{{ overlapping_variant.length }}</td>
               <td>
                 {{ overlapping_variant.region_annotations|join(', ')|truncate(40, True) }}

--- a/scout/server/blueprints/variant/templates/variant/variant.html
+++ b/scout/server/blueprints/variant/templates/variant/variant.html
@@ -152,7 +152,7 @@
     {% endif %}
     {{ rankscore_panel(rank_score_results) }}
     <div class="row">
-      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_wts, case, institute) }}</div>
+      <div class="col-12">{{ overlapping_panel(variant, overlapping_vars, overlapping_outliers, case, institute) }}</div>
     </div>
     <div class="mt-3 row">
       <div class="col-12">

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -116,11 +116,11 @@ def populate_institute_soft_filters(form, institute_obj):
         form.institute_soft_filters.data = ",".join(institute_obj["soft_filters"])
 
 
-def set_ovelapping_variants(variant_obj: dict):
+def set_overlapping_variants(variant_obj: dict):
     """Define DNA or WTS variants that are overlapping with a gene of a variant."""
-    overlapping_dna, overlapping_wts = store.hgnc_overlapping(variant_obj)
-    variant_obj["overlapping"] = list(overlapping_dna) or None
-    variant_obj["overlapping_wts"] = list(overlapping_wts) or None
+    overlapping_variants, overlapping_outliers = store.hgnc_overlapping(variant_obj)
+    variant_obj["overlapping"] = list(overlapping_variants) or None
+    variant_obj["overlapping_outliers"] = list(overlapping_outliers) or None
 
 
 def variants(
@@ -149,7 +149,7 @@ def variants(
 
     variants = []
     for variant_obj in variant_res:
-        set_ovelapping_variants(variant_obj)
+        set_overlapping_variants(variant_obj)
 
         evaluations = []
         is_research = variant_obj["variant_type"] == "research"
@@ -244,7 +244,7 @@ def sv_variants(store, institute_obj, case_obj, variants_query, variant_count, p
     case_dismissed_vars = store.case_dismissed_variants(institute_obj, case_obj)
 
     for variant_obj in variants_query.skip(skip_count).limit(per_page):
-        set_ovelapping_variants(variant_obj)
+        set_overlapping_variants(variant_obj)
 
         # show previous classifications for research variants
         clinical_var_obj = variant_obj
@@ -292,7 +292,7 @@ def mei_variants(
     case_dismissed_vars = store.case_dismissed_variants(institute_obj, case_obj)
 
     for variant_obj in variants_query.skip(skip_count).limit(per_page):
-        set_ovelapping_variants(variant_obj)
+        set_overlapping_variants(variant_obj)
 
         # show previous classifications for research variants
         clinical_var_obj = variant_obj
@@ -1463,7 +1463,7 @@ def cancer_variants(store, institute_id, case_name, variants_query, variant_coun
         variant_obj["second_rep_gene"] = secondary_gene
         variant_obj["clinical_assessments"] = get_manual_assessments(variant_obj)
 
-        set_ovelapping_variants(variant_obj)
+        set_overlapping_variants(variant_obj)
 
         evaluations = []
         # Get previous ClinGen-CGC-VIGG evaluations of the variant from other cases

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -447,9 +447,9 @@
     {% endif %}
   {% endif %}
 
-  {% if variant.overlapping_wts %}
+  {% if variant.overlapping_outliers %}
     <a href="#" class="badge bg-success text-white" data-bs-toggle="popover" data-bs-placement="left"
     data-bs-html="true" data-bs-trigger="hover click" data-bs-content="<div>Gene overlapping WTS outliers</div>
-      {{ overlapping_tooltip_table(institute, case, variant.overlapping_wts[:40]) }}">Gene overlapping (WTS)</a>
+      {{ overlapping_tooltip_table(institute, case, variant.overlapping_outliers[:40]) }}">Gene overlapping (WTS)</a>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5383 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by
- [x] tests executed by
