### PR TITLE
Build sens match managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
-- Managed variants matching follows build on case page (#6554)
+- Managed variants matching follows build on case page (#6254)
 
 ## [4.110.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
+- Managed variants matching follows build on case page (#6554)
 
 ## [4.110.0]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -426,14 +426,16 @@ class VariantHandler(VariantLoader):
 
         return causatives
 
-    def check_managed(self, case_obj: dict = None, limit_genes: list[int] = None):
+    def check_managed(
+        self, case_obj: dict = None, limit_genes: list[int] = None, build: Optional[str] = None
+    ):
         """Check if there are any variants in case that match a managed variant.
 
             Given a case, limit search to affected individuals.
         Returns:
             managed_variants(iterable(Variant))
         """
-        positional_variant_ids = self.get_managed_variants()
+        positional_variant_ids = self.get_managed_variants(build=build)
 
         if len(positional_variant_ids) == 0:
             return []

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -427,7 +427,7 @@ class VariantHandler(VariantLoader):
         return causatives
 
     def check_managed(
-        self, case_obj: dict = None, limit_genes: list[int] = None, build: Optional[str] = None
+        self, case_obj: dict = None, limit_genes: list[int] = None, build: Optional[str] = "37"
     ):
         """Check if there are any variants in case that match a managed variant.
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -556,6 +556,7 @@ def case(
     default_managed_variants = []
     managed_variants = []
 
+    genome_build = get_case_genome_build(case_obj)
     if hide_matching is False:
         # Limit secondary findings according to institute settings
         limit_genes = store.safe_genes_filter(institute_obj["_id"])
@@ -569,12 +570,15 @@ def case(
         )
 
         managed_variants = [
-            var for var in store.check_managed(case_obj=case_obj, limit_genes=limit_genes)
+            var
+            for var in store.check_managed(
+                case_obj=case_obj, limit_genes=limit_genes, build=genome_build
+            )
         ]
         default_managed_variants = [
             var
             for var in store.check_managed(
-                case_obj=case_obj, limit_genes=limit_genes_default_panels
+                case_obj=case_obj, limit_genes=limit_genes_default_panels, build=genome_build
             )
         ]
 
@@ -606,7 +610,7 @@ def case(
         "tissue_types": SAMPLE_SOURCE,
         "report_types": CUSTOM_CASE_REPORTS,
         "mme_nodes": matchmaker.connected_nodes,
-        "gens_info": gens.connection_settings(get_case_genome_build(case_obj)),
+        "gens_info": gens.connection_settings(genome_build),
         "display_rerunner": rerunner.connection_settings.get("display", False),
         "hide_matching": hide_matching,
         "audits": store.case_events_by_verb(


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6253 

<img width="411" height="316" alt="Screenshot 2026-04-30 at 12 56 14" src="https://github.com/user-attachments/assets/bd7e55bd-0d9a-44e4-a669-d81d01ac8050" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
