### PR TITLE
Fix trying to load research in build 37 for cases with build 38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)
 - Paraphase region names alphabetically sorted on SMN/Dark regions page (#6301)
+- Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 ()
 
 ## [4.111.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)
 - Paraphase region names alphabetically sorted on SMN/Dark regions page (#6301)
-- Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 ()
+- Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 (#6322)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -249,7 +249,7 @@ class GeneHandler(object):
             LOG.info("Dropping the hgnc_gene collection")
             self.hgnc_collection.drop()
 
-    def hgncid_to_gene(self, build="37", genes=None):
+    def hgncid_to_gene(self, build: str, genes: Optional[List[dict]] = None) -> Dict[int, dict]:
         """Return a dictionary with hgnc_id as key and gene_obj as value
 
         The result will have ONE entry for each gene in the database.

--- a/scout/adapter/mongo/hgnc.py
+++ b/scout/adapter/mongo/hgnc.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import intervaltree
 from pymongo.errors import BulkWriteError, DuplicateKeyError
@@ -250,19 +250,7 @@ class GeneHandler(object):
             self.hgnc_collection.drop()
 
     def hgncid_to_gene(self, build: str, genes: Optional[List[dict]] = None) -> Dict[int, dict]:
-        """Return a dictionary with hgnc_id as key and gene_obj as value
-
-        The result will have ONE entry for each gene in the database.
-        (For a specific build)
-
-        Args:
-            build(str):
-            genes(iterable(scout.models.HgncGene)):
-
-        Returns:
-            hgnc_dict(dict): {<hgnc_id(int)>: <gene(dict)>}
-
-        """
+        """Return a dictionary with hgnc_id as key and gene_obj as value."""
         hgnc_dict = {}
         LOG.info("Building hgncid_to_gene")
         if not genes:

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -29,6 +29,7 @@ def upload_research_variants(
         variant_type=variant_type,
         category=category,
         rank_threshold=rank_treshold,
+        build=case_obj["genome_build"],
     )
 
 

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -161,7 +161,7 @@ rank_model_version: '1.20'
 sv_rank_model_version: '1.5'
 rank_score_threshold: -100
 analysis_date: 2016-10-12 14:00:46
-human_genome_build: '38'
+human_genome_build: '37'
 rna_human_genome_build: '38'
 rank_model_url: scout/demo/rank_model_-v1.20-.ini
 sv_rank_model_url: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/refs/heads/master/rare-disease/rank_model/svrank_model_-v1.5-.ini

--- a/scout/demo/643594.config.yaml
+++ b/scout/demo/643594.config.yaml
@@ -161,7 +161,7 @@ rank_model_version: '1.20'
 sv_rank_model_version: '1.5'
 rank_score_threshold: -100
 analysis_date: 2016-10-12 14:00:46
-human_genome_build: '37'
+human_genome_build: '38'
 rna_human_genome_build: '38'
 rank_model_url: scout/demo/rank_model_-v1.20-.ini
 sv_rank_model_url: https://raw.githubusercontent.com/Clinical-Genomics/reference-files/refs/heads/master/rare-disease/rank_model/svrank_model_-v1.5-.ini

--- a/tests/adapter/mongo/test_gene_handler.py
+++ b/tests/adapter/mongo/test_gene_handler.py
@@ -380,7 +380,7 @@ def test_hgncid_to_gene(adapter):
     assert sum(1 for _ in res) == 2
 
     ##THEN assert that the correct number of genes where fetched
-    res = adapter.hgncid_to_gene()
+    res = adapter.hgncid_to_gene(build="37")
     assert gene_obj["hgnc_id"] in res
     assert gene_obj2["hgnc_id"] in res
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6316 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
