### PR TITLE
Fix links to SNVs and SVs from SMN page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)
+- Consistent panel display on variants pages for unselected "All" panels (#5600)
 
 ## [4.103.3]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Filter cancer variants by archived number of cancer somatic panel observations (#5598)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
+- Links to SNVs and SVs from SMN CN page (#5600)
 
 ## [4.103.3]
 ### Changed

--- a/scout/server/blueprints/cases/templates/cases/case_sma.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma.html
@@ -52,19 +52,19 @@
       <span class="d-flex">
         {% if case.vcf_files.vcf_snv %}
         <span class="me-3">
-          <form action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name) }}">
+          <form target="_blank" rel="noopener" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
             <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
-            <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
-            <span><button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes SMN1 and SMN2">SNVs</button></span>
+            <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
+            <span><button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes SMN1 and SMN2">SNVs</button></span>
           </form>
         </span>
         {% endif %}
         {% if case.vcf_files.vcf_sv %}
           <span class="me-3">
-            <form action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name) }}">
+            <form target="_blank" rel="noopener" action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
               <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
-              <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
-              <button type="submit" class="btn btn-secondary btn-sm" target="_blank" rel="noopener" data-bs-toggle="tooltip" title="Structural variants view filtered for the genes SMN1 and SMN2">SVs</button>
+              <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
+              <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="Structural variants view filtered for the genes SMN1 and SMN2">SVs</button>
             </form>
           </span>
         {% endif %}

--- a/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
+++ b/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
@@ -36,6 +36,11 @@
   </li>
 {% endblock %}
 
+{% block top_nav_right %}
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
+  {{ super() }}
+{% endblock %}
+
 {% block content_main %}
   <div class="container-float">
     <form method="POST" id="filters_form" action="{{url_for('omics_variants.outliers', institute_id=institute._id, case_name=case.display_name)}}"

--- a/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
+++ b/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
@@ -79,14 +79,14 @@
                   {% if case.vcf_files.vcf_snv %}
                     <form action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name) }}" target="_blank">
                     <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{% for gene in variant.genes %}{{gene.hgnc_symbol}}{{ ", " if not loop.last else "" }}{% endfor %}"></input>
-                    <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
+                    <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
                     <span><button type="submit" class="btn btn-secondary btn-sm" style="float: right;" data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the gene(s) {% for gene in variant.genes %}{{gene.hgnc_symbol}}{{ ", " if not loop.last else "" }}{% endfor %} ">SNVs</button></span>
                     </form>
                   {% endif %}
                   {% if case.vcf_files.vcf_sv %}
                     <form action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name) }}" target="_blank">
                     <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{% for gene in variant.genes %}{{gene.hgnc_symbol}}{{ ", " if not loop.last else "" }}{% endfor %}"></input>
-                    <input type="hidden" id="gene_panels" name="gene_panels" value="['']"></input>
+                    <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
                     <button type="submit" class="btn btn-secondary btn-sm" data-bs-toggle="tooltip" title="SV variants view filtered for the gene(s) {% for gene in variant.genes %}{{gene.hgnc_symbol}}{{ ", " if not loop.last else "" }}{% endfor %} ">SVs</button></span>
                   </form>
                   {% endif %}

--- a/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/cancer-sv-variants.html
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/mei-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/mei-variants.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/sv-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/sv-variants.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 

--- a/scout/server/blueprints/variants/templates/variants/variants.html
+++ b/scout/server/blueprints/variants/templates/variants/variants.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block top_nav_right %}
-  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data or ['All'])|join(',') }}</p></li>
+  <li class="nav-item text-nowrap"><p class="navbar-text">Panels: {{ (form.gene_panels.data if form.gene_panels.data and form.gene_panels.data != [""] else ['All'])|join(',') }}</p></li>
   {{ super() }}
 {% endblock %}
 {% block content_main %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #4833
- Fixes the [''] panel issue
- Opens correctly the link into a new tab

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Deploy on stage server and test for instance with [this case](https://scout-stage.scilifelab.se/cust000/NIST-Ashkenazim-family-240125-validation/sma), which has a SV falling in that region

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
