### PR TITLE
controllers.variants tests in the app context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 - Scope of overlapping functions (#5385)
+- Tests involving the variants controllers, which failed when not runned in a specific order. Fixed by mocking the `controllers.set_overlapping_variants` function
 
 ## [4.99]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Style of Alamut button on variant page (#5358)
 - Scope of overlapping functions (#5385)
-- Tests involving the variants controllers, which failed when not runned in a specific order. Fixed by mocking the `controllers.set_overlapping_variants` function
+- Tests involving the variants controllers, which failed when not runned in a specific order.
 
 ## [4.99]
 ### Added

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -451,9 +451,7 @@ def test_variants_assessment_shared_with_group(
         return_value=[{"_id": "cust000"}],
     )
 
-    mocker.patch(
-        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
-    )
+    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -507,9 +505,7 @@ def test_variants_research_no_shadow_clinical_assessments(
         return_value=[{"_id": "cust000"}],
     )
 
-    mocker.patch(
-        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
-    )
+    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -555,9 +551,7 @@ def test_variants_research_shadow_clinical_assessments(
         return_value=[{"_id": "cust000"}],
     )
 
-    mocker.patch(
-        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
-    )
+    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -614,9 +608,7 @@ def test_sv_variants_research_shadow_clinical_assessments(
         return_value=[{"_id": "cust000"}],
     )
 
-    mocker.patch(
-        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
-    )
+    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -451,6 +451,10 @@ def test_variants_assessment_shared_with_group(
         return_value=[{"_id": "cust000"}],
     )
 
+    mocker.patch(
+        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
+    )
+
     # GIVEN a db with variants,
     adapter = real_variant_database
     case_id = case_obj["_id"]
@@ -487,7 +491,6 @@ def test_variants_assessment_shared_with_group(
     variants_query_res = adapter.variants(
         other_case_id, query=variants_query, category=variant["category"]
     )
-
     res = variants(adapter, institute_obj, other_case_obj, variants_query_res, 1000)
     res_variants = res["variants"]
 
@@ -502,6 +505,10 @@ def test_variants_research_no_shadow_clinical_assessments(
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
+    )
+
+    mocker.patch(
+        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
     )
 
     # GIVEN a db with variants,
@@ -546,6 +553,10 @@ def test_variants_research_shadow_clinical_assessments(
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
+    )
+
+    mocker.patch(
+        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
     )
 
     # GIVEN a db with variants,
@@ -601,6 +612,10 @@ def test_sv_variants_research_shadow_clinical_assessments(
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
+    )
+
+    mocker.patch(
+        "scout.server.blueprints.variants.controllers.set_overlapping_variants", return_value=None
     )
 
     # GIVEN a db with variants,

--- a/tests/server/blueprints/variants/test_variants_controllers.py
+++ b/tests/server/blueprints/variants/test_variants_controllers.py
@@ -444,14 +444,12 @@ def test_gene_panel_choices(app, institute_obj, case_obj):
 
 
 def test_variants_assessment_shared_with_group(
-    mocker, real_variant_database, institute_obj, case_obj
+    app, mocker, real_variant_database, institute_obj, case_obj
 ):
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
     )
-
-    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -498,14 +496,12 @@ def test_variants_assessment_shared_with_group(
 
 
 def test_variants_research_no_shadow_clinical_assessments(
-    mocker, real_variant_database, institute_obj, case_obj
+    app, mocker, real_variant_database, institute_obj, case_obj
 ):
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
     )
-
-    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -544,14 +540,12 @@ def test_variants_research_no_shadow_clinical_assessments(
 
 
 def test_variants_research_shadow_clinical_assessments(
-    mocker, real_variant_database, institute_obj, case_obj
+    app, mocker, real_variant_database, institute_obj, case_obj
 ):
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
     )
-
-    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database
@@ -601,14 +595,12 @@ def test_variants_research_shadow_clinical_assessments(
 
 
 def test_sv_variants_research_shadow_clinical_assessments(
-    mocker, real_variant_database, institute_obj, case_obj
+    app, mocker, real_variant_database, institute_obj, case_obj
 ):
     mocker.patch(
         "scout.server.blueprints.variants.controllers.user_institutes",
         return_value=[{"_id": "cust000"}],
     )
-
-    mocker.patch("scout.server.blueprints.variants.controllers.set_overlapping_variants")
 
     # GIVEN a db with variants,
     adapter = real_variant_database


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Some tests invoking the variants controller's [def variants](https://github.com/Clinical-Genomics/scout/blob/9dfbf5bf59d011bf90d38e63963440dee0ea0b16/scout/server/blueprints/variants/controllers.py#L126) function are failing when runned by themselves.

### Rationale
I suspect that they fail because they work with a mocked database (real_variant_database) that works fine as long queries are like this: adapter.variants(params). But when they invoke the variants controllers then there is this function to collect [overlapping vars](https://github.com/Clinical-Genomics/scout/blob/9dfbf5bf59d011bf90d38e63963440dee0ea0b16/scout/server/blueprints/variants/controllers.py#L152) that calls stuff and in the end [an adapter function](https://github.com/Clinical-Genomics/scout/blob/9dfbf5bf59d011bf90d38e63963440dee0ea0b16/scout/adapter/mongo/variant.py#L715) that is not working well with the mocked db

These tests do not fail when runned together with the other tests in that file because probably the complete database is set somehow in one of the previous tests


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On main branch, run the tests by themselves, see that they fail
2. Switch to this branch and they should pass

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions, CR, DN
