### PR TITLE
Fix formatting  on managed variant export documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `scout delete variants` command now accepts an optional `--out-file` where to print a detailed report of the deletion process (#6094)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 - By default, display STR loci from VCF also when no call is made (#6197)
+### Fixed
+- Formatting of a list on managed variant export documentation (#6202)
 
 ## [4.109.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 - By default, display STR loci from VCF also when no call is made (#6197)
 ### Fixed
-- Formatting of a list on managed variant export documentation (#6202)
+- Formatting of a list on managed variant export documentation (#6203)
 
 ## [4.109.3]
 ### Fixed

--- a/docs/user-guide/variants.md
+++ b/docs/user-guide/variants.md
@@ -145,6 +145,7 @@ Initial lines starting with `##` are considered comments and are ignored.
 The first other line starting with `#`, or the first line in the file is treated as the header line.
 
 The columns that will be used by Scout are the following.
+
 - **chromosome(str)** Chromosome name. *Mandatory*
 - **position(int)** Start position. *Mandatory*
 - **end(int)** End position. *Optional*


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Formatting of a list on managed variant export documentation

### Main branch

<img width="644" height="561" alt="image" src="https://github.com/user-attachments/assets/04380234-b3d5-4faf-b19a-7e4fafa752af" />


### This branch

<img width="645" height="674" alt="image" src="https://github.com/user-attachments/assets/83fad79a-968f-41dc-b52c-6c8da9a6fd48" />



<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
