### PR TITLE
Alamut alignment file link

### DIFF
--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -19,6 +19,19 @@ LOG = logging.getLogger(__name__)
 DEFAULT_TRACK_NAMES = ["Genes", "ClinVar", "ClinVar CNVs"]
 
 
+def check_user_authentication():
+    """Make sure that a user requesting a resource is authenticated
+
+    Returns
+        True is user has access to resource else False
+    """
+    # Check that user is logged in or that file extension is valid
+    if current_user.is_authenticated is False:
+        LOG.warning("Unauthenticated user requesting resource via remote_static_whole")
+        return False
+    return True
+
+
 def check_session_tracks(resource):
     """Make sure that a user requesting a resource is authenticated and resource is in session IGV tracks
 

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -8,11 +8,7 @@ from flask_login import current_user
 
 from scout.constants import CASE_SPECIFIC_TRACKS, HUMAN_REFERENCE, IGV_TRACKS
 from scout.server.extensions import config_igv_tracks, store
-from scout.server.utils import (
-    case_append_alignments,
-    find_index,
-    get_case_genome_build,
-)
+from scout.server.utils import case_append_alignments, find_index, get_case_genome_build
 from scout.utils.ensembl_rest_clients import EnsemblRestApiClient
 
 LOG = logging.getLogger(__name__)

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -2,14 +2,17 @@
 import logging
 from typing import Optional
 
+import jwt
 import requests
 from flask import (
     Blueprint,
     Response,
     abort,
     copy_current_request_context,
+    current_app,
     render_template,
     request,
+    send_file,
     session,
 )
 
@@ -83,6 +86,31 @@ def remote_static():
 
     new_resp = send_file_partial(file_path)
     return new_resp
+
+
+@alignviewers_bp.route("/remote/static/whole", methods=["OPTIONS", "GET"])
+def remote_static_whole():
+    allowed_file_types = ["bam", "cram"]
+    if controllers.check_user_authentication() is False:
+        return abort(403)
+    index = False
+    token = request.args.get("token")
+    if not token:
+        return abort(400)
+    if token.count(".") == 3:
+        index = token.split(".")[-1]
+        token = token[: -(len(index) + 1)]
+    try:
+        payload = jwt.decode(token, current_app.config["SECRET_KEY"], algorithms="HS256")
+    except Exception as error:
+        return abort(400)
+    file_path = payload["file"]
+    if file_path.split(".")[-1] not in allowed_file_types:
+        return abort(403)
+    if index:
+        file_path = file_path + "." + index
+    resp = send_file(file_path)
+    return resp
 
 
 @alignviewers_bp.route(

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -34,7 +34,7 @@ from scout.server.blueprints.variant.utils import (
 )
 from scout.server.blueprints.variants.utils import update_case_panels
 from scout.server.extensions import LoqusDB, chanjo2, config_igv_tracks, gens
-from scout.server.links import disease_link, get_variant_links
+from scout.server.links import alamut_file_links, disease_link, get_variant_links
 from scout.server.utils import (
     case_has_alignments,
     case_has_chanjo2_coverage,
@@ -337,6 +337,8 @@ def variant(
 
     # Convert affection status to strings for the template
     is_affected(variant_obj, case_obj)
+
+    case_obj["alamut_file_links"] = alamut_file_links(institute_obj, case_obj)
 
     if variant_obj.get("genetic_models"):
         variant_models = set(model.split("_", 1)[0] for model in variant_obj["genetic_models"])

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -126,18 +126,6 @@
           {{ splice_junctions_button(institute._id, case, variant._id) }}
         </div>
       {% endif %}
-      {% if variant.alamut_link %}
-        <div class="ms-1">
-          <a href="{{ variant.alamut_link }}" class="btn btn-sm btn-secondary" target="_blank" data-bs-toggle="tooltip" title="Alamut Visual (Plus) - Open variant - with genome g. coordinate">Alamut g.</a>
-        </div>
-      {% endif %}
-      {% for gene in variant.genes %}
-        <div class="ms-1">
-        {% if gene.alamut_link %}
-          <a href="{{ gene.alamut_link }}" class="btn btn-sm btn-secondary text-white" rel="noopener" referrerpolicy="no-referrer" target="_blank" data-bs-toggle="tooltip" title="Alamut Visual (Plus) - Open variant - with gene transcript c. coordinate">Alamut {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }} c.</a>
-        {% endif %}
-        </div>
-      {% endfor %}
     </li>
     <li class="list-group-item">
       <div>
@@ -148,6 +136,32 @@
       <li class="list-group-item d-flex justify-content-between">
         {{ gene_coverage(institute, variant, case, config) }}
       </li>
+    {% endif %}
+    {% if variant.alamut_link  %}
+    <li class="list-group-item d-flex justify-content-between">
+      <div>
+      Alamut Visual Plus 
+      </div>
+      <div>
+        Open coordinates
+      {% if variant.alamut_link %}
+          <input type="button" class="btn btn-sm btn-secondary text-white" data-bs-toggle="tooltip" title="Alamut Visual (Plus) - Open variant - with genome g. coordinate" value='genome' onclick='linkOutsideSoftware("{{variant.alamut_link}}");'/>
+      {% endif %}
+      {% for gene in variant.genes %}
+        {% if gene.alamut_link %}
+          <input type="button" class="btn btn-sm btn-secondary text-white" data-bs-toggle="tooltip" title="Alamut Visual (Plus) - Open variant - with gene transcript c. coordinate" value=' {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}' onclick='linkOutsideSoftware("{{gene.alamut_link}}");'/>
+        {% endif %}
+      {% endfor %}
+      </div>
+      <div>
+      {% if case['alamut_file_links'] %}
+        Open align. file:
+      {% for sample, file_link in case['alamut_file_links'].items() %}
+          <input type="button" class="btn btn-sm btn-secondary text-white" value='{{sample}}' data-bs-toggle="tooltip" title="Open alignment file for sample {{sample}}" onclick='linkOutsideSoftware("{{file_link[0] + url_for('alignviewers.remote_static_whole', token=file_link[1], _external=True)}}");'/>
+          {% endfor %}
+      {% endif %}
+      </div>
+    </li>
     {% endif %}
   </ul>
 {% endmacro %}
@@ -546,5 +560,12 @@
       }
     }
 
+    function linkOutsideSoftware(alamut_coord_link) {
+    // open Alamut browser
+    var http_req = new XMLHttpRequest();
+    http_req.open( "GET", alamut_coord_link, true);
+    http_req.send();
+
+  }
   </script>
 {% endmacro %}

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
+import jwt
 
 from flask import current_app
 
@@ -889,6 +890,54 @@ def alamut_gene_link(
         build_str=build_str,
         hgvs_identifier=quote(hgvs_raw),
     )
+
+
+def alamut_file_links(
+    institute_obj: Dict[str, Any],
+    case_obj: Dict[str, Any],
+):
+    """Compose a link which loads an alignment file in the Alamut software.
+    Alamut links require some settings from the institute object.
+
+    Args:
+        institute_obj(scout.models.Institute)
+        case_obj(scout.models.Case)
+    Returns:
+        dict url_template(str): link to Alamut browser
+        links(dict): {
+            sample_display_name: url_template(str)}
+    """
+
+    if current_app.config.get("HIDE_ALAMUT_LINK"):
+        return False
+
+    if not institute_obj:
+        return False
+
+    (search_verb, alamut_key_arg, alamut_inst_arg) = _get_alamut_config(institute_obj)
+
+    if alamut_key_arg == "":
+        return False
+
+    url_template = (
+        "http://localhost:10000/open?{alamut_key_arg}{alamut_inst_arg}filetype={file_type}&path="
+    )
+    links = {}
+    for ind in case_obj.get("individuals"):
+        file = ind.get("bam_file")
+        if file is not None:
+            file_type = file.split(".")[-1]
+            link = url_template.format(
+                alamut_key_arg=alamut_key_arg,
+                alamut_inst_arg=alamut_inst_arg,
+                file_type=file_type,
+            )
+            payload = {"file": file}
+            token = jwt.encode(
+                payload=payload, key=current_app.config["SECRET_KEY"], algorithm="HS256"
+            )
+            links[ind.get("display_name")] = (link, token)
+    return links
 
 
 def _get_alamut_config(institute_obj: dict) -> Tuple[str, ...]:

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote
-import jwt
 
+import jwt
 from flask import current_app
 
 from scout.utils.convert import amino_acid_residue_change_3_to_1


### PR DESCRIPTION
This PR would close issue #1621

Well. This works, at least in my end, which is about all I can say for it

Some explanantions: Alamut takes the path given in the url and adds ".bai" to the end to find the index, and if that path doesn't lead to it, loading the file fails. So that has to be worked around.

While tokens as I understand generally are sent in a header, I don't know if there's anyway to tell Alamut to send a specific header with the request, so with the url it goes... Also, an ampersand in the path gets interpreted the end of the path, so I can't get it to take both a filename and a seperate token.

Functionally, the biggest downside is that Alamut displays the path above the alignment, so when the path is encoded, that name becomes less than helpful.

Any suggestions?

OR

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
