### PR TITLE
Fall back to gens v3 if v4 not detected, if not configured otherwise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Genome build is now shown on variant verification "Sanger" emails (#6194)
+- Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 
 ## [4.109.3]
 ### Fixed

--- a/scout/server/blueprints/cases/templates/cases/gens.html
+++ b/scout/server/blueprints/cases/templates/cases/gens.html
@@ -1,4 +1,5 @@
 {% macro gens_individual_button(case, ind, gens_info=None) %}
+
   {% if gens_info and gens_info.display %}
     <a style="font-size: .8rem;" class="btn btn-secondary text-white btn-sm float-end" target="_blank" href={% if gens_info.version > 3 %}
         "https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&sample_ids={{ind.individual_id}}"

--- a/scout/server/blueprints/cases/templates/cases/gens.html
+++ b/scout/server/blueprints/cases/templates/cases/gens.html
@@ -1,5 +1,4 @@
 {% macro gens_individual_button(case, ind, gens_info=None) %}
-
   {% if gens_info and gens_info.display %}
     <a style="font-size: .8rem;" class="btn btn-secondary text-white btn-sm float-end" target="_blank" href={% if gens_info.version > 3 %}
         "https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&sample_ids={{ind.individual_id}}"

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -52,7 +52,7 @@ class GensViewer:
         The base API URL for Gens v4 has the version returned.
         The same page for v3 will return a Gens error page, though with status 200.
         """
-        base_url = f"https://{self.host}:{self.port}" if self.port else self.host
+        base_url = f"https://{self.host}:{self.port}" if self.port else f"https://{self.host}"
         json_resp = get_request_json(f"{base_url}/api/")
         version = GENS_DEFAULT_VERSION
         content = json_resp.get("content", {})

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -22,7 +22,6 @@ class GensViewer:
         self.host = None
         self.port = None
         self.version: int | None = None
-        self.auth_failure: bool = False
 
     def init_app(self, app):
         """Setup Gens config."""
@@ -35,11 +34,8 @@ class GensViewer:
     def connection_settings(self, genome_build: str = "37") -> dict:
         """Return information on where Gens is hosted.
         Check version if no version is set already. This needs to be done
-        after authentication, so delaying until called from a Scout view .
+        after authentication, so delaying until called from a Scout view.
         """
-
-        if self.auth_failure:
-            self.version = self.get_version()
 
         settings = {}
         if self.host:
@@ -47,7 +43,7 @@ class GensViewer:
             settings = {
                 "host": base_url,
                 "genome_build": genome_build,
-                "version": self.version if self.version else self.get_version(),
+                "version": self.version or self.get_version(),
             }
         return {"display": bool(settings), **settings}
 
@@ -86,9 +82,10 @@ class GensViewer:
         content = json_resp.get("content", {})
         if json_resp.get("status_code") == 200 and "version" in content:
             version = int(content.get("version")[0])
-            self.auth_failure = False
             return version
         if json_resp.get("status_code") == 401:
-            self.auth_failure = True
-            return None
+            LOG.warning(
+                "Authentication failure when trying to get Gens version. Gens is at least v4."
+            )
+            return 4
         return None

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -12,7 +12,7 @@ import logging
 from scout.utils.scout_requests import get_request_json
 
 LOG = logging.getLogger(__name__)
-GENS_DEFAULT_VERSION = 4
+GENS_DEFAULT_VERSION = 3
 
 
 class GensViewer:

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -22,6 +22,7 @@ class GensViewer:
         self.host = None
         self.port = None
         self.version: int | None = None
+        self.auth_failure: bool = False
 
     def init_app(self, app):
         """Setup Gens config."""
@@ -34,8 +35,12 @@ class GensViewer:
     def connection_settings(self, genome_build: str = "37") -> dict:
         """Return information on where Gens is hosted.
         Check version if no version is set already. This needs to be done
-        after authentication, so delaying until called from a Scout view.
+        after authentication, so delaying until called from a Scout view .
         """
+
+        if self.auth_failure:
+            self.version = self.get_version()
+
         settings = {}
         if self.host:
             base_url = f"{self.host}:{self.port}" if self.port else self.host
@@ -72,9 +77,18 @@ class GensViewer:
         return GENS_DEFAULT_VERSION
 
     def _check_version(self, base_url: str) -> int | None:
+        """Check the version of Gens by making a request to the base API URL.
+        This will only work for Gens v4 and onward, as earlier versions do not have this endpoint.
+        Keep track if we received an authentication failure on the last try. Then it would be useful
+        to make individual checks once the user is logged in."""
+
         json_resp = get_request_json(f"{base_url}/api/")
         content = json_resp.get("content", {})
         if json_resp.get("status_code") == 200 and "version" in content:
             version = int(content.get("version")[0])
+            self.auth_failure = False
             return version
+        if json_resp.get("status_code") == 401:
+            self.auth_failure = True
+            return None
         return None

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -58,21 +58,19 @@ class GensViewer:
         base_url = (
             f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
         )
-        if version := self._check_version(base_url):
+        if version := self.get_version_from_api(base_url):
             return version
-        else:
-            protocol = "http"
-            base_url = (
-                f"{protocol}://{self.host}:{self.port}"
-                if self.port
-                else f"{protocol}://{self.host}"
-            )
-            if version := self._check_version(base_url):
-                return version
+
+        protocol = "http"
+        base_url = (
+            f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
+        )
+        if version := self.get_version_from_api(base_url):
+            return version
 
         return GENS_DEFAULT_VERSION
 
-    def _check_version(self, base_url: str) -> int | None:
+    def get_version_from_api(self, base_url: str) -> int | None:
         """Check the version of Gens by making a request to the base API URL.
         This will only work for Gens v4 and onward, as earlier versions do not have this endpoint.
         Keep track if we received an authentication failure on the last try. Then it would be useful

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -54,21 +54,15 @@ class GensViewer:
         The same page for v3 will return a Gens error page, though with status 200.
         """
 
-        protocol = "https"
-        base_url = (
-            f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
-        )
-        if version := self.get_version_from_api(base_url):
-            return version
-
-        protocol = "http"
-        base_url = (
-            f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
-        )
-        if version := self.get_version_from_api(base_url):
-            return version
+        for protocol in ["http", "https"]:
+            if version := self.get_version_from_api(self.get_base_url(protocol)):
+                return version
 
         return GENS_DEFAULT_VERSION
+
+    def get_base_url(self, protocol: str = "https") -> str:
+        """Return the base URL for Gens, with the specified protocol."""
+        return f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
 
     def get_version_from_api(self, base_url: str) -> int | None:
         """Check the version of Gens by making a request to the base API URL.

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -49,15 +49,32 @@ class GensViewer:
     def get_version(self) -> int:
         """Return gens version.
 
-        The base API URL for Gens v4 has the version returned.
+        The base API URL for Gens v4 has the version returned. Server could be https or http.
         The same page for v3 will return a Gens error page, though with status 200.
         """
-        base_url = f"https://{self.host}:{self.port}" if self.port else f"https://{self.host}"
+
+        protocol = "https"
+        base_url = (
+            f"{protocol}://{self.host}:{self.port}" if self.port else f"{protocol}://{self.host}"
+        )
+        if version := self._check_version(base_url):
+            return version
+        else:
+            protocol = "http"
+            base_url = (
+                f"{protocol}://{self.host}:{self.port}"
+                if self.port
+                else f"{protocol}://{self.host}"
+            )
+            if version := self._check_version(base_url):
+                return version
+
+        return GENS_DEFAULT_VERSION
+
+    def _check_version(self, base_url: str) -> int | None:
         json_resp = get_request_json(f"{base_url}/api/")
-        version = GENS_DEFAULT_VERSION
         content = json_resp.get("content", {})
         if json_resp.get("status_code") == 200 and "version" in content:
-            version = int(content.get("version", "3")[0])
-            self.version = version
-
-        return version
+            version = int(content.get("version")[0])
+            return version
+        return None

--- a/scout/server/extensions/gens_extension.py
+++ b/scout/server/extensions/gens_extension.py
@@ -51,7 +51,6 @@ class GensViewer:
         """Return gens version.
 
         The base API URL for Gens v4 has the version returned. Server could be https or http.
-        The same page for v3 will return a Gens error page, though with status 200.
         """
 
         for protocol in ["http", "https"]:
@@ -67,8 +66,11 @@ class GensViewer:
     def get_version_from_api(self, base_url: str) -> int | None:
         """Check the version of Gens by making a request to the base API URL.
         This will only work for Gens v4 and onward, as earlier versions do not have this endpoint.
-        Keep track if we received an authentication failure on the last try. Then it would be useful
-        to make individual checks once the user is logged in."""
+
+        The same page for v3 will return a Gens error page, though with status 200.
+
+        If the call fails with status 401, then we have found a >v4 gens server.
+        """
 
         json_resp = get_request_json(f"{base_url}/api/")
         content = json_resp.get("content", {})


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Probably should have been this way from the start. It is still possible to configure a version in the server config anyway.

<img width="192" height="176" alt="Screenshot 2026-04-13 at 11 35 09" src="https://github.com/user-attachments/assets/02546fae-c882-40f8-bd1d-83bbf2c38f46" />
<img width="678" height="54" alt="Screenshot 2026-04-13 at 11 38 06" src="https://github.com/user-attachments/assets/99a7f478-6cf5-44bc-b8a5-59cb7ccd7a3c" />
<img width="204" height="164" alt="Screenshot 2026-04-13 at 11 37 42" src="https://github.com/user-attachments/assets/a7429860-b1ae-490a-91a1-6aba32135999" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
