### PR TITLE
Refactor pretty_variant moving from jinja template to Python filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `scout delete variants` command now accepts an optional `--out-file` where to print a detailed report of the deletion process (#6094)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 - By default, display STR loci from VCF also when no call is made (#6197)
-- Refactor variant formatting logic (pretty_variant) out of Jinja2 template (#)
+- Refactor variant formatting logic (pretty_variant) out of Jinja2 template (#6218)
 ### Fixed
 - Formatting of a list on managed variant export documentation (#6203)
 - Exception for singletons from the "Include variants present only in unaffected" filter (#6209)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `scout delete variants` command now accepts an optional `--out-file` where to print a detailed report of the deletion process (#6094)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 - By default, display STR loci from VCF also when no call is made (#6197)
+- Refactor variant formatting logic (pretty_variant) out of Jinja2 template (#)
 ### Fixed
 - Formatting of a list on managed variant export documentation (#6203)
 - Exception for singletons from the "Include variants present only in unaffected" filter (#6209)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -320,7 +320,7 @@ def register_filters(app):
     def pretty_variant(variant: dict) -> str:
         """Recaps variant info to string which is both visually appealing and informative."""
 
-        def truncate(value: str | None, length: int = 20)  -> str:
+        def truncate(value: str | None, length: int = 20) -> str:
             if not value:
                 return ""
             value = str(value)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -324,7 +324,7 @@ def register_filters(app):
             if not value:
                 return ""
             value = str(value)
-            return value if len(value) <= length else value[:length]
+            return value[:length]
 
         category = variant.get("category")
 

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -331,8 +331,6 @@ def register_filters(app):
         match category:
             # --- STR ---
             case "str":
-                genes = variant.get("genes", [])
-
                 main = (
                     variant.get("str_repid")
                     or variant.get("str_trid")

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -343,7 +343,7 @@ def register_filters(app):
                     else truncate(variant.get("alternative", ""), 20)
                 )
 
-                return " ".join(filter(None, [main, tail]))
+                return " ".join(part for part in (main, tail) if part)
 
             # --- SNV / cancer ---
             case "snv" | "cancer":

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -388,7 +388,12 @@ def register_filters(app):
                         )
                     case "expression":
                         l2fc = variant.get("l2fc", 0)
-                        arrow = "↑" if l2fc > 0 else "↓" if l2fc < 0 else ""
+                        if l2fc > 0:
+                            arrow = "↑"
+                        elif l2fc < 0:
+                            arrow = "↓"
+                        else:
+                            arrow = ""
                         detail = f"{l2fc}{arrow}"
                     case "methylation":
                         cpg = variant.get("cpg_label", "")

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -320,7 +320,7 @@ def register_filters(app):
     def pretty_variant(variant: dict) -> str:
         """Recaps variant info to string which is both visually appealing and informative."""
 
-        def truncate(value, length):
+        def truncate(value: str | None, length: int = 20)  -> str:
             if not value:
                 return ""
             value = str(value)

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -319,6 +319,7 @@ def register_filters(app):
     @app.template_filter()
     def pretty_variant(variant: dict) -> str:
         """Recaps variant info to string which is both visually appealing and informative."""
+
         def truncate(value, length):
             if not value:
                 return ""
@@ -347,7 +348,7 @@ def register_filters(app):
                 return " ".join(filter(None, [main, tail]))
 
             # --- SNV / cancer ---
-            case"snv" | "cancer":
+            case "snv" | "cancer":
                 display_genes = []
 
                 for g in variant.get("genes", []):
@@ -367,16 +368,13 @@ def register_filters(app):
 
                 return ", ".join(display_genes)
 
-             # --- OUTLIER ---
+            # --- OUTLIER ---
             case "outlier":
                 subcat = variant.get("sub_category", "")
                 genes = variant.get("genes", [])
 
                 gene_part = (
-                    " ".join(
-                        g.get("hgnc_symbol") or str(g.get("hgnc_id", ""))
-                        for g in genes
-                    )
+                    " ".join(g.get("hgnc_symbol") or str(g.get("hgnc_id", "")) for g in genes)
                     if genes
                     else variant.get("gene_name_orig", "")
                 )

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -349,10 +349,10 @@ def register_filters(app):
             case "snv" | "cancer":
                 display_genes = []
 
-                for g in variant.get("genes", []):
-                    symbol = g.get("hgnc_symbol")
-                    hgvs = g.get("hgvs_identifier")
-                    hgnc_id = g.get("hgnc_id")
+                for gene in variant.get("genes", []):
+                    symbol = gene.get("hgnc_symbol")
+                    hgvs = gene.get("hgvs_identifier")
+                    hgnc_id = gene.get("hgnc_id")
 
                     if symbol and hgvs:
                         display_genes.append(f"{symbol} {truncate(hgvs, 20)}")

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -404,7 +404,7 @@ def register_filters(app):
 
                 return " - ".join(filter(None, [subcat.upper(), gene_part, detail]))
 
-            # --- SVs ---
+            # --- SVs, MEIs ---
             case _:
                 return "{}({}{}-{}{})".format(
                     variant.get("sub_category", "").upper(),

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -336,7 +336,7 @@ def register_filters(app):
                 main = (
                     variant.get("str_repid")
                     or variant.get("str_trid")
-                    or " ".join(g.get("symbol", "") for g in genes)
+                    or " ".join(gene.get("symbol", "") for gene in variant.get("genes", []))
                 )
 
                 tail = (

--- a/scout/server/app.py
+++ b/scout/server/app.py
@@ -317,6 +317,101 @@ def register_filters(app):
         return cosmicId
 
     @app.template_filter()
+    def pretty_variant(variant: dict) -> str:
+        """Recaps variant info to string which is both visually appealing and informative."""
+        def truncate(value, length):
+            if not value:
+                return ""
+            value = str(value)
+            return value if len(value) <= length else value[:length]
+
+        category = variant.get("category")
+
+        match category:
+            # --- STR ---
+            case "str":
+                genes = variant.get("genes", [])
+
+                main = (
+                    variant.get("str_repid")
+                    or variant.get("str_trid")
+                    or " ".join(g.get("symbol", "") for g in genes)
+                )
+
+                tail = (
+                    f"STR{variant.get('str_mc')}"
+                    if variant.get("str_mc")
+                    else truncate(variant.get("alternative", ""), 20)
+                )
+
+                return " ".join(filter(None, [main, tail]))
+
+            # --- SNV / cancer ---
+            case"snv" | "cancer":
+                display_genes = []
+
+                for g in variant.get("genes", []):
+                    symbol = g.get("hgnc_symbol")
+                    hgvs = g.get("hgvs_identifier")
+                    hgnc_id = g.get("hgnc_id")
+
+                    if symbol and hgvs:
+                        display_genes.append(f"{symbol} {truncate(hgvs, 20)}")
+                    elif symbol:
+                        display_genes.append(symbol)
+                    elif hgvs and hgnc_id:
+                        display_genes.append(f"{hgnc_id} {truncate(hgvs, 20)}")
+
+                if not display_genes:
+                    display_genes.append(truncate(variant.get("simple_id", ""), 40))
+
+                return ", ".join(display_genes)
+
+             # --- OUTLIER ---
+            case "outlier":
+                subcat = variant.get("sub_category", "")
+                genes = variant.get("genes", [])
+
+                gene_part = (
+                    " ".join(
+                        g.get("hgnc_symbol") or str(g.get("hgnc_id", ""))
+                        for g in genes
+                    )
+                    if genes
+                    else variant.get("gene_name_orig", "")
+                )
+
+                match subcat:
+                    case "splicing":
+                        detail = (
+                            f"{variant.get('delta_psi', '')}Δψ "
+                            f"{variant.get('potential_impact', '')} - fs "
+                            f"{variant.get('causes_frameshift', '')}"
+                        )
+                    case "expression":
+                        l2fc = variant.get("l2fc", 0)
+                        arrow = "↑" if l2fc > 0 else "↓" if l2fc < 0 else ""
+                        detail = f"{l2fc}{arrow}"
+                    case "methylation":
+                        cpg = variant.get("cpg_label", "")
+                        cpg = cpg.split("_")[0] if cpg else ""
+                        detail = f"{variant.get('compare_label', '')} {cpg}"
+                    case _:
+                        detail = ""
+
+                return " - ".join(filter(None, [subcat.upper(), gene_part, detail]))
+
+            # --- SVs ---
+            case _:
+                return "{}({}{}-{}{})".format(
+                    variant.get("sub_category", "").upper(),
+                    variant.get("chromosome", ""),
+                    variant.get("cytoband_start", ""),
+                    variant.get("end_chrom", ""),
+                    variant.get("cytoband_end", ""),
+                )
+
+    @app.template_filter()
     def format_variant_canonical_transcripts(variant: dict) -> List[str]:
         lines = set()
         genes = variant.get("genes") or []

--- a/scout/server/blueprints/cases/templates/cases/utils.html
+++ b/scout/server/blueprints/cases/templates/cases/utils.html
@@ -79,7 +79,7 @@
                         {% if var.category == "snv" %} <!-- Share either gene names or variant details for SNVs -->
 
                           <!-- Share variant it is, could be a multi-gene variant, resulting into multiple gene submission-->
-                          <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}"> ~ Variant {{count.value}} {% if var.genes|length > 1 %} ({{var.genes|length}} genes) {%endif%} ~ {{ pretty_variant(var) }}<span class="badge bg-success">SNV</span><br>
+                          <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}"> ~ Variant {{count.value}} {% if var.genes|length > 1 %} ({{var.genes|length}} genes) {%endif%} ~ {{ var | pretty_variant }}<span class="badge bg-success">SNV</span><br>
 
                           {% if var.genes|length > 1 %} <!-- Share single gene variants from a multi-gene variant -->
                             {% for gene in var.genes %}
@@ -91,7 +91,7 @@
 
                         {% elif var.category == "sv" %} <!-- Share only gene names from SVs -->
                           {% for gene in var.genes %}
-                            <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}"> ~ Variant {{count.value}} ~  {{gene.hgnc_symbol or gene.hgnc_id}} - {{ pretty_variant(var) }} <span class="badge bg-warning">SV</span><br>
+                            <input type="checkbox" name="selected_var" id="var_details" value="{{var._id}}|{{gene.hgnc_symbol or gene.hgnc_id}}"> ~ Variant {{count.value}} ~  {{gene.hgnc_symbol or gene.hgnc_id}} - {{ var | pretty_variant }} <span class="badge bg-warning">SV</span><br>
                           {% endfor %}
                         {% endif %}
                       {% endfor %}
@@ -255,63 +255,6 @@
 </form>
 {% endmacro %}
 
-{% macro pretty_variant(variant) %}
-
-  {% if variant.category %}
-    {% if variant.category in "str" %}
-      {% if variant.str_repid %}
-        {{ variant.str_repid }}
-      {% elif variant.str_trid %}
-        {{ variant.str_trid  }}
-      {% else %}
-        {% for gene in variant.genes %} {{ gene.symbol }} {% endfor %}
-      {% endif %}
-      {% if variant.str_mc %}
-        STR{{ variant.str_mc }}
-      {% else %}
-        {{ variant.alternative|truncate(20,True) }}
-      {% endif %}
-    {% elif variant.category in ("snv", "cancer") %}
-      {% set display_genes = [] %}
-      {% for gene in variant.genes %}
-        {% if gene.hgvs_identifier and gene.hgnc_symbol  %}
-          {{ "" if display_genes.append(gene.hgnc_symbol + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
-        {% elif gene.hgnc_symbol %}
-          {{ "" if display_genes.append(gene.hgnc_symbol) }}
-        {% elif gene.hgvs_identifier and gene.hgnc_id %}
-          {{ "" if display_genes.append( gene.hgnc_id|string + ' ' + gene.hgvs_identifier|truncate(20,True)) }}
-        {% endif %}
-      {% endfor %}
-
-      {% if not display_genes %}
-          {{ "" if display_genes.append( variant.simple_id|truncate(40,True) ) }}
-      {% endif %}
-
-      {{ display_genes|join(", ") }}
-
-    {% elif variant.category == "outlier" %}
-      {{ variant.sub_category|upper }} - {% if variant.genes %}
-        {% for gene in variant.genes %}
-           {% if gene.hgnc_symbol %}
-             {{ gene.hgnc_symbol }}
-           {% else %}
-             {{gene.hgnc_id}}
-           {% endif %}
-        {% endfor %} {% else %}
-          {{ variant.gene_name_orig }}{% endif %} - {% if variant.sub_category == "splicing" %}
-          {{ variant.delta_psi }}&Delta;&psi;  {{ variant.potential_impact }} - fs {{ variant.causes_frameshift }}
-        {% elif variant.sub_category == "expression" %}
-          {{ variant.l2fc }}{% if variant.l2fc > 0 %}&uarr;{% elif variant.l2fc < 0 %}&darr;{% endif %}
-        {% elif variant.sub_category == "methylation" %}
-          {{ variant.compare_label }} {{ variant.cpg_label.split("_")[0] }}
-        {% endif %}
-    {% else %} <!-- structural variants -->
-      {{ variant.sub_category|upper }}({{ variant.chromosome }}{{ variant.cytoband_start }}-{{ variant.end_chrom }}{{ variant.cytoband_end }})
-    {% endif %}
-  {% endif %}
-
-{% endmacro %}
-
 {% macro pretty_link_variant(variant, case) %}
 {# Returns human readable links to the corresponding variant page #}
 
@@ -342,7 +285,7 @@
                               case_name=case.display_name,
                               variant_id=variant._id) }}' target='_blank'>
   {% endif %}
-  {{ pretty_variant(variant) }}
+  {{ variant | pretty_variant }}
   </a>
 {% endmacro %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Refactor pretty_variant moving from jinja template to Python filter

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:

### Main branch

<img width="429" height="417" alt="image" src="https://github.com/user-attachments/assets/a70ca3fc-c363-44de-ae43-8c142c5b7552" />


### This branch

<img width="395" height="402" alt="image" src="https://github.com/user-attachments/assets/fb2aff5f-757d-48cf-b918-cb62e342daed" />


**Expected outcome**:

Page should not change

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
