### PR TITLE
Fix downloading of json ClinVar submission with no observation data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - More clearly dim cases for empty queries (#5507)
 - Case search form enforces numeric input for number of results returned (`Limit` field) (#5519)
 - Parsing of canonical transcript in variants genes when variant is outside the coding sequence (#5515)
-- Download of ClinVar submission's json file when observation data is no longer present in the database (#)
+- Download of ClinVar submission's json file when observation data is no longer present in the database (#5520)
 
 ## [4.102]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - More clearly dim cases for empty queries (#5507)
 - Case search form enforces numeric input for number of results returned (`Limit` field) (#5519)
 - Parsing of canonical transcript in variants genes when variant is outside the coding sequence (#5515)
+- Download of ClinVar submission's json file when observation data is no longer present in the database (#)
 
 ## [4.102]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - More clearly dim cases for empty queries (#5507)
 - Case search form enforces numeric input for number of results returned (`Limit` field) (#5519)
 - Parsing of canonical transcript in variants genes when variant is outside the coding sequence (#5515)
-- Download of ClinVar submission's json file when observation data is no longer present in the database (#5520)
+- Download of a ClinVar submission's json file when observation data is no longer present in the database (#5520)
 
 ## [4.102]
 ### Added

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -335,8 +335,8 @@ class ClinVarHandler(object):
             criteria = {"assertionCriteriaDB": amc_db, "assertionCriteriaID": amc_id}
             return criteria
 
-    def clinvar_objs(self, submission_id, key_id):
-        """Collects a list of objects from the clinvar collection (variants of case data) as specified by the key_id in the clinvar submission
+    def clinvar_objs(self, submission_id: str, key_id: str) -> list:
+        """Collects a list of objects from the ClinVar collection (variants of case data) as specified by the key_id in the submission.
 
         Args:
             submission_id(str): the _id key of a clinvar submission
@@ -345,8 +345,8 @@ class ClinVarHandler(object):
 
         Returns:
             clinvar_objects(list) : a list of clinvar objects (either variants of casedata)
-
         """
+
         # Get a submission object
         submission = self.clinvar_submission_collection.find_one({"_id": ObjectId(submission_id)})
 
@@ -356,7 +356,7 @@ class ClinVarHandler(object):
             clinvar_objects = self.clinvar_collection.find({"_id": {"$in": clinvar_obj_ids}})
             return list(clinvar_objects)
 
-        return None
+        return []
 
     def rename_casedata_samples(self, submission_id, case_id, old_name, new_name):
         """Rename all samples associated to a clinVar submission

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -403,7 +403,7 @@ def json_api_submission(submission_id):
     variant_data: list = store.clinvar_objs(submission_id, "variant_data")
     obs_data: list = store.clinvar_objs(submission_id, "case_data")
 
-    if variant_data == [] or obs_data == []:
+    if not variant_data or not obs_data:
         flash("Submission must contain both Variant and CaseData info", "warning")
         return safe_redirect_back(request)
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -404,8 +404,7 @@ def json_api_submission(submission_id):
     obs_data: list = store.clinvar_objs(submission_id, "case_data")
 
     if not variant_data or not obs_data:
-        flash("Submission must contain both Variant and CaseData info", "warning")
-        return safe_redirect_back(request)
+        return (400, "Submission must contain both Variant and CaseData info")
 
     # Retrieve eventual assertion criteria for the submission
     extra_params = store.clinvar_assertion_criteria(variant_data[0]) or {}

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple, Union
 
-from flask import flash
+from flask import flash, request
 from flask_login import current_user
 from pydantic_core._pydantic_core import ValidationError
 from werkzeug.datastructures import ImmutableMultiDict

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -400,13 +400,10 @@ def json_api_submission(submission_id):
     Returns:
         A tuple: code(int), conversion_res(dict) - corresponding to response.status and response.__dict__ from preClinVar
     """
-    variant_data = store.clinvar_objs(submission_id, "variant_data")
-    obs_data = store.clinvar_objs(submission_id, "case_data")
+    variant_data: list = store.clinvar_objs(submission_id, "variant_data")
+    obs_data: list = store.clinvar_objs(submission_id, "case_data")
 
-    LOG.warning(variant_data)
-    LOG.error(obs_data)
-
-    if None in [variant_data, obs_data]:
+    if variant_data == [] or obs_data == []:
         flash("Submission must contain both Variant and CaseData info", "warning")
         return safe_redirect_back(request)
 

--- a/scout/server/blueprints/clinvar/controllers.py
+++ b/scout/server/blueprints/clinvar/controllers.py
@@ -21,7 +21,7 @@ from scout.constants.variant_tags import MANUAL_RANK_OPTIONS
 from scout.models.clinvar import OncogenicitySubmissionItem, clinvar_variant
 from scout.server.blueprints.variant.utils import add_gene_info
 from scout.server.extensions import clinvar_api, store
-from scout.server.utils import get_case_genome_build
+from scout.server.utils import get_case_genome_build, safe_redirect_back
 from scout.utils.hgvs import validate_hgvs
 from scout.utils.scout_requests import fetch_refseq_version
 
@@ -403,8 +403,12 @@ def json_api_submission(submission_id):
     variant_data = store.clinvar_objs(submission_id, "variant_data")
     obs_data = store.clinvar_objs(submission_id, "case_data")
 
+    LOG.warning(variant_data)
+    LOG.error(obs_data)
+
     if None in [variant_data, obs_data]:
-        return (400, "Submission must contain both Variant and CaseData info")
+        flash("Submission must contain both Variant and CaseData info", "warning")
+        return safe_redirect_back(request)
 
     # Retrieve eventual assertion criteria for the submission
     extra_params = store.clinvar_assertion_criteria(variant_data[0]) or {}

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -132,26 +132,27 @@ def clinvar_update_submission(institute_id, submission):
 
 
 @clinvar_bp.route("/<submission>/download/json/<clinvar_id>", methods=["GET"])
-def clinvar_download_json(submission, clinvar_id):
+def clinvar_download_json(submission: str, clinvar_id: str):
     """Download a json for a clinVar submission"""
+    filename = clinvar_id if clinvar_id != "None" else submission
 
     code, conversion_res = controllers.json_api_submission(submission_id=submission)
 
     if code in [200, 201]:
         # Write temp CSV file and serve it in response
-        tmp_json = NamedTemporaryFile(mode="a+", prefix=clinvar_id, suffix=".json")
+        tmp_json = NamedTemporaryFile(mode="a+", prefix=filename, suffix=".json")
         tmp_json.write(dumps(conversion_res, indent=4))
 
         tmp_json.flush()
         tmp_json.seek(0)
         return send_file(
             tmp_json.name,
-            download_name=f"{clinvar_id}.json",
+            download_name=f"{filename}.json",
             mimetype="application/json",
             as_attachment=True,
         )
     else:
-        flash(f"JSON file could not be crated for ClinVar submission: {clinvar_id} ", "warning")
+        flash(f"JSON file could not be crated for ClinVar submission: {filename} ", "warning")
         return redirect(request.referrer)
 
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -5,6 +5,7 @@ from typing import List, Tuple
 
 from flask import (
     Blueprint,
+    Response,
     flash,
     redirect,
     render_template,
@@ -132,8 +133,14 @@ def clinvar_update_submission(institute_id, submission):
 
 
 @clinvar_bp.route("/<submission>/download/json/<clinvar_id>", methods=["GET"])
-def clinvar_download_json(submission: str, clinvar_id: str):
-    """Download a json for a clinVar submission"""
+def clinvar_download_json(submission: str, clinvar_id: Optional[str]) -> Response:
+    """Download a json for a clinVar submission.
+
+    Accepts:
+        submission:. It's the _id of the submission in the database
+        clinvar_id: It's the submission number (i.e. SUB123456). Might be available or not in the submission dictionary
+
+    """
     filename = clinvar_id if clinvar_id != "None" else submission
 
     code, conversion_res = controllers.json_api_submission(submission_id=submission)

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -152,7 +152,10 @@ def clinvar_download_json(submission: str, clinvar_id: str):
             as_attachment=True,
         )
     else:
-        flash(f"JSON file could not be crated for ClinVar submission: {filename} ", "warning")
+        flash(
+            f"JSON file could not be crated for ClinVar submission: {filename}: {conversion_res}",
+            "warning",
+        )
         return redirect(request.referrer)
 
 

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -1,7 +1,7 @@
 import logging
 from json import dumps
 from tempfile import NamedTemporaryFile
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from flask import (
     Blueprint,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5459

<img width="1238" alt="image" src="https://github.com/user-attachments/assets/0d30c141-ccc0-493a-806b-2a273bf13a37" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On cg-vm1, go to cust000 and try to download the currently open ClinVar submission as a json.
2. Compare behaviour of this PR branch with main branch (main branch crashes)

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
