### PR TITLE
Remove unused "variant_count" param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bootstrap-based pagination on variantS pages (#5697)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
+- Remove unused `variant_count` parameter from several functions involved with variant queries (#5700)
 ### Fixed
 - Typo in PR template (#5682)
 - Highlight affected individuals/samples on `GT call` tables (#5682)

--- a/scout/adapter/client.py
+++ b/scout/adapter/client.py
@@ -8,7 +8,11 @@ Establish a connection to the database
 import logging
 
 from pymongo import MongoClient
-from pymongo.errors import ConnectionFailure, OperationFailure, ServerSelectionTimeoutError
+from pymongo.errors import (
+    ConnectionFailure,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
 
 try:
     from urllib.parse import quote_plus

--- a/scout/commands/serve.py
+++ b/scout/commands/serve.py
@@ -5,7 +5,11 @@ import sys
 import click
 from flask.cli import current_app, with_appcontext
 from livereload import Server
-from pymongo.errors import ConnectionFailure, OperationFailure, ServerSelectionTimeoutError
+from pymongo.errors import (
+    ConnectionFailure,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
 from werkzeug.serving import run_simple
 
 LOG = logging.getLogger(__name__)

--- a/scout/exceptions/__init__.py
+++ b/scout/exceptions/__init__.py
@@ -1,4 +1,10 @@
 from .config import ConfigError
-from .database import DatabaseError, DataError, DataNotFoundError, IntegrityError, OperationalError
+from .database import (
+    DatabaseError,
+    DataError,
+    DataNotFoundError,
+    IntegrityError,
+    OperationalError,
+)
 from .pedigree import PedigreeError
 from .vcf import VcfError

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -17,7 +17,11 @@ except ImportError:
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-from scout.constants import ANALYSIS_TYPES, ORDERED_FILE_TYPE_MAP, ORDERED_OMICS_FILE_TYPE_MAP
+from scout.constants import (
+    ANALYSIS_TYPES,
+    ORDERED_FILE_TYPE_MAP,
+    ORDERED_OMICS_FILE_TYPE_MAP,
+)
 from scout.exceptions import PedigreeError
 from scout.utils.date import get_date
 

--- a/scout/parse/panelapp.py
+++ b/scout/parse/panelapp.py
@@ -3,7 +3,11 @@
 import logging
 from typing import Optional, Set
 
-from scout.constants import INCOMPLETE_PENETRANCE_MAP, MODELS_MAP, PANELAPP_CONFIDENCE_EXCLUDE
+from scout.constants import (
+    INCOMPLETE_PENETRANCE_MAP,
+    MODELS_MAP,
+    PANELAPP_CONFIDENCE_EXCLUDE,
+)
 from scout.utils.date import get_date
 
 LOG = logging.getLogger(__name__)

--- a/scout/parse/variant/coordinates.py
+++ b/scout/parse/variant/coordinates.py
@@ -1,6 +1,12 @@
 """Code to parse variant coordinates"""
 
-from scout.constants import BND_ALT_PATTERN, CHR_PATTERN, CYTOBANDS_37, CYTOBANDS_38, SV_TYPES
+from scout.constants import (
+    BND_ALT_PATTERN,
+    CHR_PATTERN,
+    CYTOBANDS_37,
+    CYTOBANDS_38,
+    SV_TYPES,
+)
 
 
 def get_cytoband_coordinates(chrom, pos, build):

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -801,9 +801,7 @@ def get_sanger_unevaluated(
     return unevaluated, evaluated_by_others
 
 
-def export_gene_variants(
-    store: MongoAdapter, gene_symbol: str, pymongo_cursor: Cursor, variant_count: int
-) -> Response:
+def export_gene_variants(store: MongoAdapter, gene_symbol: str, pymongo_cursor: Cursor) -> Response:
     """Export 500 gene variants for an institute resulting from a customer query"""
 
     def generate(header, lines):
@@ -814,7 +812,6 @@ def export_gene_variants(
     data: dict = gene_variants(
         store=store,
         pymongo_cursor=pymongo_cursor,
-        variant_count=variant_count,
         per_page=500,
     )
 
@@ -884,7 +881,7 @@ def export_gene_variants(
     )
 
 
-def gene_variants(store, pymongo_cursor, variant_count, page=1, per_page=50):
+def gene_variants(store, pymongo_cursor, page=1, per_page=50):
     """Pre-process list of variants."""
 
     skip_count = per_page * max(page - 1, 0)

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -189,7 +189,6 @@ def gene_variants(institute_id):
                 store=store,
                 gene_symbol=request.form.get("hgnc_symbols").split(",")[0].strip(),
                 pymongo_cursor=results,
-                variant_count=result_size,
             )
 
         data = controllers.gene_variants(

--- a/scout/server/blueprints/omics_variants/controllers.py
+++ b/scout/server/blueprints/omics_variants/controllers.py
@@ -6,7 +6,11 @@ from scout.adapter import MongoAdapter
 from scout.constants import EXPORTED_VARIANTS_LIMIT
 from scout.server.blueprints.variant.utils import update_variant_case_panels
 from scout.server.blueprints.variants.utils import update_case_panels
-from scout.server.utils import case_has_alignments, case_has_mt_alignments, case_has_rna_tracks
+from scout.server.utils import (
+    case_has_alignments,
+    case_has_mt_alignments,
+    case_has_rna_tracks,
+)
 
 
 def outliers(
@@ -14,7 +18,6 @@ def outliers(
     institute_obj: dict,
     case_obj: dict,
     omics_variants_query: CursorType,
-    variant_count: int,
     page: int = 1,
     per_page: int = 50,
 ):

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -86,7 +86,7 @@ def outliers(institute_id, case_name):
         case_id=case_obj["_id"], query=form.data, category=category, build=genome_build
     )
 
-    data = controllers.outliers(store, institute_obj, case_obj, variants_query, result_size, page)
+    data = controllers.outliers(store, institute_obj, case_obj, variants_query, page)
 
     return dict(
         case=case_obj,

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -21,12 +21,16 @@ from scout.constants import (
     CCV_MAP,
     CCV_OPTIONS,
 )
-from scout.server.blueprints.variant.controllers import ccv_evaluation as ccv_evaluation_controller
+from scout.server.blueprints.variant.controllers import (
+    ccv_evaluation as ccv_evaluation_controller,
+)
 from scout.server.blueprints.variant.controllers import (
     check_reset_variant_ccv_classification,
     check_reset_variant_classification,
 )
-from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
+from scout.server.blueprints.variant.controllers import (
+    evaluation as evaluation_controller,
+)
 from scout.server.blueprints.variant.controllers import (
     get_gene_has_full_coverage,
     observations,

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -21,16 +21,12 @@ from scout.constants import (
     CCV_MAP,
     CCV_OPTIONS,
 )
-from scout.server.blueprints.variant.controllers import (
-    ccv_evaluation as ccv_evaluation_controller,
-)
+from scout.server.blueprints.variant.controllers import ccv_evaluation as ccv_evaluation_controller
 from scout.server.blueprints.variant.controllers import (
     check_reset_variant_ccv_classification,
     check_reset_variant_classification,
 )
-from scout.server.blueprints.variant.controllers import (
-    evaluation as evaluation_controller,
-)
+from scout.server.blueprints.variant.controllers import evaluation as evaluation_controller
 from scout.server.blueprints.variant.controllers import (
     get_gene_has_full_coverage,
     observations,

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -129,7 +129,6 @@ def variants(
     institute_obj,
     case_obj,
     variants_query,
-    variant_count,
     page=1,
     per_page=50,
     query_form=None,
@@ -235,7 +234,6 @@ def sv_mei_variants(
     institute_obj: dict,
     case_obj: dict,
     variants_query: CursorType,
-    variant_count: int,
     page: int = 1,
     per_page: int = 50,
 ) -> Dict[str, Any]:
@@ -302,9 +300,7 @@ def str_variants(
     return return_view_data
 
 
-def fusion_variants(
-    store, institute_obj, case_obj, variants_query, variant_count, page=1, per_page=50
-):
+def fusion_variants(store, institute_obj, case_obj, variants_query, page=1, per_page=50):
     """Pre-process list of fusion variants."""
     skip_count = per_page * max(page - 1, 0)
 
@@ -1370,7 +1366,7 @@ def get_variant_info(genes):
     return data
 
 
-def cancer_variants(store, institute_id, case_name, variants_query, variant_count, form, page=1):
+def cancer_variants(store, institute_id, case_name, variants_query, form, page=1):
     """Fetch data related to cancer variants for a case.
 
     For each variant, if one or more gene panels are selected, assign the gene present

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -153,7 +153,6 @@ def variants(institute_id, case_name):
         institute_obj,
         case_obj,
         variants_query,
-        result_size,
         page,
         query_form=form.data,
     )
@@ -328,9 +327,7 @@ def sv_variants(institute_id, case_name):
     if request.form.get("export"):
         return controllers.download_variants(store, case_obj, variants_query)
 
-    data = controllers.sv_mei_variants(
-        store, institute_obj, case_obj, variants_query, result_size, page
-    )
+    data = controllers.sv_mei_variants(store, institute_obj, case_obj, variants_query, page)
 
     return dict(
         case=case_obj,
@@ -423,9 +420,7 @@ def mei_variants(institute_id, case_name):
     if request.form.get("export"):
         return controllers.download_variants(store, case_obj, variants_query)
 
-    data = controllers.sv_mei_variants(
-        store, institute_obj, case_obj, variants_query, result_size, page
-    )
+    data = controllers.sv_mei_variants(store, institute_obj, case_obj, variants_query, page)
 
     return dict(
         case=case_obj,
@@ -538,7 +533,6 @@ def cancer_variants(institute_id, case_name):
         institute_id,
         case_name,
         variants_query,
-        result_size,
         form,
         page=page,
     )
@@ -698,9 +692,7 @@ def fusion_variants(institute_id, case_name):
     if request.form.get("export"):
         return controllers.download_variants(store, case_obj, variants_query, category=category)
 
-    data = controllers.fusion_variants(
-        store, institute_obj, case_obj, variants_query, result_size, page
-    )
+    data = controllers.fusion_variants(store, institute_obj, case_obj, variants_query, page)
 
     return dict(
         case=case_obj,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- This is something I noticed when I was refactoring the variants function last week, but I didn't want to add too many changes in #5697 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
