### PR TITLE
Version 4.111.3 - reintroduce alias for panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [4.111.3]
+### Fixed
+- Reintroduce GRCh38 alias conversion for export panels (#6289)
+
 ## [4.111.2]
 ### Fixed
 - Partly revert alias change, and instead use GRCh38 to mean write chr prefix in export commands (#6288)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.111.2"
+version = "4.111.3"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Måns Magnusson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}

--- a/scout/export/panel.py
+++ b/scout/export/panel.py
@@ -58,7 +58,10 @@ def export_panels(adapter, panels, versions=None, build="37"):
         for gene_obj in panel_obj["genes"]:
             panel_geneids.add(gene_obj["hgnc_id"])
 
-    gene_objs = adapter.hgncid_to_gene(build=build)
+    if build == "GRCh38":
+        genome_build = "38"
+
+    gene_objs = adapter.hgncid_to_gene(build=genome_build)
 
     for hgnc_id in panel_geneids:
         hgnc_geneobj = gene_objs.get(hgnc_id)

--- a/scout/export/panel.py
+++ b/scout/export/panel.py
@@ -58,6 +58,7 @@ def export_panels(adapter, panels, versions=None, build="37"):
         for gene_obj in panel_obj["genes"]:
             panel_geneids.add(gene_obj["hgnc_id"])
 
+    genome_build = build
     if build == "GRCh38":
         genome_build = "38"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2135,7 +2135,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.111.2"
+version = "4.111.3"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
This PR marks a new Scout release. We apply semantic versioning. This is a patch release for reasons.

Fix issue with `scout export panels --build GRCh38` not finding any genes. Find a middle ground where an alias to the internal "38" is used when fetching genes, but `GRCh38` used to trigger adding `chr`-prefixes.

Before
<img width="990" height="395" alt="Screenshot 2026-05-12 at 18 50 54" src="https://github.com/user-attachments/assets/eb82fbc4-5d4e-46a6-b7e6-efeb2243085e" />
<img width="828" height="789" alt="Screenshot 2026-05-12 at 18 51 12" src="https://github.com/user-attachments/assets/9d6580ee-c195-49e4-8f9f-21de05d60df3" />
<img width="909" height="403" alt="Screenshot 2026-05-12 at 18 50 58" src="https://github.com/user-attachments/assets/1a5af9e6-4d3b-413d-8ff1-43a71af5f8b8" />

After
<img width="903" height="764" alt="Screenshot 2026-05-12 at 18 48 44" src="https://github.com/user-attachments/assets/88ece7fd-66c5-4e38-a29d-ddd60be010eb" />
<img width="867" height="724" alt="Screenshot 2026-05-12 at 18 49 13" src="https://github.com/user-attachments/assets/ffc4a455-1812-4167-b1c0-ecb2c0a4cf9a" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
