### PR TITLE
Fix #5726 - handle pagination on undefined result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing query results on STR variantS page (#5713)
 - Links to variants with missing rank scores from Causatives and Verified pages (#5715)
 - Clinical filter button on research variants, wrongly redirecting to respective clinical variants pages (#5725)
+- Pagination to handle empty search results (#5727)
 
 ## [4.104]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Links to variants with missing rank scores from Causatives and Verified pages (#5715)
 - Clinical filter button on research variants, wrongly redirecting to respective clinical variants pages (#5725)
 - Pagination to handle empty search results (#5727)
+- Gene variants page to return all resulting variants again (#5727)
 
 ## [4.104]
 ### Added

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 from typing import Dict, List, Optional, Tuple
 
+import pymongo.cursor
 from flask import Response, current_app, flash, request, url_for
 from flask_login import current_user
 from pymongo import ASCENDING, DESCENDING
@@ -881,11 +882,11 @@ def export_gene_variants(store: MongoAdapter, gene_symbol: str, pymongo_cursor: 
     )
 
 
-def gene_variants(store, pymongo_cursor, page=1, per_page=50):
+def gene_variants(store: MongoAdapter, results: Cursor, page: int = 1, per_page: int = 50) -> dict:
     """Pre-process list of variants."""
 
     skip_count = per_page * max(page - 1, 0)
-    variant_res = pymongo_cursor.skip(skip_count).limit(per_page)
+    variant_res = results.skip(skip_count).limit(per_page)
     variants = []
 
     for variant_obj in variant_res:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 from typing import Dict, List, Optional, Tuple
 
-import pymongo.cursor
 from flask import Response, current_app, flash, request, url_for
 from flask_login import current_user
 from pymongo import ASCENDING, DESCENDING
@@ -802,7 +801,7 @@ def get_sanger_unevaluated(
     return unevaluated, evaluated_by_others
 
 
-def export_gene_variants(store: MongoAdapter, gene_symbol: str, pymongo_cursor: Cursor) -> Response:
+def export_gene_variants(store: MongoAdapter, gene_symbol: str, results: Cursor) -> Response:
     """Export 500 gene variants for an institute resulting from a customer query"""
 
     def generate(header, lines):
@@ -812,7 +811,7 @@ def export_gene_variants(store: MongoAdapter, gene_symbol: str, pymongo_cursor: 
 
     data: dict = gene_variants(
         store=store,
-        pymongo_cursor=pymongo_cursor,
+        results=results,
         per_page=500,
     )
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -2,7 +2,7 @@
 import json
 import logging
 
-from flask import Blueprint, flash, jsonify, render_template, request
+from flask import Blueprint, flash, jsonify, redirect, render_template, request
 from flask_login import current_user
 from pymongo import DESCENDING
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -189,7 +189,7 @@ def gene_variants(institute_id):
             return controllers.export_gene_variants(
                 store=store,
                 gene_symbol=request.form.get("hgnc_symbols").split(",")[0].strip(),
-                pymongo_cursor=results,
+                results=results,
             )
 
         data = controllers.gene_variants(

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -193,7 +193,7 @@ def gene_variants(institute_id):
             )
 
         data = controllers.gene_variants(
-            store, results, result_size, page
+            store, results=results, page=page
         )  # decorated variant results, max 50 in a page
 
     return dict(

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -2,7 +2,7 @@
 import json
 import logging
 
-from flask import Blueprint, flash, jsonify, redirect, render_template, request
+from flask import Blueprint, flash, jsonify, render_template, request
 from flask_login import current_user
 from pymongo import DESCENDING
 

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1177,9 +1177,14 @@
   {{ pin_indicator(variant, case) }}
 {% endmacro %}
 
-{% macro pagination_hidden_div(page, total_variants) %}
+{% macro pagination_hidden_div(page, result_size) %}
   {% set per_page = 50 %}
-  {% set total_pages = (total_variants // per_page) + (1 if total_variants % per_page > 0 else 0) %}
+  {% if result_size is not none %}
+    {% set total_pages = (result_size // per_page) + (1 if result_size % per_page > 0 else 0) %}
+  {% else %}
+    {% set total_pages = 1 %}
+  {% endif %}
+
   <div class="hidden">
     <input type="submit" name="page" id="paginate-first" value="1" hidden>
     <input type="submit" name="page" id="paginate-previous" value="{{ page-1 }}" hidden>
@@ -1195,9 +1200,14 @@
   </div>
 {% endmacro %}
 
-{% macro pagination_footer(page, total_variants) %}
+{% macro pagination_footer(page, result_size) %}
   {% set per_page = 50 %}
-  {% set total_pages = (total_variants // per_page) + (1 if total_variants % per_page > 0 else 0) %}
+
+  {% if result_size is not none %}
+    {% set total_pages = (result_size // per_page) + (1 if result_size % per_page > 0 else 0) %}
+  {% else %}
+    {% set total_pages = 1 %}
+  {% endif %}
   {% set window = 2 %} {# pages around current page #}
 
   {# Clamp page number #}

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -8,6 +8,29 @@ OVERVIEW_GENE_VARIANTS_ENDPOINT = "overview.gene_variants"
 
 
 def test_gene_variants(app, user_obj, institute_obj):
+    """Test the page that returns all variants for an institute, without a query.
+    It should return the empty search page."""
+
+    # GIVEN an initialized app
+    with app.test_client() as client:
+        # WITH a logged user
+        client.get(url_for("auto_login"))
+
+        # WHEN form is submitted by POST request
+        resp = client.post(
+            url_for(
+                OVERVIEW_GENE_VARIANTS_ENDPOINT,
+                institute_id=institute_obj["internal_id"],
+            ),
+        )
+        # THEN it should return a valid page
+        assert resp.status_code == 200
+
+        # THEN the result shall contain a string indicating no variants available yet.
+        assert "No variants to display" in str(resp.data)
+
+
+def test_gene_variants(app, user_obj, institute_obj):
     """Test the page that returns all SNPs and INDELs given a gene provided by user"""
 
     # GIVEN a form filled in by the user


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5726
- Fix #5729 

Before: `500 internal error` 

After:
<img width="979" height="526" alt="Screenshot 2025-09-29 at 10 36 08" src="https://github.com/user-attachments/assets/66c976df-0143-43cc-979c-51d1194fdc8c" />

and multiple results:
<img width="971" height="553" alt="Screenshot 2025-09-29 at 11 11 23" src="https://github.com/user-attachments/assets/a9155a22-db91-48ce-9267-5fabfd524120" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
