### PR TITLE
Fix #6177 - variant verification aka Sanger order includes build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Changed
-- Genome build is now shown on variant verification "Sanger" emails (#6193)
+- Genome build is now shown on variant verification "Sanger" emails (#6194)
 
 ## [4.109.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- Genome build is now shown on variant verification "Sanger" emails (#6193)
+
 ## [4.109.3]
 ### Fixed
 - Revert form data passing for SNVs (#6191)

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -60,6 +60,7 @@ from .utils import (
     frequency,
     get_callers,
     get_filters,
+    get_variant_genome_build,
     is_affected,
     predictions,
 )
@@ -235,7 +236,7 @@ def variant(
 
     variant_id = variant_obj["variant_id"]
 
-    genome_build = get_case_genome_build(case_obj)
+    genome_build = get_variant_genome_build(variant_obj, case_obj)
 
     # is variant located on the mitochondria
     variant_obj["is_mitochondrial"] = any(
@@ -458,7 +459,7 @@ def set_edge_genes(store: MongoAdapter, case_obj: dict, variant_obj: dict):
     if variant_obj["category"] not in ["sv", "cancer_sv"]:
         return
 
-    genome_build = get_case_genome_build(case_obj)
+    genome_build = get_variant_genome_build(variant_obj, case_obj)
 
     start_genes = store.genes_by_coordinate(
         chromosome=variant_obj["chromosome"],
@@ -759,7 +760,7 @@ def variant_acmg(store: MongoAdapter, institute_id: str, case_name: str, variant
         store, variant_obj, institute_id, case_name
     )
 
-    genome_build = get_case_genome_build(case_obj)
+    genome_build = get_variant_genome_build(variant_obj, case_obj)
 
     add_gene_info(store, variant_obj, genome_build=genome_build)
 

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -12,6 +12,7 @@ from scout.constants import (
     VARIANT_FILTERS,
 )
 from scout.server.links import add_gene_links, add_tx_links
+from scout.server.utils import get_case_genome_build
 
 LOG = logging.getLogger(__name__)
 
@@ -694,3 +695,11 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
     if alt_num:
         alt_mc = int(alt_num.group())
         return alt_mc
+
+
+def get_variant_genome_build(variant_obj: dict, case_obj: dict) -> str:
+    """Return variant genome build from variant object or case object.
+    Some variants, e.g. omics outliers, have genome build set. Otherwise, use case build.
+    """
+
+    return variant_obj.get("build", get_case_genome_build(case_obj))

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -8,9 +8,10 @@ from flask_mail import Message
 
 from scout.server.extensions import mail as ex_mail
 from scout.server.links import external_primer_order_link
-from scout.server.utils import get_case_genome_build, get_variant_genome_build
+from scout.server.utils import get_case_genome_build
 
 from .controllers import variant as variant_controller
+from .utils import get_variant_genome_build
 
 LOG = logging.getLogger(__name__)
 

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -105,7 +105,7 @@ def variant_verification(
     external_primer_link = ""
 
     # Some variants, e.g. omics outliers, have genome build set. Otherwise, use case build.
-    genome_build = variant_obj.get("build", case_obj.get("build"))
+    genome_build = variant_obj.get("build", case_obj.get("genome_build"))
 
     if category == "snv":  # SNV
         view_type = "variant.variant"

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -8,6 +8,7 @@ from flask_mail import Message
 
 from scout.server.extensions import mail as ex_mail
 from scout.server.links import external_primer_order_link
+from scout.server.utils import get_case_genome_build, get_variant_genome_build
 
 from .controllers import variant as variant_controller
 
@@ -104,14 +105,15 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
-    # Some variants, e.g. omics outliers, have genome build set. Otherwise, use case build.
-    genome_build = variant_obj.get("build", case_obj.get("genome_build"))
+    genome_build = get_variant_genome_build(variant_obj, case_obj)
 
     if category == "snv":  # SNV
         view_type = "variant.variant"
         tx_changes = []
 
-        external_primer_link = external_primer_order_link(variant_obj, case_obj["genome_build"])
+        external_primer_link = external_primer_order_link(
+            variant_obj, get_case_genome_build(case_obj)
+        )
 
         for gene_obj in variant_obj.get("genes", []):
             for tx_obj in gene_obj["transcripts"]:

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -104,7 +104,7 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
-    # Some variants, e.g. omics outliers, have genome build set. Case always does.
+    # Some variants, e.g. omics outliers, have genome build set. Otherwise, use case build.
     genome_build = variant_obj.get("build", case_obj.get("build"))
 
     if category == "snv":  # SNV

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -104,7 +104,7 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
-    if build in variant_obj:
+    if "build in variant_obj:
         genome_build = variant_obj["genome_build"]
     else:
         genome_build = case_obj["genome_build"]

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -104,11 +104,8 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
-    if "build" in variant_obj:
-        # Some variants, eg omics outliers, have build set
-        genome_build = variant_obj["build"]
-    else:
-        genome_build = case_obj["genome_build"]
+    # Some variants, e.g. omics outliers, have genome build set. Case always does.
+    genome_build = variant_obj.get("build", case_obj.get("build"))
 
     if category == "snv":  # SNV
         view_type = "variant.variant"

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -104,8 +104,9 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
-    if "build in variant_obj:
-        genome_build = variant_obj["genome_build"]
+    if "build" in variant_obj:
+        # Some variants, eg omics outliers, have build set
+        genome_build = variant_obj["build"]
     else:
         genome_build = case_obj["genome_build"]
 

--- a/scout/server/blueprints/variant/verification_controllers.py
+++ b/scout/server/blueprints/variant/verification_controllers.py
@@ -104,6 +104,11 @@ def variant_verification(
     tx_changes = []
     external_primer_link = ""
 
+    if build in variant_obj:
+        genome_build = variant_obj["genome_build"]
+    else:
+        genome_build = case_obj["genome_build"]
+
     if category == "snv":  # SNV
         view_type = "variant.variant"
         tx_changes = []
@@ -159,6 +164,7 @@ def variant_verification(
         display_name=display_name,
         category=category.upper(),
         subcategory=variant_obj.get("sub_category").upper(),
+        build=genome_build,
         breakpoint_1=breakpoint_1,
         breakpoint_2=breakpoint_2,
         chr_position=chr_position,
@@ -222,22 +228,23 @@ def variant_verification(
 
 
 def verification_email_body(
-    case_name,
-    url,
-    display_name,
-    category,
-    subcategory,
-    chr_position,
-    breakpoint_1,
-    breakpoint_2,
-    hgnc_symbol,
-    panels,
-    gtcalls,
-    tx_changes,
-    name,
-    comment,
-    external_primer_link,
-):
+    case_name: str,
+    url: str,
+    display_name: str,
+    category: str,
+    subcategory: str,
+    chr_position: str,
+    build: str,
+    breakpoint_1: str,
+    breakpoint_2: str,
+    hgnc_symbol: str,
+    panels: str,
+    gtcalls: str,
+    tx_changes: str,
+    name: str,
+    comment: str,
+    external_primer_link: str,
+) -> str:
     """
     Builds the html code for the variant verification emails (order verification and cancel verification)
 
@@ -272,6 +279,7 @@ def verification_email_body(
            <strong>Case {case_name}</strong>: <a href="{url}">{display_name}</a>
          </li>
          <li><strong>Variant type</strong>: {category} ({subcategory})
+         <li><strong>Genome build</strong>: {build}</li>
          <li><strong>Chromosomal position</strong>: {chr_position}</li>
          <li><strong>Breakpoint 1</strong>: {breakpoint_1}</li>
          <li><strong>Breakpoint 2</strong>: {breakpoint_2}</li>
@@ -291,6 +299,7 @@ def verification_email_body(
         display_name=display_name,
         category=category,
         subcategory=subcategory,
+        build=build,
         chr_position=chr_position,
         breakpoint_1=breakpoint_1,
         breakpoint_2=breakpoint_2,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6177

<img width="301" height="101" alt="Screenshot 2026-04-09 at 16 08 31" src="https://github.com/user-attachments/assets/9346e52f-75b9-49f4-8698-3da22e2e8592" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN