### PR TITLE
Dowload Ensembl data last when running "scout downloading everything"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `scout delete variants` command now accepts an optional `--out-file` where to print a detailed report of the deletion process (#6094)
 - Gens fallback to v3 if no GENS_VERSION given, and no version detected from Gens API (#6195)
 - Refactor variant formatting logic (pretty_variant) out of Jinja2 template (#6218)
+- `scout download everything` command downloads Ensembl data last, so that if the Ensembl download fails, it does not prevent the other files from being downloaded (#6269)
 ### Fixed
 - Formatting of a list on managed variant export documentation (#6203)
 - Exception for singletons from the "Include variants present only in unaffected" filter (#6209)

--- a/scout/commands/download/everything.py
+++ b/scout/commands/download/everything.py
@@ -40,5 +40,5 @@ def everything(ctx, out_dir, api_key, skip_tx, exons, build):
     ctx.invoke(hpo, out_dir=out_dir)
     ctx.invoke(exac, out_dir=out_dir)
     ctx.invoke(hgnc, out_dir=out_dir)
-    ctx.invoke(ensembl, out_dir=out_dir, skip_tx=skip_tx, exons=exons, build=build)
     ctx.invoke(panelapp, out_dir=out_dir)
+    ctx.invoke(ensembl, out_dir=out_dir, skip_tx=skip_tx, exons=exons, build=build)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Download Ensembl data last, so **any failures don't prevent the downloading of other files (panelapp file specifically)**
- In case the last download fails one can always download the files manually via schug or use old files

<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
