### PR TITLE
Fix #6006 - python 3.11 cannot use native iterable with subtype for type hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Smalled PDFs exported from ACMG classification page (#5976)
 - When adding a germline variant to a ClinVar submission, make sure it ends up in a germline submission (#5990)
 - Invalid scroll_pos handling in variants view (#5999)
+- Native type hint of iterable with subtype not compatible with python 3.11 (#6007)
 
 ## [4.107.2]
 ### Fixed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1,7 +1,7 @@
 import decimal
 import logging
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from flask import Response, flash, request, session, url_for
 from flask_login import current_user
@@ -1578,7 +1578,7 @@ def upload_panel(store, institute_id, case_name, stream):
     return hgnc_symbols
 
 
-def gene_panel_choices(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> list(tuple):
+def gene_panel_choices(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> List[Tuple]:
     """Populates the multiselect containing all the gene panels to be used in variants filtering."""
 
     case_panels = [


### PR DESCRIPTION
- Fix #6006 

This PR adds a functionality or fixes a bug.

Before:
```
[daniel.nilsson@hasta:~] [S_base] $ python --version
Python 3.11.6
[daniel.nilsson@hasta:~] [S_base] $ scout --version
Traceback (most recent call last):
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/bin/scout", line 5, in <module>
    from scout.commands import cli
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/commands/__init__.py", line 1, in <module>
    from .base import cli
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/commands/base.py", line 21, in <module>
    from scout.server.app import create_app
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/app.py", line 26, in <module>
    from .blueprints import (
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/blueprints/cases/__init__.py", line 2, in <module>
    from .views import cases_bp
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/blueprints/cases/views.py", line 32, in <module>
    from scout.server.blueprints.variants.controllers import activate_case
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/blueprints/variants/__init__.py", line 2, in <module>
    from .views import variants_bp
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/blueprints/variants/views.py", line 28, in <module>
    from . import controllers
  File "/home/proj/stage/bin/miniconda3/envs/S_scout/lib/python3.11/site-packages/scout/server/blueprints/variants/controllers.py", line 1581, in <module>
    def gene_panel_choices(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> list(tuple):
                                                                                        ^^^^^^^^^^^
TypeError: 'type' object is not iterable
```

After:
```
[daniel.nilsson@hasta:~] [S_base] $ scout --version
scout, version 4.107.2
```



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
