### PR TITLE
Remove observations when removing ClinVar variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix long STR variant pinned display on case page (#5455)
 - Variant page crashing when Loqusdb instance is chosen on institute settings but is not found at the given URL (#5447)
 - Show assignees in case list when user ID is different from email (#5460)
+- When removing a germline variant from a ClinVar submission, make sure to remove also its associated observations from the database (#5463)
 
 ## [4.101]
 ### Changed

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -397,7 +397,7 @@ class ClinVarHandler(object):
         self.clinvar_submission_collection.find_one_and_update(
             {"_id": ObjectId(submission_id)},
             {"$pull": {"case_data": {"$regex": f"^{re.escape(object_id)}"}}},
-            return_document=ReturnDocument.AFTER,  # Or BEFORE, depending on what you want
+            return_document=ReturnDocument.AFTER,
         )
 
         return self.clinvar_submission_collection.find_one_and_update(

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -394,16 +394,13 @@ class ClinVarHandler(object):
 
         # in any case remove reference to it in the submission object 'case_data' list field
 
-        self.clinvar_submission_collection.find_one_and_update(
-            {"_id": ObjectId(submission_id)},
-            {"$pull": {"case_data": {"$regex": f"^{re.escape(object_id)}"}}},
-            return_document=ReturnDocument.AFTER,
-        )
-
         return self.clinvar_submission_collection.find_one_and_update(
-            {"_id": submission_id},
-            {"$set": {"updated_at": datetime.now()}},
-            return_document=pymongo.ReturnDocument.AFTER,
+            {"_id": ObjectId(submission_id)},
+            {
+                "$set": {"updated_at": datetime.now()},
+                "$pull": {"case_data": {"$regex": f"^{re.escape(object_id)}"}},
+            },
+            return_document=ReturnDocument.AFTER,
         )
 
     def case_to_clinVars(self, case_id):

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
+import re
 from datetime import datetime
 from typing import List, Optional
 
 import pymongo
-from bson import ObjectId
 from bson.objectid import ObjectId
 from pymongo import ReturnDocument
 
@@ -393,8 +393,11 @@ class ClinVarHandler(object):
             self.clinvar_collection.delete_one({"_id": object_id})
 
         # in any case remove reference to it in the submission object 'case_data' list field
+
         self.clinvar_submission_collection.find_one_and_update(
-            {"_id": ObjectId(submission_id)}, {"$pull": {"case_data": object_id}}
+            {"_id": ObjectId(submission_id)},
+            {"$pull": {"case_data": {"$regex": f"^{re.escape(object_id)}"}}},
+            return_document=ReturnDocument.AFTER,  # Or BEFORE, depending on what you want
         )
 
         return self.clinvar_submission_collection.find_one_and_update(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5462 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
