### PR TITLE
Treat panel analyses as WES when getting chanjo2 stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
 - Filter cancer variants by archived number of cancer somatic panel observations (#5598)
+### Changed
+- Compute chanjo2 coverage on exons only when at least case individual has analysis_type=panel (#5601)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 

--- a/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
+++ b/scout/server/blueprints/cases/templates/cases/chanjo2_form.html
@@ -23,7 +23,7 @@
     {% endif %}
   {% endfor %}
 
-  {% if "wes" in analysis_types %}
+  {% if "wes" in analysis_types or "panel" in analysis_types %}
     {% set interval_type = "exons" %}
   {% elif "wts" in analysis_types %}
     {% set interval_type = "transcripts" %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Panel data doesn't have associated panels at the moment and when d4 files are provided for these cases the chanjo2 stats are computed as if they were WGS cases, resulting in very low coverage stats. Treating these cases as WES (still incorrect) would help improving the stats 
- This PR has to be used in a combo with a fix for this issue on chanjo2 -> https://github.com/Clinical-Genomics/chanjo2/issues/488, otherwise the stats won't change. But I guess it can be fixed in scout anyway because if you provide a gene list in the request then it would work perfectly

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. Test with [this case](https://scout-stage.scilifelab.se/cust087/F0043044-2)


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
