### PR TITLE
Sort institutes on institute settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On `Local Observations` panels, set number of homozygous observations to 0 and not N/A if Nr obs. is 0 (#6038)
 - Color case LR badges (#6050)
 - Make sorting of gene panels containing a gene case-insensitive (#6052 and #6056)
-- Make sorting of institutes case-insensitive on new user form and dashboard (#6061)
+- Make sorting of institutes case-insensitive on new user form, dashboard and institute settings (#6061, #6062)
 
 ## [4.107.2]
 ### Fixed

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -302,7 +302,9 @@ def populate_institute_form(form, institute_obj):
     """
     # get all other institutes to populate the select of the possible collaborators
     institutes_tuples = []
-    for inst in store.institutes():
+    all_institutes = list(store.institutes())
+    all_institutes.sort(key=lambda i: i.get("display_name", i["_id"]).lower())
+    for inst in all_institutes:
         if not inst["_id"] == institute_obj["_id"]:
             institutes_tuples.append((inst["_id"], f'{inst["display_name"]} - {inst["_id"]}'))
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Found another case immediately after I merged last PR :-/

### Before 

<img width="384" height="374" alt="image" src="https://github.com/user-attachments/assets/1ce32c06-95e9-46c1-8816-0529cbc79f5a" />


### After

<img width="355" height="370" alt="image" src="https://github.com/user-attachments/assets/264de14c-80cd-4a06-9b49-b932b0ec49fe" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
