### PR TITLE
Fix #5524 - dont warn on unset file types on case load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Case search form enforces numeric input for number of results returned (`Limit` field) (#5519)
 - Parsing of canonical transcript in variants genes when variant is outside the coding sequence (#5515)
 - Download of a ClinVar submission's json file when observation data is no longer present in the database (#5520)
+- Removed extra warnings for missing file types on case loading (#5525)
 
 ## [4.102]
 ### Added

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -657,14 +657,18 @@ class VariantLoader(object):
             if vcf_dict["category"] != category:
                 continue
 
-            LOG.info(f"Loading'{vcf_file_key}' variants")
             variant_file = (
                 case_obj["vcf_files"].get(vcf_file_key) if case_obj.get("vcf_files") else None
             )
 
-            if not variant_file or not self._has_variants_in_file(variant_file):
+            if variant_file:
+                LOG.info(f"Loading {vcf_file_key} variants")
+            else:
+                continue
+
+            if not self._has_variants_in_file(variant_file):
                 LOG.warning(
-                    f"File '{variant_file}' not found on disk. Please update case {case_obj['_id']} with a valid file path for variant category: '{category}'."
+                    f"File '{variant_file}' not found on disk. Please update case {case_obj['_id']} with a valid file path for the {category} variant category ."
                 )
                 continue
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5524 - it was just an unnecessary warning

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
