### PR TITLE
Methbat uncategorized icon - missed a push after review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Cases page crashing due to missing analysis date when a case is loaded using VCF + ped file (#6067)
 - Add user dropdown selects visible in dark mode (#6068)
 - Fixed links to Ensembl and NCBI transcripts from main `Transcripts` and `Protein` panel on variant page (#6041)
+- Methbat methylation Uncategorized icon display (#6074)
 
 ## [4.107.2]
 ### Fixed

--- a/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
+++ b/scout/server/blueprints/omics_variants/templates/omics_variants/outliers.html
@@ -85,14 +85,14 @@
             <span data-bs-toggle="tooltip" data-bs-html="true" title='The log2 fold change (fold change) - click to see OUTRIDER vignette for details.'>
             {{ variant.l2fc }} ({{variant.l2fc|l2fc_2_fc|round(2)}}x) &nbsp;&nbsp;<a target="_blank" href="https://www.bioconductor.org/packages/devel/bioc/vignettes/OUTRIDER/inst/doc/OUTRIDER.pdf" rel="noopener noreferrer">{% if variant.l2fc > 0 %}&uarr;{% elif variant.l2fc < 0 %}&darr;{% endif %}</a></span>
           {% elif variant.sub_category == "methylation" %}
-            <a target="_blank" data-bs-toggle="tooltip" data-bs-html="true" title='MethBat compare label {{ variant.compare_label }}' href="https://github.com/PacificBiosciences/MethBat/blob/main/docs/profile_guide.md#single-dataset-profiles" rel="noopener noreferrer">{% if "Hyper" in variant.compare_label %}&uarr;{% elif "Hypo" in variant.compare_label %}&darr;{% endif %}{% if "ASM" in variant.compare_label %}ASM{% elif "InsufficientData" in variant.compare_label %}?{% elif "Uncategorized" in variant.compare_label %}&rarr;{% endif %}</a>
+            <a target="_blank" data-bs-toggle="tooltip" data-bs-html="true" title='MethBat compare label {{ variant.compare_label }}' href="https://github.com/PacificBiosciences/MethBat/blob/main/docs/profile_guide.md#single-dataset-profiles" rel="noopener noreferrer">{% if "Hyper" in variant.compare_label %}&uarr;{% elif "Hypo" in variant.compare_label %}&darr;{% endif %}{% if "ASM" in variant.compare_label %}ASM{% elif "InsufficientData" in variant.compare_label %}?{% elif "Uncategorized" in variant.compare_label %}&asymp;{% endif %}</a>
           {% endif %}
         </td>
         <td>
           {% if variant.sub_category == "splicing" %}
             {{ variant.potential_impact }} - fs {{ variant.causes_frameshift }}
           {% elif variant.sub_category == "methylation" %}
-            <a target="_blank" href="https://github.com/PacificBiosciences/MethBat/blob/main/docs/profile_guide.md#single-dataset-profiles" data-bs-toggle="tooltip" data-bs-html="true" title='MethBat summary label {{ variant.summary_label }}' rel="noopener noreferrer">{% if "Methylated" in variant.summary_label %}&uarr;{% elif "Unmethylated" in variant.summary_label %}&darr;{% elif "AlleleSpecificMethylation" in variant.summary_label %}ASM{% elif "NoData" in variant.summary_label %}?{% else %}&rarr;{% endif %}</a>
+            <a target="_blank" href="https://github.com/PacificBiosciences/MethBat/blob/main/docs/profile_guide.md#single-dataset-profiles" data-bs-toggle="tooltip" data-bs-html="true" title='MethBat summary label {{ variant.summary_label }}' rel="noopener noreferrer">{% if "Methylated" in variant.summary_label %}&uarr;{% elif "Unmethylated" in variant.summary_label %}&darr;{% elif "AlleleSpecificMethylation" in variant.summary_label %}ASM{% elif "NoData" in variant.summary_label %}?{% else %}&asymp;{% endif %}</a>
           {% endif %}
         </td>
         {% if variant.sub_category == "methylation" %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Fixes the icon on Uncategorised methylation entries; sorry, I missed a push after the review changes. 😊 
Before
<img width="823" height="105" alt="Screenshot 2026-02-25 at 09 35 31" src="https://github.com/user-attachments/assets/05a589ec-ba16-4cbc-82ed-4170a351ed28" />
After
<img width="877" height="127" alt="Screenshot 2026-02-25 at 09 37 24" src="https://github.com/user-attachments/assets/8975ee55-d445-4ef8-8396-c3eecaafe927" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
