### PR TITLE
Centralised config loader for cli and web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole caseS row clickable link for case page (#5620)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
+- Refactored the parsing of the app config file so there exists only one centralized loader for both cli and web app (#5638)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -57,17 +57,20 @@ def get_app(ctx=None):
     if options.params.get("demo"):
         cli_config["demo"] = "scout-demo"
 
+    # python config file
     flask_conf = options.params.get("flask_config")
 
     # collect CLI options into a dict
     cli_options = {
-        "mongodb": "scout-demo" if options.params.get("demo") else options.params.get("mongodb"),
-        "host": options.params.get("host"),
-        "port": options.params.get("port"),
-        "username": options.params.get("username"),
-        "password": options.params.get("password"),
-        "mongo_uri": options.params.get("mongo_uri"),
-        "omim_api_key": cli_config.get("omim_api_key"),
+        "MONGO_DBNAME": (
+            "scout-demo" if options.params.get("demo") else options.params.get("mongodb")
+        ),
+        "MONGO_HOST": options.params.get("host"),
+        "MONGO_PORT": options.params.get("port"),
+        "MONGO_USERNAME": options.params.get("username"),
+        "MONGO_PASSWORD": options.params.get("password"),
+        "MONGO_URI": options.params.get("mongo_uri"),
+        "OMIM_API_KEY": cli_config.get("omim_api_key"),
     }
 
     # Echo the database name if demo mode is used

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -1,5 +1,3 @@
-"""Code for CLI base"""
-
 import logging
 import pathlib
 
@@ -15,8 +13,6 @@ from scout.commands.delete import delete
 from scout.commands.download import download as download_command
 from scout.commands.export import export
 from scout.commands.index_command import index as index_command
-
-# Commands
 from scout.commands.load import load as load_command
 from scout.commands.serve import serve
 from scout.commands.setup import setup as setup_command
@@ -24,6 +20,7 @@ from scout.commands.update import update as update_command
 from scout.commands.view import view as view_command
 from scout.commands.wipe_database import wipe
 from scout.server.app import create_app
+from scout.utils.config import load_config
 
 LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 LOG = logging.getLogger(__name__)
@@ -44,44 +41,43 @@ def get_app(ctx=None):
     """Create an app with the correct config or with default app params"""
 
     loglevel()  # Set up log level even before creating the app object
-
-    # store provided params into a options variable
     options = ctx.find_root()
+
+    # YAML config (deprecated)
     cli_config = {}
-    # if a .yaml config file was provided use its params to intiate the app
     if options.params.get("config"):
         LOG.warning(
-            "Support for launching Scout using a .yaml config file is deprecated and will be removed in the next major release (5.0). Use a PYTHON (.py) config file instead.",
+            "Support for launching Scout using a .yaml config file is deprecated "
+            "and will be removed in the next major release (5.0). "
+            "Use a PYTHON (.py) config file instead.",
         )
         with open(options.params["config"], "r") as in_handle:
             cli_config = yaml.load(in_handle, Loader=yaml.SafeLoader)
 
-    flask_conf = None
-    if options.params.get("flask_config"):
-        flask_conf = pathlib.Path(options.params["flask_config"]).absolute()
-
     if options.params.get("demo"):
         cli_config["demo"] = "scout-demo"
 
+    flask_conf = options.params.get("flask_config")
+
+    # collect CLI options into a dict
+    cli_options = {
+        "mongodb": options.params.get("mongodb"),
+        "host": options.params.get("host"),
+        "port": options.params.get("port"),
+        "username": options.params.get("username"),
+        "password": options.params.get("password"),
+        "mongo_uri": options.params.get("mongo_uri"),
+        # still sourced from YAML if available
+        "omim_api_key": cli_config.get("omim_api_key"),
+    }
+
     try:
-        app = create_app(
-            config=dict(
-                MONGO_DBNAME=options.params.get("mongodb")
-                or cli_config.get("demo")
-                or cli_config.get("mongodb")
-                or "scout",
-                MONGO_HOST=options.params.get("host") or cli_config.get("host"),
-                MONGO_PORT=options.params.get("port") or cli_config.get("port"),
-                MONGO_USERNAME=options.params.get("username") or cli_config.get("username"),
-                MONGO_PASSWORD=options.params.get("password") or cli_config.get("password"),
-                MONGO_URI=options.params.get("mongo_uri") or cli_config.get("mongo_uri"),
-                OMIM_API_KEY=cli_config.get("omim_api_key"),
-            ),
-            config_file=flask_conf,
-        )
+        config = load_config(cli_options=cli_options, cli_config=cli_config, flask_conf=flask_conf)
+        app = create_app(config=config)
     except SyntaxError as err:
         LOG.error(err)
         raise click.Abort
+
     return app
 
 
@@ -125,6 +121,7 @@ def cli(**_):
     """scout: manage interactions with a scout instance."""
 
 
+# Register all commands
 cli.add_command(load_command)
 cli.add_command(wipe)
 cli.add_command(setup_command)

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -72,7 +72,7 @@ def get_app(ctx=None):
 
     # Echo the database name if demo mode is used
     if options.params.get("demo"):
-        click.echo(f"Database name: {cli_options['mongodb']}")
+        click.echo(f"Demo mode - database name is: {cli_options['mongodb']}")
 
     try:
         config = load_config(cli_options=cli_options, cli_config=cli_config, flask_conf=flask_conf)

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -61,15 +61,18 @@ def get_app(ctx=None):
 
     # collect CLI options into a dict
     cli_options = {
-        "mongodb": options.params.get("mongodb"),
+        "mongodb": "scout-demo" if options.params.get("demo") else options.params.get("mongodb"),
         "host": options.params.get("host"),
         "port": options.params.get("port"),
         "username": options.params.get("username"),
         "password": options.params.get("password"),
         "mongo_uri": options.params.get("mongo_uri"),
-        # still sourced from YAML if available
         "omim_api_key": cli_config.get("omim_api_key"),
     }
+
+    # Echo the database name if demo mode is used
+    if options.params.get("demo"):
+        click.echo(f"Database name: {cli_options['mongodb']}")
 
     try:
         config = load_config(cli_options=cli_options, cli_config=cli_config, flask_conf=flask_conf)

--- a/scout/commands/base.py
+++ b/scout/commands/base.py
@@ -75,7 +75,7 @@ def get_app(ctx=None):
 
     # Echo the database name if demo mode is used
     if options.params.get("demo"):
-        click.echo(f"Demo mode - database name is: {cli_options['mongodb']}")
+        click.echo(f"Demo mode - database name is: {cli_options['MONGO_DBNAME']}")
 
     try:
         config = load_config(cli_options=cli_options, cli_config=cli_config, flask_conf=flask_conf)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -20,6 +20,7 @@ from scout.constants import (
     SPLICEAI_SCORE_LABEL_COLOR_MAP,
 )
 from scout.log import init_log
+from scout.utils.config import load_config
 
 from . import extensions
 from .blueprints import (
@@ -56,14 +57,18 @@ def create_app(config_file=None, config=None):
     app.jinja_env.add_extension("jinja2.ext.do")
     app.jinja_env.globals["SCOUT_VERSION"] = __version__
 
-    app.config.from_pyfile("config.py")  # Load default config file
-    if (
-        config
-    ):  # Params from an optional .yaml config file provided by the user or created by the app cli
-        app.config.update((k, v) for k, v in config.items() if v is not None)
-    if config_file:  # Params from an optional .py config file provided by the user
-        app.config.from_pyfile(config_file)
+    # 1. Always load defaults from config.py
+    app.config.from_pyfile("config.py")
 
+    # 2. Merge everything through load_config
+    merged_config = load_config(
+        cli_options=config,  # when invoked via CLI
+        cli_config=None,  # YAML handled upstream in CLI
+        flask_conf=config_file,
+    )
+    app.config.update({k: v for k, v in merged_config.items() if v is not None})
+
+    # 3. Apply session timeout if configured
     session_timeout_minutes = app.config.get("SESSION_TIMEOUT_MINUTES")
     if session_timeout_minutes:
         session_duration = timedelta(minutes=session_timeout_minutes)
@@ -72,15 +77,18 @@ def create_app(config_file=None, config=None):
 
     app.json.sort_keys = False
 
+    # 4. Register app parts
     init_log(log=LOG, app=app)
     configure_extensions(app)
     register_blueprints(app)
     register_filters(app)
     register_tests(app)
 
+    # 5. Optional email error logging
     if not (app.debug or app.testing) and app.config.get("MAIL_USERNAME"):
-        # setup email logging of errors
         configure_email_logging(app)
+
+    return app
 
     @app.before_request
     def check_user():

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -63,7 +63,7 @@ def create_app(config_file=None, config=None):
     # 2. Merge everything through load_config
     merged_config = load_config(
         cli_options=config,  # when invoked via CLI
-        cli_config=None,  # YAML handled upstream in CLI
+        cli_config=None,  # YAML handled upstream - only used for pure CLI commands
         flask_conf=config_file,
     )
     app.config.update({k: v for k, v in merged_config.items() if v is not None})

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -88,8 +88,6 @@ def create_app(config_file=None, config=None):
     if not (app.debug or app.testing) and app.config.get("MAIL_USERNAME"):
         configure_email_logging(app)
 
-    return app
-
     @app.before_request
     def check_user():
         if not app.config.get("LOGIN_DISABLED") and request.endpoint:

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -55,7 +55,7 @@ def create_app(config_file=None, config=None):
     # 2. Merge everything through load_config
     # 3. Apply session timeout if configured
     # 4. Register app parts
-     # 5. Optional email error logging
+    # 5. Optional email error logging
     """
 
     app = Flask(__name__)

--- a/scout/utils/config.py
+++ b/scout/utils/config.py
@@ -1,6 +1,6 @@
 import pathlib
 
-DEFAULTS = {
+DEFAULT_CONFIG = {
     "MONGO_DBNAME": "scout",
 }
 

--- a/scout/utils/config.py
+++ b/scout/utils/config.py
@@ -7,7 +7,7 @@ DEFAULT_CONFIG = {
 
 def load_config(cli_options=None, cli_config=None, flask_conf=None) -> dict:
     """Merge CLI options, YAML config, Flask config file, and defaults into one dict."""
-    config = DEFAULTS.copy()
+    config = DEFAULT_CONFIG.copy()
 
     # 1. CLI options (highest priority)
     if cli_options:

--- a/scout/utils/config.py
+++ b/scout/utils/config.py
@@ -1,3 +1,4 @@
+import copy
 import pathlib
 
 DEFAULT_CONFIG = {
@@ -6,25 +7,33 @@ DEFAULT_CONFIG = {
 
 
 def load_config(cli_options=None, cli_config=None, flask_conf=None) -> dict:
-    """Merge CLI options, YAML config, Flask config file, and defaults into one dict."""
-    config = DEFAULT_CONFIG.copy()
+    """Merge CLI options, YAML config, Flask config file, and defaults into one dict.
 
-    # 1. CLI options (highest priority)
-    if cli_options:
-        config.update({k.upper(): v for k, v in cli_options.items() if v is not None})
+    Priority (lowest → highest):
+        1. Defaults
+        2. Flask config file
+        3. YAML config (deprecated but supported)
+        4. CLI options
+    """
+    # 1. Defaults
+    config = copy.deepcopy(DEFAULT_CONFIG)
 
-    # 2. YAML config (deprecated, but still supported for backward compatibility)
-    if cli_config:
-        config.update({k.upper(): v for k, v in cli_config.items() if v is not None})
-
-    # 3. Flask config file (.py with uppercase vars)
+    # 2. Flask config file (.py with uppercase vars)
     if flask_conf:
         flask_conf_path = pathlib.Path(flask_conf).absolute()
         flask_conf_dict = {}
         with open(flask_conf_path) as f:
             code = compile(f.read(), str(flask_conf_path), "exec")
-            exec(code, flask_conf_dict)
+            exec(code, {}, flask_conf_dict)
         flask_conf_dict = {k: v for k, v in flask_conf_dict.items() if k.isupper()}
         config.update(flask_conf_dict)
+
+    # 3. YAML config (deprecated, but still supported)
+    if cli_config:
+        config.update({k.upper(): v for k, v in cli_config.items() if v is not None})
+
+    # 4. CLI options (highest priority)
+    if cli_options:
+        config.update({k.upper(): v for k, v in cli_options.items() if v is not None})
 
     return config

--- a/scout/utils/config.py
+++ b/scout/utils/config.py
@@ -1,0 +1,30 @@
+import pathlib
+
+DEFAULTS = {
+    "MONGO_DBNAME": "scout",
+}
+
+
+def load_config(cli_options=None, cli_config=None, flask_conf=None) -> dict:
+    """Merge CLI options, YAML config, Flask config file, and defaults into one dict."""
+    config = DEFAULTS.copy()
+
+    # 1. CLI options (highest priority)
+    if cli_options:
+        config.update({k.upper(): v for k, v in cli_options.items() if v is not None})
+
+    # 2. YAML config (deprecated, but still supported for backward compatibility)
+    if cli_config:
+        config.update({k.upper(): v for k, v in cli_config.items() if v is not None})
+
+    # 3. Flask config file (.py with uppercase vars)
+    if flask_conf:
+        flask_conf_path = pathlib.Path(flask_conf).absolute()
+        flask_conf_dict = {}
+        with open(flask_conf_path) as f:
+            code = compile(f.read(), str(flask_conf_path), "exec")
+            exec(code, flask_conf_dict)
+        flask_conf_dict = {k: v for k, v in flask_conf_dict.items() if k.isupper()}
+        config.update(flask_conf_dict)
+
+    return config

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -30,4 +30,4 @@ def test_base_cmd():
     # test the cli with --demo option
     result = runner.invoke(cli, ["--demo"])
     assert result.exit_code == 0
-    assert "Database name: scout-demo" in result.output
+    assert "Demo mode - database name is: scout-demo" in result.output

--- a/tests/commands/test_base_command.py
+++ b/tests/commands/test_base_command.py
@@ -1,4 +1,3 @@
-import pytest
 from click.testing import CliRunner
 
 from scout import __version__


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Refactored how app config file is parsed to have a centralised function only

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DNIL, github actions
