### PR TITLE
On variant SNVs search, display multiple HGVS for multigenic variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Add cancer SNVs to Oncogenicity ClinVar submissions (downloadable json document only) (#5449)
+### Changed
+- On `Search SNVs and SVs` page, display multiple HGVS descriptors when variant has mpre than one gene ()
 ### Fixed
 - Instance badge class and config option documentation (#5500)
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -282,6 +282,31 @@ def register_filters(app):
         return cosmicId
 
     @app.template_filter()
+    def format_variant_canonical_transcripts(variant):
+        """Formats canonical transcripts for all genes in a variant."""
+
+        def truncate_string(s, length):
+            if s and len(s) > length:
+                return s[: length - 3] + "..."
+            return s
+
+        output_lines = []
+
+        for gene in variant.get("genes", []):
+            for tx in gene.get("transcripts", []):
+                if tx.get("is_canonical"):
+                    line = f"{gene.get('canonical_transcript', '')} ({gene.get('hgnc_symbol', '')})"
+                    hgvs = gene.get("hgvs_identifier")
+                    if hgvs:
+                        line += " " + truncate_string(hgvs, 20)
+                    protein = tx.get("protein_sequence_name")
+                    if protein:
+                        line += " " + truncate_string(protein, 20)
+                    output_lines.append(line)
+
+        return output_lines
+
+    @app.template_filter()
     def upper_na(string):
         """
         Uppercase ocurences of "dna" and "rna" for nice display.

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -96,11 +96,13 @@
         {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.end_chrom }}{{ variant.cytoband_end }})
        {% endif %}
   {% else %}
-    <a href="{{ url_for('variant.variant', institute_id=variant.institute,
+      <a href="{{ url_for('variant.variant', institute_id=variant.institute,
             case_name=variant.case_display_name, variant_id=variant._id) }}" target="_blank">
-    {{ (variant.hgvs or '')|url_decode }}
+      {% for gene in variant.genes %}
+          {{ gene.hgvs_identifier|url_decode }}
+      {% endfor %}
   {% endif %}
-  </a>
+   </a>
 {% endmacro %}
 
 {% macro cell_rank(variant) %}

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -98,18 +98,9 @@
   {% else %}
       <a href="{{ url_for('variant.variant', institute_id=variant.institute,
             case_name=variant.case_display_name, variant_id=variant._id) }}" target="_blank">
-      {% for gene in variant.genes %}
-        {% for tx in gene.transcripts %}
-          {% if tx.is_canonical %}
-            {% set output = gene.canonical_transcript + " (" + gene.hgnc_symbol + ") " + (gene.hgvs_identifier | truncate(20, True)) %}
-            {% if tx.protein_sequence_name %}
-              {{ output + " " + (tx.protein_sequence_name | truncate(20, True)) }}
-            {% else %}
-              {{ output }}
-            {% endif %}
-          {% endif %}
-        {% endfor %}
-    {% endfor %}
+      {% for line in variant | format_variant_canonical_transcripts %}
+        {{ line }}
+      {% endfor %}
   {% endif %}
    </a>
 {% endmacro %}

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -99,8 +99,17 @@
       <a href="{{ url_for('variant.variant', institute_id=variant.institute,
             case_name=variant.case_display_name, variant_id=variant._id) }}" target="_blank">
       {% for gene in variant.genes %}
-          {{ gene.hgvs_identifier|url_decode }}
-      {% endfor %}
+        {% for tx in gene.transcripts %}
+          {% if tx.is_canonical %}
+            {% set output = gene.canonical_transcript + " (" + gene.hgnc_symbol + ") " + (gene.hgvs_identifier | truncate(20, True)) %}
+            {% if tx.protein_sequence_name %}
+              {{ output + " " + (tx.protein_sequence_name | truncate(20, True)) }}
+            {% else %}
+              {{ output }}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+    {% endfor %}
   {% endif %}
    </a>
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5512 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
