### PR TITLE
Fix parsing of canonical transcripts for variants outside genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add cancer SNVs to Oncogenicity ClinVar submissions (downloadable json document only) (#5449)
 ### Fixed
 - Instance badge class and config option documentation (#5500)
+- Parsing of canonical transcript in variants genes when variant is outside the coding sequence (#5515)
 
 ## [4.102]
 ### Added

--- a/scout/parse/variant/gene.py
+++ b/scout/parse/variant/gene.py
@@ -48,10 +48,6 @@ def parse_genes(transcripts):
     # List with all genes and their transcripts
     genes = []
 
-    hgvs_identifier = None
-    canonical_transcript = None
-    exon = None
-
     # Loop over all genes
     for gene_id in genes_to_transcripts:
         # Get the transcripts for a gene
@@ -78,8 +74,7 @@ def parse_genes(transcripts):
             hgnc_symbol = transcript["hgnc_symbol"]
             if not hgvs_identifier:
                 hgvs_identifier = transcript.get("coding_sequence_name")
-            if not canonical_transcript:
-                canonical_transcript = transcript["transcript_id"]
+
             if not exon:
                 exon = transcript["exon"]
 
@@ -102,10 +97,11 @@ def parse_genes(transcripts):
                 most_severe_spliceai_position = transcript["spliceai_delta_position"]
                 spliceai_prediction = transcript["spliceai_prediction"]
 
-            if transcript["is_canonical"] and transcript.get("coding_sequence_name"):
-                hgvs_identifier = transcript.get("coding_sequence_name")
+            if transcript["is_canonical"]:
                 canonical_transcript = transcript["transcript_id"]
-                exon = transcript["exon"]
+                if transcript.get("coding_sequence_name"):
+                    hgvs_identifier = transcript.get("coding_sequence_name")
+                    exon = transcript["exon"]
 
         gene = {
             "transcripts": gene_transcripts,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5515 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
