### PR TITLE
 remote static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bootstrap-based pagination on variantS pages (#5697)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
+- Authorize access to IGV track files at endpoint, not with session cookie (#5710)
 ### Fixed
 - Typo in PR template (#5682)
 - Highlight affected individuals/samples on `GT call` tables (#5682)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Bootstrap-based pagination on variantS pages (#5697)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
-- Authorize access to IGV track files at endpoint, not with session cookie (#5710)
+- Authorize access to IGV track files at endpoint, not with session cookie. Allows huge case groups and many open igv sessions. (#5710)
 ### Fixed
 - Typo in PR template (#5682)
 - Highlight affected individuals/samples on `GT call` tables (#5682)

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -70,6 +70,7 @@ from .gene_tags import (
     UPDATE_GENES_RESOURCES,
 )
 from .igv_tracks import (
+    CASE_INDIVIDUAL_DISPLAY_OBJECT_MAP,
     CASE_SPECIFIC_TRACKS,
     HUMAN_REFERENCE,
     IGV_TRACKS,

--- a/scout/constants/igv_tracks.py
+++ b/scout/constants/igv_tracks.py
@@ -147,3 +147,24 @@ IGV_TRACKS = {
     "37": [HUMAN_GENES_37, CLINVAR_SNV_37, CLINVAR_SV_37],
     "38": [HUMAN_GENES_38, CLINVAR_SNV_38, CLINVAR_SV_38],
 }
+
+CASE_INDIVIDUAL_DISPLAY_OBJECT_MAP = [
+    {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
+    {"path": "assembly_alignment_path", "append_to": "assembly_alignments", "index": None},
+    {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
+    {
+        "path": "paraphase_alignment_path",
+        "append_to": "paraphase_alignments",
+        "index": None,
+    },
+    {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
+    {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
+    {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},
+    {"path": "upd_sites_bed", "append_to": "upd_sites_beds", "index": None},
+    {
+        "path": "minor_allele_frequency_wig",
+        "append_to": "minor_allele_frequency_wigs",
+        "index": None,
+    },
+    {"path": "tiddit_coverage_wig", "append_to": "tiddit_coverage_wigs", "index": None},
+]

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -60,11 +60,11 @@ def check_case_individual_file_path(resource: str, case: dict) -> bool:
         return True
 
     accepted_index_paths = [
-        individual.get(case_display_map["index"])
-        for case_display_map in CASE_INDIVIDUAL_DISPLAY_OBJECT_MAP
-        for individual in case["individuals"]
-        if case_display_map["index"]
+        find_index(file_path)
+        for file_path in accepted_file_paths
+        if file_path and os.path.exists(file_path)
     ]
+    LOG.debug(f"accepted index paths: {accepted_index_paths}")
     if resource in accepted_index_paths:
         return True
 
@@ -103,8 +103,8 @@ def check_case_tracks(resource: str, case: dict):
     if check_case_config_custom_tracks(resource):
         return True
 
-    if check_case_individual_file_path(resource, case):
-        return True
+    #    if check_case_individual_file_path(resource, case):
+    #        return True
 
     if check_case_group_alignment_file_path(resource, case):
         return True

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -100,7 +100,7 @@ def check_case_tracks(resource: str, case: dict):
     if check_case_individual_file_path(resource, case):
         return True
 
-    if check_case_group_alignment_path(resouce, case):
+    if check_case_group_alignment_file_path(resource, case):
         return True
 
     LOG.warning(f"Requested resource to be displayed in IGV not in cases list of IGV tracks")

--- a/scout/server/blueprints/alignviewers/controllers.py
+++ b/scout/server/blueprints/alignviewers/controllers.py
@@ -29,6 +29,7 @@ def check_case_common_tracks(resource: str) -> bool:
     for igv_tracks in IGV_TRACKS:
         if resource in igv_tracks:
             return True
+    return False
 
 
 def check_case_config_custom_tracks(resource: str) -> bool:
@@ -40,6 +41,7 @@ def check_case_config_custom_tracks(resource: str) -> bool:
             build_tracks = config_igv_tracks.tracks.get(build, [])
             if resource in build_tracks:
                 return True
+    return False
 
 
 def check_case_individual_file_path(resource: str, case: dict) -> bool:
@@ -66,6 +68,8 @@ def check_case_individual_file_path(resource: str, case: dict) -> bool:
     if resource in accepted_index_paths:
         return True
 
+    return False
+
 
 def check_case_group_alignment_file_path(resource: str, case: dict) -> bool:
     """Accept file requests for the alignment paths from cases in the same case group."""
@@ -77,6 +81,8 @@ def check_case_group_alignment_file_path(resource: str, case: dict) -> bool:
     for group_case in grouped_cases:
         if check_case_individual_file_path(resource, group_case):
             return True
+
+    return False
 
 
 def check_case_tracks(resource: str, case: dict):

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -62,8 +62,8 @@
                                 name: "{{ track.name }}",
                                 order: {{counter.loop}},
                                 type: "alignment",
-                                url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) }}",
-                                indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
+                                url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) | safe }}",
+                                indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}",
                                 sourceType: "file",
                                 format: "{{ track.format }}",
                                 height: {{ track.aln_height }}
@@ -79,7 +79,7 @@
                                   {
                                     type: 'wig',
                                     format: "bigwig",
-                                    url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig, institute_id=institute_id, case_name=case_display_name) }}",
+                                    url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig, institute_id=institute_id, case_name=case_display_name) | safe }}",
                                     height: 500,
                                   },
                                   {
@@ -88,8 +88,8 @@
                                     colorBy: 'strand',
                                     thicknessBasedOn: 'numUniqueRead',
                                     labelUniqueReadCount: true,
-                                    url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed, institute_id=institute_id, case_name=case_display_name) }}",
-                                    indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index, institute_id=institute_id, case_name=case_display_name) }}",
+                                    url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed, institute_id=institute_id, case_name=case_display_name) | safe }}",
+                                    indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index, institute_id=institute_id, case_name=case_display_name) | safe }}",
                                     minUniquelyMappedReads: 1,
                                     height: 500,
                                   },

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -62,8 +62,8 @@
                                 name: "{{ track.name }}",
                                 order: {{counter.loop}},
                                 type: "alignment",
