### PR TITLE
Safe redirects for variantS views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
 - Filter cancer variants by archived number of cancer somatic panel observations (#5598)
+### Changed
+- Safer redirect to previous page for variants views (#5599)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -19,7 +19,12 @@ from scout.constants import (
     SEVERE_SO_TERMS_SV,
 )
 from scout.server.extensions import store
-from scout.server.utils import get_case_genome_build, institute_and_case, templated
+from scout.server.utils import (
+    get_case_genome_build,
+    institute_and_case,
+    safe_redirect_back,
+    templated,
+)
 
 from . import controllers
 from .forms import (
@@ -49,7 +54,7 @@ def reset_dismissed(institute_id, case_name):
     """Reset all dismissed variants for a case"""
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
     controllers.reset_all_dismissed(store, institute_obj, case_obj)
-    return redirect(request.referrer)
+    return safe_redirect_back(request)
 
 
 @variants_bp.route("/<institute_id>/<case_name>/variants", methods=["GET", "POST"])
@@ -118,7 +123,7 @@ def variants(institute_id, case_name):
             stream = io.StringIO(file.stream.read().decode("utf-8"), newline=None)
         except UnicodeDecodeError as error:
             flash("Only text files are supported!", "warning")
-            return redirect(request.referrer)
+            return safe_redirect_back(request)
 
         hgnc_symbols_set = set(form.hgnc_symbols.data)
         new_hgnc_symbols = controllers.upload_panel(store, institute_id, case_name, stream)
@@ -725,13 +730,13 @@ def upload_panel(institute_id, case_name):
 
     if panel_file.filename == "":
         flash("No selected file", "warning")
-        return redirect(request.referrer)
+        return safe_redirect_back(request)
 
     try:
         stream = io.StringIO(panel_file.stream.read().decode("utf-8"), newline=None)
     except UnicodeDecodeError as error:
         flash("Only text files are supported!", "warning")
-        return redirect(request.referrer)
+        return safe_redirect_back(request)
 
     category = request.args.get("category")
 
@@ -778,4 +783,4 @@ def unaudit_filter():
     store.unaudit_filter(
         audit_id=request.args.get("audit_id"), user_obj=store.user(current_user.email)
     )
-    return redirect(request.referrer)
+    return safe_redirect_back(request)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Partial fix to #4707

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
