### PR TITLE
Clinvar links on report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- ClinVar data with link to ClinVar for variants present on the general case report (#5478)
 ### Changed
 - Refactored and simplified code that fetches case's genome build (#5443)
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -2,6 +2,7 @@
 {% from "utils.html" import comments_table, variant_related_comments_table %}
 {% from "variant/gene_disease_relations.html" import inheritance_badge %}
 {% from "variants/components.html" import fusion_variants_header, default_fusion_variant_cells %}
+{% from "variant/components.html" import clinsig_table %}
 
 {% extends "report_base.html" %}
 
@@ -592,6 +593,7 @@
           </td>
           <td style="width:3%"></td>
           <td>
+            {{ clinsig_table(variant) }}
             <table id="panel-table" class="table table-sm" style="background-color: transparent">
               <thead>
                 <tr>
@@ -670,6 +672,7 @@
             {% if not cancer %}
               <th>Inheritance models</th>
             {% endif %}
+            <th>ClinVar</th>
             <th>ACMG classification</th>
             <th>Bayesian classification</th>
             {% if cancer %}
@@ -716,6 +719,9 @@
                 </span>
               </td>
             {% endif %}
+            <td>
+
+            </td>
             <td>
               {% if variant.acmg_classification %}
                 <span class="badge rounded-pill bg-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['label']}}">{{variant.acmg_classification['label'] }}</span>

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -672,7 +672,6 @@
             {% if not cancer %}
               <th>Inheritance models</th>
             {% endif %}
-            <th>ClinVar</th>
             <th>ACMG classification</th>
             <th>Bayesian classification</th>
             {% if cancer %}
@@ -719,9 +718,6 @@
                 </span>
               </td>
             {% endif %}
-            <td>
-
-            </td>
             <td>
               {% if variant.acmg_classification %}
                 <span class="badge rounded-pill bg-{{variant.acmg_classification['color'] if variant.acmg_classification['color'] else 'secondary'}}" title="{{variant.acmg_classification['label']}}">{{variant.acmg_classification['label'] }}</span>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5473. I'm placing this table on top of the pop frequency one (1000G, ExaC, etc) on purpose because the latter is going to be smaller in the future (see #5474)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
