### PR TITLE
Add GT check to overlapping genes search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Exporting managed variants from the command line with the `--collaborator` option will return variants from the specified institute plus those not assigned to any institute (#5607)
 - Safer redirect to previous page for variants views (#5599)
 - Make whole caseS row clickable link for case page (#5620)
+- Restrict gene-overlapping variants search to variants affecting the same individuals as the original variant (#5623)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -702,12 +702,24 @@ class VariantHandler(VariantLoader):
         if not limit:
             limit = 30 if variant_obj["category"] == "snv" else 45
 
+        variant_carriers = [
+            s["sample_id"] for s in samples if re.search(CARRIER, s["genotype_call"])
+        ]
+
         query = {
             "$and": [
                 {"case_id": variant_obj["case_id"]},
                 {"category": category},
                 {"variant_type": variant_type},
                 {"hgnc_ids": {"$in": hgnc_ids}},
+                {
+                    "samples": {
+                        "$elemMatch": {
+                            "sample_id": {"$in": variant_carriers},
+                            "genotype_call": {"$regex": CARRIER},
+                        }
+                    }
+                },
             ]
         }
         sort_key = [("rank_score", pymongo.DESCENDING)]

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -703,7 +703,7 @@ class VariantHandler(VariantLoader):
             limit = 30 if variant_obj["category"] == "snv" else 45
 
         variant_carriers = [
-            s["sample_id"] for s in samples if re.search(CARRIER, s["genotype_call"])
+            s["sample_id"] for s in variant_obj["samples"] if re.search(CARRIER, s["genotype_call"])
         ]
 
         query = {


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5621 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
