### PR TITLE
Fix #6208 - singleton exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - By default, display STR loci from VCF also when no call is made (#6197)
 ### Fixed
 - Formatting of a list on managed variant export documentation (#6203)
+- Exception for singletons from the "Include variants present only in unaffected" filter (#6209)
 
 ## [4.109.3]
 ### Fixed

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -360,10 +360,10 @@ class QueryHandler(object):
         case_obj = self.case(case_id=case_id, projection=CASE_AFFECTED_INDS_PROJECTION)
         case_inds = case_obj.get("individuals", [])
 
-        gt_query = gt_query or {"$nin": ["0/0", "./.", "./0", "0/."]}
-
         if len(case_inds) == 1 and not gt_query:
             return
+
+        gt_query = gt_query or {"$nin": ["0/0", "./.", "./0", "0/."]}
 
         affected_query = {
             "$elemMatch": {

--- a/tests/adapter/mongo/test_query.py
+++ b/tests/adapter/mongo/test_query.py
@@ -72,6 +72,20 @@ def test_build_query_hide_not_in_affected(adapter, case_obj):
     }
 
 
+def test_build_query_show_unaffected_singleton(adapter, singleton_case):
+    """Test variants query build with show_unaffected parameter for singletons"""
+
+    # GIVEN a singleton case (only one sample)
+    adapter.case_collection.insert_one(singleton_case)
+
+    # WHEN show_unaffected = True param is provided to the query builder
+    query = {"show_unaffected": False}
+    mongo_query = adapter.build_query(singleton_case["_id"], query=query)
+
+    # Then the variant query should not restrain sample id or genotype
+    assert "samples" not in mongo_query
+
+
 def test_build_query_hide_dismissed(adapter, case_obj):
     """Test variants query with hide_dismissed parameter"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -688,6 +688,15 @@ def case_obj(request, parsed_case):
 
 
 @pytest.fixture(scope="function")
+def singleton_case(case_obj):
+    """A fixture that returns a singleton object. Useful for testing that the same object is returned across multiple calls."""
+
+    case_obj["individuals"] = [case_obj["individuals"][0]]
+
+    return case_obj
+
+
+@pytest.fixture(scope="function")
 def one_individual(case_obj):
     return case_obj["individuals"][0]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -689,7 +689,7 @@ def case_obj(request, parsed_case):
 
 @pytest.fixture(scope="function")
 def singleton_case(case_obj):
-    """A fixture that returns a singleton object. Useful for testing that the same object is returned across multiple calls."""
+    """A fixture that returns a singleton case object."""
 
     case_obj["individuals"] = [case_obj["individuals"][0]]
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6208

This seems likely to have been around since 4.107, 260113.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. On a singleton SV variants view, reset filter, uncheck panels. 
2. note the number of variants found with "Filter Include variants present only in unaffected" checked - should be all
3. uncheck "Filter Include variants present only in unaffected" notice the count go down with a handful of odd variants
4. apply patch
5. note all variants filtered in again, even with the toggle unchecked.


**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
