### PR TITLE
Fix failing causatives export on variants that are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Git missing from docker bookworm slim image (#5642)
 - Matching cancer_snv managed variants failure (#5647)
 - Parsing of database name when provided on a .yaml config file (#5663)
-- Export causatives command crashing on variants with null chromosome (#5665)
+- Export causatives command crashing on variants that have been removed (#5665)
 
 ## [4.103.3]
 ### Changed

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -35,11 +35,13 @@ def export_causative_variants(
 
     for doc_id in variant_ids:
         variant_obj = adapter.variant(doc_id)
-        chrom = variant_obj.get("chromosome")
+        if variant_obj is None:
+            continue
+        chrom = variant_obj["chromosome"]
         # Convert chromosome to integer for sorting
         chrom_int = CHROMOSOME_INTEGERS.get(chrom)
         if not chrom_int:
-            LOG.info(f"Unknown chromosome {chrom} for variant with ID {variant_obj['_id']}")
+            LOG.info("Unknown chromosome %s", chrom)
             continue
 
         # Add chromosome and position to prepare for sorting


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5664 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
