### PR TITLE
Fix #6307 - add export category tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Contigs on exported variants VCF files (managed and causative variants) (#6310)
-### Changed
 - Display genome build on managed variants page (#6297)
+- INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - Contigs on exported variants VCF files (managed and causative variants) (#6310)
-- Display genome build on managed variants page (#6297)
 - INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
+### Changed
+- Display genome build on managed variants page (#6297)
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -153,7 +153,7 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     valid_lines = []
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj, build=build)
+        variant_string = get_vcf_entry(variant_obj, build=build, info_tags={"EXPORT_CATEGORY": "MANAGED"})
         if variant_string:
             valid_lines.append(variant_string)
 
@@ -222,13 +222,15 @@ def causatives(
         click.echo(line)
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj, case_id=case_id, build=build)
+        variant_string = get_vcf_entry(variant_obj, case_id=case_id, build=build, info_tags={"EXPORT_CATEGORY": "CAUSATIVES"})
         click.echo(variant_string)
 
 
-def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37") -> str:
+def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37", info_tags: dict) -> str:
     """
     Get vcf entry from variant object
+
+    Add any additional INFO tags in a dict info_tags.
     """
 
     pos = variant_obj["position"]
@@ -242,6 +244,9 @@ def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37") -> 
         info_field = f"{var_type}={subcat}"
     else:
         info_field = f"END={end};{var_type}={subcat}"
+
+    for key, value in info_tags.items():
+        info_field += f";{key}={value}"
 
     ref = variant_obj.get("reference") or "N"
     if ref == ".":

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -224,7 +224,7 @@ def causatives(
 
     for variant_obj in variants:
         if variant_string := get_vcf_entry(
-            variant_obj, case_id=case_id, build=build, info_tags={"EXPORT_CATEGORY": "CAUSATIVES"}
+            variant_obj, case_id=case_id, build=build, info_tags={"EXPORT_CATEGORY": "CAUSATIVE"}
         ):
             click.echo(variant_string)
 

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 import click
 from flask import current_app
@@ -153,8 +153,9 @@ def managed(collaborator: str, category: Tuple[str], build: str, json: bool):
     valid_lines = []
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj, build=build, info_tags={"EXPORT_CATEGORY": "MANAGED"})
-        if variant_string:
+        if variant_string := get_vcf_entry(
+            variant_obj, build=build, info_tags={"EXPORT_CATEGORY": "MANAGED"}
+        ):
             valid_lines.append(variant_string)
 
     for line in vcf_header:
@@ -222,11 +223,15 @@ def causatives(
         click.echo(line)
 
     for variant_obj in variants:
-        variant_string = get_vcf_entry(variant_obj, case_id=case_id, build=build, info_tags={"EXPORT_CATEGORY": "CAUSATIVES"})
-        click.echo(variant_string)
+        if variant_string := get_vcf_entry(
+            variant_obj, case_id=case_id, build=build, info_tags={"EXPORT_CATEGORY": "CAUSATIVES"}
+        ):
+            click.echo(variant_string)
 
 
-def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37", info_tags: dict) -> str:
+def get_vcf_entry(
+    variant_obj: dict, case_id: str = None, build: str = "37", info_tags: Optional[dict] = None
+) -> str | None:
     """
     Get vcf entry from variant object
 
@@ -245,7 +250,7 @@ def get_vcf_entry(variant_obj: dict, case_id: str = None, build: str = "37", inf
     else:
         info_field = f"END={end};{var_type}={subcat}"
 
-    for key, value in info_tags.items():
+    for key, value in info_tags.items() if info_tags else {}:
         info_field += f";{key}={value}"
 
     ref = variant_obj.get("reference") or "N"

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -13,7 +13,7 @@ from xlsxwriter import Workbook
 
 from scout.constants import CALLERS, DATE_DAY_FORMATTER
 from scout.constants.managed_variant import MANAGED_CATEGORIES
-from scout.constants.variants_export import VCF_HEADER, VERIFIED_VARIANTS_HEADER
+from scout.constants.variants_export import VERIFIED_VARIANTS_HEADER
 from scout.export.variant import (
     export_causative_variants,
     export_managed_variants,

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -55,6 +55,7 @@ VCF_HEADER = [
     '##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">',
     '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">',
     '##INFO=<ID=TYPE,Number=1,Type=String,Description="Type of variant">',
+    '##INFO=<ID=EXPORT_CATEGORY,Number=1,Type=String,Description="Type of Scout variant export - MANAGED, CAUSATIVE">',
     '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
 ]
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6307 - add INFO tags `EXPORT_CATEGORY=[MANAGED|CAUSATIVE]`

<img width="1397" height="938" alt="Screenshot 2026-05-21 at 15 45 36" src="https://github.com/user-attachments/assets/017f523f-f883-41e0-a226-c0b6a1e52e63" />

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
