### PR TITLE
Old expected_coverage option removed from docs, blog post, some layout and typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,15 +3,15 @@ OR
 This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.
 
 <details>
-<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>
+<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>
 
 **Prepare for testing**
 1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
 1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
-1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
+1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
 1. `sudo -iu hiseq.clinical`
 1. `ssh localhost`
-1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
+1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
 1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
 1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
 1. Make sure the branch is deployed: `systemctl --user status scout.target`
@@ -24,12 +24,17 @@ This PR marks a new Scout release. We apply semantic versioning. This is a major
 **Prepare for testing**
 1. `ssh <USER.NAME>@hasta.scilifelab.se`
 1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
-1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
+1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
 1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
 1. Make sure the branch is deployed: `us; scout --version`
 1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
 </details>
 
+<details>
+<summary>Testing docs locally with `uv`</summary>
+1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
+1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
+</details>
 
 **How to test**:
 1. how to test it, possibly with real cases/data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
 - Managed variants matching follows build on case page (#6254)
 - Updated docs on load case images (#6267)
+- Blog posts for 4.111 and 4.110 releases, removed obsolete `expected_coverage` key from documentation (#6270)
+
 
 ## [4.110.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Saltshaker report update command (#6246)
 - Managed variants counter, wrongly defaulting to build 37 (#6252)
 - Managed variants matching follows build on case page (#6254)
+- Updated docs on load case images (#6267)
 
 ## [4.110.0]
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,6 @@
 
 ![v4](img/v4.png)
 
-**Latest entry in the blog**: [What's new in 4.72?](blog/new-4.72.md)
+**Latest entry in the blog**: [What's new in 4.111?](blog/new-4.111.md)
 
 **Version migration issues**: [Breaking](admin-guide/breaking.md)

--- a/docs/admin-guide/containers/kubernetes.md
+++ b/docs/admin-guide/containers/kubernetes.md
@@ -7,16 +7,16 @@ Kubernetes is an open-source platform for managing containerized applications. T
 brew install hyperkit
 brew install minikube
 ```
-The second command, brew install minikube, will install also the Kubernetes cli (kubectl). Minikube can be alternatively installed using another container manager, such as Podman or VMWare. More documentation is available [here](https://minikube.sigs.k8s.io/docs/start/).
+The second command, `brew install minikube`, will install also the Kubernetes cli (`kubectl`). Minikube can be alternatively installed using another container manager, such as Podman or VMWare. More documentation is available [here](https://minikube.sigs.k8s.io/docs/start/).
 
 ### Installation and Setup of the database and config files
 1. Start minikube kubernetes cluster inside hypervisor (hyperkit):
 ```
 minikube start --vm-driver=hyperkit
 ```
-1. Note that all files described in this tutorial are available in the folder "containers", in the scout root directory.
+1. Note that all files described in this tutorial are available in the folder `containers`, in the Scout root directory.
 
-1. The file named "secrets.yaml" contains 2 files: one storing the secrets for the mongodb service (mongodb-secret) and one for the secrets of the Scout app (scout-secret). Secrets can also be stored in different files. In the example they're on the same file, separated by "---".
+1. The file named `secrets.yaml` contains 2 files: one storing the secrets for the mongodb service (mongodb-secret) and one for the secrets of the Scout app (scout-secret). Secrets can also be stored in different files. In the example they're on the same file, separated by "---".
 ```
 # mongodb secrets
 apiVersion: v1
@@ -65,12 +65,12 @@ The config parameters should be modified according to the MongoDB connection set
 1. **Create the configmap** with the command:
 `kubectl apply -f scout/containers/kubernetes/scout-configmap.yaml`
 
-1. Create a Deployment for mongo and a relative service that will run on port 27017. Note that the example file (mongo.yaml) is running a lightweight version image of Mongo (vepo/mongo) and not the official Mongo image. This container can be replaced with any other application that serves a MongoDB using authentication.
+1. Create a Deployment for mongo and a relative service that will run on port 27017. Note that the example file (`mongo.yaml`) is running a lightweight version image of Mongo (vepo/mongo) and not the official Mongo image. This container can be replaced with any other application that serves a MongoDB using authentication.
 Run the Deployment and the service:
 `kubectl apply -f scout/containers/kubernetes/mongo.yaml`
 
 ### Deploying the Scout command line
-To create a running container with the Scout command line can be used a Docker image stored either locally (in that case the Scout Dockerfile should be built first) or on the Docker Hub. This example pulls the latest from Docker Hub to build an interactive pod. Define a scout-cli.yaml file with the following content:
+To create a running container with the Scout command line can be used a Docker image stored either locally (in that case the Scout Dockerfile should be built first) or on the Docker Hub. This example pulls the latest from Docker Hub to build an interactive pod. Define a `scout-cli.yaml` file with the following content:
 ```
 # Scout pod for running cli commands
 apiVersion: v1
@@ -159,7 +159,7 @@ spec:
 `kubectl apply -f scout/containers/kubernetes/scout-web.yaml`
 
 ### Overview of the running containers and starting the minikube service
-1. After the steps above a number of container should be running on the virtual machine. An overview of all containers together with accessory services and itams will be available using the command:
+1. After the steps above a number of container should be running on the virtual machine. An overview of all containers together with accessory services and items will be available using the command:
 ```
 kubectl get all
 ```

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -4,7 +4,7 @@ A case and its individuals (or samples, in cancer track) can be uploaded into Sc
 
 The format is [Yaml][yaml].
 
-Example configuration files are found here: `<scout root dir>/scout/demo/643594.config.yaml` or on [Github](https://github.com/Clinical-Genomics/scout/blob/update_config_docs-210428/scout/demo/643594.config.yaml).
+Example configuration files are found here: `scout/demo/643594.config.yaml` or on [Github](https://raw.githubusercontent.com/Clinical-Genomics/scout/refs/heads/main/scout/demo/643594.config.yaml).
 
 ### Deprecation Warnings:
 `bam_file`, `bam_path` and `alignment_path` are redundant in internal usage. Future versions of Scout will only
@@ -68,7 +68,6 @@ Below are available configuration parameters for a Scout case. Names marked with
         - **upd_sites** _String_ Path to file.
     - **confirmed_parent** _Bool_ True if parent confirmed.
     - **d4_path** _String_ Path to [.d4 file][d4_file]. Required for Chanjo2 integration
-    - **expected_coverage** _Int_ The level of expected coverage.
     - **father** _String/Int_ Sample ID for father or 0.
     - **hrd** _Int_ Homologous recombination deficiency.
     - **is_sma** _Bool/None_ if SMA status determined - None if not done.
@@ -147,7 +146,6 @@ samples:
     sample_name: NA12878
     phenotype: affected
     sex: male
-    expected_coverage: 30
 
 vcf_snv: scout/demo/643594.clinical.vcf.gz
 ```

--- a/docs/admin-guide/load-config.md
+++ b/docs/admin-guide/load-config.md
@@ -12,7 +12,7 @@ support `alignment_path`.
 
 
 ### Configuration Parameters
-Below are available configuration parameters for a Scout case. Names marked with asterix (*) are mandatory.
+Below are available configuration parameters for a Scout case. Names marked with an asterisk (*) are mandatory.
 
 - **analysis_date(*)** _Datetime_ Time for analysis in datetime format. Defaults to time of uploading. Example `2016-10-12 14:00:46`.
 - **cnv_report** _String_ Path to the CNV report file.
@@ -20,6 +20,20 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **cohorts** _List of strings_ Meta organising study participants or cases.
 - **collaborators** _List of strings_ List of collaborators.
 - **coverage_qc_report** _String_ Path to HTML file with coverage and QC report.
+- **custom_images** _Object_ Custom images displayed on case pages or STR variant pages. Supported formats are `gif`, `svg`, `png`, `jpg`, `jpeg`.
+    - **case_images** _Dictionary of lists_ Images grouped by section name for case view. Each section will be displayed as a separate panel on the case view. (Alias: `case`)
+        - **title** _String_ Image title (mandatory).
+        - **description** _String_ Image description (mandatory).
+        - **path** _String_ Path to image file (mandatory).
+        - **width** _Int_ Optional image width.
+        - **height** _Int_ Optional image height.
+    - **str_variants_images** _List_ Images connected to STR variants. (Alias: `str`)
+        - **title** _String_ Image title (mandatory).
+        - **description** _String_ Image description (mandatory).
+        - **path** _String_ Path to image file (mandatory).
+        - **str_repid** _String_ REPID for the STR variant (mandatory, for example `AFF2`).
+        - **width** _Int_ Optional image width.
+        - **height** _Int_ Optional image height.
 - **default_gene_panels** _List of strings_ List of default gene panels. Variants from the genes in the gene panels specified will be shown when opening the case in scout.
 - **delivery_report** _String_: Path to HTML delivery report.
 - **exe_ver**: Pipeline detailed software versions (YAML)
@@ -34,8 +48,8 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **multiqc** _String_ Path to a [multiqc][multiqc] report with arbitrary information.
 - **multiqc_rna** _String_ Path to a [nf-core/rnafusion multiqc][rna-multiqc] report with arbitrary information.
 - **omics_files** _List_ List of multiomics results files for the case:
-    - **fraser** _String_ Path to TSV file to parse WTS [DROP][drop] FRASER splice outlier omics variants as produded by e.g. [Tomte][tomte]
-    - **outrider** _String_ Path to TSV file to parse WTS [DROP][drop] OUTRIDER expression outlier omics variants as produded by e.g. [Tomte][tomte]
+    - **fraser** _String_ Path to TSV file to parse WTS [DROP][drop] FRASER splice outlier omics variants as produced by e.g. [Tomte][tomte]
+    - **outrider** _String_ Path to TSV file to parse WTS [DROP][drop] OUTRIDER expression outlier omics variants as produced by e.g. [Tomte][tomte]
     - **methbat** _String_ Path to TSV file to parse LRS [MethBat][methbat] methylation outlier omics variants as produced by e.g. [Nallo][nallo]
 - **owner(*)**  _String_ Institute who owns current case. Must refer to existing institute.
 - **paraphrase** _String_ Path to a [Paraphrase][paraphrase] json file.
@@ -92,12 +106,12 @@ Below are available configuration parameters for a Scout case. Names marked with
     - **omics_sample_id** _String_ Sample ID for RNA, as in outliers files
     - **rhocall_bed** _String_ Path to BED file to view alignments [Reference][rhocall].
     - **rhocall_wig** _String_ Path to WIG file to view alignments [Reference][rhocall].
-    - **samlple_id(*)** _String_ Identifyer for a sample.
+    - **sample_id(*)** _String_ Identifier for a sample.
     - **sample_name**: _String_ Name of sample.
     - **sex (*)** _String_ One of: {male, female, unknown}. Sex of the sample in human readable format.
-    - **smn1_cn** _Int_ Copynumber.
-    - **smn2_cn** _Int_ Copynumber.
-    - **smn2delta78_cn** _Int_ Copynumber.
+    - **smn1_cn** _Int_ Copy number.
+    - **smn2_cn** _Int_ Copy number.
+    - **smn2delta78_cn** _Int_ Copy number.
     - **splice_junctions_bed** _String_ Path to indexed junctions .bed.gz file
     - **subject_id** _String_ Individual identifier - multiple samples could belong to the same individual
     - **tiddit_coverage_wig** or **coverage_wig** _String_ Path to WIG file to view alignment coverage overview from e.g. [Reference][tiddit] or [Reference][hificnv].
@@ -118,7 +132,7 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **track** _String_ Type of track: {"rare", "cancer"}. Default: "rare".
 - **sv_rank_model_url** _String_ Full URL for SV rank model used when scoring SV variants. If not defined, server config `SV_RANK_MODEL_LINK_PREFIX` and `_POSTFIX` will be added to make the URL.
 - **sv_rank_model_version** _String_ SV rank model version used when scoring SV variants.
-- **vcf_cancer** _String_ Path to canver VCF file (tumor case only).
+- **vcf_cancer** _String_ Path to cancer VCF file (tumor case only).
 - **vcf_cancer_research** _String_ Path to VCF file with all variants (tumor case only).
 - **vcf_snv** _String_ Path to SNV VCF file  containing only clinical variants (a subset of all variants).
 - **vcf_snv_research** _String_ Path to VCF file with all variants.
@@ -126,6 +140,8 @@ Below are available configuration parameters for a Scout case. Names marked with
 - **vcf_sv_research** _String_ Path to VCF file with all SV variants.
 
 
+See [loading case](loading-case.md) for more information on how to load a case using the config file, as well as details on
+custom images and custom reports.
 
 ### Example Minimal config
 

--- a/docs/admin-guide/loading-case.md
+++ b/docs/admin-guide/loading-case.md
@@ -1,6 +1,9 @@
 # Loading Scout cases
 
 When loading a case into scout it is possible to use either a config file or to specify parameters on the command line.
+The most common way to load a case is to use a config file, which is a `.yaml` file that contains all information describing the case and its samples. The command to load a case with a config file is:
+`scout load case my_config.yaml`
+
 
 ### Scout Load Config
 
@@ -24,7 +27,6 @@ samples:
     phenotype: affected
     sex: male
     bam_path: path/to/bam
-    expected_coverage: 30
   - analysis_type: wes
     sample_id: ADM1059A1
     capture_kit: Agilent_SureSelectCRE.V1
@@ -34,7 +36,6 @@ samples:
     phenotype: unaffected
     sex: male
     bam_path: path/to/bam
-    expected_coverage: 30
   - analysis_type: wes
     sample_id: ADM1059A3
     capture_kit: Agilent_SureSelectCRE.V1
@@ -44,7 +45,6 @@ samples:
     phenotype: unaffected
     sex: female
     bam_path: path/to/bam
-    expected_coverage: 30
 
 vcf_snv: scout/demo/643594.clinical.vcf.gz
 vcf_sv: scout/demo/643594.clinical.SV.vcf.gz

--- a/docs/admin-guide/loading-case.md
+++ b/docs/admin-guide/loading-case.md
@@ -106,11 +106,16 @@ Options:
 
 #### Adding custom images to a case
 
-Scout can display custom images as new panels on the case view or variant view which could be used to display analysis results from a separate pipeline. The custom images are defined in the case config file and stored in the database. Scout currently supports     `gif`, `jpeg`, `png` and `svg` images.
+Scout can display custom images as new panels on the case view or variant view which could be used to display analysis results from a separate pipeline.
+The custom images are defined in the case config file. Scout stores image metadata (for example title, description, dimensions and path) in the database, while image files are read from disk when rendered. Scout currently supports `gif`, `jpeg`, `png` and `svg` images.
 
-The syntax for loading an image differed depending on where they are going to be displayed. Images on the caes view can be grouped into different groups that are displayed as accordion-type UI elemment named after the group. Images can be associated with stru    ctural variants with a given hgnc symbol.
+The syntax for loading an image differs depending on where it is going to be displayed.
+Images on the case view can be grouped into different groups that are displayed as accordion-type UI elements named after the group.
+Images can be associated with structural variants with a given HGNC symbol.
 
-The fields `title`, `description` and `path` are mandatory regarless of location. The image size can be defined with the optional parameters `width` and `height`. If you dont specify a unit its going to default to use pixels as unit. *Note*: adding images lar    ger than 16mb are not reccomended as it might degrade the performance.
+The fields `title`, `description` and `path` are mandatory regardless of location.
+The image size can be defined with the optional parameters `width` and `height`.
+The image height and width unit is pixels.
 
 ``` yaml
 
@@ -119,12 +124,12 @@ custom_images:
     group_one:
       - title: <string> title of image [mandatory]
         description: <string> replacement description of image [mandatory]
-        width: <string> 500px
-        height: <string> 100px
+        width: <int> 500
+        height: <int> 100
         path: <string> scout/demo/images/custom_images/640x480_one.png [mandatory]
       - title: <string> A jpg image [mandatory]
         description: <string> A very good description [mandatory]
-        width: <string> 500px
+        width: <string> 500
         path: <string> scout/demo/images/custom_images/640x480_two.jpg [mandatory]
     group_two:
       - title: <string> An SVG image [mandatory]
@@ -134,24 +139,28 @@ custom_images:
     - title: <string> title of image [mandatory]
       str_repid: AFF2 [mandatory]
       description: <string> replacement description of image [mandatory]
-      width: <string> 500px
-      height: <string> 100px
+      width: <string> 500
+      height: <string> 100
       path: <string> scout/demo/images/custom_images/640x480_one.png [mandatory]
     - title: <string> A jpg image [mandatory]
       str_repid: AFF2 [mandatory]
       description: <string> A very good description [mandatory]
-      width: <string> 500px
+      width: <string> 500
       path: <string> scout/demo/images/custom_images/640x480_two.jpg [mandatory]
 
 ```
 
 ##### Loading multiple images with wildcards
 
-If you have multiple images you would like to associate with a different variants you can use wildcards to reduce the number of lines in the load config file. For example, you have two images `640x480_AR.svg` and `640x480_ATN1.svg` that should be attaced to variants in replicions AR and ATN1. Instead of writing a long list with one entry per image you could use wildcards to flag which parts of the path name that corresponds to the repid. Wildcards are a variable name surrounded by curly brackets, `{VARIALBE_NAME}`. The varible name can contain letters, numbers and underscore and score.
+If you have multiple images you would like to associate with different variants, you can use wildcards to reduce the number of lines in the load config file.
+For example, you have two images `640x480_AR.svg` and `640x480_ATN1.svg` that should be attached to variants in _AR_ and _ATN1_.
+Instead of writing a long list with one entry per image, you can use wildcards to flag which part of the path name corresponds to the REPID.
+Wildcards are a variable name surrounded by curly brackets, `{VARIABLE_NAME}`. The variable name can contain letters, numbers and underscores.
 
-When the images are loaded into the database the algorithm finds files matching the pattern and substitutes the wildcard with the sting. In other words will this enable the user to extract information encoded in the path and populate the configuration with it.
+When custom image metadata is loaded the algorithm finds files matching the pattern and substitutes the wildcard with the string.
+In other words this expands the path using the configuration pattern and populates the case object accordingly.
 
-Given the two files above will this configuration
+Given the two files above, this configuration
 
 ``` yaml
 custom_images:
@@ -161,7 +170,7 @@ custom_images:
       path: <string> scout/demo/images/custom_images/640x480_{REPID}.jpg [mandatory]
 ```
 
-be equivalent to
+is equivalent to
 
 ``` yaml
 custom_images:

--- a/docs/admin-guide/updating-case.md
+++ b/docs/admin-guide/updating-case.md
@@ -49,4 +49,4 @@ Options:
   --rankscore-treshold TEXT      Set a new rank score treshold if desired
   --sv-rankmodel-version TEXT    Update the SV rank model version
   --help                         Show this message and exit.
- ```
+```

--- a/docs/admin-guide/updating-individuals.md
+++ b/docs/admin-guide/updating-individuals.md
@@ -22,31 +22,33 @@ Options:
   --help              Show this message and exit.
 ```
 And the tracks that can be updated are the following:
-- assembly_alignment_path
-- bam_file
-- d4_file
-- rna_alignment_path
-- mt_bam
-- vcf2cytosure
-- paraphase_alignment_path
-- phase_blocks
-- rhocall_bed
-- rhocall_wig
-- tiddit_coverage_wig
-- minor_allele_frequency_wig
-- upd_regions_bed
-- upd_sites_bed
-- rna_coverage_bigwig
-- splice_junctions_bed
+
+- `assembly_alignment_path`
+- `bam_file`
+- `d4_file`
+- `rna_alignment_path`
+- `mt_bam`
+- `vcf2cytosure`
+- `paraphase_alignment_path`
+- `phase_blocks`
+- `rhocall_bed`
+- `rhocall_wig`
+- `tiddit_coverage_wig`
+- `minor_allele_frequency_wig`
+- `upd_regions_bed`
+- `upd_sites_bed`
+- `rna_coverage_bigwig`
+- `splice_junctions_bed`
 
 Additional sample descriptors:
-- subject_id
-- omics_sample_id
+
+- `subject_id`
+- `omics_sample_id`
 
 Additional non-track individual data
-- bionano_access
-- chromograph_images
-- reviewer
+- `bionano_access`
+- `chromograph_images`
+- `reviewer`
 
 
 ## Description of custom individual tracks
@@ -54,16 +56,16 @@ Additional non-track individual data
 ### DNA-sequencing alignment files
 The following files are used by the [igv.js](https://github.com/igvteam/igv.js/wiki/Alignment-Track) integrated browser to display sequence variation alignments. The igv.js browser can be opened by clicking on the relative link (button) present on variants page. The link is displayed only if at least one individual of the case contains one bam_file or mt_bam track saved.
 
-| key name            | key value                                                   |
-| --------------------|:------------------------------------------------------------|
-| bam_file            | path to a bam/cram alignment file                           |
-| mt_bam              | path to a downsampled mitochondrial bam/cram alignment file |
-| minor_allele_frequency_wig | path to hificnv maf wig file                         |
-| rhocall_bed         | path to rhocall output bed file                             |
-| rhocall_wig         | path to rhocall output wig file                             |
-| tiddit_coverage_wig | path to tiddit wig coverage file                            |
-| upd_regions_bed     | path to upd_regions_bed                                     |
-| upd_sites_bed       | path to vcf2cytosure file                                   |
+| key name                          | key value                                                   |
+|-----------------------------------|:------------------------------------------------------------|
+| `alignment_path` alias `bam_file` | path to a `bam`/`cram` alignment file                           |
+| `mt_bam`                            | path to a downsampled mitochondrial `bam`/`cram` alignment file |
+| `minor_allele_frequency_wig`        | path to hificnv maf `wig` file                                |
+| `rhocall_bed`                       | path to rhocall output `bed` file                             |
+| `rhocall_wig`                       | path to rhocall output `wig` file                             |
+| `tiddit_coverage_wig`               | path to tiddit `wig` coverage file                            |
+| `upd_regions_bed`                   | path to upd_regions_bed                                     |
+| `upd_sites_bed`                     | path to vcf2cytosure file                                   |
 
 `rhocall_bed` and `rhocall_wig` files are both obtained from [rhocall](https://github.com/dnil/rhocall),
 a software that calls and annotates autozygosity from VCF files.
@@ -90,7 +92,7 @@ A link to the splice junction view is present on variants pages of cases with at
 
 | key name      | key value                 |
 |:--------------|:--------------------------|
-| vcf2cytosure  | path to vcf2cytosure file |
+| `vcf2cytosure`  | path to vcf2cytosure file |
 
 [vcf2cytosure](https://github.com/NBISweden/vcf2cytosure) is a tool that converts a VCF with structural variations to the “.CGH” format used by the commercial [CytoSure Interpret Software](https://www.ogt.com/products/product-search/cytosure-interpret-software/) by OGT (Oxford Gene Technology). Once the individual is updated with this track, vcf2cytosure files will be available for download from the individuals table present on Scout's case page.
 
@@ -116,30 +118,30 @@ value is assumed: e.g. `"reviewer.alignment"` -> `ind["reviewer"]["alignment"]`.
 ### BioNano Access
 | key name               | key value         |
 |:-----------------------|:------------------|
-| bionano_access.sample  | BioNano Sample ID |
-| bionano_access.project | BioNano Project   |
+| `bionano_access.sample`  | BioNano Sample ID |
+| `bionano_access.project` | BioNano Project   |
 
 See [BioNano Access Integration](../admin-guide/bionano_access_integration.md).
 
 ### Chromograph
 | key name                       | key value                                           |
 |:-------------------------------|:----------------------------------------------------|
-| chromograph_images.autozygous  | Path wildcard to files - exclude chromosome name    |
-| chromograph_images.coverage    | Path wildcard to files - exclude chromosome name    |
-| chromograph_images.upd_regions | Path wildcard to files - exclude chromosome name    |
-| chromograph_images.upd_sites   | Path wildcard to files - exclude chromosome name    |
+| `chromograph_images.autozygous`  | Path wildcard to files - exclude chromosome name    |
+| `chromograph_images.coverage`    | Path wildcard to files - exclude chromosome name    |
+| `chromograph_images.upd_regions` | Path wildcard to files - exclude chromosome name    |
+| `chromograph_images.upd_sites`   | Path wildcard to files - exclude chromosome name    |
 See e.g. [User guide - Cases - Cytogenomics](../user-guide/cases.md#Cytogenomics) for a description of Chromograph.
 
 ### Scout REViewer Service
 
 | key name                 | key value |
 |:-------------------------|:----------|
-| reviewer.alignment       | Path      |
-| reviewer.alignment_index | Path      |
-| reviewer.vcf             | Path      |
-| reviewer.catalog         | Path      |
-| reviewer.reference       | Path      |
-| reviewer.trgt            | Bool      |
+| `reviewer.alignment`       | Path      |
+| `reviewer.alignment_index` | Path      |
+| `reviewer.vcf`             | Path      |
+| `reviewer.catalog`         | Path      |
+| `reviewer.reference`       | Path      |
+| `reviewer.trgt`            | Bool      |
 
 See [Admin guide - Scout REViewer Service](reviewer_service.md) for details on SRS.
 

--- a/docs/blog/new-4.110.md
+++ b/docs/blog/new-4.110.md
@@ -1,0 +1,18 @@
+# What's new in Scout v4.110.0?
+
+_Posted: Apr 24, 2026_
+
+Dear users and admins,
+
+✨🌸 We have a shiny spring Scout release for you today, v4.110.0.
+
+✨The main features include loading and display of Paraphrase parsed Paraphase calls from long read sequencing, renaming the `SMN` button to `SMN - Dark regions`. In Solna, be advised these will not start loading until after the next Nallo and CG updates.
+
+🛠️ Between version 4.107 (released 260113) and this release, there has been an unintended lifting of the singleton exception to the "Include variants present only in unaffected” variants filter.
+This meant that variants that were not explicitly genotyped for the singleton individual, such as inconclusive “.”/“./.” STR and SV calls, were not shown in searches, unless the "Include variants present only in unaffected” option was used. We are aware of a small number of WES GATK DUPs and for WGS, small, noisy region TIDDIT de novo assembly BNDs. Please consider if you have cases impacted where you relied on the exception and recheck these, either after the update or simply now with the "Include variants present only in unaffected” option toggled on.
+
+Note that this is the standard mode of operation for cases with more than one individual. In order to hide unaffected carrier status from incidental discovery, variants like these are not displayed unless the checkbox is ticked.
+
+Institutes who use the always-on option for “Include variants present only in unaffected” have not been affected.
+
+⚙️Admins, note some new options have been added to make export of causatives, verified and managed variants easier and more similar.

--- a/docs/blog/new-4.111.md
+++ b/docs/blog/new-4.111.md
@@ -1,0 +1,25 @@
+## What's new in 4.111?
+
+_Posted: May 7 2026_
+
+Scout 4.111 is a focused release with improvements around panel handling, managed variants,
+and Saltshaker support.
+
+### Highlights
+
+- **PanelApp workflow improvements:** You can now download all PanelApp panels to a file and
+  also load/update `PANELAPP-GREEN` from a pre-downloaded file. This makes panel handling
+  easier in controlled or offline-friendly workflows.
+- **Better build-aware managed variant linking:** We improved matching and counters so managed
+  variants follow the case genome build correctly. In practice, this gives more reliable linking
+  of causative variants, including build 37 causatives viewed in build 38 contexts.
+- **Saltshaker support for rare disease rollout:** Scout now supports loading custom MT
+  Saltshaker HTML reports, and the Saltshaker update command was fixed. This prepares us to use
+  Saltshaker with new rare disease cases as soon as pipeline automation is updated.
+
+### Also included
+
+- Better handling of conflicts and duplicates when uploading managed variants.
+- Updated default hg38 gnomAD linkout to the `non_uk_biobank` subset.
+- Case page quality-of-life update: empty case categories are now hidden dynamically.
+- New command to remove loaded rank models. Old Nallo cases in Solna used the same URL for different rank models. This will help in updating these eventually.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-## My email is white listed but I can't log into Scout
+## My email has been added as a Scout user but I can't log into Scout
 
 You can be logged into multiple Google accounts at the same time. If you are only logged into
 one account, it will automatically be used when you click "Login with Google".

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Install Scout
 This guide will walk you through how to setup a working instance of Scout by cloning the repository from GitHub and installing it with a Python package manager.
 Our best recommendation is to use `uv` as the package manager, but you can also use `pip` if you prefer.
-It is also possible to install Scout using containers
-For instructions on how to deploy Scout command line and server using containers check the [Deploy Scout in containers][containers] page.
+It is also possible to install Scout in containers and launch it from there.
+For instructions on how to deploy Scout command line and server using containers, see the [Deploy Scout in containers][containers] page.
 Containers are a great option for testing and development. We use containers also for production, but for performance it is recommended to install the database engine (mongodb) outside containers.
 The instructions are divided into multiple sections.
 One section describes how to set up a demo version with some cases just to see how it could look like.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,11 @@
 # Install Scout
-This guide will walk you through how to setup a working instance of scout by cloning the repository from GitHub and installing it with the `pip install command`. For instructions on how to deploy Scout command line and server using containers check the [Deploy Scout in containers][containers] page
+This guide will walk you through how to setup a working instance of Scout by cloning the repository from GitHub and installing it with a Python package manager.
+Our best recommendation is to use `uv` as the package manager, but you can also use `pip` if you prefer.
+It is also possible to install Scout using containers
+For instructions on how to deploy Scout command line and server using containers check the [Deploy Scout in containers][containers] page.
+Containers are a great option for testing and development. We use containers also for production, but for performance it is recommended to install the database engine (mongodb) outside containers.
 The instructions are divided into multiple sections.
 One section describes how to set up a demo version with some cases just to see how it could look like.
-
 
 ## 0. Intro
 Make sure you have a `mongod` process running. First install [mongodb][mongodb] and follow the instructions.
@@ -49,7 +52,7 @@ the Flask instance config. To learn more about possible settings, take a
 look in the ``scout/settings.py`` module.
 
 
-### Autentication
+### Authentication
 If you intend to use authentication, which you should, there are several options!
 
 OAuth2 via an ODIC provider (we have good experience with Google) or a KeyCloak server of you own. Scout also supports LDAP.
@@ -63,13 +66,13 @@ find your "CLIENT ID" and "CLIENT SECRET". You also need to add some
 
 **REDIRECT URLS**:
 
-  - http://localhost:5023/authorized
-  - https://localhost:5023/authorized
+  - `http://localhost:5023/authorized`
+  - `https://localhost:5023/authorized`
 
 **JAVASCRIPT ORIGINS**:
 
-  - http://localhost:5023
-  - https://localhost:5023
+  - `http://localhost:5023`
+  - `https://localhost:5023`
 
 Remember that it might take a while for the tokens to start working.
 
@@ -108,14 +111,14 @@ scout setup database
 ```
 You will want to make sure you have a full complement of these genes, diseases etc before you start working on cases.
 
-```
+```bash
 scout download everything --api-key YOUR_OMIM_API_KEY
 scout update hpo --hpoterms hpo.obo --hpo-to-genes phenotype_to_genes.txt
 scout update diseases -f .
 scout update genes -f .
 ```
 
-A common task is to have a couple of broad screening panels for rare disease genomics set up. We provide automation for two such in silico panels
+A common task is to have a couple of broad screening panels for rare disease genomics set up. We provide automation for two such _in silico_ panels
 out of the box, one with OMIM morbid genes, and one with all PanelApp ``Green`` genes. Here you provide the name of an institute you created that
 will serve as responsible for these panels (`cust002` below):
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,8 @@ nav:
       - Whats new in 4.34?: 'blog/new-4.34.md'
       - Whats new in 4.67?: 'blog/new-4.67.md'
       - Whats new in 4.72?: 'blog/new-4.72.md'
-
+      - Whats new in 4.110?: 'blog/new-4.110.md'
+      - Whats new in 4.111?: 'blog/new-4.111.md'
 
 not_in_nav: |
     admin-guide/reference-sets/genes_transcripts.md

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -26,7 +26,6 @@ samples:
     subject_id: subj_ADM1059A2
     phenotype: affected
     sex: male
-    expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/hugelymodelbat_lanes_1_sorted_md_mitodel.txt
     mt_bam: scout/demo/reduced_mt.bam
@@ -58,7 +57,6 @@ samples:
     sample_name: NA12877
     phenotype: unaffected
     sex: male
-    expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/slowlycivilbuck_lanes_1_sorted_md_mitodel.txt
     mt_bam: scout/demo/reduced_mt.bam
@@ -77,7 +75,6 @@ samples:
     sample_name: NA12878
     phenotype: unaffected
     sex: female
-    expected_coverage: 30
     tissue_type: blood
     mitodel_file: scout/demo/mitodel_test_files/earlycasualcaiman_lanes_1_sorted_md_mitodel.txt
     mt_bam: scout/demo/reduced_mt.bam

--- a/scout/demo/643595.config.yaml
+++ b/scout/demo/643595.config.yaml
@@ -13,7 +13,6 @@ samples:
     sample_name: NA12882
     phenotype: affected
     sex: male
-    expected_coverage: 30
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A2.test.cgh
     tissue_type: blood
@@ -28,7 +27,6 @@ samples:
     sample_name: NA12877
     phenotype: unaffected
     sex: male
-    expected_coverage: 30
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A1.test.cgh
     tissue_type: blood
@@ -41,7 +39,6 @@ samples:
     sample_name: NA12878
     phenotype: unaffected
     sex: female
-    expected_coverage: 30
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/ADM1059A3.test.cgh
     tissue_type: blood

--- a/scout/demo/cancer.load_config.yaml
+++ b/scout/demo/cancer.load_config.yaml
@@ -12,7 +12,6 @@ samples:
     sample_name: 999-99
     phenotype: affected
     sex: male
-    expected_coverage: 90
     mt_bam: scout/demo/reduced_mt.bam
     vcf2cytosure: scout/demo/999-99.test.cgh
     tmb: 7
@@ -26,7 +25,6 @@ samples:
     sample_name: 998-99
     phenotype: unaffected
     sex: male
-    expected_coverage: 90
     mt_bam: scout/demo/reduced_mt.bam
 
 vcf_cancer: scout/demo/cancer_test.vcf.gz

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -546,7 +546,6 @@ def case(
         }
     add_link_for_disease(case_obj)
     if case_obj.get("custom_images"):
-        # re-encode images as base64
         case_obj["custom_images"] = case_obj["custom_images"].get(
             "case_images", case_obj["custom_images"].get("case", {})
         )


### PR DESCRIPTION
This PR fixes documentation

- blog post for 4.111
- blog post for 4.110 retroactively from email. We could do this for more old releases, perhaps even automate it...
- the `expected_coverage` option must have been obsolete for a very long time - removed it from the docs and demo
- clicked through docs and fixed some random formatting issues and typos, like this:
<img width="660" height="439" alt="Screenshot 2026-05-07 at 10 05 07" src="https://github.com/user-attachments/assets/d225a68e-61ff-4541-aae6-90f0367d46a0" />


<details>
<summary>Testing on cg-vm1 server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-vm1.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on cg-vm1: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>


**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
