### PR TITLE
Igv autoscale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Display number of available/displayed variants on variantS pages without having to expand search filters (#5571) with collapsing chevron (#5572)
 - Update to IGV.js v3.4.1 (#5573)
+- Allow autoscaling on IGV tracks, but group alignment scale (#5574)
 
 ## [4.103.1]
 ### Fixed

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -278,13 +278,14 @@ def get_tracks(name_list: list, file_list: list) -> List[Dict]:
     for name, track in zip(name_list, file_list):
         if track == "missing":
             continue
-        track_config = {"name": name, "url": track, "min": 0.0, "max": 30.0}
+        track_config = {"name": name, "url": track, "min": 0.0}
         index = find_index(track)
         if index:
             track_config["indexURL"] = index
         file_format_ending = track.split(".")[-1]
         if file_format_ending in ["bam", "cram"]:
             track_config["format"] = file_format_ending
+            track_config["autoscaleGroup"] = "alignments"
         track_list.append(track_config)
     return track_list
 

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -97,7 +97,7 @@
                         {# indexURL: '{{ url_for("alignviewers.remote_static", file=wtrack.url)  }}', #}
                         color: "rgb(60, 37, 17)",
                         min: '{{ wtrack.min }}',
-                        max: '{{ wtrack.max }}',
+                        autoscaleGroup: '{{ wtrack.autoscaleGroup }}',
                         sourceType: 'file'
                       },
                       {% endfor %}
@@ -155,7 +155,7 @@
                         groupBy: "tag:HP",
                         indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL)  }}',
                         min: '{{ ptrack.min }}',
-                        max: '{{ ptrack.max }}',
+                        autoscaleGroup: '{{ ptrack.autoscaleGroup }}',
                         sourceType: 'file'
                       },
                       {% endfor %}
@@ -170,7 +170,7 @@
                         showCoverage: false,
                         indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL)  }}',
                         min: '{{ atrack.min }}',
-                        max: '{{ atrack.max }}',
+                        autoscaleGroup: '{{ atrack.autoscaleGroup }}',
                         sourceType: 'file'
                       },
                       {% endfor %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5549

The main idea here is to enable autoscaling for tracks like rhocall autozygosity (0-1). We do so by simply removing the fixed default max value of 30 (30x depth). To make the alignment depths comparable at a glance, we instead group them in an autoscaleGroup.

![Screenshot 2025-07-08 at 16 54 24](https://github.com/user-attachments/assets/a3f36852-8949-442f-9503-d9d739008035)


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
