### PR TITLE
Do not raise error when trying to load missing omics files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Refactored and simplified code that fetches case's genome build (#5443)
+- Loading of outliers files (Fraser and Outrider) do not raise error when path to these files is missing or wrong, just a warning (#5485)
 ### Fixed
 - Fix long STR variant pinned display on case page (#5455)
 - Variant page crashing when Loqusdb instance is chosen on institute settings but is not found at the given URL (#5447)

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from typing import Dict, Iterable, List, Optional
 
 from pymongo import ASCENDING, DESCENDING
@@ -129,6 +130,13 @@ class OmicsVariantHandler:
         omics_file_type: dict = ORDERED_OMICS_FILE_TYPE_MAP.get(file_type)
 
         nr_inserted = 0
+
+        file_path = case_obj["omics_files"].get(file_type)
+        if file_path is None or os.path.exists(file_path) is False:
+            LOG.warning(
+                f"File '{file_path}' not found on disk. Please update case {case_obj['_id']} with a valid file path for {file_type}."
+            )
+            return
 
         file_handle = open(case_obj["omics_files"].get(file_type), "r")
 

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -642,7 +642,6 @@ class VariantLoader(object):
         Returns:
             nr_inserted(int)
         """
-
         institute_id = case_obj["owner"]
 
         nr_inserted = 0
@@ -662,6 +661,9 @@ class VariantLoader(object):
             variant_file = case_obj["vcf_files"].get(vcf_file_key)
 
             if not variant_file or not self._has_variants_in_file(variant_file):
+                LOG.warning(
+                    f"File '{variant_file}' not found on disk. Please update case {case_obj['_id']} with a valid file path for variant category: '{category}'."
+                )
                 continue
 
             vcf_obj = VCF(variant_file)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5483 

### Trying to load omics files for a case not having these files:

<img width="1296" alt="image" src="https://github.com/user-attachments/assets/74ac58d6-6912-410f-ad6d-bb3f6eaa6948" />


### Trying to load a type of variant where the case has no associated files for it:

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/2dac508d-359e-4c98-8bd7-c9cb5fdd039f" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
