### PR TITLE
Show assignees in case list when user ID is different from email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix long STR variant pinned display on case page (#5455)
 - Variant page crashing when Loqusdb instance is chosen on institute settings but is not found at the given URL (#5447)
+- Show assignees in case list when using LDAP authentication (#5460)
 
 ## [4.101]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Fix long STR variant pinned display on case page (#5455)
 - Variant page crashing when Loqusdb instance is chosen on institute settings but is not found at the given URL (#5447)
-- Show assignees in case list when using LDAP authentication (#5460)
+- Show assignees in case list when user ID is different from email (#5460)
 
 ## [4.101]
 ### Changed

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -619,7 +619,7 @@ def populate_case_obj(case_obj: dict, store: MongoAdapter):
         analysis_types = set(["mixed"])
     case_obj["analysis_types"] = list(analysis_types)
 
-    case_obj["assignees"] = [store.user(user_email) for user_email in case_obj.get("assignees", [])]
+    case_obj["assignees"] = [store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])]
 
     last_analysis_date = case_obj.get("analysis_date", datetime.datetime.now())
     all_analyses_dates = {

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -619,7 +619,9 @@ def populate_case_obj(case_obj: dict, store: MongoAdapter):
         analysis_types = set(["mixed"])
     case_obj["analysis_types"] = list(analysis_types)
 
-    case_obj["assignees"] = [store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])]
+    case_obj["assignees"] = [
+        store.user(user_id=user_id) for user_id in case_obj.get("assignees", [])
+    ]
 
     last_analysis_date = case_obj.get("analysis_date", datetime.datetime.now())
     all_analyses_dates = {


### PR DESCRIPTION
This PR fixes an issue where the assignees for a case wouldn't be visible in the list of cases. This is exactly the same fix as for #3979, but here it wasn't as apparent that something was missing.