### PR TITLE
Fix research clinical filter buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow updating case owner on `scout load case -u` (#5681)
 - Missing query results on STR variantS page (#5713)
 - Links to variants with missing rank scores from Causatives and Verified pages (#5715)
+- Clinical filter button on research variants, wrongly redirecting to respective clinical variants pages (#5725)
 
 ## [4.104]
 ### Added

--- a/scout/server/blueprints/omics_variants/views.py
+++ b/scout/server/blueprints/omics_variants/views.py
@@ -53,8 +53,7 @@ def outliers(institute_id, case_name):
 
     if request.method == "GET":
         form = OutlierFiltersForm(request.args)
-        variant_type = request.args.get("variant_type", "clinical")
-        form.variant_type.data = variant_type
+
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
         if form.gene_panels.data == [] and variant_type == "clinical":
@@ -64,6 +63,8 @@ def outliers(institute_id, case_name):
         form = populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request.form
         )
+
+    form.variant_type.data = variant_type
 
     # populate available panel choices
     form.gene_panels.choices = gene_panel_choices(store, institute_obj, case_obj)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1724,13 +1724,14 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
     form = SvFiltersForm(request_obj.args)
     user_obj = store.user(current_user.email)
 
+    variant_type = request_obj.values.get("variant_type", "clinical")
+
     if request_obj.method == "GET":
         if category == "sv":
             form = SvFiltersForm(request_obj.args)
         elif category == "cancer_sv":
             form = CancerSvFiltersForm(request_obj.args)
-        variant_type = request_obj.args.get("variant_type", "clinical")
-        form.variant_type.data = variant_type
+
         # set chromosome to all chromosomes
         form.chrom.data = request_obj.args.get("chrom", "")
         if form.gene_panels.data == [] and variant_type == "clinical":
@@ -1740,6 +1741,8 @@ def populate_sv_filters_form(store, institute_obj, case_obj, category, request_o
         form = populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request_obj.form
         )
+
+    form.variant_type.data = variant_type
 
     populate_force_show_unaffected_vars(institute_obj, form)
 

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -140,8 +140,6 @@ def variants(institute_id, case_name):
     genome_build = get_case_genome_build(case_obj)
     cytobands = store.cytoband_by_chrom(genome_build)
 
-    LOG.warning(form.data)
-
     variants_query = store.variants(
         case_obj["_id"], query=form.data, category=category, build=genome_build
     )
@@ -396,11 +394,10 @@ def mei_variants(institute_id, case_name):
 
         if form.gene_panels.data == [] and variant_type == "clinical":
             form.gene_panels.data = controllers.case_default_panels(case_obj)
-
-        # set form variant data type the first time around
-        form.variant_type.data = variant_type
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
+
+    form.variant_type.data = variant_type
 
     # Populate chromosome select choices
     controllers.populate_chrom_choices(form, case_obj)

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -93,12 +93,14 @@ def variants(institute_id, case_name):
     else:
         form = FiltersForm(request.args)
         # set form variant data type the first time around
-        form.variant_type.data = variant_type
+
         # set chromosome to all chromosomes
         form.chrom.data = request.args.get("chrom", "")
 
         if form.gene_panels.data == [] and variant_type == "clinical":
             form.gene_panels.data = controllers.case_default_panels(case_obj)
+
+    form.variant_type.data = variant_type
 
     controllers.populate_force_show_unaffected_vars(institute_obj, form)
 
@@ -137,6 +139,8 @@ def variants(institute_id, case_name):
 
     genome_build = get_case_genome_build(case_obj)
     cytobands = store.cytoband_by_chrom(genome_build)
+
+    LOG.warning(form.data)
 
     variants_query = store.variants(
         case_obj["_id"], query=form.data, category=category, build=genome_build


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #4227 - Now if you click on clinical filter from research variants pages you will get a list of research variants with clinical filter applied, and you won't be redirected to clinical variantS page

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, DN
