### PR TITLE
Fix missing STRs repeat locus when there is not gene set in the variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Always display STRs sorted by ascending gene symbol (#5580)
 ### Fixed
 - App filter, `format_variant_canonical_transcripts function`, crashing when a gene has no canonical transcript (#5582)
-- STRs not displaying a repeat locus (#5586)
+- STRs not displaying a repeat locus (#5587)
 
 ## [4.103.2]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-### Fixed
-- App filter, `format_variant_canonical_transcripts function`, crashing when a gene has no canonical transcript (#5582)
 ### Changed
 - Sort institute multiselect alphabetically by display name on 'Search SNVs & SVs' page (#5584)
 - Always display STRs sorted by ascending gene symbol (#5580)
+### Fixed
+- App filter, `format_variant_canonical_transcripts function`, crashing when a gene has no canonical transcript (#5582)
+- STRs not displaying a repeat locus (#5586)
 
 ## [4.103.2]
 ### Changed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1023,7 +1023,7 @@ def download_str_variants(case_obj, variant_objs):
         variant_line.append(str(variant.get("variant_rank", "")))  # index
         variant_line.append(variant.get("str_repid", variant.get("str_trid", "")))  # Repeat locus
         variant_line.append(
-            variant.get("str_display_ru", variant.get("str_ru", ""))
+            variant.get("str_display_ru", variant.get("str_ru", variant.get("str_motifs", "")))
         )  # Reference repeat unit
         variant_line.append(str(get_str_mc(variant) or "."))  # Estimated size
         variant_line.append(str(variant.get("str_ref", "")))  # Reference size

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -242,7 +242,7 @@
     {%endif%}
   </div>"
   title="">{% if variant.str_repid %} {{ variant.str_repid }} {% else %}
-  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol}} {% endfor %} {% endif %}
+  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol }} {% endfor %}
   {% else %}
     {{ variant.str_trid }}
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -241,8 +241,9 @@
       {% endfor %}
     {%endif%}
   </div>"
-  title="">{% if variant.str_repid %} {{ variant.str_repid }} {% else %}
-  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol }} {% endfor %}
+  title="">{% if variant.str_repid %} {{ variant.str_repid }}
+  {% elif variant.genes %}
+    {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol }} {% endfor %}
   {% else %}
     {{ variant.str_trid }}
   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -242,7 +242,10 @@
     {%endif%}
   </div>"
   title="">{% if variant.str_repid %} {{ variant.str_repid }} {% else %}
-  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol or variant.str_trid}} {% endfor %} {% endif %}
+  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol}} {% endfor %} {% endif %}
+  {% else %}
+    {{ variant.str_trid }}
+  {% endif %}
   </a>
   {% for gene in variant.genes %}
       {% if variant.str_disease %}

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -242,7 +242,7 @@
     {%endif%}
   </div>"
   title="">{% if variant.str_repid %} {{ variant.str_repid }} {% else %}
-  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol }} {% endfor %} {% endif %}
+  {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol or variant.str_trid}} {% endfor %} {% endif %}
   </a>
   {% for gene in variant.genes %}
       {% if variant.str_disease %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fixes partially #5586 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
