### PR TITLE
Fix #4705 - Dim cases from always-show categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Refactored and simplified code that fetches case's genome build (#5443)
+- On caseS page, dim cases only included from the always display cases with status option (#5464)
 ### Fixed
 - Fix long STR variant pinned display on case page (#5455)
 - Variant page crashing when Loqusdb instance is chosen on institute settings but is not found at the given URL (#5447)

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -573,6 +573,7 @@ def cases(store: MongoAdapter, request: request, institute_id: str) -> dict:
         cases_in_status = _sort_cases(data, request, cases_in_status)
         for case_obj in cases_in_status:
             populate_case_obj(case_obj, store)
+            case_obj["dimmed_in_search"] = True
             case_groups[status].append(case_obj)
             nr_cases_showall_statuses += 1
 
@@ -597,7 +598,11 @@ def cases(store: MongoAdapter, request: request, institute_id: str) -> dict:
     # Process additional cases for the remaining statuses
     nr_cases = 0
     for case_obj in all_cases:
-        if case_obj["status"] not in status_show_all_cases:
+        if case_obj["status"] in status_show_all_cases:
+            for group_case in case_groups[status]:
+                if group_case["_id"] == case_obj["_id"]:
+                    group_case["dimmed_in_search"] = False
+        else:
             if nr_cases == limit:
                 break
             populate_case_obj(case_obj, store)

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -51,6 +51,28 @@ VAR_SPECIFIC_EVENTS = [
     "cancel_sanger",
 ]
 
+# Projection for fetching cases
+ALL_CASES_PROJECTION = {
+    "analysis_date": 1,
+    "assignees": 1,
+    "beacon": 1,
+    "case_id": 1,
+    "display_name": 1,
+    "genome_build": 1,
+    "individuals": 1,
+    "is_rerun": 1,
+    "is_research": 1,
+    "mme_submission": 1,
+    "owner": 1,
+    "panels": 1,
+    "phenotype_terms": 1,
+    "rank_model_version": 1,
+    "status": 1,
+    "sv_rank_model_version": 1,
+    "track": 1,
+    "vcf_files": 1,
+}
+
 
 def get_timeline_data(limit):
     """Retrieve chronologially ordered events from the database to display them in the timeline page
@@ -523,6 +545,32 @@ def export_case_samples(institute_id, filtered_cases) -> Response:
     )
 
 
+def get_and_set_cases_by_query(
+    store: MongoAdapter,
+    request: request,
+    institute_id: str,
+    data: dict,
+) -> list:
+    """Fetch additional cases based on filters given in request query form.
+
+    Sets metadata in data, e.g. sort order.
+    """
+
+    name_query = request.form
+    all_cases = store.cases(
+        collaborator=institute_id,
+        name_query=name_query,
+        skip_assigned=request.form.get("skip_assigned"),
+        is_research=request.form.get("is_research"),
+        has_rna_data=request.form.get("has_rna"),
+        verification_pending=request.form.get("validation_ordered"),
+        has_clinvar_submission=request.form.get("clinvar_submitted"),
+        projection=ALL_CASES_PROJECTION,
+    )
+    all_cases = _sort_cases(data, request, all_cases)
+    return all_cases
+
+
 def cases(store: MongoAdapter, request: request, institute_id: str) -> dict:
     """Preprocess case objects for the 'cases' view."""
     data = {}
@@ -538,34 +586,18 @@ def cases(store: MongoAdapter, request: request, institute_id: str) -> dict:
     sanger_ordered_not_validated = get_sanger_unevaluated(store, institute_id, current_user.email)
     data["sanger_unevaluated"], data["sanger_validated_by_others"] = sanger_ordered_not_validated
 
-    # Projection for fetching cases
-    ALL_CASES_PROJECTION = {
-        "analysis_date": 1,
-        "assignees": 1,
-        "beacon": 1,
-        "case_id": 1,
-        "display_name": 1,
-        "genome_build": 1,
-        "individuals": 1,
-        "is_rerun": 1,
-        "is_research": 1,
-        "mme_submission": 1,
-        "owner": 1,
-        "panels": 1,
-        "phenotype_terms": 1,
-        "rank_model_version": 1,
-        "status": 1,
-        "sv_rank_model_version": 1,
-        "track": 1,
-        "vcf_files": 1,
-    }
+    all_cases = get_and_set_cases_by_query(store, request, institute_id, data)
+
+    if request.form.get("export"):
+        return export_case_samples(institute_id, all_cases)
+
+    # Process cases for statuses that require all cases to be shown
+    status_show_all_cases = institute_obj.get("show_all_cases_status") or ["prioritized"]
+    nr_cases_showall_statuses = 0
 
     # Group cases by status
     case_groups = {status: [] for status in CASE_STATUSES}
-    nr_cases_showall_statuses = 0
-    status_show_all_cases = institute_obj.get("show_all_cases_status") or ["prioritized"]
 
-    # Process cases for statuses that require all cases to be shown
     for status in status_show_all_cases:
         cases_in_status = store.cases_by_status(
             institute_id=institute_id, status=status, projection=ALL_CASES_PROJECTION
@@ -577,27 +609,11 @@ def cases(store: MongoAdapter, request: request, institute_id: str) -> dict:
             case_groups[status].append(case_obj)
             nr_cases_showall_statuses += 1
 
-    # Fetch additional cases based on filters
-    name_query = request.form
-    limit = int(request.form.get("search_limit")) if request.form.get("search_limit") else 100
-    all_cases = store.cases(
-        collaborator=institute_id,
-        name_query=name_query,
-        skip_assigned=request.form.get("skip_assigned"),
-        is_research=request.form.get("is_research"),
-        has_rna_data=request.form.get("has_rna"),
-        verification_pending=request.form.get("validation_ordered"),
-        has_clinvar_submission=request.form.get("clinvar_submitted"),
-        projection=ALL_CASES_PROJECTION,
-    )
-    all_cases = _sort_cases(data, request, all_cases)
-
-    if request.form.get("export"):
-        return export_case_samples(institute_id, all_cases)
-
     # Process additional cases for the remaining statuses
     nr_cases = 0
+    limit = int(request.form.get("search_limit")) if request.form.get("search_limit") else 100
     for case_obj in all_cases:
+        # Don't dim cases that already appeared in query search results
         if case_obj["status"] in status_show_all_cases:
             for group_case in case_groups[status]:
                 if group_case["_id"] == case_obj["_id"]:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -607,10 +607,10 @@ def get_and_set_cases_by_status(
 ) -> dict:
     """Process cases for statuses that require all cases to be shown.
     Group cases by status, process additional cases for the remaining statuses
-    and ensure that we don't dim cases that already appeared in query search results (are on the all_cases).
+    and ensure that we don't dim cases that already appeared in query search results.
     """
 
-    status_show_all_cases = institute_obj.get("show_all_cases_status") or ["prioritized"]
+    status_show_all_cases = institute_obj.get("show_all_cases_status", ["prioritized"])
     nr_cases_showall_statuses = 0
 
     # Group cases by status
@@ -628,15 +628,15 @@ def get_and_set_cases_by_status(
             nr_cases_showall_statuses += 1
 
     nr_name_query_matching_displayed_cases = 0
-    limit = int(request.form.get("search_limit")) if request.form.get("search_limit") else 100
+    limit = int(request.form.get("search_limit", 100))
     for case_obj in previous_query_result_cases:
         if case_obj["status"] in status_show_all_cases:
             for group_case in case_groups[status]:
                 if group_case["_id"] == case_obj["_id"]:
                     group_case["dimmed_in_search"] = False
+        elif nr_name_query_matching_displayed_cases == limit:
+            break
         else:
-            if nr_name_query_matching_displayed_cases == limit:
-                break
             populate_case_obj(case_obj, store)
             case_groups[case_obj["status"]].append(case_obj)
             nr_name_query_matching_displayed_cases += 1

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -63,7 +63,7 @@
 
 
 {% macro case_row(case) %}
-  <tr class="{% if case.status == 'solved' %}causative{% endif %}">
+  <tr class="{% if case.status == 'solved' %}causative{% elif case.dimmed_in_search %}dismiss{% endif %}">
     <td>
       <a class="me-2"
          {% if case.individuals|length == 1 %} data-bs-toggle="tooltip" title="{{case.individuals[0].display_name}}" {% endif %}

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -153,7 +153,6 @@ def logout_oidc_user(session, provider: str):
     """Log out a user from an OIDC login provider-"""
     logout_url = current_app.config[provider].get("logout_url")
     if not logout_url or not session.get("token_response"):
-        flash(f"Could not log out - url {logout_url} session token {session.get('token_response')}")
         return
     refresh_token = session["token_response"]["refresh_token"]
     requests.post(

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -153,6 +153,7 @@ def logout_oidc_user(session, provider: str):
     """Log out a user from an OIDC login provider-"""
     logout_url = current_app.config[provider].get("logout_url")
     if not logout_url or not session.get("token_response"):
+        flash(f"Could not log out - url {logout_url} session token {session.get('token_response')}")
         return
     refresh_token = session["token_response"]["refresh_token"]
     requests.post(

--- a/tests/adapter/mongo/test_case_group_handling.py
+++ b/tests/adapter/mongo/test_case_group_handling.py
@@ -1,7 +1,5 @@
 from bson.objectid import ObjectId
 
-logger = logging.getLogger(__name__)
-
 
 def test_init_case_group(adapter, institute_obj):
     # given a database and an institute

--- a/tests/adapter/mongo/test_case_group_handling.py
+++ b/tests/adapter/mongo/test_case_group_handling.py
@@ -1,8 +1,3 @@
-import copy
-import logging
-
-import pymongo
-import pytest
 from bson.objectid import ObjectId
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #4705 

"Dismiss" color caseS that were not featured in search explicitly, but included "only" for being in an always-show category.

![Screenshot 2025-05-19 at 09 24 18](https://github.com/user-attachments/assets/95776f49-8b95-48e8-bf33-a223d1820def)

Works also when the situation is more complex, as e.g. multiple matches and some in "solved" cases that already have a highlight.

![Screenshot 2025-05-19 at 09 15 56](https://github.com/user-attachments/assets/4b1ac7fa-90b9-4ef0-bb32-e0d2970749e2)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
