### PR TITLE
Fix SpliceAI label/color when variant is multigenic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Do not create new variant-associated events, when re-uploading a case. New variant inherits key/values from old evaluated variants (#5507)
 - Increased bottom margin in ClinVar submission option on institute's sidebar (#5561)
 - `Search SNVs & SVs` for cases which have been removed (#5563)
+- SpliceAI label color when variant hits multiple genes (#5565)
 
 ## [4.102]
 ### Added

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -367,11 +367,9 @@ def register_filters(app):
         float_values = []
         for value in values:
             if isinstance(value, str):
-                if "None" in value:
-                    continue
                 if ":" in value:  # Variant hits multiple genes
                     value = value.split(":")[1].strip()
-            if value in [None, "-"]:
+            if value in [None, "-", "None"]:
                 continue
             float_values.append(float(value))
         if float_values:

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -366,13 +366,13 @@ def register_filters(app):
         """Returns a list of SpliceAI values, extracting floats only from values like 'score:0.23'."""
         float_values = []
         for value in values:
-            if value in [None, "-"]:
-                continue
             if isinstance(value, str):
                 if "None" in value:
                     continue
                 if ":" in value:  # Variant hits multiple genes
                     value = value.split(":")[1].strip()
+            if value in [None, "-"]:
+                continue
             float_values.append(float(value))
         if float_values:
             return max(float_values)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 from datetime import timedelta
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 from urllib.parse import parse_qsl, unquote, urlsplit
 
 from flask import Flask, redirect, request, url_for
@@ -360,6 +360,22 @@ def register_filters(app):
     def list_remove_none(in_list: list) -> list:
         """Returns a list after removing any None values from it."""
         return [item for item in in_list if item is not None]
+
+    @app.template_filter()
+    def spliceai_max(values) -> Optional[float]:
+        """Returns a list of SpliceAI values, extracting floats only from values like 'score:0.23'."""
+        float_values = []
+        for value in values:
+            if value in [None, "-"]:
+                continue
+            if isinstance(value, str):
+                if "None" in value:
+                    continue
+                if ":" in value:  # Variant hits multiple genes
+                    value = value.split(":")[1].strip()
+            float_values.append(float(value))
+        if float_values:
+            return max(float_values)
 
 
 def register_tests(app):

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -713,8 +713,9 @@
             <td>{{ variant.polyphen_predictions|join(', ') or '-' }}</td>
             <td>{{ variant.spidex|spidex_human if variant.spidex else none|spidex_human }}</td>
             <td>
-              {% if variant.spliceai_scores | select('!=', None) | list %}
-                <span class="badge bg-{{variant.spliceai_scores | select('!=', None) | list | max | get_label_or_color_by_score('spliceai', 'color') }}">
+              {% set spliceai_highest = variant.spliceai_scores | spliceai_max %}
+              {% if spliceai_highest %}
+                <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color') }}">
                   {{ variant.spliceai_scores|join(', ') }}
                 </span>
               {% else %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -715,7 +715,7 @@
             <td>
               {% set spliceai_highest = variant.spliceai_scores | spliceai_max %}
               {% if spliceai_highest %}
-                <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color') }}">
+                <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'label') }}">
                   {{ variant.spliceai_scores|join(', ') }}
                 </span>
               {% else %}

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -715,7 +715,7 @@
             <td>
               {% set spliceai_highest = variant.spliceai_scores | spliceai_max %}
               {% if spliceai_highest %}
-                <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'label') }}">
+                <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color') }}">
                   {{ variant.spliceai_scores|join(', ') }}
                 </span>
               {% else %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -389,13 +389,14 @@
           <span class="float-end">{{ variant.spidex|spidex_human if variant.spidex else none|spidex_human }}</span>
         </li>
         <li class="list-group-item">
+          {% set spliceai_highest = variant.spliceai_scores | spliceai_max %}
           <a href="{{ variant.spliceai_link }}" target="_blank" rel="noopener">SpliceAI</a> <a href="https://github.com/Illumina/SpliceAI" target="_blank" rel="noopener">DS max</a>
-          {% if variant.spliceai_scores | select('!=', None) | select('!=', '-') | list %}
-            <span class="badge bg-{{variant.spliceai_scores | select('!=', None) | select('!=', '-') | list | max | get_label_or_color_by_score('spliceai', 'color')}} float-end" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
+          {% if spliceai_highest %}
+            <span class="badge bg-{{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color') }} float-end" data-bs-toggle="tooltip" data-bs-html="true" data-bs-placement="bottom"
                 title="<strong>
                   {% for entry in variant.spliceai_scores %}
                     {% if entry is not none %}
-                      SpliceAI highest delta score {{ entry }} </strong> at position {{ variant.spliceai_positions[loop.index0]}} relative to this variant. {{ variant.spliceai_scores | select('!=', None) | list | max | get_label_or_color_by_score('spliceai', 'label')}} according to Walker et al 2023.
+                      SpliceAI highest delta score {{ entry }} </strong> at position {{ variant.spliceai_positions[loop.index0]}} relative to this variant. {{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color')}} according to Walker et al 2023.
                       {% if variant.spliceai_predictions[loop.index0] %}
                         <br>All scores and positions(relative to variant):<br>
                         {{ variant.spliceai_predictions[loop.index0] }} <br>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -396,7 +396,7 @@
                 title="<strong>
                   {% for entry in variant.spliceai_scores %}
                     {% if entry is not none %}
-                      SpliceAI highest delta score {{ entry }} </strong> at position {{ variant.spliceai_positions[loop.index0]}} relative to this variant. {{ spliceai_highest | get_label_or_color_by_score('spliceai', 'color')}} according to Walker et al 2023.
+                      SpliceAI highest delta score {{ entry }} </strong> at position {{ variant.spliceai_positions[loop.index0]}} relative to this variant. {{ spliceai_highest | get_label_or_color_by_score('spliceai', 'label')}} according to Walker et al 2023.
                       {% if variant.spliceai_predictions[loop.index0] %}
                         <br>All scores and positions(relative to variant):<br>
                         {{ variant.spliceai_predictions[loop.index0] }} <br>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5564 

### Before

<img width="1007" alt="image" src="https://github.com/user-attachments/assets/f663d434-d038-425e-b4a5-5fde962185dd" />


### After:

<img width="345" alt="image" src="https://github.com/user-attachments/assets/28f106cd-4170-4b88-8899-e65d1b59fae3" />




<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
