### PR TITLE
Fix #5541 - PathologicStruc parsing from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Download of a ClinVar submission's json file when observation data is no longer present in the database (#5520)
 - Removed extra warnings for missing file types on case loading (#5525)
 - Matchmaker Exchange submissions page crashing when one or more cases have no synopsis(#5534)
+- Loading PathologicStruc from Stranger annotated TRGT STR files (#5542)
 
 ## [4.102]
 ### Added

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -18,6 +18,7 @@ Uses 'DV' to describe number of paired ends that supports the event and
 
 """
 
+import ast
 import logging
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -449,6 +450,22 @@ def _parse_format_entry(
     return (ref, alt)
 
 
+def _get_pathologic_struc(variant: cyvcf2.Variant) -> Optional[list]:
+    """Check for a PathologicStruc on the variant. If not present, return None.
+    If present, and in string format, convert to a list of ints.
+    If it is already parsed to a list by a later improvement in the parser,
+    simply return it.
+    """
+
+    pathologic_struc_entry = variant.INFO.get("PathologicStruc", None)
+    if not pathologic_struc_entry:
+        return pathologic_struc_entry
+    if type(pathologic_struc_entry) is str:
+        return ast.literal_eval(pathologic_struc_entry)
+    if type(pathologic_struc_entry) is list:
+        return pathologic_struc_entry
+
+
 def _parse_format_entry_trgt_mc(variant: cyvcf2.Variant, pos: int):
     """Parse genotype entry for TRGT FORMAT MC
 
@@ -477,7 +494,7 @@ def _parse_format_entry_trgt_mc(variant: cyvcf2.Variant, pos: int):
             if allele == 0:
                 ref_idx = idx
 
-    pathologic_struc = variant.INFO.get("PathologicStruc", None)
+    pathologic_struc = _get_pathologic_struc(variant)
     pathologic_counts = 0
     for idx, allele in enumerate(mc.split(",")):
         mcs = allele.split("_")


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5541 

❌ On main
```
➜  scout git:(main) ✗ uv run scout load case -u scout/demo/testr_load.yaml
2025-06-30 12:20:23 MacBookPro scout.commands.base[14300] INFO Running scout version 4.102.0
2025-06-30 12:20:23 MacBookPro scout.adapter.client[14300] INFO Connected to MongoDB 7.0.2
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.base[14300] INFO Database name: scout
2025-06-30 12:20:23 MacBookPro scout.server.app[14300] INFO Enable Phenopacket API
2025-06-30 12:20:23 MacBookPro scout.commands.load.case[14300] INFO Use family testr
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] INFO build case with id: testr
2025-06-30 12:20:23 MacBookPro scout.build.individual[14300] INFO Building Individual with id:ADM1059A2
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel BRAIN does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel Cardiology does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel CILM does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel CH does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel CTD does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel DIAB does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel ENDO does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel EP does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel HEARING does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel HYDRO does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel IBMFS does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel IEM does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel IF does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel mcarta does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel MHT does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel MIT does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel MOVE does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel mtDNA does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel NBS-M does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel NEURODEG does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel PEDHEP does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel PID does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel PIDCAD does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel RETINA does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel SKD does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel SOVM does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel STROKE does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.build.case[14300] WARNING Panel AID does not exist in database and will not be saved in case document.
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.case[14300] INFO Nr variants with sanger verification found: 0
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.case[14300] INFO Nr variants with sanger ordered found: 0
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.variant[14300] INFO Deleting old clinical str variants for case testr
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.variant[14300] INFO 75 variants deleted
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.panel[14300] INFO Building gene to panels
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.panel[14300] INFO Fetch gene panel NMD, version 1.0 from database
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.panel[14300] INFO Fetch gene panel OMIM-AUTO, version 5.0 from database
2025-06-30 12:20:23 MacBookPro scout.adapter.mongo.panel[14300] INFO Fetch gene panel PANELAPP-GREEN, version 3.0 from database
2025-06-30 12:20:24 MacBookPro scout.adapter.mongo.hgnc[14300] INFO Building hgncid_to_gene
2025-06-30 12:20:24 MacBookPro scout.adapter.mongo.hgnc[14300] INFO Building interval trees...
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant_loader[14300] INFO Loading vcf_str variants
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant_loader[14300] INFO Number of variants present on the VCF file:75
Loading variants  [------------------------------------]    0%
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant_loader[14300] ERROR unexpected error
Traceback (most recent call last):
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/variant_loader.py", line 718, in load_variants
    nr_inserted = self._load_variants(
                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/variant_loader.py", line 422, in _load_variants
    parsed_variant = parse_variant(
                     ^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/variant.py", line 105, in parse_variant
    parsed_variant["samples"] = get_samples(variant, individual_positions, case, category)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/variant.py", line 375, in get_samples
    return parse_genotypes(variant, individuals, individual_positions)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 37, in parse_genotypes
    genotypes.append(parse_genotype(variant, ind, pos))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 101, in parse_genotype
    (_, mc_alt) = _parse_format_entry_trgt_mc(variant, pos)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 489, in _parse_format_entry_trgt_mc
    if index in pathologic_mcs:
       ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'in <string>' requires string as left operand, not int
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant_loader[14300] WARNING Deleting inserted variants
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant[14300] INFO Deleting old clinical  variants for case testr
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.variant[14300] INFO 0 variants deleted
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.case[14300] INFO Updating case testr
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.case[14300] INFO Case updated
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.case[14300] INFO Updating case testr
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.case[14300] INFO Case updated
2025-06-30 12:20:25 MacBookPro scout.adapter.mongo.case[14300] INFO Verification status updated for 0 variants
2025-06-30 12:20:25 MacBookPro scout.commands.load.case[14300] ERROR Unhandled Exception: Traceback (most recent call last):
  File "/Users/dannil/sandbox/scout/scout/commands/load/case.py", line 124, in case
    adapter.load_case(config_data, update, keep_actions)
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/case.py", line 1027, in load_case
    self._load_clinical_variants(case_obj, build=genome_build, update=update)
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/case.py", line 966, in _load_clinical_variants
    self.load_variants(
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/variant_loader.py", line 741, in load_variants
    raise error
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/variant_loader.py", line 718, in load_variants
    nr_inserted = self._load_variants(
                  ^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/adapter/mongo/variant_loader.py", line 422, in _load_variants
    parsed_variant = parse_variant(
                     ^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/variant.py", line 105, in parse_variant
    parsed_variant["samples"] = get_samples(variant, individual_positions, case, category)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/variant.py", line 375, in get_samples
    return parse_genotypes(variant, individuals, individual_positions)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 37, in parse_genotypes
    genotypes.append(parse_genotype(variant, ind, pos))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 101, in parse_genotype
    (_, mc_alt) = _parse_format_entry_trgt_mc(variant, pos)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dannil/sandbox/scout/scout/parse/variant/genotype.py", line 489, in _parse_format_entry_trgt_mc
    if index in pathologic_mcs:
       ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'in <string>' requires string as left operand, not int

Aborted!
```
✅ On this branch 
```
➜  scout git:(fix_pathologic_struc_parsing) ✗ uv run scout load case -u scout/demo/testr_load.yaml
2025-06-30 12:20:58 MacBookPro scout.commands.base[14514] INFO Running scout version 4.102.0
2025-06-30 12:20:58 MacBookPro scout.adapter.client[14514] INFO Connected to MongoDB 7.0.2
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.base[14514] INFO Database name: scout
2025-06-30 12:20:58 MacBookPro scout.server.app[14514] INFO Enable Phenopacket API
2025-06-30 12:20:58 MacBookPro scout.commands.load.case[14514] INFO Use family testr
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] INFO build case with id: testr
2025-06-30 12:20:58 MacBookPro scout.build.individual[14514] INFO Building Individual with id:ADM1059A2
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel BRAIN does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel Cardiology does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel CILM does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel CH does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel CTD does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel DIAB does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel ENDO does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel EP does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel HEARING does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel HYDRO does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel IBMFS does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel IEM does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel IF does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel mcarta does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel MHT does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel MIT does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel MOVE does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel mtDNA does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel NBS-M does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel NEURODEG does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel PEDHEP does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel PID does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel PIDCAD does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel RETINA does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel SKD does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel SOVM does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel STROKE does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.build.case[14514] WARNING Panel AID does not exist in database and will not be saved in case document.
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.case[14514] INFO Nr variants with sanger verification found: 0
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.case[14514] INFO Nr variants with sanger ordered found: 0
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.variant[14514] INFO Deleting old clinical str variants for case testr
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.variant[14514] INFO 0 variants deleted
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.panel[14514] INFO Building gene to panels
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.panel[14514] INFO Fetch gene panel NMD, version 1.0 from database
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.panel[14514] INFO Fetch gene panel OMIM-AUTO, version 5.0 from database
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.panel[14514] INFO Fetch gene panel PANELAPP-GREEN, version 3.0 from database
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.hgnc[14514] INFO Building hgncid_to_gene
2025-06-30 12:20:58 MacBookPro scout.adapter.mongo.hgnc[14514] INFO Building interval trees...
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Loading vcf_str variants
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Number of variants present on the VCF file:75
Loading variants  [####################################]  100%
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO All variants inserted, time to insert variants: 0:00:00.253130
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Nr variants parsed: 75
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Nr variants inserted: 75
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Updating variant_rank for all variants
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.variant_loader[14514] INFO Updating variant_rank done
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.case[14514] INFO Updating case testr
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.case[14514] INFO Case updated
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.case[14514] INFO Updating case testr
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.case[14514] INFO Case updated
2025-06-30 12:21:00 MacBookPro scout.adapter.mongo.case[14514] INFO Verification status updated for 0 variants
```

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
