### PR TITLE
Fix negative observations in archived loqus table and refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Refactored and simplified the LoqusDB archived observations table. -1 is no longer shown for missing observations (#5680)
+
 ## [4.104]
 ### Added
 - Parsing variant's`local_obs_cancer_somatic_panel_old` and `local_obs_cancer_somatic_panel_old_freq`from `Cancer_Somatic_Panel_Obs` and `Cancer_Somatic_Panel_Frq` INFO keys respectively (#5594)

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -288,6 +288,28 @@
   </div>
 {% endmacro %}
 
+{# Helper macro: render observation count #}
+{% macro render_obs(value) -%}
+  {% if value is not defined or value is none or value == -1 %}
+    N/A
+  {% else %}
+    {{ value }}
+  {% endif %}
+{%- endmacro %}
+
+{# Helper macro: render frequency #}
+{% macro render_freq(freq, obs, nr_cases) -%}
+  {% if freq is defined and freq is not none %}
+    {{ freq|round(6) }}
+  {% elif nr_cases and obs is defined and obs is not none and obs != -1 %}
+    {{ (obs / nr_cases)|round(5) }}
+  {% elif nr_cases %}
+    0 / {{ nr_cases }}
+  {% else %}
+    N/A
+  {% endif %}
+{%- endmacro %}
+
 {% macro old_observations_table(variant) %}
 <table class="table">
   <thead class="thead table-light">
@@ -301,28 +323,28 @@
   <tbody>
     <tr>
       <td>RD</td>
-      <td>{{ variant.local_obs_old|default('N/A') }}</td>
-      <td>{{ variant.local_obs_hom_old|default('N/A') }}</td>
-      <td>{% if variant.local_obs_old_freq %} {{variant.local_obs_old_freq|round(6)}} {% elif variant.local_obs_old_nr_cases and variant.local_obs_old %} {{ (variant.local_obs_old/variant.local_obs_old_nr_cases)|round(5) }} {% elif variant.local_obs_old_nr_cases %} 0 / {{variant.local_obs_old_nr_cases}} {% else %} N/A {% endif %}</td>
+      <td>{{ render_obs(variant.local_obs_old) }}</td>
+      <td>{{ render_obs(variant.local_obs_hom_old) }}</td>
+      <td>{{ render_freq(variant.local_obs_old_freq, variant.local_obs_old, variant.local_obs_old_nr_cases) }}</td>
     </tr>
     {% if variant.category in ['cancer', 'cancer_sv'] %}
       <tr>
         <td>Cancer Germline</td>
-        <td>{{ variant.local_obs_cancer_germline_old|default('N/A') }}</td>
-        <td>{{ variant.local_obs_cancer_germline_hom_old|default('N/A') }}</td>
-        <td>{% if variant.local_obs_cancer_germline_old_freq %} {{variant.local_obs_cancer_germline_old_freq|round(6)}} {% elif variant.local_obs_cancer_germline_old_nr_cases and variant.local_obs_cancer_germline_old %} {{ (variant.local_obs_cancer_germline_old/variant.local_obs_cancer_germline_old_nr_cases)|round(5) }} {% elif variant.local_obs_cancer_germline_old_nr_cases %} 0 / {{variant.local_obs_cancer_germline_old_nr_cases}} {% else %} N/A {% endif %}</td>
+        <td>{{ render_obs(variant.local_obs_cancer_germline_old) }}</td>
+        <td>{{ render_obs(variant.local_obs_cancer_germline_hom_old) }}</td>
+        <td>{{ render_freq(variant.local_obs_cancer_germline_old_freq, variant.local_obs_cancer_germline_old, variant.local_obs_cancer_germline_old_nr_cases) }}</td>
       </tr>
       <tr>
         <td>Cancer Somatic</td>
-        <td>{{ variant.local_obs_cancer_somatic_old|default('N/A') }}</td>
-        <td>{{ variant.local_obs_cancer_somatic_hom_old|default('N/A') }}</td>
-        <td>{% if variant.local_obs_cancer_somatic_old_freq %} {{variant.local_obs_cancer_somatic_old_freq|round(6)}} {% elif variant.local_obs_cancer_somatic_old_nr_cases and variant.local_obs_cancer_somatic_old %} {{ (variant.local_obs_cancer_somatic_old/variant.local_obs_cancer_somatic_old_nr_cases)|round(5) }} {% elif variant.local_obs_cancer_somatic_old_nr_cases %} 0 / {{variant.local_obs_cancer_somatic_old_nr_cases}} {% else %} N/A {% endif %}</td>
+        <td>{{ render_obs(variant.local_obs_cancer_somatic_old) }}</td>
+        <td>{{ render_obs(variant.local_obs_cancer_somatic_hom_old) }}</td>
+        <td>{{ render_freq(variant.local_obs_cancer_somatic_old_freq, variant.local_obs_cancer_somatic_old, variant.local_obs_cancer_somatic_old_nr_cases) }}</td>
       </tr>
       <tr>
         <td>Cancer Somatic panel</td>
-        <td>{{ variant.local_obs_cancer_somatic_panel_old|default('N/A') }}</td>
+        <td>{{ render_obs(variant.local_obs_cancer_somatic_panel_old) }}</td>
         <td>N/A</td>
-        <td>{% if variant.local_obs_cancer_somatic_panel_old_freq %} {{variant.local_obs_cancer_somatic_panel_old_freq|round(6)}} {% else %} N/A {% endif %}</td>
+        <td>{{ render_freq(variant.local_obs_cancer_somatic_panel_old_freq, variant.local_obs_cancer_somatic_panel_old, None) }}</td>
       </tr>
     {% endif %}
   </tbody>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -288,67 +288,68 @@
   </div>
 {% endmacro %}
 
-{# Helper macro: render observation count #}
-{% macro render_obs(value) -%}
-  {% if value is not defined or value is none or value == -1 %}
-    N/A
-  {% else %}
-    {{ value }}
-  {% endif %}
-{%- endmacro %}
-
-{# Helper macro: render frequency #}
-{% macro render_freq(freq, obs, nr_cases) -%}
-  {% if freq is defined and freq is not none %}
-    {{ freq|round(6) }}
-  {% elif nr_cases and obs is defined and obs is not none and obs != -1 %}
-    {{ (obs / nr_cases)|round(5) }}
-  {% elif nr_cases %}
-    0 / {{ nr_cases }}
-  {% else %}
-    N/A
-  {% endif %}
-{%- endmacro %}
-
 {% macro old_observations_table(variant) %}
-<table class="table">
-  <thead class="thead table-light">
-    <tr>
-      <th scope="col">Local archive</th>
-      <th scope="col">Nr obs.</th>
-      <th scope="col">Nr homo.</th>
-      <th scope="col">Frequency</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>RD</td>
-      <td>{{ render_obs(variant.local_obs_old) }}</td>
-      <td>{{ render_obs(variant.local_obs_hom_old) }}</td>
-      <td>{{ render_freq(variant.local_obs_old_freq, variant.local_obs_old, variant.local_obs_old_nr_cases) }}</td>
-    </tr>
-    {% if variant.category in ['cancer', 'cancer_sv'] %}
-      <tr>
-        <td>Cancer Germline</td>
-        <td>{{ render_obs(variant.local_obs_cancer_germline_old) }}</td>
-        <td>{{ render_obs(variant.local_obs_cancer_germline_hom_old) }}</td>
-        <td>{{ render_freq(variant.local_obs_cancer_germline_old_freq, variant.local_obs_cancer_germline_old, variant.local_obs_cancer_germline_old_nr_cases) }}</td>
-      </tr>
-      <tr>
-        <td>Cancer Somatic</td>
-        <td>{{ render_obs(variant.local_obs_cancer_somatic_old) }}</td>
-        <td>{{ render_obs(variant.local_obs_cancer_somatic_hom_old) }}</td>
-        <td>{{ render_freq(variant.local_obs_cancer_somatic_old_freq, variant.local_obs_cancer_somatic_old, variant.local_obs_cancer_somatic_old_nr_cases) }}</td>
-      </tr>
-      <tr>
-        <td>Cancer Somatic panel</td>
-        <td>{{ render_obs(variant.local_obs_cancer_somatic_panel_old) }}</td>
-        <td>N/A</td>
-        <td>{{ render_freq(variant.local_obs_cancer_somatic_panel_old_freq, variant.local_obs_cancer_somatic_panel_old, None) }}</td>
-      </tr>
+
+  {# Helper macro: render observation count #}
+  {% macro render_obs(value) -%}
+    {% if value is not defined or value is none or value == -1 %}
+      N/A
+    {% else %}
+      {{ value }}
     {% endif %}
-  </tbody>
-</table>
+  {%- endmacro %}
+
+  {# Helper macro: render frequency #}
+  {% macro render_freq(freq, obs, nr_cases) -%}
+    {% if freq is defined and freq is not none %}
+      {{ freq|round(6) }}
+    {% elif nr_cases and obs is defined and obs is not none and obs != -1 %}
+      {{ (obs / nr_cases)|round(5) }}
+    {% elif nr_cases %}
+      0 / {{ nr_cases }}
+    {% else %}
+      N/A
+    {% endif %}
+  {%- endmacro %}
+
+  <table class="table">
+    <thead class="thead table-light">
+      <tr>
+        <th scope="col">Local archive</th>
+        <th scope="col">Nr obs.</th>
+        <th scope="col">Nr homo.</th>
+        <th scope="col">Frequency</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>RD</td>
+        <td>{{ render_obs(variant.local_obs_old) }}</td>
+        <td>{{ render_obs(variant.local_obs_hom_old) }}</td>
+        <td>{{ render_freq(variant.local_obs_old_freq, variant.local_obs_old, variant.local_obs_old_nr_cases) }}</td>
+      </tr>
+      {% if variant.category in ['cancer', 'cancer_sv'] %}
+        <tr>
+          <td>Cancer Germline</td>
+          <td>{{ render_obs(variant.local_obs_cancer_germline_old) }}</td>
+          <td>{{ render_obs(variant.local_obs_cancer_germline_hom_old) }}</td>
+          <td>{{ render_freq(variant.local_obs_cancer_germline_old_freq, variant.local_obs_cancer_germline_old, variant.local_obs_cancer_germline_old_nr_cases) }}</td>
+        </tr>
+        <tr>
+          <td>Cancer Somatic</td>
+          <td>{{ render_obs(variant.local_obs_cancer_somatic_old) }}</td>
+          <td>{{ render_obs(variant.local_obs_cancer_somatic_hom_old) }}</td>
+          <td>{{ render_freq(variant.local_obs_cancer_somatic_old_freq, variant.local_obs_cancer_somatic_old, variant.local_obs_cancer_somatic_old_nr_cases) }}</td>
+        </tr>
+        <tr>
+          <td>Cancer Somatic panel</td>
+          <td>{{ render_obs(variant.local_obs_cancer_somatic_panel_old) }}</td>
+          <td>N/A</td>
+          <td>{{ render_freq(variant.local_obs_cancer_somatic_panel_old_freq, variant.local_obs_cancer_somatic_panel_old, None) }}</td>
+        </tr>
+      {% endif %}
+    </tbody>
+  </table>
 {% endmacro %}
 
 {% macro old_observations(variant, obs_date) %}

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -290,7 +290,6 @@
 
 {% macro old_observations_table(variant) %}
 
-  {# Helper macro: render observation count #}
   {% macro render_obs(value) -%}
     {% if value is not defined or value is none or value == -1 %}
       N/A
@@ -299,7 +298,6 @@
     {% endif %}
   {%- endmacro %}
 
-  {# Helper macro: render frequency #}
   {% macro render_freq(freq, obs, nr_cases) -%}
     {% if freq is defined and freq is not none %}
       {{ freq|round(6) }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5676 

With this
- 0 → shows 0
- -1 → shows N/A
- None or missing field → shows N/A
- Undefined frequency → falls through to N/A

### Before

<img width="536" height="151" alt="image" src="https://github.com/user-attachments/assets/a1c53ee9-ccad-42f5-a3ef-a604d9c54e01" />


### After

<img width="555" height="166" alt="image" src="https://github.com/user-attachments/assets/111b8bc8-a86e-409b-ad84-92334dc7d727" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. Fist book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
