### PR TITLE
Fix #6274 - institute settings loqusdb cleared for non-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Managed variants matching follows build on case page (#6254)
 - Updated docs on load case images (#6267)
 - Blog posts for 4.111 and 4.110 releases, removed obsolete `expected_coverage` key from documentation (#6270)
+- LoqusDB setting reset by non-admin changes to institute page (#6274)
 
 ## [4.110.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Managed variants matching follows build on case page (#6254)
 - Updated docs on load case images (#6267)
 - Blog posts for 4.111 and 4.110 releases, removed obsolete `expected_coverage` key from documentation (#6270)
-- LoqusDB setting reset by non-admin changes to institute page (#6274)
+- LoqusDB setting reset by non-admin changes to institute page (#6275)
 
 ## [4.110.0]
 ### Added

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -105,7 +105,7 @@ class InstituteHandler(object):
             "alamut_institution": alamut_institution,  # Admin setting
             "alamut_key": alamut_key,  # Admin setting
             "check_show_all_vars": check_show_all_vars,
-            "clinvar_key": clinvar_key,  # Admin setting
+            "clinvar_key": clinvar_key,
             "clinvar_submitters": clinvar_submitters,
             "cohorts": cohorts,
             "collaborators": sharing_institutes,
@@ -114,10 +114,10 @@ class InstituteHandler(object):
             "frequency_cutoff": frequency_cutoff,
             "gene_panels": gene_panels,
             "gene_panels_matching": gene_panels_matching,
-            "loqusdb_id": loqusdb_ids,
+            "loqusdb_id": loqusdb_ids,  # Admin setting
             "phenotype_groups": get_phenotype_groups(),
             "sanger_recipients": sanger_recipients,
-            "show_all_cases_status": show_all_cases_status,  # Admin setting
+            "show_all_cases_status": show_all_cases_status,
             "soft_filters": soft_filters,  # Admin setting
         }
         for key, value in UPDATE_SETTINGS.items():

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -2,7 +2,8 @@ import logging
 from datetime import datetime
 from typing import List, Optional, Union
 
-import pymongo
+from pymongo import ReturnDocument
+from pymongo.results import InsertOneResult
 
 from scout.constants import PHENOTYPE_GROUPS
 from scout.exceptions import IntegrityError
@@ -11,8 +12,8 @@ LOG = logging.getLogger(__name__)
 
 
 class InstituteHandler(object):
-    def add_institute(self, institute_obj):
-        """Add a institute to the database
+    def add_institute(self, institute_obj: dict) -> InsertOneResult:
+        """Add an institute to the database
 
         Args:
             institute_obj(Institute)
@@ -30,8 +31,9 @@ class InstituteHandler(object):
         )
 
         insert_info = self.institute_collection.insert_one(institute_obj)
-
-        LOG.info("Institute saved")
+        if insert_info.acknowledged:
+            LOG.info("Institute saved")
+        return insert_info
 
     def update_institute(
         self,
@@ -121,9 +123,11 @@ class InstituteHandler(object):
         for key, value in UPDATE_SETTINGS.items():
             if value is None:
                 continue
+
             if isinstance(value, bool):
                 updates["$set"][key] = value
                 continue
+
             if bool(value) is True:
                 updates["$set"][key] = value
             else:
@@ -134,7 +138,7 @@ class InstituteHandler(object):
             updated_institute = self.institute_collection.find_one_and_update(
                 {"_id": internal_id},
                 updates,
-                return_document=pymongo.ReturnDocument.AFTER,
+                return_document=ReturnDocument.AFTER,
             )
             LOG.info("Institute updated")
 

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -50,7 +50,7 @@ class InstituteHandler(object):
         add_groups: Optional[bool] = None,
         sharing_institutes: Optional[List[str]] = None,
         cohorts: Optional[List[str]] = None,
-        loqusdb_ids: Optional[List[str]] = [],
+        loqusdb_ids: Optional[List[str]] = None,
         alamut_key: Optional[str] = None,
         alamut_institution: Optional[str] = None,
         check_show_all_vars: Optional[str] = None,
@@ -102,7 +102,7 @@ class InstituteHandler(object):
         UPDATE_SETTINGS = {
             "alamut_institution": alamut_institution,  # Admin setting
             "alamut_key": alamut_key,  # Admin setting
-            "check_show_all_vars": check_show_all_vars is not None,
+            "check_show_all_vars": check_show_all_vars,
             "clinvar_key": clinvar_key,  # Admin setting
             "clinvar_submitters": clinvar_submitters,
             "cohorts": cohorts,
@@ -119,6 +119,11 @@ class InstituteHandler(object):
             "soft_filters": soft_filters,  # Admin setting
         }
         for key, value in UPDATE_SETTINGS.items():
+            if value is None:
+                continue
+            if isinstance(value, bool):
+                updates["$set"][key] = value
+                continue
             if bool(value) is True:
                 updates["$set"][key] = value
             else:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -465,17 +465,13 @@ def get_alamut_institution(form: MultiDict) -> Optional[str]:
 
 
 def get_show_all_cases_status(form: MultiDict) -> Optional[List[str]]:
-    """Return case statuses to always display for admins, otherwise don't update this setting."""
-    if current_user.is_admin is False:
-        return None
+    """Return case statuses to always display.."""
 
     return form.getlist("show_all_cases_status")
 
 
 def get_check_show_all_vars(form: MultiDict) -> Optional[bool]:
-    """Return explicit setting for show-all-vars checkbox for admins, otherwise don't update."""
-    if current_user.is_admin is False:
-        return None
+    """Return explicit setting for show-all-vars checkbox."""
 
     return form.get("check_show_all_vars") is not None
 

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -490,7 +490,12 @@ def get_gene_panels(store: MongoAdapter, form: MultiDict, tag: str) -> Dict:
 
 
 def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: MultiDict) -> Dict:
-    """Update institute settings with data collected from institute form."""
+    """Update institute settings with data collected from institute form.
+
+    Some form settings are only available to admins. These should not be set or cleared when an ordinary
+    user visits the page and edits something else. Do not call update_institute with admin-only settings
+    set to something other than None if the intention is not to update those settings.
+    """
 
     sharing_institutes = []
     for inst in form.getlist("institutes"):

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -442,6 +442,44 @@ def get_loqusdb_ids(form: MultiDict) -> Optional[List[str]]:
     return form.getlist("loqusdb_id")
 
 
+def get_alamut_key(form: MultiDict) -> Optional[str]:
+    """
+    Return Alamut key from the form input.
+    This is not available on the form for unprivileged users, only admin.
+    """
+    if current_user.is_admin is False:
+        return None
+
+    return form.get("alamut_key")
+
+
+def get_alamut_institution(form: MultiDict) -> Optional[str]:
+    """
+    Return Alamut institution settting from the form input.
+    This is not available on the form for unprivileged users, only admin.
+    """
+    if current_user.is_admin is False:
+        return None
+
+    return form.get("alamut_institution")
+
+
+def get_show_all_cases_status(form: MultiDict) -> Optional[List[str]]:
+    """Return case statuses to always display for admins, otherwise don't update this setting."""
+    if current_user.is_admin is False:
+        return None
+
+    return form.getlist("show_all_cases_status")
+
+
+def get_check_show_all_vars(form: MultiDict) -> Optional[bool]:
+    """Return explicit setting for show-all-vars checkbox for admins, otherwise don't update."""
+    if current_user.is_admin is False:
+        return None
+
+    return form.get("check_show_all_vars") is not None
+
+
 def get_gene_panels(store: MongoAdapter, form: MultiDict, tag: str) -> Dict:
     """
     Return gene panel objects checked in the corresponding form multiselect.
@@ -486,7 +524,7 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
             if form.get("frequency_cutoff")
             else form.get("frequency_cutoff")
         ),
-        show_all_cases_status=form.getlist("show_all_cases_status"),
+        show_all_cases_status=get_show_all_cases_status(form),
         display_name=form.get("display_name"),
         phenotype_groups=phenotype_groups,
         gene_panels=get_gene_panels(store, form, "gene_panels"),
@@ -496,9 +534,9 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
         sharing_institutes=sharing_institutes,
         cohorts=cohorts,
         loqusdb_ids=get_loqusdb_ids(form),
-        alamut_key=form.get("alamut_key"),
-        alamut_institution=form.get("alamut_institution"),
-        check_show_all_vars=form.get("check_show_all_vars"),
+        alamut_key=get_alamut_key(form),
+        alamut_institution=get_alamut_institution(form),
+        check_show_all_vars=get_check_show_all_vars(form),
         clinvar_key=form.get("clinvar_key"),
         clinvar_submitters=get_clinvar_submitters(form),
         soft_filters=get_soft_filters(form),

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -174,7 +174,7 @@
 {% endmacro %}
 
 {% macro institute_settings(form, beacon_form, institute, current_user, loqus_instances) %}
-<div clas="card w-100">
+<div class="card w-100">
   <form action="{{ url_for('overview.institute_settings', institute_id=institute._id) }}" method="POST"
     accept-charset="utf-8" id="institute_form">
   {{ form.csrf_token }}
@@ -377,6 +377,7 @@
                       </select>
                     </div>
                   </div>
+                </fieldset>
               </div>
               <!-- End of loqusdb settings -->
 
@@ -396,6 +397,7 @@
                       </select>
                     </div>
                   </div>
+                </fieldset>
               </div>
               <!-- End of custom soft filters for variants -->
 
@@ -422,12 +424,14 @@
                   {{ form.submit_btn(class="btn-primary btn") }}
               </div>
             </div>
+
         </div>
       </div>
+    </div>
   </form>
 </div>
 
-<!-- Display form to add a Beacon dataset if user is an andmin and if institute lacks one or more Beaocn datasets -->
+<!-- Display form to add a Beacon dataset if user is an admin and if institute lacks one or more Beacon datasets -->
 {% if current_user.is_admin and config.BEACON_URL and config.BEACON_TOKEN %}
 <form action="{{ url_for('overview.add_beacon_dataset', institute_id=institute._id) }}" method="post">
   <div class="card w-100">

--- a/tests/adapter/mongo/test_institute_handler.py
+++ b/tests/adapter/mongo/test_institute_handler.py
@@ -127,16 +127,20 @@ def test_update_institute_sanger_loqusDB(adapter, institute_obj, user_obj):
 def test_update_institute_preserves_loqusdb_when_not_provided(adapter, institute_obj):
     """Ensure omitted admin-only loqusdb setting is not removed by unrelated updates."""
 
+    # GIVEN an institute
     adapter.add_institute(institute_obj)
 
+    # WHEN first setting loqusdb on the institute
     loqusdb_ids = ["loqusdb_rd"]
     adapter.update_institute(internal_id=institute_obj["internal_id"], loqusdb_ids=loqusdb_ids)
 
+    # WHEN updating the institute without providing loqusdb
     adapter.update_institute(
         internal_id=institute_obj["internal_id"],
         display_name="updated institute name",
     )
 
+    # THEN the institute should still have loqusdb set
     res = adapter.institute(institute_id=institute_obj["internal_id"])
     assert res["loqusdb_id"] == loqusdb_ids
 

--- a/tests/adapter/mongo/test_institute_handler.py
+++ b/tests/adapter/mongo/test_institute_handler.py
@@ -124,6 +124,23 @@ def test_update_institute_sanger_loqusDB(adapter, institute_obj, user_obj):
     assert res["updated_at"] > institute_obj["created_at"]
 
 
+def test_update_institute_preserves_loqusdb_when_not_provided(adapter, institute_obj):
+    """Ensure omitted admin-only loqusdb setting is not removed by unrelated updates."""
+
+    adapter.add_institute(institute_obj)
+
+    loqusdb_ids = ["loqusdb_rd"]
+    adapter.update_institute(internal_id=institute_obj["internal_id"], loqusdb_ids=loqusdb_ids)
+
+    adapter.update_institute(
+        internal_id=institute_obj["internal_id"],
+        display_name="updated institute name",
+    )
+
+    res = adapter.institute(institute_id=institute_obj["internal_id"])
+    assert res["loqusdb_id"] == loqusdb_ids
+
+
 def test_update_display_name(adapter, institute_obj):
     ## GIVEN an adapter without any institutes
     assert sum(1 for _ in adapter.institutes()) == 0

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -206,6 +206,7 @@ def test_institute_settings_non_admin_preserves_loqusdb_id(app, user_obj, instit
     # AND a user without admin role
     user_obj["roles"] = ["mme_submitter"]
 
+    # WHEN changing a non admin setting
     with app.test_client() as client:
         client.get(url_for("auto_login"))
 
@@ -219,6 +220,7 @@ def test_institute_settings_non_admin_preserves_loqusdb_id(app, user_obj, instit
         )
         assert resp.status_code == 200
 
+    # THEN admin level settings shall not be unset
     updated_institute = store.institute_collection.find_one({"_id": institute_obj["internal_id"]})
     assert updated_institute["loqusdb_id"] == loqusdb_ids
 

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -193,6 +193,36 @@ def test_institute_settings(app, user_obj, institute_obj):
         assert updated_institute["soft_filters"] == ["in_normal"]
 
 
+def test_institute_settings_non_admin_preserves_loqusdb_id(app, user_obj, institute_obj):
+    """Ensure non-admin updates do not clear admin-only loqusdb settings."""
+
+    # GIVEN an existing loqusdb setting
+    loqusdb_ids = ["loqusdb_rd"]
+    store.institute_collection.find_one_and_update(
+        {"_id": institute_obj["internal_id"]},
+        {"$set": {"loqusdb_id": loqusdb_ids}},
+    )
+
+    # AND a user without admin role
+    user_obj["roles"] = ["mme_submitter"]
+
+    with app.test_client() as client:
+        client.get(url_for("auto_login"))
+
+        form_data = {
+            "display_name": "non-admin update",
+            "sanger_emails": ["bruce@banner.com"],
+        }
+        resp = client.post(
+            url_for("overview.institute_settings", institute_id=institute_obj["internal_id"]),
+            data=form_data,
+        )
+        assert resp.status_code == 200
+
+    updated_institute = store.institute_collection.find_one({"_id": institute_obj["internal_id"]})
+    assert updated_institute["loqusdb_id"] == loqusdb_ids
+
+
 def test_cases_export_samples(app, institute_obj):
     """Test the cases endpoint, providing a request to download cases samples to file."""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6274 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
