### PR TITLE
Fix failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Malformatted table cell for analysis date on caseS page (#5438)
 - Remove "Add to ClinVar submission" button for pinned MEI variants as submission is not supported at the moment (#5442)
 - Clinical variant files could once again be read in arbitrary order on load (#5452)
-- Fix test_sanger_validation test to be run in the app context (#5412)
+- Fix test_sanger_validation test to be run with a mock app instantiated (#5453)
 
 
 ## [4.100.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Malformatted table cell for analysis date on caseS page (#5438)
 - Remove "Add to ClinVar submission" button for pinned MEI variants as submission is not supported at the moment (#5442)
+- Fix test_sanger_validation test to be runned in the app context (#5412)
 
 ## [4.100.2]
 ### Fixed

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -90,7 +90,7 @@ def test_case_sanger_and_verified_variants(adapter, institute_obj, case_obj, use
 
 
 def test_get_sanger_unevaluated(
-    app, real_populated_database, variant_objs, institute_obj, case_obj, user_obj
+    mock_app, real_populated_database, variant_objs, institute_obj, case_obj, user_obj
 ):
     """Test get all sanger ordered but not evaluated for an institute"""
 

--- a/tests/adapter/mongo/test_sanger_validation.py
+++ b/tests/adapter/mongo/test_sanger_validation.py
@@ -90,7 +90,7 @@ def test_case_sanger_and_verified_variants(adapter, institute_obj, case_obj, use
 
 
 def test_get_sanger_unevaluated(
-    real_populated_database, variant_objs, institute_obj, case_obj, user_obj
+    app, real_populated_database, variant_objs, institute_obj, case_obj, user_obj
 ):
     """Test get all sanger ordered but not evaluated for an institute"""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

New release branch:

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/85bc19a4-eeee-4d72-873d-0a6979ad6de3" />


- Another fix for #5383
- Same as #5391

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
