### PR TITLE
Filter cancer variants by archived local panel observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-###
+### Added
 - Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
+- Filter cancer variants by archived number of cancer somatic panel observations (#5598)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -189,50 +189,14 @@ class QueryHandler(object):
         return select_cases
 
     def build_query(
-        self, case_id, query=None, variant_ids=None, category="snv", build="37"
+        self,
+        case_id: str,
+        query: Optional[dict] = None,
+        variant_ids: Optional[List[str]] = None,
+        category: str = "snv",
+        build: str = "37",
     ) -> dict:
-        """Build a mongo query
-
-        These are the different query options:
-            {
-                'thousand_genomes_frequency': float,
-                'exac_frequency': float,
-                'clingen_ngi': int,
-                'cadd_score': float,
-                'cadd_inclusive": boolean,
-                'tumor_frequency': float,
-                'genetic_models': list(str),
-                "genotypes": str,
-                'hgnc_symbols': list,
-                'region_annotations': list,
-                'functional_annotations': list,
-                'clinsig': list,
-                'clinvar_trusted_revstat': boolean,
-                'clinsig_exclude': bool,
-                'variant_type': str(('research', 'clinical')),
-                'chrom': str or list of str,
-                'start': int,
-                'end': int,
-                'svtype': list,
-                'size': int,
-                'size_selector': str,
-                'gene_panels': list(str),
-                'mvl_tag": boolean,
-                'clinvar_tag': boolean,
-                'cosmic_tag' boolean,
-                'decipher": boolean,
-                'hide_dismissed': boolean
-            }
-
-        Arguments:
-            case_id(str)
-            query(dict): a dictionary of query filters specified by the users
-            variant_ids(list(str)): A list of md5 variant ids
-
-        Returns:
-            mongo_query : A dictionary in the mongo query format
-
-        """
+        """Build a mongo query"""
         query = query or {}
         mongo_query = {}
         coordinate_query = None
@@ -643,6 +607,7 @@ class QueryHandler(object):
                 "local_obs_old",
                 "local_obs_cancer_germline_old",
                 "local_obs_cancer_somatic_old",
+                "local_obs_cancer_somatic_panel_old",
             ]:
                 if criterion == local_obs_old_type:
                     local_obs = query.get(local_obs_old_type)

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -34,6 +34,7 @@ SECONDARY_CRITERIA = [
     "gnomad_frequency",
     "local_obs_old",
     "local_obs_cancer_somatic_old",
+    "local_obs_cancer_somatic_panel_old",
     "local_obs_cancer_germline_old",
     "local_obs_freq",
     "clingen_ngi",

--- a/scout/server/blueprints/variants/forms.py
+++ b/scout/server/blueprints/variants/forms.py
@@ -207,6 +207,9 @@ class CancerFiltersForm(VariantFiltersForm):
     local_obs_cancer_somatic_old = IntegerField(
         "Local somatic obs. (archive)", validators=[validators.Optional()]
     )
+    local_obs_cancer_somatic_panel_old = IntegerField(
+        "Local somatic panel obs. (archive)", validators=[validators.Optional()]
+    )
     local_obs_cancer_germline_old = IntegerField(
         "Local germline obs. (archive)", validators=[validators.Optional()]
     )

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -100,6 +100,9 @@
       {{ wtf.form_field(form.local_obs_cancer_somatic_old) }}
     </div>
     <div class="col">
+      {{ wtf.form_field(form.local_obs_cancer_somatic_panel_old) }}
+    </div>
+    <div class="col">
       {{ wtf.form_field(form.local_obs_cancer_germline_old) }}
     </div>
   {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
