### PR TITLE
Patch release 4.103.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [4.103.3]
 ### Fixed
 - App filter, `format_variant_canonical_transcripts function`, crashing when a gene has no canonical transcript (#5582)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
 - Always display STRs sorted by ascending gene symbol (#5580)
 ### Fixed
-- App filter, `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs page`) crashing when a gene has no canonical transcript (#5582)
+- App filter `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs page`) crashing when a gene has no canonical transcript (#5582)
 - STRs not displaying a repeat locus (#5587)
 
 ## [4.103.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
 - Always display STRs sorted by ascending gene symbol (#5580)
 ### Fixed
-- App filter `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs page`) crashing when a gene has no canonical transcript (#5582)
+- App filter `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs` page) crashing when a gene has no canonical transcript (#5582)
 - STRs not displaying a repeat locus (#5587)
 
 ## [4.103.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
 - Always display STRs sorted by ascending gene symbol (#5580)
 ### Fixed
-- App filter `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs` page) crashing when a gene has no canonical transcript (#5582)
+- App filter `format_variant_canonical_transcripts` (used on `Search SNVs and SVs` page) crashing when a gene has no canonical transcript (#5582)
 - STRs not displaying a repeat locus (#5587)
 
 ## [4.103.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
 - Always display STRs sorted by ascending gene symbol (#5580)
 ### Fixed
-- App filter, `format_variant_canonical_transcripts function`, crashing when a gene has no canonical transcript (#5582)
+- App filter, `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs page`) crashing when a gene has no canonical transcript (#5582)
 - STRs not displaying a repeat locus (#5587)
 
 ## [4.103.2]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.103.2"
+version = "4.103.3"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Mans Magnuson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -482,7 +483,7 @@ resolution-markers = [
     "python_full_version < '3.9.2'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and platform_system == 'Windows'" },
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -498,7 +499,7 @@ resolution-markers = [
     "python_full_version == '3.10.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and platform_system == 'Windows'" },
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342 }
 wheels = [
@@ -1373,7 +1374,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
@@ -2516,6 +2517,7 @@ requires-dist = [
     { name = "wtforms" },
     { name = "xlsxwriter" },
 ]
+provides-extras = ["coverage"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## [4.103.3]

### Changed
- [x] Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
- [x] Always display STRs sorted by ascending gene symbol (#5580)
### Fixed
- [x] App filter `format_variant_canonical_transcripts function` (used on `Search SNVs and SVs page`) crashing when a gene has no canonical transcript (#5582)
- [x] STRs not displaying a repeat locus (#5587)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by DN, CR
