### PR TITLE
Fix #5586 - TRGT_ID loci gets late genes.hgnc_symbol population, and hence strange reload behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bump tj-actions-branch-names GitHub action to v9 (#5605)
 - Missing variant key `tool_hits` causing fusion variants page to crash (#5614)
 - Add/fix conflicts between ClinGen-CGC-VICC classification criteria to fix discrepancies to Horak et al (#5629)
+- Fix display of gene symbols for TRGT loci on variantS page (#5634)
 
 ## [4.103.3]
 ### Changed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -551,7 +551,7 @@ def update_variant_genes(store, variant_obj, genome_build):
             variant_obj["genes"].append(variant_gene)
         variant_genes = variant_obj.get(
             "genes"
-        )  # we need update variant_genes here, to get all fixes in one call to the funcion
+        )  # we need update variant_genes here, to get all fixes in one call to the function
 
     if variant_genes is not None:
         for gene_obj in variant_genes:

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -549,6 +549,9 @@ def update_variant_genes(store, variant_obj, genome_build):
             has_changed = True
             variant_gene = {"hgnc_id": hgnc_id}
             variant_obj["genes"].append(variant_gene)
+        variant_genes = variant_obj.get(
+            "genes"
+        )  # we need update variant_genes here, to get all fixes in one call to the funcion
 
     if variant_genes is not None:
         for gene_obj in variant_genes:

--- a/scout/server/blueprints/variants/templates/variants/str-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/str-variants.html
@@ -245,8 +245,12 @@
     {%endif%}
   </div>"
   title="">{% if variant.str_repid %} {{ variant.str_repid }}
+  {% elif variant.hgnc_symbols %}
+    {% for hgnc_symbol in variant.hgnc_symbols %} {{ hgnc_symbol }} {% endfor %}
   {% elif variant.genes %}
     {% for gene in variant.genes %} {{ gene.symbol or gene.hgnc_symbol }} {% endfor %}
+  {% elif variant.hgnc_ids %}
+    {% for hgnc_id in variant.hgnc_ids %} {{ hgnc_id }} {% endfor %}
   {% else %}
     {{ variant.str_trid }}
   {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5586 

Ok, so three-four steps here:
- [x] Firstly, we fix the display, by changing the fallback order for the symbol. `variant.hgnc_ids` and `variant.hgnc_symbols` are properly parsed for loci that are annotated with an `HNGCId` by `Stranger`, which is the case for current `Nallo` runs. This will be useful for new cases that are already uploaded as well.
Now `variant.genes` appears repopulated later when discovered missing on variants page load, and not used until later.
- [x] So, secondly, we allow the update function to work a bit more aggressively and do more updates in one reload
- [ ] Third, we should really do the "update" already at the parsing step. No reason to wait other than perhaps not to have an extra function for the same thing. Here https://github.com/Clinical-Genomics/scout/blob/9af4dbc1e7febfa9115e96ea3171d0e5861ed7a1/scout/parse/variant/variant.py#L140 or maybe better here https://github.com/Clinical-Genomics/scout/blob/9af4dbc1e7febfa9115e96ea3171d0e5861ed7a1/scout/parse/variant/variant.py#L628-L627.
- [ ] So fourth, maybe, maybe, we could refactor to merge at least a couple of these functions.

For now this kind of solves the issue already with steps 1 and 2 anyone will be hard pressed to find a use case where the variants will not simply be displayed/populated in time. But they will arguably not be fully "finished" until the second reload (compared to fourth before), so we should probably fix it. Just not Friday evening. 😝 

Here is testing with a local case reload, first on main:
❌ no symbols on the loci (will resolve after reloading, converging after four)
<img width="721" height="419" alt="Screenshot 2025-08-22 at 17 48 18" src="https://github.com/user-attachments/assets/82c04a6c-07c8-475b-b724-009e200223fd" />
✅ with this PR, looks fine from the start, though behind the scenes the db objects will not be fully updated until the second reload (or all variants have been individually visited)
<img width="749" height="414" alt="Screenshot 2025-08-22 at 17 47 11" src="https://github.com/user-attachments/assets/71f42a8b-2237-404d-ae53-e818056db203" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
