### PR TITLE
Fix #5785 - dont dim CN profile buttons on visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Fixed
 - Downgrade igv.js to 3.5.0 to restore alignment track popupData (#5783)
+- CN profile button does not dim for visited links (#5787)
 
 ## [4.105.1]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/individuals_table.html
+++ b/scout/server/blueprints/cases/templates/cases/individuals_table.html
@@ -32,7 +32,7 @@
           {% for ind in case.individuals %}
             <tr {% if ind.phenotype_human == 'tumor' %} class="bg-danger-light" {% endif %}>
               <td>{{ ind.display_name }}{% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}&individual_id={{ind.individual_id}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary text-white btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}&individual_id={{ind.individual_id}}">CN profile</a>
                 {% endif %}</td>
               {% if ind.phenotype_human == "normal" %}
                 <td>N/A</td>
@@ -132,7 +132,7 @@
                   </div>
                 </label>
                 {% if gens_info.display %}
-                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm float-end" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}&individual_id={{ind.individual_id}}">CN profile</a>
+                  <a style="font-size: .8rem;" class="btn btn-secondary btn-sm text-white float-end" target="_blank" href="http://{{gens_info.host}}/{{ind.display_name}}?&genome_build={{case.genome_build}}&case_id={{case._id}}&individual_id={{ind.individual_id}}">CN profile</a>
                 {% endif %}
                 </td>
               <td>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #5784

Tested on stage.

<img width="564" height="120" alt="Screenshot 2025-10-16 at 11 11 51" src="https://github.com/user-attachments/assets/d8477bdf-aee8-4397-8e40-53a9c370c60d" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. enable light mode
2. visit a CN profile link
3. reload case or variant page and note the link still not dimmed as if visited

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