-                                url: "{{ url_for('alignviewers.remote_static', file=track.url, institute=institute_id, case=case_display_name) }}",
-                                indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL) }}",
+                                url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) }}",
+                                indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
                                 sourceType: "file",
                                 format: "{{ track.format }}",
                                 height: {{ track.aln_height }}
@@ -79,7 +79,7 @@
                                   {
                                     type: 'wig',
                                     format: "bigwig",
-                                    url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig) }}",
+                                    url: "{{ url_for('alignviewers.remote_static', file=track.coverage_wig, institute_id=institute_id, case_name=case_display_name) }}",
                                     height: 500,
                                   },
                                   {
@@ -88,8 +88,8 @@
                                     colorBy: 'strand',
                                     thicknessBasedOn: 'numUniqueRead',
                                     labelUniqueReadCount: true,
-                                    url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed) }}",
-                                    indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index) }}",
+                                    url: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed, institute_id=institute_id, case_name=case_display_name) }}",
+                                    indexURL: "{{ url_for('alignviewers.remote_static', file=track.splicej_bed_index, institute_id=institute_id, case_name=case_display_name) }}",
                                     minUniquelyMappedReads: 1,
                                     height: 500,
                                   },

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_sashimi_viewer.html
@@ -62,7 +62,7 @@
                                 name: "{{ track.name }}",
                                 order: {{counter.loop}},
                                 type: "alignment",
-                                url: "{{ url_for('alignviewers.remote_static', file=track.url) }}",
+                                url: "{{ url_for('alignviewers.remote_static', file=track.url, institute=institute_id, case=case_display_name) }}",
                                 indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL) }}",
                                 sourceType: "file",
                                 format: "{{ track.format }}",

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -76,14 +76,14 @@
                           format: "{{ custTrack.format }}",
                           height: 70,
                           {% if "http" in custTrack.url %}
-                            url: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.url, institute_id=institute_id, case_name=case_display_name) }}",
+                            url: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}",
                             {% if custTrack.indexURL %}
-                              indexURL: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.indexURL) }}",
+                              indexURL: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.indexURL)| safe }}",
                             {% endif %}
                           {% else %}
