### PR TITLE
Clearer messages when loading vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests involving the variants controllers, which failed when not run in a specific order (#5391)
 - Option to return to the previous step in each of the steps of the ClinVar submission form (#5393)
 - chanjo2 MT report for cases in build 38 (#5397)
+- Load research variants command prints more clearly which categories of variants are being loaded
 
 ## [4.99]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Tests involving the variants controllers, which failed when not run in a specific order (#5391)
 - Option to return to the previous step in each of the steps of the ClinVar submission form (#5393)
 - chanjo2 MT report for cases in build 38 (#5397)
-- Load research variants command prints more clearly which categories of variants are being loaded
+- Load variants command prints more clearly which categories of variants are being loaded (#5409)
 
 ## [4.99]
 ### Added

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -664,7 +664,7 @@ class VariantLoader(object):
             if vcf_dict["category"] != category:
                 continue
 
-            LOG.debug("Attempt to load %s %s VCF.", variant_type, category.upper())
+            LOG.info(f"\nLoading'{vcf_file_key}' variants")
             variant_file = case_obj["vcf_files"].get(vcf_file_key)
             if variant_file:
                 variant_files.append(variant_file)

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -101,13 +101,12 @@ def research(case_id, institute, force):
                     raise_file_not_found = True
                     continue
                 files = True
-                category = ORDERED_FILE_TYPE_MAP[file_type]["category"]
-                LOG.info(f"Loading '{file_type}' variants, for {case_obj['_id']}")
+                LOG.info(f"\nLoading '{file_type}' variants, for {case_obj['_id']}")
                 upload_research_variants(
                     adapter=adapter,
                     case_obj=case_obj,
                     variant_type="research",
-                    category=category,
+                    category=ORDERED_FILE_TYPE_MAP[file_type]["category"],
                     rank_treshold=case_obj.get("rank_score_threshold", DEFAULT_RANK_THRESHOLD),
                 )
 

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -24,7 +24,6 @@ def upload_research_variants(
     """Delete existing variants and upload new variants"""
     adapter.delete_variants(case_id=case_obj["_id"], variant_type=variant_type, category=category)
 
-    LOG.info("Load %s %s for: %s", variant_type, category.upper(), case_obj["_id"])
     adapter.load_variants(
         case_obj=case_obj,
         variant_type=variant_type,
@@ -102,11 +101,13 @@ def research(case_id, institute, force):
                     raise_file_not_found = True
                     continue
                 files = True
+                category = ORDERED_FILE_TYPE_MAP[file_type]["category"]
+                LOG.info(f"Loading '{file_type}' variants, for {case_obj['_id']}")
                 upload_research_variants(
                     adapter=adapter,
                     case_obj=case_obj,
                     variant_type="research",
-                    category=ORDERED_FILE_TYPE_MAP[file_type]["category"],
+                    category=category,
                     rank_treshold=case_obj.get("rank_score_threshold", DEFAULT_RANK_THRESHOLD),
                 )
 

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -101,7 +101,6 @@ def research(case_id, institute, force):
                     raise_file_not_found = True
                     continue
                 files = True
-                LOG.info(f"\nLoading '{file_type}' variants, for {case_obj['_id']}")
                 upload_research_variants(
                     adapter=adapter,
                     case_obj=case_obj,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Displays clearly which file is being used for loading research variants
- **Does NOT fix** #5408, but makes it easier to debug 

### Before

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/8544cb4b-1b2f-4cf6-9243-06c15d4ed851" />

### After

<img width="546" alt="image" src="https://github.com/user-attachments/assets/e55f773c-a9e0-4d0e-95c4-d55704bec257" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
