### PR TITLE
Fix #6243 - hg38 variants default gnomAD link to non-UK-biobank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
+### Changed
+- Default gnomAD linkout for hg38 to non_uk_biobank subset (#6247)
 ### Fixed
 - Saltshaker report update command (#6246)
 

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -92,15 +92,15 @@
                   </li>
                   {% if pli_score %}
                   <li class="list-group-item">
-                    pLi Score (<a href={{ record.gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    pLi Score (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
                     <span class="float-end">
-                      <a target="_blank" href={{ record.exac_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank"> {{ pli_score|round(2) }}</a>
+                      {{ pli_score|round(2) }}
                     </span>
                   </li>
                   {% endif %}
                   {% if constraint_lof_oe %}
                   <li class="list-group-item">
-                    LoF o/e (<a href={{ record.gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    LoF o/e (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
                     <span class="float-end">
                       {{ constraint_lof_oe|round(2) }}({{ constraint_lof_oe_ci_lower|round(2) }} - <mark><span data-bs-toggle="tooltip" title="LOEUF {{ constraint_lof_oe_ci_upper}}">{{ constraint_lof_oe_ci_upper|round(2) }}</span></mark>)
                     </span>
@@ -108,7 +108,7 @@
                 {% endif %}
                 {% if constraint_mis_z %}
                   <li class="list-group-item">
-                    Missense Z (<a href={{ record.gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    Missense Z (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
                     <span class="float-end">
                       {{ constraint_mis_z|round(2) }}
                     </span>
@@ -116,7 +116,7 @@
                 {% endif %}
                   {% if constraint_mis_oe %}
                   <li class="list-group-item">
-                    Missense o/e (<a href={{ record.gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    Missense o/e (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
                     <span class="float-end">
                       {{ constraint_mis_oe|round(2) }}({{ constraint_mis_oe_ci_lower|round(2) }} - {{ constraint_mis_oe_ci_upper|round(2) }})
                     </span>

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -621,8 +621,12 @@ def gnomad_link(variant_obj, build=37):
         url_template += "?dataset=gnomad_r2_1"
         return url_template
 
-    if build == 38 or variant_obj["chromosome"] in ["M", "MT"]:
+    if variant_obj["chromosome"] in ["M", "MT"]:
         url_template += "?dataset=gnomad_r4"
+        return url_template
+
+    if build == 38:
+        url_template += "?dataset=gnomad_r4_non_ukb"
 
     return url_template
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -218,7 +218,7 @@ def gnomad(ensembl_id, build=37):
     if build == 37:
         link += "gnomad_r2_1"
     if build == 38:
-        link += "gnomad_r4"
+        link += "gnomad_r4_non_ukb"
 
     return link.format(ensembl_id)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6243 

No non-uk-biobank for the MT (or for gnomAD v2 / hg19).

<img width="1218" height="77" alt="Screenshot 2026-04-30 at 10 16 02" src="https://github.com/user-attachments/assets/98ef20bf-7bc0-4a1e-adc1-330e8ab61bd0" />

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN 
