### PR TITLE
Fix displaying MEIs and cancer SVs on general case report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fixed links to Ensembl and NCBI transcripts from main `Transcripts` and `Protein` panel on variant page (#6041)
 - Methbat methylation Uncategorized icon display (#6074)
 - General report page timeout when case has dozens of dismissed variants - show only the first 15 (#6035)
+- Fixed displaying dismissed MEIs and cancer SVs on general case report (#6077)
 
 ## [4.107.2]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -827,10 +827,12 @@
                   <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name[:30]}}</strong></a>
                 {% elif variant.category == 'cancer' %}
                   <a href="{{ url_for('variant.cancer_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.display_name[:30]}}</strong></a>
-                {% elif variant.category == 'sv' %}
+                {% elif variant.category in ['sv', 'cancer_sv'] %}
                   <a href="{{ url_for('variant.sv_variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>chr{{variant.chromosome}}:{{variant.position}}_{{variant.sub_category|upper}}</strong></a>
-                {% else %} <!--strs -->
+                {% elif variant.category == "str" %}
                   <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>rep. {{variant.str_repid}}</strong></a>
+                {% elif variant.category == "mei"%}
+                  <a href="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" target="_blank"><strong>{{variant.mei_name}}</strong></a>
                 {% endif %}
               </td>
               <td style="width:5%;">{{variant.category|upper}}</td>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #6076 

### Before 

<img width="1052" height="173" alt="image" src="https://github.com/user-attachments/assets/19f5cd80-b06a-4a33-8438-fe09825dbf92" />

<img width="1051" height="187" alt="image" src="https://github.com/user-attachments/assets/055fe1e7-61ee-4198-ae36-fe4419f44093" />


### After

<img width="1062" height="174" alt="image" src="https://github.com/user-attachments/assets/efa85e6f-639d-472e-b552-7c20d4f63897" />


<img width="1058" height="188" alt="image" src="https://github.com/user-attachments/assets/8ab066c4-e9c4-40ed-b57c-3d84e920b5a9" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
