### PR TITLE
Fix missing commits on Saltshaker report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
 ### Fixed
-- Saltshaker report build (#6246)
+- Saltshaker report update command (#6246)
 
 ## [4.110.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
+### Fixed
+- Saltshaker report build (#6246)
 
 ## [4.110.0]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -1187,7 +1187,7 @@ class CaseHandler(object):
                 "RNAfusion_report": case_obj.get("RNAfusion_report"),
                 "RNAfusion_report_research": case_obj.get("RNAfusion_report_research"),
                 "rna_delivery_report": case_obj.get("rna_delivery_report"),
-                "saltshaker": case_obj.get("saltshaker"),
+                "saltshaker_report": case_obj.get("saltshaker_report"),
                 "scout_load_version": case_obj.get("scout_load_version"),
                 "smn_tsv": case_obj.get("smn_tsv"),
                 "status": case_obj.get("status"),

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -14,7 +14,6 @@ from werkzeug.datastructures import ImmutableMultiDict
 
 from scout.build.case import build_case
 from scout.constants import (
-    ANALYSIS_TYPES,
     ID_PROJECTION,
     ORDERED_FILE_TYPE_MAP,
     ORDERED_OMICS_FILE_TYPE_MAP,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

One commit missing, saltshaker report update case should not work atm.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN (local)
