### PR TITLE
Fix missing git from Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Add/fix conflicts between ClinGen-CGC-VICC classification criteria to fix discrepancies to Horak et al (#5629)
 - Fix display of gene symbols for TRGT loci on variantS page (#5634)
 - Parse and store also SpliceAI, CADD scores where all scores are 0. (#5637)
+- Broken actions and deployments, caused by Git executable not found in Docker images (#5641)
 
 ## [4.103.3]
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,11 @@ LABEL about.license="MIT License (MIT)"
 # Install base dependencies
 RUN apt-get update && \
      apt-get -y upgrade && \
-     apt-get -y install -y --no-install-recommends wkhtmltopdf libpango-1.0-0 libpangocairo-1.0-0 && \
+     apt-get -y install --no-install-recommends \
+        git \
+        wkhtmltopdf \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*
 
@@ -37,19 +41,18 @@ RUN apt-get update && \
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 ENV PATH="/home/worker/app/.venv/bin:$PATH"
-
 WORKDIR /home/worker/app
 
-# Copy current app code to app dir
-COPY --chown=root:root --chmod=755 . /home/worker/app
+# Copy current app code to app dir (owned by worker)
+COPY --chown=worker:worker --chmod=755 . /home/worker/app
 
-# Copy virtual environment from builder
-COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
+# Copy virtual environment from builder (owned by worker)
+COPY --chown=worker:worker --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
-# Install only Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
-
-# Run the app as non-root user
+# Switch to non-root user *before* installing Scout
 USER worker
+
+# Install only Scout app into venv as worker (no permission issues)
+RUN uv pip install --no-cache-dir --editable .[coverage]
 
 ENTRYPOINT ["uv", "run", "scout"]

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -24,13 +24,17 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 LABEL about.home="https://github.com/Clinical-Genomics/scout"
 LABEL about.documentation="https://clinical-genomics.github.io/scout"
-LABEL about.tags="Clinical,Variant triage,WGS,WES,Rare diseases,VCF,variants,SNV,Massiviely parallel sequencing, Next generation sequencing"
+LABEL about.tags="Clinical,Variant triage,WGS,WES,Rare diseases,VCF,variants,SNV,Massively parallel sequencing,Next generation sequencing"
 LABEL about.license="MIT License (MIT)"
 
 # Install base dependencies
 RUN apt-get update && \
      apt-get -y upgrade && \
-     apt-get -y install -y --no-install-recommends wkhtmltopdf libpango-1.0-0 libpangocairo-1.0-0 && \
+     apt-get -y install --no-install-recommends \
+        git \
+        wkhtmltopdf \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 && \
      apt-get clean && \
      rm -rf /var/lib/apt/lists/*
 
@@ -38,21 +42,21 @@ RUN apt-get update && \
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 ENV PATH="/home/worker/app/.venv/bin:$PATH"
-
 WORKDIR /home/worker/app
 
-# Copy current app code to app dir
-COPY --chown=root:root --chmod=755 . /home/worker/app
+# Copy current app code to app dir (owned by worker)
+COPY --chown=worker:worker --chmod=755 . /home/worker/app
 
-# Copy virtual environment from builder
-COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
+# Copy virtual environment from builder (owned by worker)
+COPY --chown=worker:worker --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
-# Install only Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
-
-# Run the app as non-root user
+# Switch to non-root user *before* installing Scout
 USER worker
 
+# Install only Scout app into venv as worker (no permission issues)
+RUN uv pip install --no-cache-dir --editable .[coverage]
+
+# Gunicorn config
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1
 ENV GUNICORN_BIND="0.0.0.0:8000"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
