### PR TITLE
Fix #5506 - dim more cases if no specific case query given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-###
+### Added
 - Add cancer SNVs to Oncogenicity ClinVar submissions (downloadable json document only) (#5449)
+### Fixed
+- More clearly dim cases for empty queries (#5507)
 
 ## [4.102]
 ### Added

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -603,11 +603,14 @@ def get_and_set_cases_by_status(
             case_groups[status].append(case_obj)
             nr_cases_showall_statuses += 1
 
-    def get_specific_query(request):
+    def get_specific_query(request: request) -> bool:
         """Check if only (non-)specific query terms were used in query.
         If so we assume this is a default query, and dim all cases
         that match the "show_all_cases_status", highlighting the
         (max limit number) other cases that were returned.
+
+        If this is a specific query, cases returned by this query part will be highlighted even
+        if they have a status that matches "show_all_cases_status".
         """
         cases_query = store.cases(
             collaborator=institute_obj["_id"],

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -621,7 +621,7 @@ def get_and_set_cases_by_status(
         )
         LOG.warning(f"Case query was {cases_query}")
         for key, value in cases_query.items():
-            if key not in ["collaborators"] and value not in [None, ""]:
+            if key not in NONSPECIFIC_QUERY_TERMS and value not in [None, ""]:
                 return False
         return True
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -620,7 +620,7 @@ def get_and_set_cases_by_status(
             yield_query=True,
         )
         LOG.warning(f"Case query was {cases_query}")
-        for key, value in cases_query():
+        for key, value in cases_query.items():
             if key not in ["collaborators"] and value not in [None, ""]:
                 return False
         return True

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -571,17 +571,6 @@ def get_cases_by_query(
         projection=ALL_CASES_PROJECTION,
     )
 
-    cases_query = store.cases(
-        collaborator=institute_id,
-        name_query=name_query,
-        skip_assigned=request.form.get("skip_assigned"),
-        is_research=request.form.get("is_research"),
-        has_rna_data=request.form.get("has_rna"),
-        verification_pending=request.form.get("validation_ordered"),
-        has_clinvar_submission=request.form.get("clinvar_submitted"),
-        yield_query=True,
-    )
-    LOG.warning(f"Case query was {cases_query}")
     return all_cases
 
 
@@ -620,7 +609,18 @@ def get_and_set_cases_by_status(
         that match the "show_all_cases_status", highlighting the
         (max limit number) other cases that were return.
         """
-        for key, value in form.items():
+        cases_query = store.cases(
+            collaborator=institute_obj["_id"],
+            name_query=request.form,
+            skip_assigned=request.form.get("skip_assigned"),
+            is_research=request.form.get("is_research"),
+            has_rna_data=request.form.get("has_rna"),
+            verification_pending=request.form.get("validation_ordered"),
+            has_clinvar_submission=request.form.get("clinvar_submitted"),
+            yield_query=True,
+        )
+        LOG.warning(f"Case query was {cases_query}")
+        for key, value in cases_query():
             if key not in ["collaborators"] and value not in [None, ""]:
                 return False
         return True

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -604,10 +604,10 @@ def get_and_set_cases_by_status(
             nr_cases_showall_statuses += 1
 
     def get_specific_query(request):
-        """Check if only non-specific query terms were used in query.
+        """Check if only (non-)specific query terms were used in query.
         If so we assume this is a default query, and dim all cases
         that match the "show_all_cases_status", highlighting the
-        (max limit number) other cases that were return.
+        (max limit number) other cases that were returned.
         """
         cases_query = store.cases(
             collaborator=institute_obj["_id"],
@@ -622,8 +622,8 @@ def get_and_set_cases_by_status(
         LOG.warning(f"Case query was {cases_query}")
         for key, value in cases_query.items():
             if key not in NONSPECIFIC_QUERY_TERMS and value not in [None, ""]:
-                return False
-        return True
+                return True
+        return False
 
     specific_query_asked = get_specific_query(request)
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -51,6 +51,7 @@ VAR_SPECIFIC_EVENTS = [
     "cancel_sanger",
 ]
 
+# Query terms in default, non-specific queries for cases
 NONSPECIFIC_QUERY_TERMS = [
     "collaborators",
 ]
@@ -604,15 +605,17 @@ def get_and_set_cases_by_status(
             nr_cases_showall_statuses += 1
 
     def get_specific_query(request: request) -> bool:
-        """Check if only (non-)specific query terms were used in query.
+        """Check if only non-specific query terms were used in query,
+        by yielding the query without actually executing it.
+
         If so we assume this is a default query, and dim all cases
         that match the "show_all_cases_status", highlighting the
         (max limit number) other cases that were returned.
 
-        If this is a specific query, cases returned by this query part will be highlighted even
-        if they have a status that matches "show_all_cases_status".
+        If this is a specific query, cases returned by this query part will be explicitly
+        highlighted even if they have a status that matches "show_all_cases_status".
         """
-        cases_query = store.cases(
+        cases_query: dict = store.cases(
             collaborator=institute_obj["_id"],
             name_query=request.form,
             skip_assigned=request.form.get("skip_assigned"),

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -603,7 +603,7 @@ def get_and_set_cases_by_status(
             case_groups[status].append(case_obj)
             nr_cases_showall_statuses += 1
 
-    def get_specific_query(form):
+    def get_specific_query(request):
         """Check if only non-specific query terms were used in query.
         If so we assume this is a default query, and dim all cases
         that match the "show_all_cases_status", highlighting the
@@ -625,7 +625,7 @@ def get_and_set_cases_by_status(
                 return False
         return True
 
-    specific_query_asked = get_specific_query(request.form)
+    specific_query_asked = get_specific_query(request)
 
     nr_name_query_matching_displayed_cases = 0
     limit = int(request.form.get("search_limit", 100))

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -619,7 +619,6 @@ def get_and_set_cases_by_status(
             has_clinvar_submission=request.form.get("clinvar_submitted"),
             yield_query=True,
         )
-        LOG.warning(f"Case query was {cases_query}")
         for key, value in cases_query.items():
             if key not in NONSPECIFIC_QUERY_TERMS and value not in [None, ""]:
                 return True


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5506

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. go to an institute, note the cases displayed by default. 
2. ensure you have some prioritised case
3. if no prioritised case is highlighted, select a default case from the list below and prioritise it
4. If no prioritised case is dimmed, increase the limit slightly from the default (100 -> 101) to get an extra case. Mark that case prioritised.
5. go back to the normal limit (100). You should now have one prioritised case dimmed, the others "highlighted" - i e displaying as per usual, showing the issue
6. apply patch
7. note that all prio cases now appear dimmed


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
