### PR TITLE
Fix 6196 - default STR variants page to show unaffected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Refactor, speedup (dry-run only) and add a progress bar to `scout delete variants` cmd (#6094)
 - `scout delete variants` command now accepts an optional `--out-file` where to print a detailed report of the deletion process (#6094)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
+- By default, display STR loci from VCF also when no call is made (#6197)
 
 ## [4.109.3]
 ### Fixed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -1881,7 +1881,10 @@ def _populate_form_genes_from_file(
 def populate_variants_filters_form(
     store: MongoAdapter, institute_obj: dict, case_obj: dict, category: str, request_obj: LocalProxy
 ) -> Union[StrFiltersForm, SvFiltersForm, CancerSvFiltersForm, MeiFiltersForm]:
-    """Populate a filters form for SVs, cancer SVs, MEIs and STRs pages."""
+    """Populate a filters form for SVs, cancer SVs, MEIs and STRs pages.
+
+    For STR variants, ensure show_unaffected defaults to True if not explicitly set
+    """
 
     user_obj = store.user(current_user.email)
     variant_type = request_obj.values.get("variant_type", "clinical")
@@ -1893,7 +1896,8 @@ def populate_variants_filters_form(
         form.chrom.data = request_obj.args.get("chrom", "")  # set chromosome to all chromosomes
         if form.gene_panels.data == [] and variant_type == "clinical":
             form.gene_panels.data = case_default_panels(case_obj)
-
+        if category == "str" and "show_unaffected" not in request_obj.args:
+            form.show_unaffected.data = True
     else:  # POST
         form = populate_filters_form(
             store, institute_obj, case_obj, user_obj, category, request_obj.form

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -285,6 +285,34 @@ def test_str_variants(app, institute_obj, case_obj):
         assert resp.status_code == 200
 
 
+def test_str_variants_show_unaffected_default(app, institute_obj, case_obj):
+    """Test that show_unaffected checkbox is checked by default for STR variants."""
+
+    with app.test_client() as client:
+        # GIVEN that the user could be logged in
+        client.get(url_for("auto_login"))
+
+        # WHEN accessing the STR-variants page without specifying show_unaffected
+        resp = client.get(
+            url_for(
+                "variants.str_variants",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+            )
+        )
+
+        # THEN it should return a page
+        assert resp.status_code == 200
+
+        # AND the show_unaffected checkbox should be checked
+        assert b'id="show_unaffected"' in resp.data
+        # AND The checked attribute should be present on the checkbox - WTForms renders checked inputs
+        assert (
+            b"checked" in resp.data.split(b'id="show_unaffected"')[1].split(b">")[0]
+            or b"checked" in resp.data.split(b'name="show_unaffected"')[0].split(b"<input")[-1]
+        )
+
+
 def test_fusion_variants(app, institute_obj, fusion_case_obj, fusion_variant_objs):
     """Test the page that displays a list of RNA fusion variants."""
 

--- a/tests/server/blueprints/variants/test_variants_views.py
+++ b/tests/server/blueprints/variants/test_variants_views.py
@@ -264,35 +264,17 @@ def test_sv_variants_post_data(app, institute_obj, case_obj):
         assert resp.status_code == 200
 
 
-def test_str_variants(app, institute_obj, case_obj):
+def test_str_variants_show_unaffected_default(app, institute_obj, case_obj):
+    """Test that show_unaffected checkbox is checked by default for STR variants.
+    Also generally tests that the STR view works."""
+
     # GIVEN an initialized app
     # GIVEN a valid user and institute
-
-    with app.test_client() as client:
-        # GIVEN that the user could be logged in
-        resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
-
-        # WHEN accessing the str-variants page
-        resp = client.get(
-            url_for(
-                "variants.str_variants",
-                institute_id=institute_obj["internal_id"],
-                case_name=case_obj["display_name"],
-            )
-        )
-        # THEN it should return a page
-        assert resp.status_code == 200
-
-
-def test_str_variants_show_unaffected_default(app, institute_obj, case_obj):
-    """Test that show_unaffected checkbox is checked by default for STR variants."""
-
     with app.test_client() as client:
         # GIVEN that the user could be logged in
         client.get(url_for("auto_login"))
 
-        # WHEN accessing the STR-variants page without specifying show_unaffected
+        # WHEN accessing the STR-variants page - without specifying show_unaffected
         resp = client.get(
             url_for(
                 "variants.str_variants",


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6196 

Especially with LRS being a bit unreliable on large expansions, it makes sense to show as many lines as we can from the VCF, even if they are not formally called. Compare this "unknown" TRGT call, with a LowDepth flag from STRdrop.

<img width="796" height="486" alt="Screenshot 2026-04-14 at 09 02 11" src="https://github.com/user-attachments/assets/64b18931-30a4-4aef-ac5c-01d85e729c70" />
<img width="1036" height="478" alt="Screenshot 2026-04-14 at 09 02 17" src="https://github.com/user-attachments/assets/98005466-330f-4836-a551-967c610b7059" />

Now on by default for strs only, and institute `check_show_all_vars` is still respected.
<img width="997" height="206" alt="Screenshot 2026-04-14 at 09 52 37" src="https://github.com/user-attachments/assets/4722317c-97bc-4efc-a773-f7a68e4a1148" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
