### PR TITLE
Hide compounds filters form data conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Revert form data passing for SNVs (#6190)
+
 ## [4.109.2]
 ### Fixed
 - Fix more variant page `compounds follow filter` issues (#6188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- Revert form data passing for SNVs (#6190)
+- Revert form data passing for SNVs (#6191)
 
 ## [4.109.2]
 ### Fixed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -674,6 +674,8 @@ def update_variant_genes(store, variant_obj, genome_build):
 def _compound_follow_filter_freq(compound: dict, compound_var_obj: dict, query_form: dict) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
+
     There are some similarities between how the query options are filtered that we can reuse, e.g. the freq items
     are filtered the same way.
     """
@@ -713,6 +715,8 @@ def _compound_follow_filter_lt(compound: dict, compound_var_obj: dict, query_for
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the positions.
 
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
+
     Returns true if the compound was hidden.
     """
     compound_follow_lt_items = ["cadd_score", "end"]
@@ -744,6 +748,8 @@ def _compound_follow_filter_gt(compound: dict, compound_var_obj: dict, query_for
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the positions.
+
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
 
     Returns true if the compound was hidden.
     """
@@ -794,13 +800,6 @@ def _compound_follow_filter_in(compound: dict, compound_var_obj: dict, query_for
             compound_items = []
             compound_items.append(compound_var_obj.get(compound_item_name))
 
-            LOG.info(
-                "item %s compound item %s compound items %s query_form items %s",
-                item,
-                compound_item_name,
-                compound_items,
-                query_form_items,
-            )
             if not compound_items:
                 compound["is_dismissed"] = True
                 LOG.info("dismissing it!")

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -893,7 +893,9 @@ def _compound_follow_filter_clnsig(
     return False
 
 
-def _compound_follow_filter_spidex(compound, compound_var_obj, query_form):
+def _compound_follow_filter_spidex(
+    compound: dict, compound_var_obj: dict, query_form: dict
+) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some filter options that are rather unique, like the leveled spidex one. SPIDEX score levels are symmetric
@@ -901,10 +903,6 @@ def _compound_follow_filter_spidex(compound, compound_var_obj, query_form):
     The spidex score on the variant object is a scalar. The user selects one or more levels such as "medium" to filter in
     the query.
 
-    Args:
-        compound(dict)
-        compound_variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
     Returns boolean, true if the compound was hidden.
     """
     spidex_human = query_form.get("spidex_human")
@@ -937,6 +935,8 @@ def compound_follow_filter(compound: dict, compound_var_obj: dict, query_form: d
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the freq items
     are filtered the same way.
+
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
     """
 
     if _compound_follow_filter_lt(compound, compound_var_obj, query_form):
@@ -967,8 +967,8 @@ def hide_compounds_query(store: MongoAdapter, variant_obj: dict, query_form: dic
     If compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
     If a hiding compounds was engaged, non_loaded variants are considered of small interest to the users and also shaded.
 
-        variant_obj follows scout.models.Variant.
-        query_form is data derived from a VariantFiltersForm.
+    variant_obj follows scout.models.Variant.
+    query_form is data derived from a VariantFiltersForm.
     """
 
     if not query_form:
@@ -992,31 +992,25 @@ def hide_compounds_query(store: MongoAdapter, variant_obj: dict, query_form: dic
 
 
 def parse_variant(
-    store,
-    institute_obj,
-    case_obj,
-    variant_obj,
-    update=False,
-    genome_build="37",
-    get_compounds=True,
-    case_dismissed_vars=[],
-    query_form=None,
+    store: MongoAdapter,
+    institute_obj: dict,
+    case_obj: dict,
+    variant_obj: dict,
+    update: bool = False,
+    genome_build: str = "37",
+    get_compounds: bool = True,
+    case_dismissed_vars: list = [],
+    query_form: dict = None,
 ):
     """Parse information about variants.
     - Adds information about compounds and genes
     - Updates some information about compounds if necessary and 'update=True'
     - Hide compound variants if query form filter indicates so.
 
-    Args:
-        store(scout.adapter.MongoAdapter)
-        institute_obj(scout.models.Institute)
-        case_obj(scout.models.Case)
-        variant_obj(scout.models.Variant)
-        update(bool): If variant should be updated in database
-        get_compounds(bool): if compounds should be added to added to the returned variant object
-        genome_build(str)
-        case_dismissed_vars(list): list of dismissed variants for this case
-        query_form(dict): query form for additional compounds filtering
+    Args details:
+        get_compounds - flags if compounds should be added to the returned variant object
+        case_dismissed_vars - list of dismissed variants for this case
+        query_form - query form data for additional compounds filtering
     """
 
     compounds_have_changed = False

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -671,9 +671,7 @@ def update_variant_genes(store, variant_obj, genome_build):
     return has_changed
 
 
-def _compound_follow_filter_freq(
-    compound, compound_var_obj, query_form: VariantFiltersForm
-) -> bool:
+def _compound_follow_filter_freq(compound: dict, compound_var_obj: dict, query_form: dict) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the freq items
@@ -710,9 +708,7 @@ def _compound_follow_filter_freq(
     return False
 
 
-def _compound_follow_filter_lt(
-    compound: dict, compound_var_obj: dict, query_form: VariantFiltersForm
-) -> bool:
+def _compound_follow_filter_lt(compound: dict, compound_var_obj: dict, query_form: dict) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the positions.
@@ -744,9 +740,7 @@ def _compound_follow_filter_lt(
     return False
 
 
-def _compound_follow_filter_gt(
-    compound: dict, compound_var_obj: dict, query_form: VariantFiltersForm
-) -> bool:
+def _compound_follow_filter_gt(compound: dict, compound_var_obj: dict, query_form: dict) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the positions.
@@ -779,16 +773,14 @@ def _compound_follow_filter_gt(
     return False
 
 
-def _compound_follow_filter_in(compound, compound_var_obj, query_form):
+def _compound_follow_filter_in(compound: dict, compound_var_obj: dict, query_form: dict) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the ones with
     multiple categories such as sv_type or clin_sig.
 
-    Args:
-        compound(dict)
-        compound_variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
+
     Returns boolean, true if the compound was hidden.
     """
 
@@ -821,17 +813,17 @@ def _compound_follow_filter_in(compound, compound_var_obj, query_form):
     return False
 
 
-def _compound_follow_filter_in_compound(compound, compound_var_obj, query_form):
+def _compound_follow_filter_in_compound(
+    compound: dict, compound_var_obj: dict, query_form: dict
+) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the ones with
     multiple categories such as region and functional annotations. These are transferred to the compound dict itself
     upon creation, from the compound_var_obj genes and transcripts.
 
-    Args:
-        compound(dict)
-        compound_variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
+    compound_variant_obj follows scout.models.Variant, query_form is form data from a VariantFiltersForm.
+
     Returns boolean, true if the compound was hidden.
     """
     compound_follow_in_items = [
@@ -860,17 +852,15 @@ def _compound_follow_filter_in_compound(compound, compound_var_obj, query_form):
     return False
 
 
-def _compound_follow_filter_clnsig(compound, compound_var_obj, query_form):
+def _compound_follow_filter_clnsig(
+    compound: dict, compound_var_obj: dict, query_form: dict
+) -> bool:
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some filter options that are rather unique, like the ClinVar one.
 
     If prioritise_clinvar is checked, variants are currently never dismissed on ClinSig alone.
 
-    Args:
-        compound(dict)
-        compound_variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
     Returns boolean, true if the compound was hidden.
     """
     query_rank = []
@@ -943,15 +933,11 @@ def _compound_follow_filter_spidex(compound, compound_var_obj, query_form):
     return False
 
 
-def compound_follow_filter(compound, compound_var_obj, query_form):
+def compound_follow_filter(compound: dict, compound_var_obj: dict, query_form: dict):
     """When compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
 
     There are some similarities between how the query options are filtered that we can reuse, e.g. the freq items
     are filtered the same way.
-    Args:
-        compound(dict)
-        compound_variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
     """
 
     if _compound_follow_filter_lt(compound, compound_var_obj, query_form):
@@ -976,15 +962,14 @@ def compound_follow_filter(compound, compound_var_obj, query_form):
         return
 
 
-def hide_compounds_query(store, variant_obj, query_form):
+def hide_compounds_query(store: MongoAdapter, variant_obj: dict, query_form: dict):
     """Check compound against current query form values.
     Check the query hide rank score, and dismiss compound from current view if its rank score is equal or lower.
     If compound follow filter is selected, apply relevant settings from the query filter onto dismissing compounds.
     If a hiding compounds was engaged, non_loaded variants are considered of small interest to the users and also shaded.
-    Args:
-        store(scout.adapter.MongoAdapter)
-        variant_obj(scout.models.Variant)
-        query_form(VariantFiltersForm)
+
+        variant_obj follows scout.models.Variant.
+        query_form is data derived from a VariantFiltersForm.
     """
 
     if not query_form:

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -306,7 +306,7 @@ def render_variants_page(
 
     args = [store, institute_obj, case_obj, variants_query, page]
     if category == "snv":
-        args.append(request.form)
+        args.append(form.data)
     elif category == "cancer":
         args.append(form)
 
@@ -700,6 +700,7 @@ def _compound_follow_filter_freq(
         try:
             query_form_item = float(raw_form_value)
         except (TypeError, ValueError):
+            flash(f"error converting {query_form_item}", category="error")
             continue
 
         if float(compound_item) >= query_form_item:
@@ -733,6 +734,7 @@ def _compound_follow_filter_lt(
         try:
             query_form_item = float(raw_form_value)
         except (TypeError, ValueError):
+            flash(f"error converting {query_form_item}", category="error")
             continue
 
         if float(compound_item) < query_form_item:
@@ -767,6 +769,7 @@ def _compound_follow_filter_gt(
         try:
             query_form_item = float(raw_form_value)
         except (TypeError, ValueError):
+            flash(f"error converting {query_form_item}", category="error")
             continue
 
         if float(compound_item) > query_form_item:
@@ -950,6 +953,8 @@ def compound_follow_filter(compound, compound_var_obj, query_form):
         compound_variant_obj(scout.models.Variant)
         query_form(VariantFiltersForm)
     """
+
+    print(f"DEBUG: {query_form}")
 
     if _compound_follow_filter_lt(compound, compound_var_obj, query_form):
         return

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -954,8 +954,6 @@ def compound_follow_filter(compound, compound_var_obj, query_form):
         query_form(VariantFiltersForm)
     """
 
-    print(f"DEBUG: {query_form}")
-
     if _compound_follow_filter_lt(compound, compound_var_obj, query_form):
         return
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6190 
- Fix #6189 


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
