### PR TITLE
Temp fix #5782 - downgrade igv.js to 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Downgrade igv.js to 3.5.0 to restore alignment track popupData (#5783)
+
 ## [4.105.1]
 ### Fixed
 - uv lockfile update (#5780)

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
@@ -1,5 +1,5 @@
 {% macro igv_script() %}
   <link rel="shortcut icon" href="//igv.org/web/img/favicon.ico">
   <!-- IGV JS-->
-  <script src="https://cdn.jsdelivr.net/npm/igv@3.5.3/dist/igv.min.js" integrity="sha512-8viYusvOiuksaWIauJPdS7m1/ZaqE9aA/J5arfl+ZUVFhm4MhHQb7tEaYCwRNJ2lqJ26g2qzqsucHVZwSDZCpw==" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/igv@3.5.0/dist/igv.min.js" integrity="sha512-La/hwLw7eTeDKARxC5BILCUKByVpb9mtmPT1Tc5Y6LNamr7rk0jrvrLAsokWSY3mnLBTHWUlWoecCKZ1AfrdHg==" crossorigin="anonymous"></script>
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

The issue appears on release 3.5.1. It kind of looks ok (even prettier) on the igv.js live demo alignment, which is at 3.5.2, but the custom track click event popover example, which ours appears highly similar to, is also not working.

Downgrade to 3.5.0 solves it for now
<img width="468" height="463" alt="Screenshot 2025-10-16 at 10 41 42" src="https://github.com/user-attachments/assets/a266fb90-ec26-442a-bf2b-1e6efee344ca" />
but note that we loose the nice native popover formatting by doing it this way...

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