-                             url: "{{ url_for('alignviewers.remote_static', file=custTrack.url, institute_id=institute_id, case_name=case_display_name) }}",
+                             url: "{{ url_for('alignviewers.remote_static', file=custTrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}",
                              {% if custTrack.indexURL %}
-                              indexURL: "{{ url_for('alignviewers.remote_static', file=custTrack.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
+                              indexURL: "{{ url_for('alignviewers.remote_static', file=custTrack.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}",
                              {% endif %}
                           {% endif %}
                         },
@@ -92,7 +92,7 @@
                       {
                         type: "wig",
                         name: '{{ wtrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=wtrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=wtrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         format: 'bw',
                         {# indexURL: '{{ url_for("alignviewers.remote_static", file=wtrack.url)  }}', #}
                         color: "rgb(60, 37, 17)",
@@ -105,7 +105,7 @@
                       {
                         type: "annotation",
                         name: '{{ btrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=btrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=btrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         format: 'bb',
                         color: "rgb(65, 31, 30)",
                         sourceType: 'file'
@@ -115,8 +115,8 @@
                       {
                         name: "{{ track.name }}",
                         type: "alignment",
-                        url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) }}",
-                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
+                        url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) | safe }}",
+                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}",
                         sourceType: "file",
                         groupBy: "tag:HP",
                         showInsertionText: true,
@@ -131,7 +131,7 @@
                         type: "wig",
                         format: 'bw',
                         name: '{{ ttrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=ttrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=ttrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         color: "rgb(40, 0, 13)",
                         sourceType: 'file'
                       },
@@ -141,7 +141,7 @@
                         type: "wig",
                         format: 'bw',
                         name: '{{ maftrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=maftrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=maftrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         color: "rgb(60, 60, 140)",
                         sourceType: 'file'
                       },
@@ -150,10 +150,10 @@
                       {
                         type: "alignment",
                         name: "{{ ptrack.name }}",
-                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         format: "{{ ptrack.format }}",
                         groupBy: "tag:HP",
-                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL, institute_id=institute_id, case_name=case_display_name)  }}',
+                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         min: '{{ ptrack.min }}',
                         autoscaleGroup: '{{ ptrack.autoscaleGroup }}',
                         sourceType: 'file'
@@ -163,12 +163,12 @@
                       {
                         type: "alignment",
                         name: "{{ atrack.name }}",
-                        url: '{{ url_for("alignviewers.remote_static", file=atrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=atrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         format: "{{ atrack.format }}",
                         groupBy: "tag:HP",
                         height: 140,
                         showCoverage: false,
-                        indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL, institute_id=institute_id, case_name=case_display_name)  }}',
+                        indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         min: '{{ atrack.min }}',
                         autoscaleGroup: '{{ atrack.autoscaleGroup }}',
                         sourceType: 'file'
@@ -179,7 +179,7 @@
                         type: 'annotation',
                         format: 'bb',
                         name: '{{ rtrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=rtrack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=rtrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         color: "rgb(0, 204, 102)",
                         sourceType: 'file'
                       },
@@ -189,7 +189,7 @@
                         type: "annotation",
                         format: 'bb',
                         name: '{{ strack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=strack.url, institute_id=institute_id, case_name=case_display_name) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=strack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
                         color: "rgb(25, 61, 4)",
                         sourceType: 'file'
                       },

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -76,14 +76,14 @@
                           format: "{{ custTrack.format }}",
                           height: 70,
                           {% if "http" in custTrack.url %}
-                            url: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.url) }}",
+                            url: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.url, institute_id=institute_id, case_name=case_display_name) }}",
                             {% if custTrack.indexURL %}
                               indexURL: "{{ url_for('alignviewers.remote_cors', remote_url=custTrack.indexURL) }}",
                             {% endif %}
                           {% else %}
-                             url: "{{ url_for('alignviewers.remote_static', file=custTrack.url) }}",
+                             url: "{{ url_for('alignviewers.remote_static', file=custTrack.url, institute_id=institute_id, case_name=case_display_name) }}",
                              {% if custTrack.indexURL %}
