### PR TITLE
Fix #6154 - add CLI command to delete rank model from db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
+- Command to remove loaded rank models (#6261)
 ### Changed
 - Default gnomAD linkout for hg38 to non_uk_biobank subset (#6247)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Custom MT Saltshaker HTML report loading (#6242)
 - Command to download all PanelApp panels to file (#6239)
 - Alternatively load and update PANELAPP-GREEN panel from a pre-downloaded file (#6244)
-- Command to remove loaded rank models (#6261)
+- Command to remove loaded rank models (#6262)
 ### Changed
 - Default gnomAD linkout for hg38 to non_uk_biobank subset (#6247)
 ### Fixed

--- a/scout/adapter/mongo/rank_model.py
+++ b/scout/adapter/mongo/rank_model.py
@@ -60,6 +60,11 @@ class RankModelHandler(object):
 
         return {}
 
+    def delete_rank_model(self, rank_model_url: str) -> dict:
+        """Delete a rank model from database with URL as identifier"""
+
+        return self.rank_model_collection.delete_one({"_id": rank_model_url})
+
     def rank_model_url_from_version(
         self, rank_model_link_prefix: str, rank_model_version: str, rank_model_file_extension: str
     ) -> str:

--- a/scout/adapter/mongo/rank_model.py
+++ b/scout/adapter/mongo/rank_model.py
@@ -60,7 +60,7 @@ class RankModelHandler(object):
 
         return {}
 
-    def delete_rank_model(self, rank_model_url: str) -> dict:
+    def delete_rank_model(self, rank_model_url: str) -> DeleteResult:
         """Delete a rank model from database with URL as identifier"""
 
         return self.rank_model_collection.delete_one({"_id": rank_model_url})

--- a/scout/adapter/mongo/rank_model.py
+++ b/scout/adapter/mongo/rank_model.py
@@ -5,6 +5,7 @@ from os.path import exists
 
 import requests
 from configobj import ConfigObj
+from pymongo.results import DeleteResult
 
 LOG = logging.getLogger(__name__)
 TIMEOUT = 20

--- a/scout/commands/delete/delete_command.py
+++ b/scout/commands/delete/delete_command.py
@@ -5,6 +5,7 @@ from scout.commands.delete.genes import exons as exons_cmd
 from scout.commands.delete.genes import genes as genes_cmd
 from scout.commands.delete.index import index as index_cmd
 from scout.commands.delete.panel import panel as panel_cmd
+from scout.commands.delete.rank_model import rank_model as rank_model_cmd
 from scout.commands.delete.rna import rna as rna_cmd
 from scout.commands.delete.user import user as user_cmd
 from scout.commands.delete.variants import variants as variants_cmd
@@ -23,5 +24,6 @@ delete.add_command(case_cmd)
 delete.add_command(user_cmd)
 delete.add_command(index_cmd)
 delete.add_command(exons_cmd)
+delete.add_command(rank_model_cmd)
 delete.add_command(rna_cmd)
 delete.add_command(variants_cmd)

--- a/scout/commands/delete/rank_model.py
+++ b/scout/commands/delete/rank_model.py
@@ -1,0 +1,47 @@
+import logging
+
+import click
+from flask.cli import with_appcontext
+
+from scout.server.extensions import store
+
+LOG = logging.getLogger(__name__)
+
+
+@click.command("rank-model", short_help="Delete a rank model from database")
+@click.option("-f", "--force", is_flag=True, help="Force delete even if explicitly found on cases")
+@click.argument("rank_model_url")
+@with_appcontext
+def rank_model(rank_model_url, force):
+    """Delete a rank model from the database.
+
+    Takes rank model URL or file path to delete from database as argument.
+    Stops if the URL is found explicitly set on a case, but does not case rank model match versions and category against
+    rank model candidates.
+    Use force to remove the loaded model anyway.
+    Links on cases stay set, and models will reload on use.
+    """
+    LOG.info("Running scout delete rank model")
+    adapter = store
+
+    rank_model_obj = adapter.rank_model_from_url(rank_model_url)
+    if not rank_model_obj:
+        LOG.warning("Rank model {0} was not found in database".format(rank_model_url))
+        return
+
+    if not force and adapter.case_collection.find_one(
+        {"$or": [{"rank_model_url": rank_model_url}, {"sv_rank_model_url": rank_model_url}]}
+    ):
+        LOG.warning(
+            "Rank model {0} is associated to one or more cases in the database. Use --force option to delete it anyway.".format(
+                rank_model_url
+            )
+        )
+        return
+
+    result = adapter.delete_rank_model(rank_model_url)
+    if result.deleted_count == 0:
+        LOG.warning("Rank model delete unsuccessful")
+        return
+
+    LOG.info("Rank model delete successful")

--- a/tests/commands/delete/test_delete_panel.py
+++ b/tests/commands/delete/test_delete_panel.py
@@ -3,7 +3,7 @@ from scout.server.extensions import store
 
 
 def test_delete_panel_non_existing(empty_mock_app, testpanel_obj):
-    "Test the CLI command that deletes a gene panel"
+    """Test the CLI command that deletes a gene panel"""
     mock_app = empty_mock_app
     runner = mock_app.test_cli_runner()
     assert runner
@@ -29,7 +29,7 @@ def test_delete_panel_non_existing(empty_mock_app, testpanel_obj):
 
 
 def test_delete_panel(empty_mock_app, testpanel_obj):
-    "Test the CLI command that deletes a gene panel"
+    """Test the CLI command that deletes a gene panel"""
     mock_app = empty_mock_app
 
     runner = mock_app.test_cli_runner()

--- a/tests/commands/delete/test_delete_rank_model.py
+++ b/tests/commands/delete/test_delete_rank_model.py
@@ -1,0 +1,32 @@
+from scout.commands import cli
+from scout.demo import rank_score_path, sv_rank_score_path
+from scout.server.extensions import store
+
+
+def test_delete_rank_model(empty_mock_app):
+    """Test the delete_rank_model command"""
+
+    runner = empty_mock_app.test_cli_runner()
+    assert runner
+
+    ## GIVEN an empty db
+
+    ## WHEN a rank model is retrieved from file
+    rank_model_dict = store.rank_model_from_url(rank_score_path)
+
+    ## THEN the model is stored in the database
+    assert store.rank_model_collection.find_one({"_id": rank_model_dict["_id"]})
+
+    ## WHEN deleting the rank model
+    result = runner.invoke(
+        cli,
+        [
+            "delete",
+            "rank-model",
+            "--force",
+            rank_score_path,
+        ],
+    )
+
+    assert "Rank model delete successful" in result.output
+    assert not store.rank_model_collection.find_one({"_id": rank_model_dict["_id"]})

--- a/tests/commands/delete/test_delete_rank_model.py
+++ b/tests/commands/delete/test_delete_rank_model.py
@@ -27,6 +27,8 @@ def test_delete_rank_model(empty_mock_app):
             rank_score_path,
         ],
     )
+    assert result.exit_code == 0
 
+    ## THEN the model is deleted
     assert "Rank model delete successful" in result.output
     assert not store.rank_model_collection.find_one({"_id": rank_model_dict["_id"]})

--- a/tests/commands/delete/test_delete_rank_model.py
+++ b/tests/commands/delete/test_delete_rank_model.py
@@ -7,9 +7,6 @@ def test_delete_rank_model(empty_mock_app):
     """Test the delete_rank_model command"""
 
     runner = empty_mock_app.test_cli_runner()
-    assert runner
-
-    ## GIVEN an empty db
 
     ## WHEN a rank model is retrieved from file
     rank_model_dict = store.rank_model_from_url(rank_score_path)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6154 
 
Delete rank model with given URL / file name. Checks for explicit mentions of this model on cases, blocking delete unless given a `--force` flag. Will not check for blocking mention of rank model version only on cases: constants for prefix and postfix may have changed on the instance, and version is ambiguous between different rank model categories.

<img width="1716" height="970" alt="Screenshot 2026-05-05 at 12 09 05" src="https://github.com/user-attachments/assets/14407c6e-a213-4379-aba6-2ef5b330d4a2" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

**How to test**:
1. delete an existing rank model using the command, with --force
2. note it disappearing from db
3. (optional) visit a variant, and notice the model loaded afresh

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
