### PR TITLE
Fix #5752 - use proper end coord for large SVs in edge gene lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix pagination for somatic SVs (#5746)
 - Fix display of STR MC for cases with GT "./0" calls (#5749)
 - Build full HGNC genes for STR variants with HGNCId on load (#5751)
-- Use proper end position for large SVs when looking up edge genes (#5752)
+- Use proper end position for large SVs when looking up edge genes (#5755)
 
 ## [4.104]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix pagination for somatic SVs (#5746)
 - Fix display of STR MC for cases with GT "./0" calls (#5749)
 - Build full HGNC genes for STR variants with HGNCId on load (#5751)
+- Use proper end position for large SVs when looking up edge genes (#5752)
 
 ## [4.104]
 ### Added

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -471,15 +471,16 @@ def set_edge_genes(store: MongoAdapter, case_obj: dict, variant_obj: dict):
     if start_genes:
         variant_obj["start_genes"] = start_genes
 
+    variant_end = variant_obj.get("end") or variant_obj.get("end_position")
     if (
-        variant_obj.get("end_position")
-        and variant_obj["position"] != variant_obj["end_position"]
+        variant_end
+        and variant_obj["position"] != variant_end
         and variant_obj.get("sub_category") != "ins"
     ):
         end_chromosome = variant_obj.get("end_chrom") or variant_obj["chromosome"]
         end_genes = store.genes_by_coordinate(
             chromosome=end_chromosome,
-            pos=variant_obj["end_position"],
+            pos=variant_end,
             build=genome_build,
         )
         if end_genes:

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -531,7 +531,8 @@ def transcript_str(transcript_obj, gene_name=None):
 
 
 def end_position(variant_obj):
-    """Calculate end position for a variant.
+    """Calculate end position for a variant that does not have a set "end",
+    eg an indel snv or ins sv.
 
     Args:
         variant_obj(scout.models.Variant)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5752

Looks a lot better, especially visible on e.g. large dups.
Cf the one from the issue after patch:
<img width="176" height="521" alt="Screenshot 2025-10-08 at 14 41 30" src="https://github.com/user-attachments/assets/7bd28850-e6e5-4441-a9e1-1cfbd0ca127b" />

BNDs, INS and small variants with good ALT alleles were correct, or near correct already, but especially large CNV have quite a distance between end and "end_position". 🙄 It is perhaps time for a display variant class. 😊 
<img width="177" height="416" alt="Screenshot 2025-10-08 at 14 41 06" src="https://github.com/user-attachments/assets/74a5616b-1153-478f-9a5d-87d4325e0898" />
<img width="202" height="465" alt="Screenshot 2025-10-08 at 14 40 53" src="https://github.com/user-attachments/assets/29806b58-f7ce-42cb-8444-b587913edddf" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