-                              indexURL: "{{ url_for('alignviewers.remote_static', file=custTrack.indexURL) }}",
+                              indexURL: "{{ url_for('alignviewers.remote_static', file=custTrack.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
                              {% endif %}
                           {% endif %}
                         },
@@ -92,7 +92,7 @@
                       {
                         type: "wig",
                         name: '{{ wtrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=wtrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=wtrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         format: 'bw',
                         {# indexURL: '{{ url_for("alignviewers.remote_static", file=wtrack.url)  }}', #}
                         color: "rgb(60, 37, 17)",
@@ -105,7 +105,7 @@
                       {
                         type: "annotation",
                         name: '{{ btrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=btrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=btrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         format: 'bb',
                         color: "rgb(65, 31, 30)",
                         sourceType: 'file'
@@ -115,8 +115,8 @@
                       {
                         name: "{{ track.name }}",
                         type: "alignment",
-                        url: "{{ url_for('alignviewers.remote_static', file=track.url) }}",
-                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute=institute_id, case=case_display_name) }}",
+                        url: "{{ url_for('alignviewers.remote_static', file=track.url, institute_id=institute_id, case_name=case_display_name) }}",
+                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute_id=institute_id, case_name=case_display_name) }}",
                         sourceType: "file",
                         groupBy: "tag:HP",
                         showInsertionText: true,
@@ -131,7 +131,7 @@
                         type: "wig",
                         format: 'bw',
                         name: '{{ ttrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=ttrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=ttrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         color: "rgb(40, 0, 13)",
                         sourceType: 'file'
                       },
@@ -141,7 +141,7 @@
                         type: "wig",
                         format: 'bw',
                         name: '{{ maftrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=maftrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=maftrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         color: "rgb(60, 60, 140)",
                         sourceType: 'file'
                       },
@@ -150,10 +150,10 @@
                       {
                         type: "alignment",
                         name: "{{ ptrack.name }}",
-                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         format: "{{ ptrack.format }}",
                         groupBy: "tag:HP",
-                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL)  }}',
+                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL, institute_id=institute_id, case_name=case_display_name)  }}',
                         min: '{{ ptrack.min }}',
                         autoscaleGroup: '{{ ptrack.autoscaleGroup }}',
                         sourceType: 'file'
@@ -163,12 +163,12 @@
                       {
                         type: "alignment",
                         name: "{{ atrack.name }}",
-                        url: '{{ url_for("alignviewers.remote_static", file=atrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=atrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         format: "{{ atrack.format }}",
                         groupBy: "tag:HP",
                         height: 140,
                         showCoverage: false,
-                        indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL)  }}',
+                        indexURL: '{{ url_for("alignviewers.remote_static", file=atrack.indexURL, institute_id=institute_id, case_name=case_display_name)  }}',
                         min: '{{ atrack.min }}',
                         autoscaleGroup: '{{ atrack.autoscaleGroup }}',
                         sourceType: 'file'
@@ -179,7 +179,7 @@
                         type: 'annotation',
                         format: 'bb',
                         name: '{{ rtrack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=rtrack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=rtrack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         color: "rgb(0, 204, 102)",
                         sourceType: 'file'
                       },
@@ -189,7 +189,7 @@
                         type: "annotation",
                         format: 'bb',
                         name: '{{ strack.name }}',
-                        url: '{{ url_for("alignviewers.remote_static", file=strack.url) }}',
+                        url: '{{ url_for("alignviewers.remote_static", file=strack.url, institute_id=institute_id, case_name=case_display_name) }}',
                         color: "rgb(25, 61, 4)",
                         sourceType: 'file'
                       },

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -116,7 +116,7 @@
                         name: "{{ track.name }}",
                         type: "alignment",
                         url: "{{ url_for('alignviewers.remote_static', file=track.url) }}",
-                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL) }}",
+                        indexURL: "{{ url_for('alignviewers.remote_static', file=track.indexURL, institute=institute_id, case=case_display_name) }}",
                         sourceType: "file",
                         groupBy: "tag:HP",
                         showInsertionText: true,

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -75,18 +75,18 @@ def remote_cors(remote_url):
 @alignviewers_bp.route("/remote/static", methods=["OPTIONS", "GET"])
 def remote_static():
     """Stream *large* static files with special requirements."""
