### PR TITLE
Fix update panels crashing 2 - do not cast to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix display of STR MC for cases with GT "./0" calls (#5749)
 - Build full HGNC genes for STR variants with HGNCId on load (#5751)
 - Use proper end position for large SVs when looking up edge genes (#5755)
-- Fixed crash on the Gene Panel page when changes to the same panel version were applied from multiple browser tabs (#5762)
+- Fixed crash on the Gene Panel page when changes to the same panel version were applied from multiple browser tabs (#5762 and #5765)
 - Sort STRs primarily by HGNC symbol, if available (#5763)
 
 ## [4.104]

--- a/scout/server/blueprints/panels/views.py
+++ b/scout/server/blueprints/panels/views.py
@@ -210,9 +210,7 @@ def panel_update(panel_id):
     if not update_version:
         return redirect(url_for("panels.panel", panel_id=panel_id))
 
-    duplicate = store.gene_panel(
-        panel_id=panel_obj["panel_name"], version=int(float(update_version))
-    )
+    duplicate = store.gene_panel(panel_id=panel_obj["panel_name"], version=float(update_version))
     if duplicate:
         flash(
             f"A panel named '{panel_obj['panel_name']}' with version {update_version} already exists.",


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5759 - attempt 2

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
