### PR TITLE
Pass login token in chanjo2 requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add cancer SNVs to Oncogenicity ClinVar submissions (downloadable json document only) (#5449)
 ### Changed
 - Improved test that checks code collecting other categories of variants overlapping a variant (#5521)
-- Include authentication token in requests to Chanjo2 for secure endpoint access (#5525)
+- Include authentication token in requests to Chanjo2 for secure endpoint access (#5527)
 ### Fixed
 - Instance badge class and config option documentation (#5500)
 - Fix incorrect reference to non-existent pymongo.synchronous (#5517)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add cancer SNVs to Oncogenicity ClinVar submissions (downloadable json document only) (#5449)
 ### Changed
 - Improved test that checks code collecting other categories of variants overlapping a variant (#5521)
+- Include authentication token in requests to Chanjo2 for secure endpoint access (#5525)
 ### Fixed
 - Instance badge class and config option documentation (#5500)
 - Fix incorrect reference to non-existent pymongo.synchronous (#5517)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 	"Flask>=2.0",
 	"Flask-Bootstrap",
 	"Flask-CORS",
-"path.py", # this is deprecated
+	"path.py", # this is deprecated
 	"markdown",
 	"WTForms",
 	"Flask-WTF",
@@ -76,6 +76,7 @@ dependencies = [
 	"anytree",
 	# Required by scripts
 	"tabulate",
+	"python-jose>=3.5.0",
 ]
 
 [project.optional-dependencies]

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -29,7 +29,8 @@
     {% set interval_type = "transcripts" %}
   {% endif %}
 
-  <form id="chanjo2-form" name="{{form_name}}" method="post" action="{{form_action}}" target="_blank" rel="noopener">
+  <form name="{{form_name}}" method="post" action="{{form_action}}" target="_blank" rel="noopener">
+    <input type="hidden" id="access_token" name="access_token" value="{{ session.token_response.access_token if session.token_response else '' }}">
     <input type="hidden" id="build" name="build" value="{{build}}">
     <input type="hidden" id="default_level" name="default_level" value="{{default_level}}">
     <input type="hidden" id="interval_type" name="interval_type" value="{{interval_type}}">
@@ -45,40 +46,3 @@
   </form>
 
 {% endmacro %}
-
-{% block scripts %}
-  <script>
-    document.getElementById('chanjo2-form').addEventListener('submit', async function(event) {
-      event.preventDefault();  // Prevent default form submission
-      const form = event.target;
-      const formData = new FormData(form);
-      const params = new URLSearchParams();
-      for (const [key, value] of formData.entries()) {
-        params.append(key, value);
-      }
-
-      try {
-        const token = "{{ session.token_response.access_token if session.token_response else "NA" | safe }}";
-        const response = await fetch(form.action, {
-          method: 'POST',
-          headers: {
-            'Authorization': 'Bearer ' + token,
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-          body: params.toString()
-        });
-
-        if (response.ok) {
-          const blob = await response.blob();
-          const url = window.URL.createObjectURL(blob);
-          window.open(url, '_blank');  // Open response in a new tab
-        } else {
-          const errorText = await response.text();
-          alert('Submission failed: ' + errorText);
-        }
-      } catch (err) {
-        alert('Error submitting form: ' + err.message);
-      }
-    });
-  </script>
-{% endblock %}

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -63,7 +63,7 @@
           method: 'POST',
           headers: {
             'Authorization': 'Bearer ' + token,
-            'Content-Type': 'application/x-www-form-urlencoded'
+            'Content-Type': 'application/x-www-form-urlencoded',
           },
           body: params.toString()
         });

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -58,7 +58,7 @@
       }
 
       try {
-        const token = "{{ session.token_response.access_token | safe }}";  // Token passed in from Flask context
+        const token = "{{ session.token_response.access_token | safe }}";
         const response = await fetch(form.action, {
           method: 'POST',
           headers: {

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -58,7 +58,7 @@
       }
 
       try {
-        const token = "{{ session.token_response.access_token | safe }}";
+        const token = "{{ session.token_response.access_token if session.token_response else "NA" | safe }}";
         const response = await fetch(form.action, {
           method: 'POST',
           headers: {

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -29,7 +29,7 @@
     {% set interval_type = "transcripts" %}
   {% endif %}
 
-  <form name="{{form_name}}" method="post" action="{{form_action}}" target="_blank" rel="noopener">
+  <form id="chanjo2-form" name="{{form_name}}" method="post" action="{{form_action}}" target="_blank" rel="noopener">
     <input type="hidden" id="build" name="build" value="{{build}}">
     <input type="hidden" id="default_level" name="default_level" value="{{default_level}}">
     <input type="hidden" id="interval_type" name="interval_type" value="{{interval_type}}">
@@ -45,3 +45,40 @@
   </form>
 
 {% endmacro %}
+
+{% block scripts %}
+  <script>
+    document.getElementById('chanjo2-form').addEventListener('submit', async function(event) {
+      event.preventDefault();  // Prevent default form submission
+      const form = event.target;
+      const formData = new FormData(form);
+      const params = new URLSearchParams();
+      for (const [key, value] of formData.entries()) {
+        params.append(key, value);
+      }
+
+      try {
+        const token = "{{ session.token_response.access_token | safe }}";  // Token passed in from Flask context
+        const response = await fetch(form.action, {
+          method: 'POST',
+          headers: {
+            'Authorization': 'Bearer ' + token,
+            'Content-Type': 'application/x-www-form-urlencoded'
+          },
+          body: params.toString()
+        });
+
+        if (response.ok) {
+          const blob = await response.blob();
+          const url = window.URL.createObjectURL(blob);
+          window.open(url, '_blank');  // Open response in a new tab
+        } else {
+          const errorText = await response.text();
+          alert('Submission failed: ' + errorText);
+        }
+      } catch (err) {
+        alert('Error submitting form: ' + err.message);
+      }
+    });
+  </script>
+{% endblock %}

--- a/scout/server/blueprints/login/controllers.py
+++ b/scout/server/blueprints/login/controllers.py
@@ -1,10 +1,11 @@
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 import requests
 from flask import Response, current_app, flash, redirect, session, url_for
 from flask_login import login_user
+from jose import ExpiredSignatureError, JWTError, jwt
 
 from scout.server.extensions import ldap_manager, oauth_client, store
 
@@ -152,7 +153,7 @@ def perform_flask_login(user_dict: "LoginUser") -> Response:
 def logout_oidc_user(session, provider: str):
     """Log out a user from an OIDC login provider-"""
 
-    logout_url = current_app.config[provider].get("logout_url")
+    logout_url = current_app.config[provider].get("client_url") + "logout"
     if not logout_url or not session.get("token_response"):
         return
     refresh_token = session["token_response"]["refresh_token"]
@@ -164,3 +165,64 @@ def logout_oidc_user(session, provider: str):
             "refresh_token": refresh_token,
         },
     )
+
+
+def refresh_access_token(refresh_token: str) -> Dict[str, str]:
+    """
+    Use the refresh token to obtain a new access token from the token endpoint.
+
+    Args:
+        refresh_token (str): The refresh token to use.
+
+    Returns:
+        Dict[str, str]: A dictionary containing the new access and optionally refresh token.
+
+    Raises:
+        Exception: If the token refresh fails.
+    """
+    provider = None
+    for item in ["GOOGLE", "KEYCLOAK"]:
+        if current_app.config.get(item):
+            provider = item
+
+    TOKEN_URL = current_app.config[provider].get("client_url") + "token"
+
+    response = requests.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": current_app.config[provider]["client_id"],
+            "client_secret": current_app.config[provider]["client_secret"],
+        },
+    )
+
+    if response.status_code != 200:
+        raise Exception(f"Failed to refresh token: {response.text}")
+
+    return response.json()
+
+
+def ensure_valid_token(access_token: str, refresh_token: str) -> str:
+    """
+    Ensure that the access token is valid. If it is expired, refresh it using the refresh token.
+
+    Args:
+        access_token (str): The current (possibly expired) access token.
+        refresh_token (str): The refresh token to use for renewing the access token.
+
+    Returns:
+        str: A valid access token.
+
+    Raises:
+        Exception: If the access token is invalid and refreshing fails.
+    """
+    try:
+        # Decode without verifying signature just to check expiry
+        jwt.decode(access_token, options={"verify_signature": False, "verify_exp": True})
+        return access_token
+    except ExpiredSignatureError:
+        new_tokens = refresh_access_token(refresh_token)
+        return new_tokens["access_token"]
+    except JWTError as e:
+        raise Exception(f"Token verification failed: {e}")

--- a/uv.lock
+++ b/uv.lock
@@ -748,6 +748,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607 },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2166,6 +2178,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624 },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2297,6 +2323,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.11.11"
 source = { registry = "https://pypi.org/simple" }
@@ -2357,6 +2395,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymongo" },
     { name = "python-dateutil" },
+    { name = "python-jose" },
     { name = "pyyaml" },
     { name = "query-phenomizer" },
     { name = "svglib" },
@@ -2430,6 +2469,7 @@ requires-dist = [
     { name = "pymysql", marker = "extra == 'coverage'" },
     { name = "python-dateutil" },
     { name = "python-dateutil", marker = "extra == 'coverage'" },
+    { name = "python-jose", specifier = ">=3.5.0" },
     { name = "pyyaml", specifier = ">=5.1" },
     { name = "query-phenomizer" },
     { name = "svglib" },


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
