### PR TITLE
Fix Dockerfiles to remove package metadata after installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole caseS row clickable link for case page (#5620)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
+- Removing git installers when building Docker images (#5644)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,15 +44,15 @@ WORKDIR /home/worker/app
 COPY --chown=root:root --chmod=755 . /home/worker/app
 
 # Copy virtual environment from builder
-COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
+COPY --from=python-builder /app/.venv /home/worker/app/.venv
 
-# Remove INSTALLER files as root to avoid permission errors
-RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
+# Ensure worker owns everything in venv
+RUN chown -R worker:worker /home/worker/app/.venv
 
-# Install only Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
-
-# Run the app as non-root user
+# Switch to non-root user
 USER worker
+
+# Install Scout app
+RUN uv pip install --no-cache-dir --editable .[coverage]
 
 ENTRYPOINT ["uv", "run", "scout"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,9 @@ COPY --chown=root:root --chmod=755 . /home/worker/app
 # Copy virtual environment from builder
 COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
+# NEW: remove INSTALLER files to avoid permission errors
+RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
+
 # Install only Scout app
 RUN uv pip install --no-cache-dir --editable .[coverage]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY --chown=root:root --chmod=755 . /home/worker/app
 # Copy virtual environment from builder
 COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
-# NEW: remove INSTALLER files to avoid permission errors
+# Remove INSTALLER files as root to avoid permission errors
 RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
 
 # Install only Scout app

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -47,7 +47,7 @@ COPY --chown=root:root --chmod=755 . /home/worker/app
 # Copy virtual environment from builder
 COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
-# NEW: remove INSTALLER files to avoid permission errors
+# Remove INSTALLER files as root to avoid permission errors
 RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
 
 # Install only Scout app

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -45,16 +45,16 @@ WORKDIR /home/worker/app
 COPY --chown=root:root --chmod=755 . /home/worker/app
 
 # Copy virtual environment from builder
-COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
+COPY --from=python-builder /app/.venv /home/worker/app/.venv
 
-# Remove INSTALLER files as root to avoid permission errors
-RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
+# Ensure worker owns everything in venv
+RUN chown -R worker:worker /home/worker/app/.venv
 
-# Install only Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
-
-# Run the app as non-root user
+# Switch to non-root user
 USER worker
+
+# Install Scout app
+RUN uv pip install --no-cache-dir --editable .[coverage]
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -47,6 +47,9 @@ COPY --chown=root:root --chmod=755 . /home/worker/app
 # Copy virtual environment from builder
 COPY --chown=root:root --chmod=755 --from=python-builder /app/.venv /home/worker/app/.venv
 
+# NEW: remove INSTALLER files to avoid permission errors
+RUN find /home/worker/app/.venv/lib/python3.12/site-packages/ -name INSTALLER -exec rm -f {} +
+
 # Install only Scout app
 RUN uv pip install --no-cache-dir --editable .[coverage]
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5643

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
