### PR TITLE
Actually use unique aliases when searching for hgnc_id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Introduced a function that checks redirect URLs to avoid redirection to external sites (#5458)
 - Loading of missing outliers files should also not raise error if key exists but is unset (#5497)
 - Do not add null references to HPO-associated genes when parsing errors occur (#5472)
+- Trust hgnc_id for unique aliases for HPO-associated genes (#5498)
 
 ## [4.101]
 ### Changed

--- a/scout/load/hpo.py
+++ b/scout/load/hpo.py
@@ -42,10 +42,13 @@ def load_hpo_terms(
 
         # Fetch gene info to get correct HGNC id
         gene_info = alias_genes.get(hgnc_symbol)
-        if not gene_info or gene_info["true"] is None:
+        if not gene_info:
             continue
 
-        hgnc_id = gene_info["true"]
+        if gene_info["true"] is not None:
+            hgnc_id = gene_info["true"]
+        elif len(gene_info["ids"]) == 1:
+            hgnc_id = list(gene_info["ids"])[0]
 
         if hpo_id not in hpo_terms:
             continue


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5471 - the part with unique aliases
<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
