### PR TITLE
Fix adding one managed variant in build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [unreleased]"
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
+- Adding single managed variants with build 38 (#6300)
 
 ## [4.111.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]"
+## [unreleased]
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)

--- a/scout/server/blueprints/managed_variants/controllers.py
+++ b/scout/server/blueprints/managed_variants/controllers.py
@@ -78,7 +78,7 @@ def managed_variants(request: LocalProxy) -> dict:
     managed_variants_query = store.managed_variants(
         category=categories,
         query_options=query_options,
-        build=request.form.get("build"),
+        build=filters_form.build.data,
         skip_count=skip_count,
         vars_per_page=VARS_PER_PAGE,
     )
@@ -119,6 +119,7 @@ def add_managed_variant(request: LocalProxy):
 
     managed_variant_obj = build_managed_variant(
         dict(
+            build=add_form["build"].data,
             chromosome=add_form["chromosome"].data,
             position=add_form["position"].data,
             end=add_form["end"].data,

--- a/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
+++ b/scout/server/blueprints/managed_variants/templates/managed_variants/managed_variants.html
@@ -221,6 +221,7 @@
   <table class="table table-bordered table-hover">
     <thead>
       <tr>
+        <th>{{ add_form.build.label }}</th>
         <th>Chr</th>
         <th>{{ add_form.position.label }}</th>
         <th>{{ add_form.end.label }}</th>
@@ -233,6 +234,7 @@
     </thead>
     <tbody>
       <tr>
+      <td>{{ add_form.build(class_="form-control") }}</td>
       <td>{{ add_form.chromosome(class_="form-control") }}</td>
       <td>{{ add_form.position(class="form-control", type="number") }}</td>
       <td>{{ add_form.end(class="form-control", type="number") }}</td>

--- a/scout/server/blueprints/managed_variants/views.py
+++ b/scout/server/blueprints/managed_variants/views.py
@@ -103,9 +103,6 @@ def add_managed_variant():
     controllers.add_managed_variant(request)
 
     return redirect(
-        url_for(
-            ".managed_variants",
-            **request.form,
-        ),
+        url_for(".managed_variants"),
         code=307,
     )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6299 

<img width="480" height="262" alt="image" src="https://github.com/user-attachments/assets/93fca439-af01-485a-9a37-4ce72a2e69b0" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
