### PR TITLE
Small fix on managed variant upsert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
 ### Changed
 - Default gnomAD linkout for hg38 to non_uk_biobank subset (#6247)
-- Handle conflicts and duplicates when uploading managed variants (#6256 and #6258)
+- Handle conflicts and duplicates when uploading managed variants (#6256, #6258, #6259)
 ### Fixed
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -67,12 +67,6 @@ class ManagedVariantHandler(object):
                     {"_id": collision["_id"]},
                     {"$set": managed_variant_obj},
                 )
-
-                return True
-                self.managed_variant_collection.find_one_and_update(
-                    {"_id": collision["_id"]},
-                    {"$set": managed_variant_obj},
-                )
                 return True
             else:
                 LOG.debug("Collision -variant in database identical to new variant. Won't update")

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -57,9 +57,18 @@ class ManagedVariantHandler(object):
                         + (collision.get("institute") or [])
                     )
                 )
-                managed_variant_obj["description"] = (
-                    collision.get("description") + "<br>" + managed_variant_obj["description"]
+                new_desc = managed_variant_obj.get("description")
+                old_desc = collision.get("description")
+
+                if new_desc and old_desc and new_desc != old_desc:
+                    managed_variant_obj["description"] = f"{old_desc}<br>{new_desc}"
+
+                collection.find_one_and_update(
+                    {"_id": collision["_id"]},
+                    {"$set": managed_variant_obj},
                 )
+
+                return True
                 self.managed_variant_collection.find_one_and_update(
                     {"_id": collision["_id"]},
                     {"$set": managed_variant_obj},

--- a/scout/adapter/mongo/managed_variant.py
+++ b/scout/adapter/mongo/managed_variant.py
@@ -63,7 +63,7 @@ class ManagedVariantHandler(object):
                 if new_desc and old_desc and new_desc != old_desc:
                     managed_variant_obj["description"] = f"{old_desc}<br>{new_desc}"
 
-                collection.find_one_and_update(
+                self.managed_variant_collection.find_one_and_update(
                     {"_id": collision["_id"]},
                     {"$set": managed_variant_obj},
                 )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Do not duplicate description when for instance same managed variant gets loaded twice 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
