### PR TITLE
Fix #5454 - long STRs display on case page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Fix long STR variant pinned display on case page (#5455)
+
+
 ## [4.101]
 ### Changed
 - Institutes are now sorted by ID on gene panels page (#5436)

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -157,7 +157,12 @@ def coverage_report_contents(base_url, institute_obj, case_obj):
     return html_body_content
 
 
-def _populate_case_groups(store, case_obj, case_groups, case_group_label):
+def _populate_case_groups(
+    store: MongoAdapter,
+    case_obj: dict,
+    case_groups: Dict[str, List[str]],
+    case_group_label: Dict[str, str],
+):
     """Case groups allow display of information about user linked cases together on one case.
     Notably variantS lists show shared annotations and alignment views show all alignments
     available for the group.
@@ -179,12 +184,8 @@ def _populate_case_groups(store, case_obj, case_groups, case_group_label):
 
 
 def _get_partial_causatives(store: MongoAdapter, case_obj: Dict) -> List[Dict]:
-    """Return any partial causatives a case has, populated as causative objs.
-    Args:
-        store(adapter.MongoAdapter)
-        case_obj(models.Case)
-    Returns:
-        partial(list(dict))
+    """Check for partial causatives and associated phenotypes.
+    Return any partial causatives a case has, populated as causative objs.
     """
 
     partial_causatives = []
@@ -287,7 +288,7 @@ def bionano_case(store, institute_obj, case_obj) -> Dict:
     return data
 
 
-def sma_case(store, institute_obj, case_obj):
+def sma_case(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:
     """Preprocess a case for tabular view, SMA."""
 
     _populate_case_individuals(case_obj)
@@ -302,6 +303,26 @@ def sma_case(store, institute_obj, case_obj):
         "region": GENOME_REGION[case_obj.get("genome_build", "38")],
     }
     return data
+
+
+def _get_marked_variants(
+    store: MongoAdapter, institute_obj: dict, case_obj: dict, kind: str = "suspects"
+) -> list:
+    """Fetch the variant objects for suspects and causatives and decorate them.
+    If no longer available, append variant_id instead."""
+
+    marked_vars = []
+    for variant_id in case_obj.get(kind, []):
+        variant_obj = store.variant(variant_id)
+        if variant_obj:
+            marked_vars.append(
+                _get_decorated_var(
+                    store, var_obj=variant_obj, institute_obj=institute_obj, case_obj=case_obj
+                )
+            )
+        else:
+            marked_vars.append(variant_id)
+    return marked_vars
 
 
 def case(
@@ -331,21 +352,15 @@ def case(
     case_group_label = {}
     _populate_case_groups(store, case_obj, case_groups, case_group_label)
 
-    # Fetch the variant objects for suspects and causatives
-    suspects = [
-        store.variant(variant_id) or variant_id for variant_id in case_obj.get("suspects", [])
-    ]
+    suspects = _get_marked_variants(store, institute_obj, case_obj, "suspects")
     _populate_assessments(suspects)
-    causatives = [
-        store.variant(variant_id) or variant_id for variant_id in case_obj.get("causatives", [])
-    ]
+
+    causatives = _get_marked_variants(store, institute_obj, case_obj, "causatives")
     _populate_assessments(causatives)
 
-    # get evaluated variants
     evaluated_variants = store.evaluated_variants(case_obj["_id"], case_obj["owner"])
     _populate_assessments(evaluated_variants)
 
-    # check for partial causatives and associated phenotypes
     partial_causatives = _get_partial_causatives(store, case_obj)
     _populate_assessments(partial_causatives)
 
@@ -676,7 +691,9 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
             add_bayesian_acmg_classification(var_obj)
             add_bayesian_ccv_classification(var_obj)
             evaluated_variants_by_type[eval_category].append(
-                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
+                _get_decorated_var(
+                    store, var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj
+                )
             )
 
     for var_obj in store.evaluated_variants(
@@ -689,7 +706,9 @@ def case_report_variants(store: MongoAdapter, case_obj: dict, institute_obj: dic
     data["variants"] = evaluated_variants_by_type
 
 
-def _get_decorated_var(var_obj: dict, institute_obj: dict, case_obj: dict) -> dict:
+def _get_decorated_var(
+    store: MongoAdapter, var_obj: dict, institute_obj: dict, case_obj: dict
+) -> dict:
     """Decorate a variant object for display using the variant controller"""
     return variant_decorator(
         store=store,
@@ -719,7 +738,9 @@ def _append_evaluated_variant_by_type(
             add_bayesian_ccv_classification(var_obj)
 
             evaluated_variants_by_type[eval_category].append(
-                _get_decorated_var(var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj)
+                _get_decorated_var(
+                    store, var_obj=var_obj, institute_obj=institute_obj, case_obj=case_obj
+                )
             )
 
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -310,7 +310,7 @@ def sma_case(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:
     return data
 
 
-def _get_marked_variants(
+def _get_suspects_or_causatives(
     store: MongoAdapter, institute_obj: dict, case_obj: dict, kind: str = "suspects"
 ) -> list:
     """Fetch the variant objects for suspects and causatives and decorate them.
@@ -357,10 +357,10 @@ def case(
     case_group_label = {}
     _populate_case_groups(store, case_obj, case_groups, case_group_label)
 
-    suspects = _get_marked_variants(store, institute_obj, case_obj, "suspects")
+    suspects = _get_suspects_or_causatives(store, institute_obj, case_obj, "suspects")
     _populate_assessments(suspects)
 
-    causatives = _get_marked_variants(store, institute_obj, case_obj, "causatives")
+    causatives = _get_suspects_or_causatives(store, institute_obj, case_obj, "causatives")
     _populate_assessments(causatives)
 
     evaluated_variants = store.evaluated_variants(case_obj["_id"], case_obj["owner"])

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -458,21 +458,7 @@
               <div class="row">
                 <div class="col">
                   <i class="far fa-check-circle"></i>
-                  {% if variant.category == "snv" %}
-                    <a href="{{ url_for('variant.variant',
-                                        institute_id=variant.institute,
-                                        case_name=case.display_name,
-                                        variant_id=variant._id) }}">
-                          {{ variant.hgnc_symbols|join(', ') }} (partial causative)
-  		             {% else %}
-          		      <a href="{{ url_for('variant.sv_variant',
-                                              institute_id=variant.institute,
-                                              case_name=case.display_name,
-                                              variant_id=variant._id) }}">
-  		              {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.chromosome }}{{ variant.cytoband_end }})
-                    (partial causative)
-  		             {% endif %}
-                   </a>
+                  {{ pretty_link_variant(variant, case) }} (partial causative)
                 </div>
                 <div class="col-2" style="width:fit-content;">
                   {{ remove_form(url_for('cases.mark_causative',

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -301,7 +301,7 @@
         {% for gene in variant.genes %} {{ gene.symbol }} {% endfor %}
       {% endif %}
       {% if variant.str_mc %}
-        {{ variant.str_mc }}
+        STR{{ variant.str_mc }}
       {% else %}
         {{ variant.alternative|truncate(20,True) }}
       {% endif %}

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -293,8 +293,18 @@
 
   {% if variant.category %}
     {% if variant.category in "str" %}
-      {{ variant.str_repid }} {{ variant.alternative | replace("<", " ") | replace(">", "")}}
-
+      {% if variant.str_repid %}
+        {{ variant.str_repid }}
+      {% elif variant.str_trid %}
+        {{ variant.str_trid  }}
+      {% else %}
+        {% for gene in variant.genes %} {{ gene.symbol }} {% endfor %}
+      {% endif %}
+      {% if variant.str_mc %}
+        {{ variant.str_mc }}
+      {% else %}
+        {{ variant.alternative|truncate(20,True) }}
+      {% endif %}
     {% elif variant.category in ("snv", "cancer") %}
       {% set display_genes = [] %}
       {% for gene in variant.genes %}
@@ -339,18 +349,24 @@
 {% macro pretty_link_variant(variant, case) %}
 {# Returns human readable links to the corresponding variant page #}
 
-  {% if variant.category in ("mei", "str", "snv", "cancer") %}
-    {% if variant.category == "cancer" %}
-    <a href='{{ url_for('variant.cancer_variant',
-                   institute_id=variant.institute,
-                   case_name=case.display_name,
-                   variant_id=variant._id) }}' target='_blank'>
-    {% else %}
+  {% if variant.category in ("mei", "snv") %}
     <a href='{{ url_for('variant.variant',
                    institute_id=variant.institute,
                    case_name=case.display_name,
                    variant_id=variant._id) }}' target='_blank'>
-    {% endif %}
+  {% elif variant.category == "str" %}
+    <a href='{{ url_for('variant.variant',
+                   institute_id=variant.institute,
+                   case_name=case.display_name,
+                   variant_id=variant._id) }}'
+       data-bs-toggle='tooltip'
+       title='{{ variant.alternative | replace("<", " ") | replace(">", "")}}'
+       target='_blank'>
+  {% elif variant.category == "cancer" %}
+    <a href='{{ url_for('variant.cancer_variant',
+                   institute_id=variant.institute,
+                   case_name=case.display_name,
+                   variant_id=variant._id) }}' target='_blank'>
   {% elif variant.category == "outlier" %}
     <a href='{{ url_for('omics_variants.outliers',
        institute_id=variant.institute, case_name=case.display_name) }}' target='_blank'>
@@ -360,7 +376,7 @@
                               case_name=case.display_name,
                               variant_id=variant._id) }}' target='_blank'>
   {% endif %}
-    {{ pretty_variant(variant) }}
+  {{ pretty_variant(variant) }}
   </a>
 {% endmacro %}
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -28,6 +28,7 @@ from scout.constants import (
     VERBS_MAP,
 )
 from scout.server.blueprints.variant.utils import (
+    get_str_mc,
     update_representative_gene,
     update_variant_case_panels,
 )
@@ -313,6 +314,9 @@ def variant(
         )
 
     variant_obj["end_position"] = end_position(variant_obj)
+
+    # common motif count for STR variants
+    variant_obj["str_mc"] = get_str_mc(variant_obj)
 
     # Add general variant links
     variant_obj.update(get_variant_links(institute_obj, variant_obj, int(genome_build)))

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Dict, List, Optional, Tuple
 
 from scout.adapter import MongoAdapter

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -683,3 +683,25 @@ def associate_variant_genes_with_case_panels(case_obj: Dict, variant_obj: Dict) 
             geneid_gene[hgnc_id]["associated_gene_panels"] = matching_panels
 
     variant_obj["genes"] = list(geneid_gene.values())
+
+
+def get_str_mc(variant_obj: dict) -> Optional[int]:
+    """Return variant Short Tandem Repeat motif count, either as given by its ALT MC value
+    from the variant FORMAT field, or as a number given in the ALT on the form
+    '<STR123>'.
+    """
+    alt_mc = None
+    if variant_obj["alternative"] == ".":
+        return alt_mc
+
+    for sample in variant_obj["samples"]:
+        if sample["genotype_call"] in ["./.", ".|", "0/0", "0|0"]:
+            continue
+        alt_mc = sample.get("alt_mc")
+    if alt_mc:
+        return alt_mc
+
+    alt_num = NUM.search(variant_obj["alternative"])
+    if alt_num:
+        alt_mc = int(alt_num.group())
+        return alt_mc

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -14,6 +14,8 @@ from scout.server.links import add_gene_links, add_tx_links
 
 LOG = logging.getLogger(__name__)
 
+NUM = re.compile(r"\d+")
+
 
 def add_panel_specific_gene_info(panel_info: List[dict]) -> dict:
     """Adds manually curated information from a gene panel to a gene

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -15,8 +15,6 @@ from scout.server.links import add_gene_links, add_tx_links
 
 LOG = logging.getLogger(__name__)
 
-NUM = re.compile(r"\d+")
-
 
 def add_panel_specific_gene_info(panel_info: List[dict]) -> dict:
     """Adds manually curated information from a gene panel to a gene
@@ -693,6 +691,8 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
     from the variant FORMAT field, or as a number given in the ALT on the form
     '<STR123>'.
     """
+    NUM = re.compile(r"\d+")
+
     alt_mc = None
     if variant_obj["alternative"] == ".":
         return alt_mc

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -35,6 +35,7 @@ from scout.server.blueprints.variant.utils import (
     clinsig_human,
     get_callers,
     get_filters,
+    get_str_mc,
     predictions,
     update_representative_gene,
     update_variant_case_panels,
@@ -995,28 +996,6 @@ def parse_variant(
     variant_obj["filters"] = get_filters(variant_obj)
 
     return variant_obj
-
-
-def get_str_mc(variant_obj: dict) -> Optional[int]:
-    """Return variant Short Tandem Repeat motif count, either as given by its ALT MC value
-    from the variant FORMAT field, or as a number given in the ALT on the form
-    '<STR123>'.
-    """
-    alt_mc = None
-    if variant_obj["alternative"] == ".":
-        return alt_mc
-
-    for sample in variant_obj["samples"]:
-        if sample["genotype_call"] in ["./.", ".|", "0/0", "0|0"]:
-            continue
-        alt_mc = sample.get("alt_mc")
-    if alt_mc:
-        return alt_mc
-
-    alt_num = NUM.search(variant_obj["alternative"])
-    if alt_num:
-        alt_mc = int(alt_num.group())
-        return alt_mc
 
 
 def download_str_variants(case_obj, variant_objs):

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -58,8 +58,6 @@ from .forms import (
 )
 from .utils import update_case_panels
 
-NUM = re.compile(r"\d+")
-
 LOG = logging.getLogger(__name__)
 
 

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1,6 +1,5 @@
 import decimal
 import logging
-import re
 from typing import Any, Dict, List, Optional
 
 from flask import Response, flash, session, url_for

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1,5 +1,6 @@
 import decimal
 import logging
+import re
 from typing import Any, Dict, List, Optional
 
 from flask import Response, flash, session, url_for


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5454

![Screenshot 2025-05-12 at 11 22 39](https://github.com/user-attachments/assets/d406b1b7-2b69-4a76-9e39-a21157d066cd)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
