### PR TITLE
MatchMaker submissions dedicated page. Attempt nr 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Documentation on how to export data from the scout database using the command line (#5373)
 - Filter cancer SNVs by ClinVar oncogenicity. OBS: since annotations are still sparse in ClinVar, relying solely on them could be too restrictive (#5367)
 - Include eventual gene-matching WTS outliers on variantS page (Overlap column) and variant page (Gene overlapping non-SNVs table) (#5371)
+- A page showing all cases submitted to the Matchmaker Exchange, accessible from the institute's sidebar
 ### Changed
 - Allow matching compounded subcategories from SV callers e.g. DUP:INV (#5360)
 - Adjust the link to the chanjo2 gene coverage report to reflect the type of analyses used for the samples (#5368)

--- a/scout/adapter/mongo/event.py
+++ b/scout/adapter/mongo/event.py
@@ -240,16 +240,26 @@ class EventHandler(CaseEventHandler, VariantEventHandler):
 
         return self.event_collection.find(query)
 
-    def case_events_by_verb(self, category: str, institute: dict, case: dict, verb: str):
+    def events_by_institute(
+        self, category: str, institute_id: dict, verb: str
+    ) -> pymongo.cursor.Cursor:
+        """Return events with a specific verb for an institute from the newest."""
+        query = {
+            "category": category,
+            "institute": institute_id,
+            "verb": verb,
+        }
+        return self.event_collection.find(query).sort("updated_at", pymongo.DESCENDING)
+
+    def case_events_by_verb(
+        self, category: str, institute: dict, case: dict, verb: str
+    ) -> pymongo.cursor.Cursor:
         """Return events with a specific verb for a case of an institute
         Args:
             category (str): "case" or "variant"
             institute (dict): an institute id
             case (dict): a case id
             verb (str): an event action verb, example: "dismiss_variant"
-
-        Returns:
-            pymongo.Cursor: Query results
         """
         query = {
             "category": category,

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -29,6 +29,7 @@ from .blueprints import (
     institutes,
     login,
     managed_variants,
+    mme,
     omics_variants,
     panels,
     phenomodels,
@@ -185,6 +186,7 @@ def register_blueprints(app):
     app.register_blueprint(genes.genes_bp)
     app.register_blueprint(cases.cases_bp)
     app.register_blueprint(clinvar.clinvar_bp)
+    app.register_blueprint(mme.mme_bp)
     app.register_blueprint(login.login_bp)
     app.register_blueprint(variant.variant_bp)
     app.register_blueprint(variants.variants_bp)

--- a/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
+++ b/scout/server/blueprints/institutes/templates/overview/institute_sidebar.html
@@ -51,7 +51,15 @@
           </div>
       </a>
 
-    <!-- Variant filters -->
+     <!-- MME data menu item -->
+      <a href="{{ url_for('mme.mme_submissions', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
+          <div class="d-flex w-100 justify-content-start align-items-center">
+              <span class="fas fa-people-arrows me-3"></span>
+              <span class="menu-collapsed">MME submissions</span>
+          </div>
+      </a>
+
+     <!-- Variant filters -->
       <a href="{{ url_for('overview.filters', institute_id=institute._id) }}" class="bg-dark list-group-item list-group-item-action flex-column align-items-start">
           <div class="d-flex w-100 justify-content-start align-items-center">
               <span class="fa fa-filter me-3"></span>

--- a/scout/server/blueprints/mme/__init__.py
+++ b/scout/server/blueprints/mme/__init__.py
@@ -1,0 +1,1 @@
+from .views import mme_bp

--- a/scout/server/blueprints/mme/controllers.py
+++ b/scout/server/blueprints/mme/controllers.py
@@ -1,0 +1,18 @@
+from typing import List
+
+from scout.server.extensions import store
+
+
+def institute_mme_cases(institute_id: str) -> List[dict]:
+    """Retrieves all cases for a given institute with an active MatchMaker Exchange submission."""
+    institute_mme_events = store.events_by_institute(
+        category="case", institute_id=institute_id, verb="mme_add"
+    )
+    unique_case_ids = set([event["case"] for event in institute_mme_events])
+    mme_cases = []
+    for case_id in unique_case_ids:
+        case_obj = store.case(case_id=case_id)
+        if not case_obj or not case_obj.get("mme_submission"):
+            continue
+        mme_cases.append(case_obj)
+    return mme_cases

--- a/scout/server/blueprints/mme/templates/mme/mme_submissions.html 
+++ b/scout/server/blueprints/mme/templates/mme/mme_submissions.html 
@@ -1,0 +1,128 @@
+{% extends "layout.html" %}
+{% from "overview/institute_sidebar.html" import institute_actionbar %}
+
+{% block title %}
+{{ super() }} - Institutes
+{% endblock %}
+
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+{% endblock %}
+
+{% block top_nav %}
+  {{ super() }}
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('cases.index') }}">Institutes</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link" href="{{ url_for('overview.cases', institute_id=institute._id) }}">{{ institute.display_name }}</a>
+  </li>
+  <li class="nav-item active d-flex align-items-center">
+    <span class="navbar-text">Cases in MatchMaker Exchange</span>
+  </li>
+{% endblock %}
+
+{% block content_main %}
+<div class="container-float">
+  <div class="row mt-3" id="body-row"> <!--sidebar and main container are on the same row-->
+    <div class="col">
+      {{ mme_submitted() }}
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% macro mme_submitted() %}
+<table class="table table-bordered table-striped" id="mmeTable">
+  <thead>
+    <tr>
+      <th>Case Name</th>
+      <th>Synopsis</th>
+      <th>Status</th>
+      <th>Case Assignees</th>
+      <th>MME Submission Updated</th>
+      <th>MME Patient(s)</th>
+      <th>MME Phenotype Features</th>
+      <th>MME Genomic Features</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for case in mme_cases %}
+      <tr>
+        <td>
+          <a class="me-2" href="{{ url_for('cases.case', institute_id=case.owner, case_name=case.display_name) }}" target="_blank" rel="noopener">
+          {{ case.display_name }}
+          </a>
+        </td>
+        <td>{{ case.synopsis }}</td>
+        <td>{{ case.status }}</td>
+        <td>
+          {% for assignee in case.assignees %}
+            <div>{{ assignee }}</div>
+          {% endfor %}
+        </td>
+        <td>
+          {{ case.mme_submission.updated_at.strftime('%Y-%m-%d %H:%M') }}
+        </td>
+        <td>
+          {% for patient in case.mme_submission.patients %}
+            <div>
+              <strong>{{ patient.label }}</strong> ({{ patient.sex }})<br>
+              <small>Contact: {{ patient.contact.name }} - <a href="{{ patient.contact.href }}">{{ patient.contact.href }}</a></small>
+            </div>
+          {% endfor %}
+        </td>
+        <td>
+          {% for disorder in case.mme_submission.disorders %}
+            <div>{{ disorder.label }} ({{ disorder.id }})</div>
+          {% endfor %}
+        </td>
+        <td>
+          {% for patient in case.mme_submission.patients %}
+            {% for gf in patient.genomicFeatures %}
+              <div>
+                <strong>{{ gf.gene.id }}</strong><br>
+                {% if gf.variant %}
+                  Chr{{ gf.variant.referenceName }}:
+                  {{ gf.variant.start }} → {{ gf.variant.end }}<br>
+                  {{ gf.variant.referenceBases }} → {{ gf.variant.alternateBases }}<br>
+                  Assembly: {{ gf.variant.assembly }}<br>
+                  Zygosity: {{ gf.zygosity }}
+                {% endif %}
+              </div>
+              <hr>
+            {% endfor %}
+          {% endfor %}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endmacro %}
+
+
+{% block scripts %}
+  {{ super() }}
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"  integrity="sha384-VP1oT+9TxQ6aD1lqD3e6ZIXkDrRYW0HhP8F+HId3IFVd0W07I2D4x4Ao4y+zDJTc" crossorigin="anonymous"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js" integrity="sha384-aMQNm81m1H+DJ4rJ+XLXKha3vcgxP6cojDJQqRuW2hdJ1GbRaTW9Ff8TxwFcPtSB" crossorigin="anonymous"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js" integrity="sha384-YourGeneratedHashHere" crossorigin="anonymous"></script>
+  <script>
+    $(document).ready(function () {
+    $('#mmeTable').DataTable({
+      paging: true,
+      searching: true,
+      ordering: true,
+      responsive: true,
+      language: {
+        search: "Search all fields:",
+        lengthMenu: "Show _MENU_ entries",
+        info: "Showing _START_ to _END_ of _TOTAL_ cases",
+      },
+      columnDefs: [
+        { orderable: false, targets: [3, 5, 6, 7] }  // Disable sorting for multi-line complex columns
+      ]
+    });
+  });
+  </script>
+{% endblock %}

--- a/scout/server/blueprints/mme/views.py
+++ b/scout/server/blueprints/mme/views.py
@@ -1,0 +1,34 @@
+import logging
+
+from flask import (
+    Blueprint,
+    render_template,
+    url_for,
+)
+
+from scout.server.extensions import store
+from scout.server.utils import institute_and_case
+
+from . import controllers
+
+LOG = logging.getLogger(__name__)
+
+mme_bp = Blueprint(
+    "mme",
+    __name__,
+    template_folder="templates",
+    static_folder="static",
+    static_url_path="/mme/static",
+)
+
+
+@mme_bp.route("/<institute_id>/mme_submissions", methods=["GET"])
+def mme_submissions(institute_id: str):
+    """Retrieve all cases for an institute with associated a MME submission."""
+
+    institute_obj = institute_and_case(store, institute_id)
+    data = {
+        "institute": institute_obj,
+        "mme_cases": controllers.institute_mme_cases(institute_id=institute_id),
+    }
+    return render_template("mme/mme_submissions.html", **data)

--- a/tests/server/blueprints/mme/test_mme_views.py
+++ b/tests/server/blueprints/mme/test_mme_views.py
@@ -1,0 +1,20 @@
+from flask import url_for
+
+
+def test_mme_submissions(app, institute_obj):
+    """Test the page displaying cases with MME submissions for an institute."""
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # WITH a logged user
+        client.get(url_for("auto_login"))
+
+        # THEN MME submissions endpoint should return a valid page
+        resp = client.get(
+            url_for(
+                "mme.mme_submissions",
+                institute_id=institute_obj["internal_id"],
+            ),
+        )
+
+        assert resp.status_code == 200


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
