### PR TITLE
Fix #6282 - build aliases for export commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Build version alias GRCh38 to 38 for consistency in export commands (#6283)
+
 ## [4.111.0]
 ### Added
 - Custom MT Saltshaker HTML report loading (#6242)

--- a/scout/commands/export/exon.py
+++ b/scout/commands/export/exon.py
@@ -4,7 +4,6 @@ import click
 from bson.json_util import dumps
 from flask.cli import with_appcontext
 
-from scout.commands.utils import builds_option
 from scout.export.exon import export_exons, export_gene_exons
 from scout.server.extensions import store
 

--- a/scout/commands/export/gene.py
+++ b/scout/commands/export/gene.py
@@ -4,8 +4,6 @@ import click
 from bson.json_util import dumps
 from flask.cli import with_appcontext
 
-from scout.commands.utils import builds_option
-from scout.export.gene import export_genes
 from scout.server.extensions import store
 
 from .utils import build_option, json_option

--- a/scout/commands/export/gene.py
+++ b/scout/commands/export/gene.py
@@ -19,10 +19,15 @@ LOG = logging.getLogger(__name__)
 @with_appcontext
 def genes(build, json):
     """Export all genes from a build"""
+
+    if build == "GRCh38":
+        build = "38"
+
     LOG.info("Running scout export genes")
     adapter = store
     result = adapter.all_genes(build=build)
     gene_list = list(result)
+
     if build == "GRCh38":
         for gene_obj in gene_list:
             if gene_obj["chromosome"] == "MT":

--- a/scout/commands/export/gene.py
+++ b/scout/commands/export/gene.py
@@ -28,7 +28,7 @@ def genes(build, json):
     result = adapter.all_genes(build=build)
     gene_list = list(result)
 
-    if build == "GRCh38":
+    if build == "38":
         for gene_obj in gene_list:
             if gene_obj["chromosome"] == "MT":
                 gene_obj["chromosome"] = "M"

--- a/scout/commands/export/panel.py
+++ b/scout/commands/export/panel.py
@@ -33,6 +33,9 @@ def panel_cmd(panel: str, build: str, bed: bool, version: float):
         LOG.warning("Please provide at least one gene panel")
         raise click.Abort()
 
+    if build == "GRCh38":
+        build = "38"
+
     LOG.info("Exporting panels: {}".format(", ".join(panel)))
     if bed:
         if version:

--- a/scout/commands/export/transcript.py
+++ b/scout/commands/export/transcript.py
@@ -18,6 +18,9 @@ def transcripts(build):
     LOG.info("Running scout export transcripts")
     adapter = store
 
+    if build == "GRCh38":
+        build = "38"
+
     header = ["#Chrom\tStart\tEnd\tTranscript\tRefSeq\tHgncID"]
 
     for line in header:

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -130,6 +130,9 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     LOG.info("Running scout export managed variants")
     adapter = store
 
+    if build == "GRCh38":
+        build = "38"
+
     variants = export_managed_variants(
         adapter=adapter, institute=collaborator, build=build, category=list(category)
     )
@@ -176,6 +179,9 @@ def causatives(
         if not case_obj:
             LOG.info("Case %s does not exist", case_id)
             raise click.Abort
+
+    if build == "GRCh38":
+        build = "38"
 
     variants = export_causative_variants(
         adapter,

--- a/tests/commands/export/test_export_panel_cmd.py
+++ b/tests/commands/export/test_export_panel_cmd.py
@@ -72,6 +72,6 @@ def test_export_panel(mock_app):
         ],
     )
 
-    # The CLI command shoud return gene panel formatted in the expected way
+    # The CLI command should return gene panel formatted in the expected way
     assert result.exit_code == 0
-    assert "##genome_build=GRCh38" in result.output
+    assert "##genome_build=38" in result.output


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6282

This is slightly messy - we have both `builds_option` and `build_option` decorators, one with and one without the GRCh38 choice. I suspect some other lab was using the full name at one point? But anyway, for now, added aliases to the export entry points. I know it is fixed in the called functions for at least one of them, but... 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
