### PR TITLE
Fix #6287 - partly revert aliasing, use GRCh38 to mean add chr prefix…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Partly revert alias change, and instead use GRCh38 to mean write chr prefix in export commands (#6288)
+
 ## [4.111.1]
 ### Fixed
 - Build version alias GRCh38 to 38 for consistency in export commands (#6283)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [4.111.2]
 ### Fixed
 - Partly revert alias change, and instead use GRCh38 to mean write chr prefix in export commands (#6288)
 

--- a/docs/admin-guide/export.md
+++ b/docs/admin-guide/export.md
@@ -96,6 +96,7 @@ A tab-delimited list with the following header:
 ## Exporting Genes (`genes`)
 
 Export all genes from the database. Default format is a .bed file, but they can be exported as a json file by using the `--json` option.
+`--build GRCh38` will add `chr` prefix to output.
 
 ```
 Options:
@@ -138,6 +139,7 @@ Result:
 ## Exporting Managed Variants (`managed`)
 
 Export managed variants in VCF format.
+`--build GRCh38` will add `chr` prefix to output.
 
 **Example Output (VCF):**
 
@@ -168,6 +170,7 @@ Options:
 ## Exporting Gene Panels (`panel`)
 
 Export gene panels with clinical annotation in BED format.
+`--build GRCh38` will add `chr` prefix to output.
 
 ```
 Options:
@@ -187,6 +190,7 @@ Options:
 ## Exporting Transcripts (`transcripts`)
 
 Export a list of transcripts in BED format. Use the following command: `scout export transcripts`
+`--build GRCh38` will add `chr` prefix to output.
 
 ```
 Options:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.111.1"
+version = "4.111.2"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Måns Magnusson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}

--- a/scout/commands/export/gene.py
+++ b/scout/commands/export/gene.py
@@ -18,15 +18,12 @@ LOG = logging.getLogger(__name__)
 def genes(build, json):
     """Export all genes from a build"""
 
-    if build == "GRCh38":
-        build = "38"
-
     LOG.info("Running scout export genes")
     adapter = store
     result = adapter.all_genes(build=build)
     gene_list = list(result)
 
-    if build == "38":
+    if build == "GRCh38":
         for gene_obj in gene_list:
             if gene_obj["chromosome"] == "MT":
                 gene_obj["chromosome"] = "M"

--- a/scout/commands/export/panel.py
+++ b/scout/commands/export/panel.py
@@ -33,9 +33,6 @@ def panel_cmd(panel: str, build: str, bed: bool, version: float):
         LOG.warning("Please provide at least one gene panel")
         raise click.Abort()
 
-    if build == "GRCh38":
-        build = "38"
-
     LOG.info("Exporting panels: {}".format(", ".join(panel)))
     if bed:
         if version:

--- a/scout/commands/export/transcript.py
+++ b/scout/commands/export/transcript.py
@@ -19,16 +19,19 @@ def transcripts(build):
     adapter = store
 
     if build == "GRCh38":
-        build = "38"
+        genome_build = "38"
 
     header = ["#Chrom\tStart\tEnd\tTranscript\tRefSeq\tHgncID"]
 
     for line in header:
         click.echo(line)
 
-    transcript_string = "{0}\t{1}\t{2}\t{3}\t{4}\t{5}"
+    chr_prefix = ""
+    if build == "GRCh38":
+        chr_prefix = "chr"
+    transcript_string = "{chr_prefix}{0}\t{1}\t{2}\t{3}\t{4}\t{5}"
 
-    for tx_obj in export_transcripts(adapter, build):
+    for tx_obj in export_transcripts(adapter, genome_build):
         click.echo(
             transcript_string.format(
                 tx_obj["chrom"],

--- a/scout/commands/export/transcript.py
+++ b/scout/commands/export/transcript.py
@@ -18,8 +18,7 @@ def transcripts(build):
     LOG.info("Running scout export transcripts")
     adapter = store
 
-    if build == "GRCh38":
-        genome_build = "38"
+    genome_build = "38" if (build == "GRCh38") else build
 
     header = ["#Chrom\tStart\tEnd\tTranscript\tRefSeq\tHgncID"]
 
@@ -29,16 +28,9 @@ def transcripts(build):
     chr_prefix = ""
     if build == "GRCh38":
         chr_prefix = "chr"
-    transcript_string = "{chr_prefix}{0}\t{1}\t{2}\t{3}\t{4}\t{5}"
+    transcript_string = "{0}{1}\t{2}\t{3}\t{3}\t{4}\t{5}"
 
     for tx_obj in export_transcripts(adapter, genome_build):
         click.echo(
-            transcript_string.format(
-                tx_obj["chrom"],
-                tx_obj["start"],
-                tx_obj["end"],
-                tx_obj["ensembl_transcript_id"],
-                tx_obj.get("refseq_id", ""),
-                tx_obj["hgnc_id"],
-            )
+            f"{chr_prefix}{tx_obj["chrom"]}\t{tx_obj["start"]}\t{tx_obj["end"]}\t{tx_obj['ensembl_transcript_id']}\t{tx_obj.get('refseq_id', '')}\t{tx_obj['hgnc_id']}"
         )

--- a/scout/commands/export/transcript.py
+++ b/scout/commands/export/transcript.py
@@ -31,5 +31,5 @@ def transcripts(build):
 
     for tx_obj in export_transcripts(adapter, genome_build):
         click.echo(
-            f"{chr_prefix}{tx_obj["chrom"]}\t{tx_obj["start"]}\t{tx_obj["end"]}\t{tx_obj['ensembl_transcript_id']}\t{tx_obj.get('refseq_id', '')}\t{tx_obj['hgnc_id']}"
+            f"{chr_prefix}{tx_obj['chrom']}\t{tx_obj['start']}\t{tx_obj['end']}\t{tx_obj['ensembl_transcript_id']}\t{tx_obj.get('refseq_id', '')}\t{tx_obj['hgnc_id']}"
         )

--- a/scout/commands/export/transcript.py
+++ b/scout/commands/export/transcript.py
@@ -28,7 +28,6 @@ def transcripts(build):
     chr_prefix = ""
     if build == "GRCh38":
         chr_prefix = "chr"
-    transcript_string = "{0}{1}\t{2}\t{3}\t{3}\t{4}\t{5}"
 
     for tx_obj in export_transcripts(adapter, genome_build):
         click.echo(

--- a/scout/commands/export/utils.py
+++ b/scout/commands/export/utils.py
@@ -26,5 +26,5 @@ build_option = click.option(
     default="37",
     type=click.Choice(BUILDS),
     show_default=True,
-    help="Genome build version",
+    help="Genome build version - GRCh38 will add chr prefix to output",
 )

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -133,8 +133,12 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     if build == "GRCh38":
         build = "38"
 
+    genome_build = build
+    if build == "GRCh38":
+        genome_build = "38"
+
     variants = export_managed_variants(
-        adapter=adapter, institute=collaborator, build=build, category=list(category)
+        adapter=adapter, institute=collaborator, build=genome_build, category=list(category)
     )
 
     if json:
@@ -147,7 +151,7 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     valid_lines = []
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj)
+        variant_string = get_vcf_entry(variant_obj, build=build)
         if variant_string:
             valid_lines.append(variant_string)
 
@@ -169,7 +173,10 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
 def causatives(
     build: str, collaborator: str, category: str, document_id: str, case_id: str, json: bool
 ):
-    """Export causatives for a collaborator in .vcf format"""
+    """Export causatives for a collaborator in .vcf format
+
+    If build is 'GRCh38', retrieve variants in build 38, but print them with a chr prefix
+    """
 
     LOG.info("Running scout export variants")
     adapter = store
@@ -180,15 +187,16 @@ def causatives(
             LOG.info("Case %s does not exist", case_id)
             raise click.Abort
 
+    genome_build = build
     if build == "GRCh38":
-        build = "38"
+        genome_build = "38"
 
     variants = export_causative_variants(
         adapter,
         collaborator,
         document_id=document_id,
         case_id=case_id,
-        build=build,
+        build=genome_build,
         category=category,
     )
 
@@ -210,11 +218,11 @@ def causatives(
         click.echo(line)
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj, case_id=case_id)
+        variant_string = get_vcf_entry(variant_obj, case_id=case_id, build=build)
         click.echo(variant_string)
 
 
-def get_vcf_entry(variant_obj: dict, case_id: str = None) -> str:
+def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37") -> str:
     """
     Get vcf entry from variant object
     """
@@ -239,9 +247,16 @@ def get_vcf_entry(variant_obj: dict, case_id: str = None) -> str:
     if alt in [".", "-", variant_obj["sub_category"]]:
         alt = f"<{subcat}>" if category == "sv" else "N"
 
+    chrom = variant_obj["chromosome"]
+    if build == "GRCh38":
+        chrom = variant_obj["chromosome"]
+        if chrom == "MT":
+            chrom = "M"
+        chrom = "".join(["chr", chrom])
+
     filters = ";".join(variant_obj.get("filters", [])) or "."
     vcf_fields = [
-        variant_obj["chromosome"],
+        chrom,
         str(pos),
         variant_obj.get("dbsnp_id", ".") or ".",
         ref,

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -130,9 +130,6 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     LOG.info("Running scout export managed variants")
     adapter = store
 
-    if build == "GRCh38":
-        build = "38"
-
     genome_build = build
     if build == "GRCh38":
         genome_build = "38"

--- a/scout/export/panel.py
+++ b/scout/export/panel.py
@@ -58,9 +58,6 @@ def export_panels(adapter, panels, versions=None, build="37"):
         for gene_obj in panel_obj["genes"]:
             panel_geneids.add(gene_obj["hgnc_id"])
 
-    if build == "GRCh38":
-        build = "38"
-
     gene_objs = adapter.hgncid_to_gene(build=build)
 
     for hgnc_id in panel_geneids:

--- a/tests/commands/export/test_export_panel_cmd.py
+++ b/tests/commands/export/test_export_panel_cmd.py
@@ -74,4 +74,4 @@ def test_export_panel(mock_app):
 
     # The CLI command should return gene panel formatted in the expected way
     assert result.exit_code == 0
-    assert "##genome_build=38" in result.output
+    assert "##genome_build=GRCh38" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -2135,7 +2135,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.111.1"
+version = "4.111.2"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
… also for export variants

This PR adds a functionality or fixes a bug.

- Fix #6287 

Before:

<img width="991" height="434" alt="Screenshot 2026-05-12 at 14 04 07" src="https://github.com/user-attachments/assets/2c6b0de9-fb36-4489-8e24-7dd2a9cb0d8a" />

After:

<img width="845" height="299" alt="Screenshot 2026-05-12 at 16 05 57" src="https://github.com/user-attachments/assets/0672c585-04ed-4809-a1b8-21160d6d7e73" />
<img width="872" height="275" alt="Screenshot 2026-05-12 at 16 05 46" src="https://github.com/user-attachments/assets/23d03b97-4a13-4a7d-b5c2-0df1c079229a" />
<img width="868" height="306" alt="Screenshot 2026-05-12 at 16 04 44" src="https://github.com/user-attachments/assets/c8a8c070-32e9-4182-a5a5-0846a827fe85" />
<img width="850" height="310" alt="Screenshot 2026-05-12 at 16 04 34" src="https://github.com/user-attachments/assets/5d42a11a-2b61-42c3-b63d-ca0bd266c34a" />
<img width="839" height="766" alt="Screenshot 2026-05-12 at 15 55 13" src="https://github.com/user-attachments/assets/e835f97b-e25a-4ef3-948d-d09d952a52fc" />
<img width="723" height="345" alt="Screenshot 2026-05-12 at 16 57 56" src="https://github.com/user-attachments/assets/e1c438e6-9713-4fe9-ab4f-08be1b2fa833" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
