### PR TITLE
Fix #5450 - patched file read order from #5411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Malformatted table cell for analysis date on caseS page (#5438)
 - Remove "Add to ClinVar submission" button for pinned MEI variants as submission is not supported at the moment (#5442)
+- Clinical variant files could once again be read in arbitrary order on load (#5452)
 
 ## [4.100.2]
 ### Fixed

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -935,12 +935,17 @@ class CaseHandler(object):
             for key, value in ORDERED_FILE_TYPE_MAP.items()
             if value["variant_type"] != "research"
         )
-        load_type_cat = set()
+
+        load_type_cat = []
+        cat_seen = set()
         for file_name, vcf_dict in CLINICAL_ORDERED_FILE_TYPE_MAP.items():
             if not case_obj["vcf_files"].get(file_name):
                 LOG.debug("didn't find {}, skipping".format(file_name))
                 continue
-            load_type_cat.add((vcf_dict["variant_type"], vcf_dict["category"]))
+            pair = (vcf_dict["variant_type"], vcf_dict["category"])
+            if pair not in cat_seen:
+                cat_seen.add(pair)
+                load_type_cat.append(pair)
 
         for variant_type, category in load_type_cat:
             if update:

--- a/scout/constants/file_types.py
+++ b/scout/constants/file_types.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-# Variants in Scout will be loadedfor a case  in the same order as these ordered dictionaries
+# Variants in Scout will be loaded for a case in the same order as these ordered dictionaries
 ORDERED_FILE_TYPE_MAP = OrderedDict(
     [
         ("vcf_cancer", {"category": "cancer", "variant_type": "clinical"}),

--- a/tests/adapter/mongo/test_load_adapter_case.py
+++ b/tests/adapter/mongo/test_load_adapter_case.py
@@ -48,3 +48,13 @@ def test_load_case_empty_vcf(real_panel_database, parsed_case, empty_sv_clinical
 
     ## THEN assert that the empty VCF was used
     assert existing_case["vcf_files"]["vcf_sv"] == empty_sv_clinical_file
+
+
+def test_get_load_order(adapter, cancer_case_obj):
+    ### GIVEN a database adapter and a parsed case
+
+    ### WHEN determining variant load order
+    load_type_cat = adapter.get_load_type_categories(cancer_case_obj)
+
+    ### THEN cancer SNVs are taken before cancer SVs
+    assert load_type_cat == [("clinical", "cancer"), ("clinical", "cancer_sv")]


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5450

 <details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
