### PR TITLE
Clearer export causatives command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
 - Removing git installers when building Docker images (#5644)
-- Clearer cli command to export causative variants (#5654)
+- Renamed `scout export variants` to `scout export causatives`, but the old commands still works (#5654)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
 - Removing git installers when building Docker images (#5644)
-- Update command: scout export variants now scout export causatives (backward-compatible) (#5654)
+- Update command: `scout export variants` now `scout export causatives` (backward-compatible) (#5654)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
 - Removing git installers when building Docker images (#5644)
+- Clearer cli command to export causative variants (#5654)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Make whole variantS row clickable link for variant page (#5618)
 - Refined the filtering logic for Clinical WTS variants. The clinical filter now selects variants with either `padjust` < 0.05 or (`p_adjust_gene` < 0.1 and abs(`delta_psi`) > 0.1), for OUTRIDER expression variants and FRASER splicing variants respectively (#5630)
 - Removing git installers when building Docker images (#5644)
-- Renamed `scout export variants` to `scout export causatives`, but the old commands still works (#5654)
+- Update command: scout export variants now scout export causatives (backward-compatible) (#5654)
 ### Fixed
 - Treat -1 values as None values when parsing archived LoqusDB frequencies (#5591)
 - Links to SNVs and SVs from SMN CN page (#5600)

--- a/docs/admin-guide/export.md
+++ b/docs/admin-guide/export.md
@@ -194,7 +194,7 @@ Options:
 ```
 ---
 
-## Exporting Causative Variants (`variants`)
+## Exporting Causative Variants (`causatives`, alias: `variants`)
 
 Export causative variants for a case or an institute. Output is VCF by default, or JSON if specified.
 

--- a/scout/commands/export/export_command.py
+++ b/scout/commands/export/export_command.py
@@ -9,7 +9,7 @@ Created by Måns Magnusson on 2016-05-11.
 Copyright (c) 2016 ScoutTeam__. All rights reserved.
 
 """
-
+import copy
 import logging
 
 import click
@@ -40,7 +40,15 @@ export.add_command(panel_cmd)
 export.add_command(genes)
 export.add_command(transcripts)
 export.add_command(exons)
+# Register normally
 export.add_command(causatives)
+
+# Create a shallow copy of the command for the alias
+variants_cmd = copy.copy(causatives)
+variants_cmd.hidden = True
+
+# Register the alias
+export.add_command(variants_cmd, "variants")
 export.add_command(verified)
 export.add_command(managed)
 export.add_command(hpo_genes)

--- a/scout/commands/export/export_command.py
+++ b/scout/commands/export/export_command.py
@@ -47,7 +47,7 @@ export.add_command(causatives)
 variants_cmd = copy.copy(causatives)
 variants_cmd.hidden = True
 
-# Register the alias
+# Register the alias to maintain backward compatibility
 export.add_command(variants_cmd, "variants")
 export.add_command(verified)
 export.add_command(managed)

--- a/scout/commands/export/export_command.py
+++ b/scout/commands/export/export_command.py
@@ -40,7 +40,6 @@ export.add_command(panel_cmd)
 export.add_command(genes)
 export.add_command(transcripts)
 export.add_command(exons)
-# Register normally
 export.add_command(causatives)
 
 # Create a shallow copy of the command for the alias

--- a/scout/commands/export/export_command.py
+++ b/scout/commands/export/export_command.py
@@ -22,7 +22,7 @@ from .hpo import hpo_genes
 from .mitochondrial_report import mt_report
 from .panel import panel_cmd
 from .transcript import transcripts
-from .variant import managed, variants, verified
+from .variant import causatives, managed, verified
 
 LOG = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ export.add_command(panel_cmd)
 export.add_command(genes)
 export.add_command(transcripts)
 export.add_command(exons)
-export.add_command(variants)
+export.add_command(causatives)
 export.add_command(verified)
 export.add_command(managed)
 export.add_command(hpo_genes)

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -12,8 +12,8 @@ from scout.constants import CALLERS, DATE_DAY_FORMATTER
 from scout.constants.managed_variant import MANAGED_CATEGORIES
 from scout.constants.variants_export import VCF_HEADER, VERIFIED_VARIANTS_HEADER
 from scout.export.variant import (
+    export_causative_variants,
     export_managed_variants,
-    export_variants,
     export_verified_variants,
 )
 from scout.server.extensions import store
@@ -152,7 +152,7 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
         click.echo(variant_string)
 
 
-@click.command("variants", short_help="Export variants")
+@click.command("variants", short_help="Export causative variants")
 @click.option(
     "-c",
     "--collaborator",
@@ -162,7 +162,7 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
 @click.option("--case-id", help="Find causative variants for case")
 @json_option
 @with_appcontext
-def variants(collaborator: str, document_id: str, case_id: str, json: bool):
+def causatives(collaborator: str, document_id: str, case_id: str, json: bool):
     """Export causatives for a collaborator in .vcf format"""
     LOG.info("Running scout export variants")
     adapter = store
@@ -174,7 +174,9 @@ def variants(collaborator: str, document_id: str, case_id: str, json: bool):
             LOG.info("Case %s does not exist", case_id)
             raise click.Abort
 
-    variants = export_variants(adapter, collaborator, document_id=document_id, case_id=case_id)
+    variants = export_causative_variants(
+        adapter, collaborator, document_id=document_id, case_id=case_id
+    )
 
     if json:
         click.echo(json_lib.dumps([var for var in variants], default=bson_handler))

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -152,7 +152,7 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
         click.echo(variant_string)
 
 
-@click.command("variants", short_help="Export causative variants")
+@click.command("causatives", short_help="Export causative variants")
 @click.option(
     "-c",
     "--collaborator",

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -12,7 +12,7 @@ from scout.models.managed_variant import ManagedVariant
 LOG = logging.getLogger(__name__)
 
 
-def export_variants(
+def export_causative_variants(
     adapter: MongoAdapter, collaborator: str, document_id: str = None, case_id: str = None
 ) -> dict:
     """Export causative variants for a collaborator.

--- a/tests/commands/export/test_export_causatives_cmd.py
+++ b/tests/commands/export/test_export_causatives_cmd.py
@@ -4,7 +4,7 @@ from scout.commands import cli
 from scout.server.extensions import store
 
 
-def test_export_variants(mock_app, case_obj):
+def test_export_causatives(mock_app, case_obj):
     """Test the CLI command that exports causatives into vcf format"""
 
     runner = mock_app.test_cli_runner()

--- a/tests/commands/export/test_export_causatives_verified_cmd.py
+++ b/tests/commands/export/test_export_causatives_verified_cmd.py
@@ -14,7 +14,7 @@ def test_export_causatives(mock_app, case_obj):
     assert store.variant_collection.find_one() is None
 
     # Load snv variants using the cli
-    result = runner.invoke(cli, ["load", "variants", case_obj["_id"], "--snv"])
+    runner.invoke(cli, ["load", "variants", case_obj["_id"], "--snv"])
     assert sum(1 for _ in store.variant_collection.find()) > 0
 
     # update case registering a causative variant
@@ -76,7 +76,7 @@ def test_export_verified(mock_app, case_obj, user_obj, institute_obj):
     assert runner
 
     # Load snv variants using the cli
-    result = runner.invoke(cli, ["load", "variants", case_obj["_id"], "--snv"])
+    runner.invoke(cli, ["load", "variants", case_obj["_id"], "--snv"])
 
     assert store.variant_collection.find_one() is not None
 
@@ -98,9 +98,9 @@ def test_export_verified(mock_app, case_obj, user_obj, institute_obj):
         validate_type="True positive",
     )
     var_res = store.variant_collection.find({"validation": "True positive"})
-    assert sum(1 for i in var_res) == 1
+    assert sum(1 for _ in var_res) == 1
     event_res = store.event_collection.find({"verb": "validate"})
-    assert sum(1 for i in event_res) == 1
+    assert sum(1 for _ in event_res) == 1
 
     # Test the cli without parameters
     result = runner.invoke(cli, ["export", "verified", "--test"])


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Clearer CLI export of causative variants. I was confused myself when using it

If you run `scout export --help`

# before - command had export "variants"

<img width="399" height="223" alt="image" src="https://github.com/user-attachments/assets/683dcc7a-4f2d-47aa-a11f-b1d09e5ca8c0" />


# After - command has export "causatives"

<img width="373" height="235" alt="image" src="https://github.com/user-attachments/assets/08632ed2-da31-4445-b3fc-498a4575f369" />


Using this branch, you should be able to use both the option causatives or variants without difference



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
