### PR TITLE
Fix #6266 - Update docs on case config custom images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
 - Managed variants matching follows build on case page (#6254)
+- Updated docs on load case images (#6267)
 
 ## [4.110.0]
 ### Added

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -12,7 +12,7 @@ support `alignment_path`.
 
 
 ### Configuration Parameters
-Below are available configuration parameters for a Scout case. Names marked with asterix (*) are mandatory.
+Below are available configuration parameters for a Scout case. Names marked with an asterisk (*) are mandatory.
 
 - **analysis_date(*)** _Datetime_ Time for analysis in datetime format. Defaults to time of uploading. Example `2016-10-12 14:00:46`.
 - **cnv_report** _String_ Path to the CNV report file.
@@ -20,6 +20,20 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **cohorts** _List of strings_ Meta organising study participants or cases.
 - **collaborators** _List of strings_ List of collaborators.
 - **coverage_qc_report** _String_ Path to HTML file with coverage and QC report.
+- **custom_images** _Object_ Custom images displayed on case pages or STR variant pages. Supported formats are `gif`, `svg`, `png`, `jpg`, `jpeg`.
+    - **case_images** _Dictionary of lists_ Images grouped by section name for case view. Each section will be displayed as a separate panel on the case view. (Alias: `case`)
+        - **title** _String_ Image title (mandatory).
+        - **description** _String_ Image description (mandatory).
+        - **path** _String_ Path to image file (mandatory).
+        - **width** _Int_ Optional image width.
+        - **height** _Int_ Optional image height.
+    - **str_variants_images** _List_ Images connected to STR variants. (Alias: `str`)
+        - **title** _String_ Image title (mandatory).
+        - **description** _String_ Image description (mandatory).
+        - **path** _String_ Path to image file (mandatory).
+        - **str_repid** _String_ REPID for the STR variant (mandatory, for example `AFF2`).
+        - **width** _Int_ Optional image width.
+        - **height** _Int_ Optional image height.
 - **default_gene_panels** _List of strings_ List of default gene panels. Variants from the genes in the gene panels specified will be shown when opening the case in scout.
 - **delivery_report** _String_: Path to HTML delivery report.
 - **exe_ver**: Pipeline detailed software versions (YAML)
@@ -34,8 +48,8 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **multiqc** _String_ Path to a [multiqc][multiqc] report with arbitrary information.
 - **multiqc_rna** _String_ Path to a [nf-core/rnafusion multiqc][rna-multiqc] report with arbitrary information.
 - **omics_files** _List_ List of multiomics results files for the case:
-    - **fraser** _String_ Path to TSV file to parse WTS [DROP][drop] FRASER splice outlier omics variants as produded by e.g. [Tomte][tomte]
-    - **outrider** _String_ Path to TSV file to parse WTS [DROP][drop] OUTRIDER expression outlier omics variants as produded by e.g. [Tomte][tomte]
+    - **fraser** _String_ Path to TSV file to parse WTS [DROP][drop] FRASER splice outlier omics variants as produced by e.g. [Tomte][tomte]
+    - **outrider** _String_ Path to TSV file to parse WTS [DROP][drop] OUTRIDER expression outlier omics variants as produced by e.g. [Tomte][tomte]
     - **methbat** _String_ Path to TSV file to parse LRS [MethBat][methbat] methylation outlier omics variants as produced by e.g. [Nallo][nallo]
 - **owner(*)**  _String_ Institute who owns current case. Must refer to existing institute.
 - **paraphrase** _String_ Path to a [Paraphrase][paraphrase] json file.
@@ -93,12 +107,12 @@ Below are available configuration parameters for a Scout case. Names marked with
     - **omics_sample_id** _String_ Sample ID for RNA, as in outliers files
     - **rhocall_bed** _String_ Path to BED file to view alignments [Reference][rhocall].
     - **rhocall_wig** _String_ Path to WIG file to view alignments [Reference][rhocall].
-    - **samlple_id(*)** _String_ Identifyer for a sample.
+    - **sample_id(*)** _String_ Identifier for a sample.
     - **sample_name**: _String_ Name of sample.
     - **sex (*)** _String_ One of: {male, female, unknown}. Sex of the sample in human readable format.
-    - **smn1_cn** _Int_ Copynumber.
-    - **smn2_cn** _Int_ Copynumber.
-    - **smn2delta78_cn** _Int_ Copynumber.
+    - **smn1_cn** _Int_ Copy number.
+    - **smn2_cn** _Int_ Copy number.
+    - **smn2delta78_cn** _Int_ Copy number.
     - **splice_junctions_bed** _String_ Path to indexed junctions .bed.gz file
     - **subject_id** _String_ Individual identifier - multiple samples could belong to the same individual
     - **tiddit_coverage_wig** or **coverage_wig** _String_ Path to WIG file to view alignment coverage overview from e.g. [Reference][tiddit] or [Reference][hificnv].
@@ -119,7 +133,7 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **track** _String_ Type of track: {"rare", "cancer"}. Default: "rare".
 - **sv_rank_model_url** _String_ Full URL for SV rank model used when scoring SV variants. If not defined, server config `SV_RANK_MODEL_LINK_PREFIX` and `_POSTFIX` will be added to make the URL.
 - **sv_rank_model_version** _String_ SV rank model version used when scoring SV variants.
-- **vcf_cancer** _String_ Path to canver VCF file (tumor case only).
+- **vcf_cancer** _String_ Path to cancer VCF file (tumor case only).
 - **vcf_cancer_research** _String_ Path to VCF file with all variants (tumor case only).
 - **vcf_snv** _String_ Path to SNV VCF file  containing only clinical variants (a subset of all variants).
 - **vcf_snv_research** _String_ Path to VCF file with all variants.
@@ -127,6 +141,8 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **vcf_sv_research** _String_ Path to VCF file with all SV variants.
 
 
+See [loading case](loading-case.md) for more information on how to load a case using the config file, as well as details on
+custom images and custom reports.
 
 ### Example Minimal config
 

--- a/docs/admin-guide/loading-case.md
+++ b/docs/admin-guide/loading-case.md
@@ -106,11 +106,16 @@ Options:
 
 #### Adding custom images to a case
 
-Scout can display custom images as new panels on the case view or variant view which could be used to display analysis results from a separate pipeline. The custom images are defined in the case config file and stored in the database. Scout currently supports     `gif`, `jpeg`, `png` and `svg` images.
+Scout can display custom images as new panels on the case view or variant view which could be used to display analysis results from a separate pipeline.
+The custom images are defined in the case config file. Scout stores image metadata (for example title, description, dimensions and path) in the database, while image files are read from disk when rendered. Scout currently supports `gif`, `jpeg`, `png` and `svg` images.
 
-The syntax for loading an image differed depending on where they are going to be displayed. Images on the caes view can be grouped into different groups that are displayed as accordion-type UI elemment named after the group. Images can be associated with stru    ctural variants with a given hgnc symbol.
+The syntax for loading an image differs depending on where it is going to be displayed.
+Images on the case view can be grouped into different groups that are displayed as accordion-type UI elements named after the group.
+Images can be associated with structural variants with a given HGNC symbol.
 
-The fields `title`, `description` and `path` are mandatory regarless of location. The image size can be defined with the optional parameters `width` and `height`. If you dont specify a unit its going to default to use pixels as unit. *Note*: adding images lar    ger than 16mb are not reccomended as it might degrade the performance.
+The fields `title`, `description` and `path` are mandatory regardless of location.
+The image size can be defined with the optional parameters `width` and `height`.
+The image height and width unit is pixels.
 
 ``` yaml
 
@@ -119,12 +124,12 @@ custom_images:
     group_one:
       - title: <string> title of image [mandatory]
         description: <string> replacement description of image [mandatory]
-        width: <string> 500px
-        height: <string> 100px
+        width: <int> 500
+        height: <int> 100
         path: <string> scout/demo/images/custom_images/640x480_one.png [mandatory]
       - title: <string> A jpg image [mandatory]
         description: <string> A very good description [mandatory]
-        width: <string> 500px
+        width: <string> 500
         path: <string> scout/demo/images/custom_images/640x480_two.jpg [mandatory]
     group_two:
       - title: <string> An SVG image [mandatory]
@@ -134,24 +139,28 @@ custom_images:
     - title: <string> title of image [mandatory]
       str_repid: AFF2 [mandatory]
       description: <string> replacement description of image [mandatory]
-      width: <string> 500px
-      height: <string> 100px
+      width: <string> 500
+      height: <string> 100
       path: <string> scout/demo/images/custom_images/640x480_one.png [mandatory]
     - title: <string> A jpg image [mandatory]
       str_repid: AFF2 [mandatory]
       description: <string> A very good description [mandatory]
-      width: <string> 500px
+      width: <string> 500
       path: <string> scout/demo/images/custom_images/640x480_two.jpg [mandatory]
 
 ```
 
 ##### Loading multiple images with wildcards
 
-If you have multiple images you would like to associate with a different variants you can use wildcards to reduce the number of lines in the load config file. For example, you have two images `640x480_AR.svg` and `640x480_ATN1.svg` that should be attaced to variants in replicions AR and ATN1. Instead of writing a long list with one entry per image you could use wildcards to flag which parts of the path name that corresponds to the repid. Wildcards are a variable name surrounded by curly brackets, `{VARIALBE_NAME}`. The varible name can contain letters, numbers and underscore and score.
+If you have multiple images you would like to associate with different variants, you can use wildcards to reduce the number of lines in the load config file.
+For example, you have two images `640x480_AR.svg` and `640x480_ATN1.svg` that should be attached to variants in _AR_ and _ATN1_.
+Instead of writing a long list with one entry per image, you can use wildcards to flag which part of the path name corresponds to the REPID.
+Wildcards are a variable name surrounded by curly brackets, `{VARIABLE_NAME}`. The variable name can contain letters, numbers and underscores.
 
-When the images are loaded into the database the algorithm finds files matching the pattern and substitutes the wildcard with the sting. In other words will this enable the user to extract information encoded in the path and populate the configuration with it.
+When custom image metadata is loaded the algorithm finds files matching the pattern and substitutes the wildcard with the string.
+In other words this expands the path using the configuration pattern and populates the case object accordingly.
 
-Given the two files above will this configuration
+Given the two files above, this configuration
 
 ``` yaml
 custom_images:
@@ -161,7 +170,7 @@ custom_images:
       path: <string> scout/demo/images/custom_images/640x480_{REPID}.jpg [mandatory]
 ```
 
-be equivalent to
+is equivalent to
 
 ``` yaml
 custom_images:

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -546,7 +546,6 @@ def case(
         }
     add_link_for_disease(case_obj)
     if case_obj.get("custom_images"):
-        # re-encode images as base64
         case_obj["custom_images"] = case_obj["custom_images"].get(
             "case_images", case_obj["custom_images"].get("case", {})
         )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6266  

Revised docs on `custom_images` and added a link to the detailed description from the config page.

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
