### PR TITLE
Export managed variants CLI now accepts one or more categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Added
 - Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)
 - Filter cancer variants by archived number of cancer somatic panel observations (#5598)
+- Export Managed Variants: CLI now supports `--category` to filter by one or more categories (snv, sv, cancer_snv, cancer_sv). Defaults to all. (#5608)
 ### Changed
 - Avoid `utcnow()` deprecated code by installing Flask-Login from its main branch (#5592)
 - Compute chanjo2 coverage on exons only when at least case individual has analysis_type=panel (#5601)

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -5,6 +5,7 @@ from bson import ObjectId
 from pymongo.cursor import Cursor
 from pymongo.errors import DuplicateKeyError
 
+from scout.constants.managed_variant import MANAGED_CATEGORIES
 from scout.exceptions import IntegrityError
 
 LOG = logging.getLogger(__name__)
@@ -128,7 +129,7 @@ class ManagedVariantHandler(object):
 
     def managed_variants(
         self,
-        category: list = ["snv", "sv", "cancer_snv", "cancer_sv"],
+        category: list = MANAGED_CATEGORIES,
         query_options: str = None,
         build: str = None,
         institute: str = None,
@@ -144,6 +145,7 @@ class ManagedVariantHandler(object):
             query["build"] = build
         if institute:
             query["institute"] = institute
+
         query_with_options = self.add_options(query, query_options)
         return self.managed_variant_collection.find(query_with_options)
 

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -128,7 +128,7 @@ def verified(collaborator, test, outpath=None):
 @build_option
 @json_option
 @with_appcontext
-def managed(collaborator: str, category: Tuple[str, ...], build: str, json: bool):
+def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     """Export managed variants for a collaborator in VCF or JSON format"""
     LOG.info("Running scout export managed variants")
     adapter = store

--- a/scout/constants/managed_variant.py
+++ b/scout/constants/managed_variant.py
@@ -1,0 +1,1 @@
+MANAGED_CATEGORIES = ["snv", "sv", "cancer_snv", "cancer_sv"]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -6,6 +6,7 @@ from pymongo import ASCENDING
 
 from scout.adapter.mongo.base import MongoAdapter
 from scout.constants import CHROMOSOME_INTEGERS
+from scout.constants.managed_variant import MANAGED_CATEGORIES
 from scout.models.managed_variant import ManagedVariant
 
 LOG = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ def export_managed_variants(
     adapter: MongoAdapter,
     institute: str = None,
     build: str = None,
-    category: list = ["snv", "sv"],
+    category: list = MANAGED_CATEGORIES,
 ) -> ManagedVariant:
     """Export managed variants, optionally for a given institute or variant category (["snv", "cancer_sv", ...])"""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5604

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
