### PR TITLE
Fix cli param spelled wrong - with alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Remove unused `variant_count` parameter from several functions involved with variant queries (#5700)
 - Consolidated and simplified case handling tests (#5708)
 - Authorize access to IGV.js track files at endpoint, instead of by session cookie. Allows huge case groups and many open IGV.js sessions. (#5712)
+- Fix CLI parameter typo --rank-treshold with backward-compatible alias and deprecation warning (#)
 ### Fixed
 - Typo in PR template (#5682)
 - Highlight affected individuals/samples on `GT call` tables (#5682)

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -37,9 +37,14 @@ LOG = logging.getLogger(__name__)
 @click.option("--hgnc-id", type=int, help="If all variants from a gene, specify the gene id")
 @click.option("--hgnc-symbol", help="If all variants from a gene, specify the gene symbol")
 @click.option(
+    "--rank-threshold",
     "--rank-treshold",
     default=5,
-    help="Specify the rank score threshold. Deprecation warning: this parameter name will change in a later release.",
+    help=(
+        "Specify the rank score threshold. "
+        "Deprecation warning: the misspelled parameter '--rank-treshold' "
+        "will be removed in the next major release."
+    ),
     show_default=True,
 )
 @click.option("-f", "--force", is_flag=True, help="upload without request")

--- a/tests/commands/delete/test_delete_cmd.py
+++ b/tests/commands/delete/test_delete_cmd.py
@@ -15,7 +15,7 @@ def test_delete_variants_dry_run(mock_app, case_obj, user_obj):
     # Given a database with SNV variants
     runner = mock_app.test_cli_runner()
     result = runner.invoke(
-        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-treshold", 5]
+        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-threshold", 5]
     )
     assert result.exit_code == 0
     n_initial_vars = sum(1 for _ in store.variant_collection.find())
@@ -55,7 +55,7 @@ def test_delete_variants(mock_app, case_obj, user_obj):
     # Given a case with with SNV variants
     runner = mock_app.test_cli_runner()
     result = runner.invoke(
-        cli, ["load", "variants", "--snv", "--rank-treshold", 0, case_obj["_id"]]
+        cli, ["load", "variants", "--snv", "--rank-threshold", 0, case_obj["_id"]]
     )
     assert result.exit_code == 0
     nr_snvs = sum(1 for _ in store.variant_collection.find())

--- a/tests/commands/load/test_load_variants_cmd.py
+++ b/tests/commands/load/test_load_variants_cmd.py
@@ -17,7 +17,7 @@ def test_load_variants(mock_app, case_obj):
 
     # Test CLI by uploading SNV variants for a case
     result = runner.invoke(
-        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-treshold", 10]
+        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-threshold", 10]
     )
     assert result.exit_code == 0
 
@@ -93,7 +93,7 @@ def test_reload_variants(mock_app, case_obj, user_obj, institute_obj):
 
     # After using the CLI uploading SNV variants for a case
     result = runner.invoke(
-        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-treshold", 10]
+        cli, ["load", "variants", case_obj["_id"], "--snv", "--rank-threshold", 10]
     )
     assert result.exit_code == 0
 
@@ -142,7 +142,7 @@ def test_reload_variants(mock_app, case_obj, user_obj, institute_obj):
             "variants",
             case_obj["_id"],
             "--snv",
-            "--rank-treshold",
+            "--rank-threshold",
             10,
             "--force",
         ],


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- fix #5090

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
