### PR TITLE
Fix #5545 - REVEL and SpliceAI missing dash color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed extra warnings for missing file types on case loading (#5525)
 - Matchmaker Exchange submissions page crashing when one or more cases have no synopsis(#5534)
 - Loading PathologicStruc from Stranger annotated TRGT STR files (#5542)
+- Badge color for missing REVEL and SpliceAI scores (#5546)
 
 ## [4.102]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -19,7 +19,7 @@
             {% elif variant.category == "sv" %}
               <th rowspan="2" colspan="1" title="SV caller specific quality score. Note different scales for different callers.">SV quality</th>
             {% elif variant.category == "str" %}
-              <th rowspan="2" colspan="1">ExpansionHunter support</th>
+              <th rowspan="2" colspan="1">Expansion support</th>
             {% else %}
 	      {% if variant.chromosome in ["MT","M"] %}
                 <th rowspan="2" colspan="1" title="Variant Allele Frequency.">Variant Allele Frequency (VAF)</th>
@@ -352,12 +352,14 @@
         <li class="list-group-item">
           <a href="https://sites.google.com/site/revelgenomics/about" target="_blank" data-bs-toggle="tooltip"
             title="An ensemble score based on 13 individual scores for predicting the pathogenicity of missense variants. Scores range from 0 to 1. The larger the score the more likely the SNP has damaging effect">REVEL score</a>
-          {% if variant.revel %}
+          {% if variant.revel and variant.revel != "-" %}
             <span class="badge float-end bg-{{variant.revel|get_label_or_color_by_score('revel', 'color')}}" data-bs-toggle="tooltip" title="{{variant.revel|get_label_or_color_by_score('revel', 'label')}}">
               {{ variant.revel }}
             </span>
           {% else %}
-            <span class="badge float-end bg-secondary">–</span>
+            <span class="float-end">
+              {{ "-" }}
+            </span>
           {% endif %}
         </li>
         <li class="list-group-item">
@@ -387,8 +389,8 @@
         </li>
         <li class="list-group-item">
           <a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>
-          {% if variant.spliceai_scores | select('!=', None) | list %}
-            <span class="badge bg-{{variant.spliceai_scores | select('!=', None) | list | max | get_label_or_color_by_score('spliceai', 'color')}} float-end" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
+          {% if variant.spliceai_scores | select('!=', None) | select('!=', '-') | list %}
+            <span class="badge bg-{{variant.spliceai_scores | select('!=', None) | select('!=', '-') | list | max | get_label_or_color_by_score('spliceai', 'color')}} float-end" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
                 title="<strong>
                   {% for entry in variant.spliceai_scores %}
                     {% if entry is not none %}
@@ -405,7 +407,7 @@
                 ">
                 {{ variant.spliceai_scores|join(', ') }}
             {% else %}
-              <span class="badge float-end bg-secondary">–
+              <span class="float-end">{{ "-" }}
             {% endif %}
           </span>
         </li>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5545 - missing value REVEL and SpliceAI are set to `"-"` at the rendering stage

After, for a variant with missing values (STR):
![Screenshot 2025-07-02 at 09 52 16](https://github.com/user-attachments/assets/24e38228-a647-4e47-bd64-7bb78a1a4166)
For comparison and safety, a variant (SNV) with values:
![Screenshot 2025-07-02 at 09 54 43](https://github.com/user-attachments/assets/cc3ad47b-1c72-4f87-b0b4-b11070a886c6)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**
1. visit a variant page with missing values for REVEL or SpliceAI, e.g. an STR on current `main` branch
2. notice crash
3. apply patch
4. notice page rendering and `-` for missing values as intended

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by AR
- [x] tests executed by DN
