### PR TITLE
Display number of fusion vars shown on fusions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Search genes at breakpoint for larger SVs (#5722)
 - Code for refreshing id token, if needed. To be used for authenticated requests to chanjo2 (#5532)
 - Genotype to the gene variants view (#5736)
-- Display number of fusion variants are shown on the page, just like the other variant types (#5754)
+- Display the number of fusion variants on the variantS page, just like the other variant types (#5754)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
 - Remove unused `variant_count` parameter from several functions involved with variant queries (#5700)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Search genes at breakpoint for larger SVs (#5722)
 - Code for refreshing id token, if needed. To be used for authenticated requests to chanjo2 (#5532)
 - Genotype to the gene variants view (#5736)
+- Display number of fusion variants are shown on the page, just like the other variant types (#5754)
 ### Changed
 - Better access to ALT allele for SVs (#5693)
 - Remove unused `variant_count` parameter from several functions involved with variant queries (#5700)

--- a/scout/server/blueprints/variants/templates/variants/fusion-variants.html
+++ b/scout/server/blueprints/variants/templates/variants/fusion-variants.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% from "utils.html" import clickable_table_row_script %}
-{% from "variants/utils.html" import cell_rank, dismiss_variants_block, filter_form_footer, filter_script_main, fusion_filters, pagination_footer, pagination_hidden_div, update_stash_filter_button_status, variant_link_href %}
+{% from "variants/utils.html" import cell_rank, dismiss_variants_block, filters_form_header, filter_form_footer, filter_script_main, fusion_filters, pagination_footer, pagination_hidden_div, update_stash_filter_button_status, variant_link_href %}
 {% from "variants/components.html" import external_scripts, external_stylesheets, fusion_variant_gene_symbols_cell, fusion_variants_header, default_fusion_variant_cells %}
 
 {% block title %}
@@ -43,6 +43,7 @@ onsubmit="return validateForm()">
   <div class="container-float">
     {{ pagination_hidden_div(page, result_size) }}
     <div class="card panel-default" id="accordion">
+      {{ filters_form_header(result_size, total_variants) }}
       <div class="card-header">
         <strong><a data-bs-toggle="collapse" data-parent="#accordion" href="#collapseFilters">FusionFilters</a></strong>
       </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #5753 
- Pagination is included in the page and it should work, see [here](https://github.com/Clinical-Genomics/scout/blob/fc88765b7270cc66a91e1e90687759413722f771/scout/server/blueprints/variants/templates/variants/fusion-variants.html#L74)

<img width="1076" height="675" alt="image" src="https://github.com/user-attachments/assets/814b5155-115a-4cf5-9a0c-578f00d923c0" />



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [X] tests executed by DN, CR
