### PR TITLE
Fix #6241 - add Saltshaker html case report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Custom MT Saltshaker HTML report loading (#6242)
+
 ## [4.110.0]
 ### Added
 - A documentation page for institute settings (#6212)

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -53,6 +53,7 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **RNAfusion_report_research** _String_ Path to HTML [nf-core/rnafusion report][rnafusion-report] containing all detected fusions.
 - **rna_human_genome_build** _String_ Version of reference genome used for RNA components of build. "37" or "38", default "38".
 - **rna_delivery_report** _String_: Path to HTML RNA delivery report.
+- **saltshaker_report** _String_: Path to HTML Saltshaker MT analysis report.
 - **samples** _List_ List of samples included in the case:
     - **alignment_path** _String_ Path to BAM/CRAM file to view alignments.
     - **analysis_type** _String_ Specifies the analysis type for the sample. Options: {wgs, wgs-lr, wes, wts, panel, panel-lr, panel-umi, ogm, unknown, external}.

--- a/docs/admin-guide/loading-case.md
+++ b/docs/admin-guide/loading-case.md
@@ -100,7 +100,7 @@ Usage: scout load report [OPTIONS] CASE_ID REPORT_PATH
   Load a report document for a case.
 
 Options:
-  -t, --report-type [delivery|cnv|cov_qc|exe_ver|multiqc|multiqc_rna|gene_fusion|gene_fusion_research|reference_info|RNAfusion_inspector|RNAfusion_inspector_research|RNAfusion_report|RNAfusion_report_research]
+  -t, --report-type [delivery|cnv|cov_qc|exe_ver|multiqc|multiqc_rna|gene_fusion|gene_fusion_research|reference_info|RNAfusion_inspector|RNAfusion_inspector_research|RNAfusion_report|RNAfusion_report_research|saltshaker_report]
                                   Type of report  [required]
 ```
 

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -1187,6 +1187,7 @@ class CaseHandler(object):
                 "RNAfusion_report": case_obj.get("RNAfusion_report"),
                 "RNAfusion_report_research": case_obj.get("RNAfusion_report_research"),
                 "rna_delivery_report": case_obj.get("rna_delivery_report"),
+                "saltshaker": case_obj.get("saltshaker"),
                 "scout_load_version": case_obj.get("scout_load_version"),
                 "smn_tsv": case_obj.get("smn_tsv"),
                 "status": case_obj.get("status"),

--- a/scout/constants/case_tags.py
+++ b/scout/constants/case_tags.py
@@ -48,6 +48,7 @@ CUSTOM_CASE_REPORTS = {
         "format": "HTML",
         "pdf_export": False,
     },
+    "saltshaker_report": {"key_name": "saltshaker_report", "format": "HTML", "pdf_export": False},
 }
 
 CASE_REPORT_VARIANT_TYPES = {

--- a/scout/models/case/case_loading_models.py
+++ b/scout/models/case/case_loading_models.py
@@ -66,6 +66,7 @@ CASE_FILE_PATH_CHECKS = [
     "RNAfusion_report",
     "RNAfusion_report_research",
     "rna_delivery_report",
+    "saltshaker_report",
     "smn_tsv",
     "somalier_ancestry",
     "somalier_pairs",
@@ -459,6 +460,7 @@ class CaseLoader(BaseModel):
     RNAfusion_report: Optional[str] = None
     RNAfusion_report_research: Optional[str] = None
     rna_delivery_report: Optional[str] = None
+    saltshaker_report: Optional[str] = None
     smn_tsv: Optional[str] = None
     sv_rank_model_url: Optional[str] = None
     sv_rank_model_version: Optional[str] = None


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6241 

<img width="227" height="431" alt="Screenshot 2026-04-28 at 14 41 11" src="https://github.com/user-attachments/assets/f55f9894-b79a-46d7-adb6-183652ffc194" />

<img width="832" height="321" alt="Screenshot 2026-04-28 at 14 41 14" src="https://github.com/user-attachments/assets/c62c8887-0719-4f21-86c1-4f17c6136f99" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
