### PR TITLE
Expand tx info on SV variants summary (variants with <= 5 genes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Support for variants annotated with an unmodified ClinVar VCF (#5691)
 - Parse and display copy number on SV page, genotype table (#5692)
 - Bootstrap-based pagination on variantS pages (#5697)
+- More transcript insights on variant summary for SV variants hitting max 5 genes (#5706)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
 - Remove unused `variant_count` parameter from several functions involved with variant queries (#5700)

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -1,9 +1,9 @@
-{% from "cases/utils.html" import variant_transcripts, filter_audits %}
+{% from "cases/utils.html" import filter_audits %}
 {% from "utils.html" import comments_table, variant_related_comments_table %}
 {% from "variant/gene_disease_relations.html" import inheritance_badge %}
 {% from "variants/components.html" import fusion_variants_header, default_fusion_variant_cells %}
 {% from "variant/variant_details.html" import frequencies_table, old_observations_table %}
-{% from "variant/components.html" import clinsig_table %}
+{% from "variant/components.html" import clinsig_table, variant_transcripts  %}
 
 {% extends "report_base.html" %}
 

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -256,39 +256,6 @@
 </form>
 {% endmacro %}
 
-{% macro variant_transcripts(gene) %}
-<!-- Used in case_report template. Populate a table div with gene transcripts that are canonical, primary (max 5) or disease-associated -->
-  {% set n_primary_txs = namespace(count=0) %}
-  <ul>
-    {% for transcript in gene.transcripts %}
-      <!-- increase counter if it has associated refseq -->
-      {% if transcript.refseq_identifiers %}
-        {% set n_primary_txs.count = n_primary_txs.count + 1 %}
-      {% endif %}
-
-        <!-- show transcript info only if it's canonical, disease-associated or primary (print max 5 primary transcripts) -->
-      {% if transcript.refseq_identifiers and n_primary_txs.count <= 5 or transcript.is_canonical or transcript.is_disease_associated or transcript.is_primary %}
-        <li class="mb-1">{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name or '')|url_decode|truncate(20, True) }}
-          {% if transcript.is_canonical %}
-            <span class="badge rounded-pill bg-info text-white" title="canonical">C</span>
-          {% endif %}
-          {% if transcript.is_disease_associated %}
-            <span class="badge rounded-pill bg-danger text-white" title="disease_associated">D</span>
-          {% endif %}
-          {% if transcript.is_primary %}
-            <span class="badge rounded-pill bg-primary text-white" title="primary_ref_transcript">hgnc primary:{{transcript.refseq_id}}</span>
-          {% endif %}
-        </li>
-      {% endif %}
-
-    {% endfor %} <!-- end of { for transcript in gene.transcripts } loop -->
-  </ul>
-  {% if n_primary_txs.count > 5 %}
-  .. other transcripts available for this variant are not shown.<br><br>
-  {% endif %}
-{% endmacro %}
-
-
 {% macro pretty_variant(variant) %}
 
   {% if variant.category %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -551,3 +551,59 @@
 
   </script>
 {% endmacro %}
+
+{% macro variant_genes(variant) %}
+{% if variant.genes %}
+<li class="list-group-item p-1">
+  <div id="genes-{{ variant._id }}">
+    {% for gene in variant.genes %}
+      <div class="d-flex justify-content-between align-items-center flex-wrap mb-1">
+        <div class="text-truncate">
+          <a class="fw-bold text-decoration-none me-1"
+             href="{{ url_for('genes.gene', hgnc_id=gene.hgnc_id) }}">
+            {{ gene.common.hgnc_symbol if gene.common else gene.hgnc_id }}
+          </a>
+          <small class="text-muted">{{ gene.description|title if gene.description else '' }}</small>
+          <span class="badge bg-light text-dark ms-1">{{ gene.region_annotation }}</span>
+        </div>
+        <div class="ms-auto">
+          {{ variant_transcripts(gene) }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</li>
+{% endif %}
+{% endmacro %}
+
+{% macro variant_transcripts(gene) %}
+<!-- Used in case_report template. Populate a table div with gene transcripts that are canonical, primary (max 5) or disease-associated -->
+  {% set n_primary_txs = namespace(count=0) %}
+  <ul>
+    {% for transcript in gene.transcripts %}
+      <!-- increase counter if it has associated refseq -->
+      {% if transcript.refseq_identifiers %}
+        {% set n_primary_txs.count = n_primary_txs.count + 1 %}
+      {% endif %}
+
+        <!-- show transcript info only if it's canonical, disease-associated or primary (print max 5 primary transcripts) -->
+      {% if transcript.refseq_identifiers and n_primary_txs.count <= 5 or transcript.is_canonical or transcript.is_disease_associated or transcript.is_primary %}
+        <li class="mb-1">{{transcript.transcript_id}}, RefSeq:[{{ transcript.refseq_identifiers|join(", ") or "-" }}], {{ (transcript.coding_sequence_name or '')|truncate(20, True) }},  {{ (transcript.protein_sequence_name or '')|url_decode|truncate(20, True) }}
+          {% if transcript.is_canonical %}
+            <span class="badge rounded-pill bg-info text-white" title="canonical">C</span>
+          {% endif %}
+          {% if transcript.is_disease_associated %}
+            <span class="badge rounded-pill bg-danger text-white" title="disease_associated">D</span>
+          {% endif %}
+          {% if transcript.is_primary %}
+            <span class="badge rounded-pill bg-primary text-white" title="primary_ref_transcript">hgnc primary:{{transcript.refseq_id}}</span>
+          {% endif %}
+        </li>
+      {% endif %}
+
+    {% endfor %} <!-- end of { for transcript in gene.transcripts } loop -->
+  </ul>
+  {% if n_primary_txs.count > 5 %}
+  .. other transcripts available for this variant are not shown.<br><br>
+  {% endif %}
+{% endmacro %}

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -571,7 +571,6 @@
       </div>
     {% endfor %}
   </div>
-</li>
 {% endif %}
 {% endmacro %}
 

--- a/scout/server/blueprints/variant/templates/variant/components.html
+++ b/scout/server/blueprints/variant/templates/variant/components.html
@@ -554,7 +554,6 @@
 
 {% macro variant_genes(variant) %}
 {% if variant.genes %}
-<li class="list-group-item p-1">
   <div id="genes-{{ variant._id }}">
     {% for gene in variant.genes %}
       <div class="d-flex justify-content-between align-items-center flex-wrap mb-1">

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 {% from "utils.html" import activity_panel, comments_panel, pedigree_panel %}
 {% from "variant/variant_details.html" import old_observations %}
-{% from "variant/components.html" import external_scripts, external_stylesheets, matching_variants, panel_classify_sv, variant_scripts %}
+{% from "variant/components.html" import external_scripts, external_stylesheets, matching_variants, panel_classify_sv, variant_scripts, variant_genes %}
 {% from "variant/utils.html" import causative_button, genes_panel, igv_track_selection, modal_causative, overlapping_panel, sv_alignments, pin_button, transcripts_panel, custom_annotations, gene_panels %}
 {% from "variant/rank_score_results.html" import rankscore_panel %}
 {% from "variant/gene_disease_relations.html" import orpha_omim_phenotypes %}
@@ -244,6 +244,13 @@
           <span class="d-inline">Type</span>
           <span class="d-inline float-end">{{ variant.sub_category|upper }}</span>
         </li>
+
+        {% if variant.genes and variant.genes|length <= 5 %}
+        <li class="list-group-item p-1">
+          {{ variant_genes(variant) }}
+        </li>
+        {% endif %}
+
         {% if gens_info.display %}
         <li class="list-group-item">
           <span class="d-inline">Copy number profile</span>

--- a/tests/server/blueprints/cases/test_cases_templates.py
+++ b/tests/server/blueprints/cases/test_cases_templates.py
@@ -34,7 +34,7 @@ def test_report_transcripts_macro(app, institute_obj, case_obj, variant_gene_upd
         assert resp.status_code == 200
 
         # WHEN feeding an updated variant gene to the transcripts macro
-        macro = get_template_attribute("cases/utils.html", "variant_transcripts")
+        macro = get_template_attribute("variant/components.html", "variant_transcripts")
         html = macro(variant_gene_updated_info)
 
         # THEN the transcripts visualized should be the first and the third


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5703 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. For instance, [this variant](https://scout-stage.scilifelab.se/cust000/G1A1471p10_Balsamic/sv/variants/8b2917409b77efebebfa2fed028d0ddc)

### Before

<img width="548" height="445" alt="image" src="https://github.com/user-attachments/assets/d83b7836-a858-413a-886e-e4d5cf141123" />


### After

<img width="560" height="621" alt="image" src="https://github.com/user-attachments/assets/a2ecb4c5-d816-4300-9b3a-187ce1d8c16d" />


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
