### PR TITLE
Fix #5714 - change default track options for paraphase alignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Authorize access to IGV.js track files at endpoint, instead of by session cookie. Allows huge case groups and many open IGV.js sessions. (#5712)
 - On the variant page, the corresponding button opens the ACMG and CCV classification tools in a new tab (#5723)
 - Fix CLI parameter typo --rank-treshold with backward-compatible alias and deprecation warning (#5720)
+- Default paraphase igv.js track settings: color by YC, squish, extend visibility window, auto-height and place last in view. (#5724)
 ### Fixed
 - Typo in PR template (#5682)
 - Highlight affected individuals/samples on `GT call` tables (#5682)

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/igv_viewer.html
@@ -146,19 +146,6 @@
                         sourceType: 'file'
                       },
                       {% endfor %}
-                      {% for ptrack in paraphase_alignments %}
-                      {
-                        type: "alignment",
-                        name: "{{ ptrack.name }}",
-                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
-                        format: "{{ ptrack.format }}",
-                        groupBy: "tag:HP",
-                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}',
-                        min: '{{ ptrack.min }}',
-                        autoscaleGroup: '{{ ptrack.autoscaleGroup }}',
-                        sourceType: 'file'
-                      },
-                      {% endfor %}
                       {% for atrack in assembly_alignments %}
                       {
                         type: "alignment",
@@ -194,6 +181,26 @@
                         sourceType: 'file'
                       },
                       {% endfor %}
+                      {% for ptrack in paraphase_alignments %}
+                      {
+                        type: "alignment",
+                        name: "{{ ptrack.name }}",
+                        url: '{{ url_for("alignviewers.remote_static", file=ptrack.url, institute_id=institute_id, case_name=case_display_name) | safe }}',
+                        format: "{{ ptrack.format }}",
+                        autoHeight: true,
+                        groupBy: "tag:HP",
+                        colorBy: "tag:YC",
+                        displayMode: "SQUISHED",
+                        showInsertionText: true,
+                        showDeletionText: true,
+                        indexURL: '{{ url_for("alignviewers.remote_static", file=ptrack.indexURL, institute_id=institute_id, case_name=case_display_name) | safe }}',
+                        min: '{{ ptrack.min }}',
+                        autoscaleGroup: '{{ ptrack.autoscaleGroup }}',
+                        visibilityWindow: 600000,
+                        sourceType: 'file'
+                      },
+                      {% endfor %}
+
                   ]
               };
       igv.createBrowser(div, options)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5714 
<img width="1788" height="673" alt="Screenshot 2025-09-26 at 15 33 04" src="https://github.com/user-attachments/assets/17a8055f-ef01-40cc-bace-67be3191435a" />

Much better. I tried turning on the "squished" display mode by default as well, like in the tutorials over at Paraphase. It's nice for an overview; perhaps not ideal for looking at a single variant though. Thoughts @fellen31?

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
