### PR TITLE
Hide empty categories of cases on caseS page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Default gnomAD linkout for hg38 to non_uk_biobank subset (#6247)
 - Handle conflicts and duplicates when uploading managed variants (#6256, #6258, #6259)
+- On caseS page, dynamically hide empty categories of cases (#6260)
 ### Fixed
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -227,7 +227,7 @@
         {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'ignored'] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}
-            {% if status == group_name and case_group%}
+            {% if status == group_name and case_group %}
               <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
             {% endif %}
           {% endfor %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -227,7 +227,7 @@
         {% set ordered_statuses = ['prioritized', 'inactive', 'active', 'archived', 'solved', 'ignored'] -%}
         {% for status in ordered_statuses %}
           {% for group_name, case_group in cases %}
-            {% if status == group_name %}
+            {% if status == group_name and case_group%}
               <div class="table-responsive">{{ cases_table(group_name, case_group) }}</div>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #5866 - Institutes with no prioritised cases will not see the category this way

### Main branch

<img width="1275" height="750" alt="image" src="https://github.com/user-attachments/assets/e2a985ad-ac78-4b62-a7fc-15818a0ce3f9" />


### This branch

<img width="1279" height="409" alt="image" src="https://github.com/user-attachments/assets/6da8da61-3fd5-4b2a-b5c3-eea5f41c8fe6" />

 

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
