### PR TITLE
Fix managed variants counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
+### Fixed
+- Managed variants counter, wrongly defaulting to build 37 (#)
 
 ## [4.110.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
+### Fixed
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
 ### Fixed
-- Managed variants counter, wrongly defaulting to build 37 (#)
+- Managed variants counter, wrongly defaulting to build 37 (#6252)
 
 ## [4.110.0]
 ### Added

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -157,6 +157,7 @@ class ManagedVariantHandler(object):
             pipeline.append({"$limit": vars_per_page})
 
         managed_vars = list(self.managed_variant_collection.aggregate(pipeline))
+
         all_maintainers = set()
         for var in managed_vars:
             all_maintainers.update(var.get("maintainer", []))
@@ -175,7 +176,7 @@ class ManagedVariantHandler(object):
     def count_managed_variants(
         self,
         category=["snv", "sv", "cancer_snv", "cancer_sv"],
-        build="37",
+        build: str = None,
         query_options=None,
     ):
         """Return count of documents to all managed variants of a particular category and build.
@@ -189,7 +190,9 @@ class ManagedVariantHandler(object):
             integer
 
         """
-        query = {"category": {"$in": category}, "build": build}
+        query = {"category": {"$in": category}}
+        if build:
+            query["build"] = build
         query_with_options = self.add_options(query, query_options)
 
         return self.managed_variant_collection.count_documents(query_with_options)

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -78,11 +78,14 @@ def managed_variants(request: LocalProxy) -> dict:
     managed_variants_query = store.managed_variants(
         category=categories,
         query_options=query_options,
+        build=request.form.get("build"),
         skip_count=skip_count,
         vars_per_page=VARS_PER_PAGE,
     )
 
-    variant_count = store.count_managed_variants(category=categories, query_options=query_options)
+    variant_count = store.count_managed_variants(
+        category=categories, build=request.form.get("build"), query_options=query_options
+    )
     total_count = store.count_managed_variants()
     managed_variants = list(managed_variants_query)
 

--- a/scout/server/blueprints/managed_variants/forms.py
+++ b/scout/server/blueprints/managed_variants/forms.py
@@ -48,7 +48,9 @@ class ManagedVariantForm(FlaskForm):
     )
     description = StringField(label="Description")
     build = SelectField(
-        "Genome build", [validators.Optional()], choices=[("37", "37"), ("38", "38")]
+        "Genome build",
+        choices=[("", "Select a build"), ("37", "37"), ("38", "38")],
+        validators=[validators.Optional()],
     )
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6249

### Tested locally with the same managed variants from stage 38

### Main branch

<img width="231" height="71" alt="image" src="https://github.com/user-attachments/assets/70d813a4-2e9a-4fd8-819b-908a65ac840e" />

No pagination (depends on variant counter):

<img width="541" height="83" alt="image" src="https://github.com/user-attachments/assets/0e2dcc7d-7f28-4b8c-ae27-ddeaa59210d4" />


### This branch

<img width="296" height="90" alt="image" src="https://github.com/user-attachments/assets/ac345731-4c1e-4090-b6ce-80bbbea60cf2" />

<img width="462" height="121" alt="image" src="https://github.com/user-attachments/assets/f6e1df2e-686a-408a-961b-f79000ca6638" />




<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
