### PR TITLE
Do not build editable for docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Removed ClinVar submissions instructions from case pages - it's still present on the ClinVar submissions page (#5806)
 - Render the case report's pedigree SVG to a temporary file without Cairo when exporting it to PDF (#5791)
 - Deprecate python 3.9 which has reached its EOL, default build to 3.14 (#5818)
+- Don't build in editable mode for Docker images (#5819)
 ### Fixed
 - Filter `f` hotkey not working on cancer variantS pages (#5788)
 - IGV.js updated to v3.5.4 (#5790)

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,6 @@ RUN chown -R worker:worker /home/worker/app/.venv
 USER worker
 
 # Install Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
+RUN uv pip install --no-cache-dir .[coverage]
 
 ENTRYPOINT ["uv", "run", "scout"]

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -47,7 +47,7 @@ RUN chown -R worker:worker /home/worker/app/.venv
 USER worker
 
 # Install Scout app
-RUN uv pip install --no-cache-dir --editable .[coverage]
+RUN uv pip install --no-cache-dir .[coverage]
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Do not build app in editable for docker images

We use importlib to read the scout `config.py`, and for development it would anyway be a hassle to mount all of the code for editable mode - if so, easier to make a separate dev docker.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
