### PR TITLE
Parse cancer somatic panel local freqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Added
-- Parsing variant's`local_obs_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively ()
+- Parsing variant's`local_obs_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
+### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 
 ## [4.103.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-### Fixed
+### Added
+- Parsing variant's`local_obs_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively ()
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 
 ## [4.103.3]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-### Added
-- Parsing variant's`local_obs_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
+###
+- Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -285,6 +285,9 @@ def build_variant(
     # local observations from cancer pipeline
     variant_obj["local_obs_cancer_germline_old"] = variant.get("local_obs_cancer_germline_old")
     variant_obj["local_obs_cancer_somatic_old"] = variant.get("local_obs_cancer_somatic_old")
+    variant_obj["local_obs_cancer_somatic_panel_old"] = variant.get(
+        "local_obs_cancer_somatic_panel_old"
+    )
     variant_obj["local_obs_cancer_germline_hom_old"] = variant.get(
         "local_obs_cancer_germline_hom_old"
     )
@@ -296,6 +299,9 @@ def build_variant(
     )
     variant_obj["local_obs_cancer_somatic_old_freq"] = variant.get(
         "local_obs_cancer_somatic_old_freq"
+    )
+    variant_obj["local_obs_cancer_somatic_panel_old_freq"] = variant.get(
+        "local_obs_cancer_somatic_panel_old_freq"
     )
 
     ##### Add the severity predictors #####

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -260,9 +260,6 @@ def set_loqus_archive_frequencies(parsed_variant: dict, variant: dict, local_arc
         )
 
 
-Cancer_Somatic_Panel_Frq
-
-
 def set_severity_predictions(parsed_variant: dict, variant: dict, parsed_transcripts: dict):
     """
     Set severity predictions on parsed variant.

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -230,9 +230,14 @@ def set_loqus_archive_frequencies(parsed_variant: dict, variant: dict, local_arc
     info = variant.INFO
 
     # RD observations (SNVs or SVs)
-    local_obs_old = (
-        info.get("Obs") or info.get("clinical_genomics_loqusObs") or info.get("clin_obs")
-    )
+    OBS_KEYS = [
+        "Obs",
+        "clinical_genomics_loqusObs",
+        "clin_obs",
+        "Cancer_Somatic_Panel_Obs",
+    ]
+    local_obs_old = next((info.get(k) for k in OBS_KEYS if info.get(k) is not None), None)
+
     parsed_variant["local_obs_old"] = safe_val(call_safe(int, local_obs_old))
     parsed_variant["local_obs_hom_old"] = safe_val(call_safe(int, info.get("Hom")))
     parsed_variant["local_obs_old_freq"] = safe_val(
@@ -243,7 +248,8 @@ def set_loqus_archive_frequencies(parsed_variant: dict, variant: dict, local_arc
     set_local_archive_info(parsed_variant, local_archive_info)
 
     # Cancer observations (germline and somatic)
-    for prefix in ["Cancer_Germline", "Cancer_Somatic"]:
+    FREQ_KEYS = ["Cancer_Germline", "Cancer_Somatic", "Cancer_Somatic_Panel"]
+    for prefix in FREQ_KEYS:
         key = prefix.lower()
         parsed_variant[f"local_obs_{key}_old"] = safe_val(call_safe(int, info.get(f"{prefix}_Obs")))
         parsed_variant[f"local_obs_{key}_hom_old"] = safe_val(
@@ -252,6 +258,9 @@ def set_loqus_archive_frequencies(parsed_variant: dict, variant: dict, local_arc
         parsed_variant[f"local_obs_{key}_old_freq"] = safe_val(
             call_safe(float, info.get(f"{prefix}_Frq"))
         )
+
+
+Cancer_Somatic_Panel_Frq
 
 
 def set_severity_predictions(parsed_variant: dict, variant: dict, parsed_transcripts: dict):

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -230,14 +230,9 @@ def set_loqus_archive_frequencies(parsed_variant: dict, variant: dict, local_arc
     info = variant.INFO
 
     # RD observations (SNVs or SVs)
-    OBS_KEYS = [
-        "Obs",
-        "clinical_genomics_loqusObs",
-        "clin_obs",
-        "Cancer_Somatic_Panel_Obs",
-    ]
-    local_obs_old = next((info.get(k) for k in OBS_KEYS if info.get(k) is not None), None)
-
+    local_obs_old = (
+        info.get("Obs") or info.get("clinical_genomics_loqusObs") or info.get("clin_obs")
+    )
     parsed_variant["local_obs_old"] = safe_val(call_safe(int, local_obs_old))
     parsed_variant["local_obs_hom_old"] = safe_val(call_safe(int, info.get("Hom")))
     parsed_variant["local_obs_old_freq"] = safe_val(

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -317,6 +317,12 @@
         <td>{{ variant.local_obs_cancer_somatic_hom_old|default('N/A') }}</td>
         <td>{% if variant.local_obs_cancer_somatic_old_freq %} {{variant.local_obs_cancer_somatic_old_freq|round(6)}} {% elif variant.local_obs_cancer_somatic_old_nr_cases and variant.local_obs_cancer_somatic_old %} {{ (variant.local_obs_cancer_somatic_old/variant.local_obs_cancer_somatic_old_nr_cases)|round(5) }} {% elif variant.local_obs_cancer_somatic_old_nr_cases %} 0 / {{variant.local_obs_cancer_somatic_old_nr_cases}} {% else %} N/A {% endif %}</td>
       </tr>
+      <tr>
+        <td>Cancer Somatic panel</td>
+        <td>{{ variant.local_obs_cancer_somatic_panel_old|default('N/A') }}</td>
+        <td>N/A</td>
+        <td>{% if variant.local_obs_cancer_somatic_panel_old_freq %} {{variant.local_obs_cancer_somatic_panel_old_freq|round(6)}} {% else %} N/A {% endif %}</td>
+      </tr>
     {% endif %}
   </tbody>
 </table>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -253,7 +253,7 @@
         {% if variant.category in ['snv', 'sv'] %}
           {{ variant.local_obs_old or 0 }}
         {% elif variant.category in ['cancer', 'cancer_sv'] %}
-          germline:{{ variant.local_obs_cancer_germline_old or 'NA'}}, somatic:{{variant.local_obs_cancer_somatic_old or 'NA'}} somatic_panel: {{variant.local_obs_cancer_somatic_panel_old or 'NA'}}, rare-disease: {{ variant.local_obs_old or 'NA'}},
+          germline:{{ variant.local_obs_cancer_germline_old or 0}}, somatic:{{variant.local_obs_cancer_somatic_old or 0}} somatic_panel: {{variant.local_obs_cancer_somatic_panel_old or 0}}, rare-disease: {{ variant.local_obs_old or 0}},
         {% endif %} obs.
       </div>
       {% if variant.mitomap_associated_diseases %}
@@ -294,9 +294,9 @@
   {% if variant.clingen_cgh_pathogenic %}
     <span class="badge bg-secondary">CGH Pathogenic</span>
   {% endif %}
-  {% if variant.local_obs_old or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old %}
+  {% if variant.local_obs_old or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old or variant.local_obs_cancer_somatic_panel_old %}
     <span class="badge bg-secondary">Local {% if variant.category in ['snv', 'sv'] %}<span class="badge bg-dark text-white">
-          {{ variant.local_obs_old or 0 }}</span>{% endif %}</span>
+          {{ or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old or variant.local_obs_cancer_somatic_panel_old or 0 }}</span>{% endif %}</span>
     <br>
   {% endif %}
   </div>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -296,7 +296,7 @@
   {% endif %}
   {% if variant.local_obs_old or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old or variant.local_obs_cancer_somatic_panel_old %}
     <span class="badge bg-secondary">Local {% if variant.category in ['snv', 'sv'] %}<span class="badge bg-dark text-white">
-          {{ or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old or variant.local_obs_cancer_somatic_panel_old or 0 }}</span>{% endif %}</span>
+          {{ variant.local_obs_old or variant.local_obs_cancer_germline_old or variant.local_obs_cancer_somatic_old or variant.local_obs_cancer_somatic_panel_old or 0 }}</span>{% endif %}</span>
     <br>
   {% endif %}
   </div>

--- a/scout/server/blueprints/variants/templates/variants/components.html
+++ b/scout/server/blueprints/variants/templates/variants/components.html
@@ -253,7 +253,7 @@
         {% if variant.category in ['snv', 'sv'] %}
           {{ variant.local_obs_old or 0 }}
         {% elif variant.category in ['cancer', 'cancer_sv'] %}
-          germline:{{ variant.local_obs_cancer_germline_old or 0}}, somatic:{{variant.local_obs_cancer_somatic_old or 0}}, rare-disease: {{ variant.local_obs_old or 0}},
+          germline:{{ variant.local_obs_cancer_germline_old or 'NA'}}, somatic:{{variant.local_obs_cancer_somatic_old or 'NA'}} somatic_panel: {{variant.local_obs_cancer_somatic_panel_old or 'NA'}}, rare-disease: {{ variant.local_obs_old or 'NA'}},
         {% endif %} obs.
       </div>
       {% if variant.mitomap_associated_diseases %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
Added:
- Parse `Cancer_Somatic_Panel_Frq` and `Cancer_Somatic_Panel_Obs` keys from VCF INFO field

**OBS: This PR fixes the parsing and displaying of the freq and observations on variant and variantS pages. It does not include the keys into the variants filters - we'll address it in another PR**

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test with [this case](https://scout-stage.scilifelab.se/cust087/F0063285-Mye54)
2. Deploy this branch on hasta stage
4. Load case into scout using this branch
5. Deploy this branch on cg-vm1
6. Go to the case above, SNVs. 

**Expected outcome**:
- Local somatic panel freqs should be shown on variantS page and variant page


**Review:**
- [x] code approved by mathiasbio
- [x] tests executed by CT, mathiasbio
