### PR TITLE
Fix style and text wrapping for ACMG PDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Comments' text wrapping in ACMG classifications exported as PDF (#6086)
+
 ## [4.108.2]
 ### Fixed
 - IGV browser page crashing when clicking on `IGV gDNA` or `IGV mtDNA` buttons (#6084)

--- a/scout/server/blueprints/variant/templates/variant/acmg_base.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg_base.html
@@ -7,6 +7,26 @@
   </li>
 {% endblock %}
 
+{% block css %}
+  {{ super() }}
+  <style>
+  .limited-column {
+    max-width: 50vw !important;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .comment-box {
+    width: 90%;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    white-space: normal;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  </style>
+{% endblock %}
+
 {% macro evaluation_tables() %}
  <div class="container mt-3 mb-5">
    {% if not institute %}
@@ -47,7 +67,7 @@
 
       <div class="d-flex flex-row justify-content-between mt-3">
         {% for category, criteria_group in CRITERIA.items() %}
-          <div class="flex-column {{ 'me-3' if not loop.last }}">
+          <div class="flex-column {{ 'me-3' if not loop.last }} limited-column">
             <h4>Evidence of {{ category }}</h4>
             {% for evidence, criteria in criteria_group.items() %}
               <ul class="list-group mt-3">
@@ -90,8 +110,14 @@
                         </select>
                       </div>
                       <div class="row">
-                        <textarea {{ 'disabled' if evaluation and edit is false }} class="form-control"
-                          name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ comment }}</textarea>
+                        {% if evaluation %}
+                          <div class="comment-box">
+                            {{ comment }}
+                          </div>
+                        {% else %}
+                          <textarea {{ 'disabled' if evaluation and edit is false }} class="form-control"
+                            name="comment-{{ criterion_code }}" rows="3" placeholder="Comment (optional)">{{ comment }}</textarea>
+                        {% endif %}
                       </div>
                       <input type="url" {{ 'disabled' if evaluation and edit is false }} class="form-control" name="link-{{ criterion_code }}"
                         placeholder="{{ link or 'Supporting link (optional)' }}" value="">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6085 

### Main branch, web page

<img width="1069" height="538" alt="image" src="https://github.com/user-attachments/assets/7e125510-50ba-4aa6-8a2a-e3ed6de87dc2" />

### Main branch, PDF

<img width="801" height="383" alt="image" src="https://github.com/user-attachments/assets/0a847d57-e607-4816-a614-9dbe562e5bde" />


### This branch, web page

<img width="1047" height="649" alt="image" src="https://github.com/user-attachments/assets/52c55eca-f4b8-47ec-81fd-e030dfb610c4" />

### This branch, PDF

<img width="797" height="505" alt="image" src="https://github.com/user-attachments/assets/6f7d2416-693b-4507-9e31-6daecd65215d" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
