### PR TITLE
Fix #5414 - this particular test was also really matching a compound...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to return to the previous step in each of the steps of the ClinVar submission form (#5393)
 - chanjo2 MT report for cases in build 38 (#5397)
 - Load variants command prints more clearly which categories of variants are being loaded (#5409)
+- Fixed some more tests accessing database in and out of app context (#5415)
 
 ## [4.99]
 ### Added

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -428,27 +428,27 @@ def test_filter_cancer_variants_wrong_params(app, institute_obj, case_obj):
 def test_filter_cancer_variants_by_vaf(app, institute_obj, cancer_case_obj, cancer_variant_obj):
     """Tests the cancer form filter by VAF"""
 
-    # GIVEN a database containing a cancer case
-    assert store.case_collection.insert_one(cancer_case_obj)
-
-    # with a variant with a given tumor VAF
-    cancer_variant_obj["tumor"] = {"alt_freq": 0.49}
-    assert store.variant_collection.insert_one(cancer_variant_obj)
-
-    # GIVEN a variant belonging to the case that has tumor alternate frequency
-    assert store.variant_collection.find_one_and_update(
-        {"_id": cancer_variant_obj["_id"]},
-        {
-            "$set": {
-                "case_id": cancer_case_obj["_id"],
-                "category": "cancer",
-                "tumor": {"alt_freq": 0.49},
-            }
-        },
-    )
-
     # GIVEN an initialized app
     with app.test_client() as client:
+        # GIVEN a database containing a cancer case
+        assert store.case_collection.insert_one(cancer_case_obj)
+
+        # with a variant with a given tumor VAF
+        cancer_variant_obj["tumor"] = {"alt_freq": 0.49}
+        assert store.variant_collection.insert_one(cancer_variant_obj)
+
+        # GIVEN a variant belonging to the case that has tumor alternate frequency
+        assert store.variant_collection.find_one_and_update(
+            {"_id": cancer_variant_obj["_id"]},
+            {
+                "$set": {
+                    "case_id": cancer_case_obj["_id"],
+                    "category": "cancer",
+                    "tumor": {"alt_freq": 0.49},
+                }
+            },
+        )
+
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
 
@@ -487,12 +487,12 @@ def test_filter_cancer_variants_by_vaf(app, institute_obj, cancer_case_obj, canc
 def test_sv_cancer_variants(app, institute_obj, cancer_case_obj):
     """Test the SVs page for a cancer case"""
 
-    # GIVEN a database containing a cancer case
-    assert store.case_collection.insert_one(cancer_case_obj)
-
     # GIVEN an initialized app
     # GIVEN a valid user and institute
     with app.test_client() as client:
+        # GIVEN a database containing a cancer case
+        assert store.case_collection.insert_one(cancer_case_obj)
+
         # GIVEN that the user could be logged in
         resp = client.get(url_for("auto_login"))
         assert resp.status_code == 200


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5414 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by GitHub Actions, DN
