### PR TITLE
Fix #5487 - update HPO deep link URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - When removing a germline variant from a ClinVar submission, make sure to remove also its associated observations from the database (#5463)
 - Chanjo2 genes full coverage check when variant has no genes (#5468)
 - Full Flask user logout blocked by session clear (#5470)
+- HPO term deep link URL updated to a working one (#5488)
 
 ## [4.101]
 ### Changed

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -78,6 +78,7 @@ from .indexes import ID_PROJECTION, INDEXES
 from .panels import PANELAPP_CONFIDENCE_EXCLUDE
 from .phenotype import (
     COHORT_TAGS,
+    HPO_LINK_URL,
     HPO_URL,
     HPOTERMS_URL,
     ORPHA_URLS,

--- a/scout/constants/phenotype.py
+++ b/scout/constants/phenotype.py
@@ -2,6 +2,7 @@ HPO_URL = "http://purl.obolibrary.org/obo/hp/hpoa/{}"
 HPOTERMS_URL = (
     "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo"
 )
+HPO_LINK_URL = "https://hpo.jax.org/browse/term/"
 
 ORPHA_URLS = {
     "orpha_to_hpo": "https://www.orphadata.com/data/xml/en_product4.xml",

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -22,6 +22,7 @@ from scout.constants import (
     CUSTOM_CASE_REPORTS,
     DATE_DAY_FORMATTER,
     GENOME_REGION,
+    HPO_LINK_URL,
     INHERITANCE_PALETTE,
     MITODEL_HEADER,
     MT_COV_STATS_HEADER,
@@ -388,9 +389,7 @@ def case(
     for hpo_term in itertools.chain(
         case_obj.get("phenotype_groups") or [], case_obj.get("phenotype_terms") or []
     ):
-        hpo_term["hpo_link"] = "http://hpo.jax.org/app/browse/term/{}".format(
-            hpo_term["phenotype_id"]
-        )
+        hpo_term["hpo_link"] = f"{HPO_LINK_URL}{hpo_term['phenotype_id']}"
 
     _set_rank_model_links(case_obj)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