-    file_path = request.args.get("file") or "."
-    institute_id = request.args.get("institute_id") or "."
-    case_name = request.args.get("case_name") or "."
-
-    # Ensure the user really has access to this case's tracks by
-    # retrieving case (only allowed if user has access)
-    _, case_obj = institute_and_case(store, institute_id, case_name)
+    file_path = request.args.get("file", default=".", type=str)
+    institute_id = request.args.get("institute_id", default=".", type=str)
+    case_name = request.args.get("case_name", default=".", type=str)
 
     # Check that user is logged in
     if current_user.is_authenticated is False:
         LOG.warning("Unauthenticated user requesting resource via remote_static")
         return False
+
+    # Ensure the user really has access to this case's tracks by
+    # retrieving case (only allowed if user has access)
+    institute_and_case(store, institute_id, case_name)
 
     # And ensure that the file is on the case
     if controllers.check_case_tracks(file_path) is False:

--- a/scout/server/blueprints/alignviewers/views.py
+++ b/scout/server/blueprints/alignviewers/views.py
@@ -86,10 +86,10 @@ def remote_static():
 
     # Ensure the user really has access to this case's tracks by
     # retrieving case (only allowed if user has access)
-    institute_and_case(store, institute_id, case_name)
+    _, case_obj = institute_and_case(store, institute_id, case_name)
 
     # And ensure that the file is on the case
-    if controllers.check_case_tracks(file_path) is False:
+    if controllers.check_case_tracks(file_path, case_obj) is False:
         return abort(403)
 
     range_header = request.headers.get("Range", None)

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -24,6 +24,8 @@ from flask import (
 from flask_login import current_user
 from werkzeug.local import LocalProxy
 
+from scout.constants import CASE_INDIVIDUAL_DISPLAY_OBJECT_MAP
+
 LOG = logging.getLogger(__name__)
 
 
@@ -357,26 +359,6 @@ def case_append_alignments(case_obj: dict):
     index is set only if it is expected as a separate key on the indiviudal: an
     attempt at discovery is still made for files with index: None.
     """
-    unwrap_settings = [
-        {"path": "bam_file", "append_to": "bam_files", "index": "bai_files"},
-        {"path": "assembly_alignment_path", "append_to": "assembly_alignments", "index": None},
-        {"path": "mt_bam", "append_to": "mt_bams", "index": "mt_bais"},
-        {
-            "path": "paraphase_alignment_path",
-            "append_to": "paraphase_alignments",
-            "index": None,
-        },
-        {"path": "rhocall_bed", "append_to": "rhocall_beds", "index": None},
-        {"path": "rhocall_wig", "append_to": "rhocall_wigs", "index": None},
-        {"path": "upd_regions_bed", "append_to": "upd_regions_beds", "index": None},
-        {"path": "upd_sites_bed", "append_to": "upd_sites_beds", "index": None},
-        {
-            "path": "minor_allele_frequency_wig",
-            "append_to": "minor_allele_frequency_wigs",
-            "index": None,
-        },
-        {"path": "tiddit_coverage_wig", "append_to": "tiddit_coverage_wigs", "index": None},
-    ]
 
     def process_file(case_obj, individual, setting):
         """Process a single file and its optional index."""
@@ -403,7 +385,7 @@ def case_append_alignments(case_obj: dict):
         )
 
         # Process all file settings
-        for setting in unwrap_settings:
+        for setting in CASE_INDIVIDUAL_DISPLAY_OBJECT_MAP:
             process_file(case_obj, individual, setting)
 
 

--- a/tests/server/blueprints/alignviewers/test_alignviewers_views.py
+++ b/tests/server/blueprints/alignviewers/test_alignviewers_views.py
@@ -142,9 +142,6 @@ def test_igv_authorized(app, user_obj, case_obj, variant_obj):
 
         # THEN the response should be a valid HTML page
         assert resp.status_code == 200
-        # AND when the response is closed case IGV tracks should be removed from session
-        resp.close()
-        assert session.get("igv_tracks") is None
 
 
 @responses.activate


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5696 - refactor session object igv_tracks to recreate list of authorised case files on case at the endpoint (`/ remote/static`)

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
