### PR TITLE
Fix #Removing variant from ClinVar submission, missing case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed some variantS view tests accessing database out of app context (#5415)
 - Display of matching manual rank on the SV variant page (#5419)
 - Broken `scout setup database` command (#5422)
-- Collecting and removing ClinVar submission data for cases which have been removed (#5421)
+- Collecting submission data for cases which have been removed (#5421)
+- Removing submission data for cases which have been removed ()
 
 ## [4.99]
 ### Added

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -619,8 +619,10 @@ def remove_item_from_submission(submission: str, object_type: str, subm_variant_
     if object_type == "variant_data":
         variant_id: str = subm_variant_id.split("_")[-1]
         variant_obj: dict = store.variant(document_id=variant_id)
-        case_obj: dict = store.case(case_id=variant_obj["case_id"])
-        if not case_obj or not variant_obj:
+        if not variant_obj:
+            return
+        case_obj = store.case(case_id=variant_obj["case_id"])
+        if not case_obj:
             return
         institute_obj: dict = store.institute(institute_id=variant_obj["institute"])
         user_obj: dict = store.user(user_id=current_user._id)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5428 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
