### PR TITLE
Fix #5469 - let flask login deal with clearing session itself in its time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show assignees in case list when user ID is different from email (#5460)
 - When removing a germline variant from a ClinVar submission, make sure to remove also its associated observations from the database (#5463)
 - Chanjo2 genes full coverage check when variant has no genes (#5468)
+- Full Flask user logout blocked by session clear (#5470)
 
 ## [4.101]
 ### Changed

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -106,7 +106,6 @@ def logout():
     for provider in ["GOOGLE", "KEYCLOAK"]:
         if current_app.config.get(provider):
             controllers.logout_oidc_user(session, provider)
-    session.clear()
     flash("you logged out", "success")
     return redirect(url_for("public.index"))
 

--- a/scout/server/blueprints/login/views.py
+++ b/scout/server/blueprints/login/views.py
@@ -13,7 +13,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import login_user, logout_user
+from flask_login import logout_user
 
 from scout.server.extensions import login_manager, oauth_client, store
 from scout.server.utils import public_endpoint


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. hit logout on main
2. hit logout on branch


**Expected outcome**:
Main
![Screenshot 2025-05-20 at 12 07 54](https://github.com/user-attachments/assets/bacda550-336d-4967-9d9b-e4fb77cca8d4)


Branch
![Screenshot 2025-05-20 at 12 09 07](https://github.com/user-attachments/assets/a3aafb14-677c-4566-8d9a-2d1cad628054)


**Review:**
- [ ] code approved by
- [ ] tests executed by
