### PR TITLE
Fix #5636 - missing 0 value SpliceAI annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing variant key `tool_hits` causing fusion variants page to crash (#5614)
 - Add/fix conflicts between ClinGen-CGC-VICC classification criteria to fix discrepancies to Horak et al (#5629)
 - Fix display of gene symbols for TRGT loci on variantS page (#5634)
+- Parse and store also SpliceAI scores where all scores are 0 - it can help users and is different from missing. (#5637)
 
 ## [4.103.3]
 ### Changed

--- a/scout/parse/variant/transcript.py
+++ b/scout/parse/variant/transcript.py
@@ -150,12 +150,14 @@ def parse_transcripts_spliceai(transcript, entry):
         "SPLICEAI_PRED_DS_DL": "spliceai_ds_dl",
     }
     for spliceai_tag_csq, spliceai_annotation in spliceai_positions_csq.items():
-        if entry.get(spliceai_tag_csq):
-            transcript[spliceai_annotation] = int(entry.get(spliceai_tag_csq))
+        if entry.get(spliceai_tag_csq) is None:
+            continue
+        transcript[spliceai_annotation] = int(entry.get(spliceai_tag_csq))
 
     for spliceai_tag_csq, spliceai_annotation in spliceai_delta_scores_csq.items():
-        if entry.get(spliceai_tag_csq):
-            transcript[spliceai_annotation] = float(entry.get(spliceai_tag_csq))
+        if entry.get(spliceai_tag_csq) is None:
+            continue
+        transcript[spliceai_annotation] = float(entry.get(spliceai_tag_csq))
 
     spliceai_pairs = {
         "spliceai_ds_ag": "spliceai_dp_ag",
@@ -168,7 +170,7 @@ def parse_transcripts_spliceai(transcript, entry):
     spliceai_delta_position = None
     spliceai_prediction = None
     spliceai_delta_scores = [transcript.get(tag) for tag in spliceai_pairs.keys()]
-    if any(spliceai_delta_scores):
+    if any(score is not None for score in spliceai_delta_scores):
         spliceai_delta_score = max(spliceai_delta_scores)
         index = spliceai_delta_scores.index(spliceai_delta_score)
         spliceai_delta_position = (


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5636 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
