### PR TITLE
Fix variantS page scroller when you have half pixels and when you browse thru pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Parse STRdrop details where available (#5991)
 - Incomplete penetrance badge, according to HPO (#6008)
 - Support for additional variant scoring systems: `MivmirScore`, `GicamScore` (#5970)
-<<<<<<< parse_mivmirexplanation
 - Parse and display `MivmirExplanation` key/values on variant page, when available (#6011)
-=======
 - Display inheritance models on structural variantS pages (#6015)
->>>>>>> main
 ### Changed
 - Institutes are now ordered alphabetically by display name on gene panels search (#5965)
 - Display all available individual/sample IDs for a case (display_name, individual_id and subject_id) directly on cases page (#5966)
@@ -30,7 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - When dismissing variants from variantS page, reloaded page remembers variant selection position (#5969)
 - Smalled PDFs exported from ACMG classification page (#5976)
 - When adding a germline variant to a ClinVar submission, make sure it ends up in a germline submission (#5990)
-- Invalid scroll_pos handling in variants view (#5999)
+- Invalid scroll_pos handling in variants view (#5999 and #6022)
 - Native type hint of iterable with subtype not compatible with python 3.11 (#6007)
 - Error in parsing reduced penetrance from HPO genes to phenotypes (#6004)
 - Top left SNVs button on omics outliers page (#6001)

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -316,7 +316,7 @@ def render_variants_page(
         case=case_obj,
         cytobands=cytobands,
         dismiss_variant_options=dismiss_variant_options,
-        scroll_pos=int(request.values.get("scroll_pos") or 0),
+        scroll_pos=int(float(request.values.get("scroll_pos", 0) or 0)),
         expand_search=get_expand_search(request.form),
         filters=populate_persistent_filters_choices(
             institute_id=institute_id, category=category, form=form

--- a/scout/server/blueprints/variants/templates/variants/variants_layout.html
+++ b/scout/server/blueprints/variants/templates/variants/variants_layout.html
@@ -111,10 +111,14 @@
 
     {{ clickable_table_row_script() }}
 
-    document.querySelector("#filters_form").addEventListener("submit", function () {
-       document.getElementById("scroll_pos").value = window.scrollY;
+    document.querySelector("#filters_form").addEventListener("submit", function (event) {
+      const submitter = event.submitter;
+      if (submitter && submitter.id && submitter.id.startsWith("paginate-")) {
+        document.getElementById("scroll_pos").value = 0;
+      } else {
+        document.getElementById("scroll_pos").value = window.scrollY;
+      }
     });
-
 
   </script>
   {{ enable_variants_hotkeys() }}

--- a/scout/server/blueprints/variants/views.py
+++ b/scout/server/blueprints/variants/views.py
@@ -162,7 +162,7 @@ def variants(institute_id, case_name):
         case=case_obj,
         cytobands=cytobands,
         dismiss_variant_options=DISMISS_VARIANT_OPTIONS,
-        scroll_pos=int(request.values.get("scroll_pos") or 0),
+        scroll_pos=int(float(request.values.get("scroll_pos", 0) or 0)),
         escat_tier_options=ESCAT_TIER_OPTIONS,
         expand_search=controllers.get_expand_search(request.form),
         filters=controllers.populate_persistent_filters_choices(
@@ -389,7 +389,7 @@ def cancer_variants(institute_id, case_name):
             **DISMISS_VARIANT_OPTIONS,
             **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
         },
-        scroll_pos=int(request.values.get("scroll_pos") or 0),
+        scroll_pos=int(float(request.values.get("scroll_pos", 0) or 0)),
         expand_search=controllers.get_expand_search(request.form),
         filters=controllers.populate_persistent_filters_choices(
             institute_id=institute_id, category=category, form=form


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix page crashing when scroll_pos is a float number (fix #6021 )
- Fix when browsing the pages with the navigation footer -> when you go to another page, scroll position will be 0 instead of bottom of the page

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
