### PR TITLE
Fixes bug where likely benign overwrites benign as classification for ACMG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Adding single managed variants with build 38 (#6300)
 - Paraphase region names alphabetically sorted on SMN/Dark regions page (#6301)
 - Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 (#6322)
+- "likely benign" classification overwrites "benign" for ACMG (#6325)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/utils/acmg.py
+++ b/scout/utils/acmg.py
@@ -271,7 +271,7 @@ def get_acmg(acmg_terms: set) -> Optional[str]:
     else:
         if benign:
             prediction = "benign"
-        if likely_benign:
+        elif likely_benign:
             prediction = "likely_benign"
 
     return prediction

--- a/tests/utils/test_acmg.py
+++ b/tests/utils/test_acmg.py
@@ -395,6 +395,12 @@ def test_get_acmg_pathogenic():
     assert res == "pathogenic"
 
 
+def test_get_acmg_benign():
+    acmg_terms = {"BS1", "BS2", "BP4"}
+    res = get_acmg(acmg_terms)
+    assert res == "benign"
+
+
 def test_get_acmg_modifier():
     acmg_terms = {"PVS1", "PS1"}
     res = get_acmg(acmg_terms)


### PR DESCRIPTION
Fixes a bug where, when doing an ACMG classification, adding a BP criterium prevents a classification from becoming "benign". If a classification already has two BS criteria (and is therefore benign), the classification falls to "likely benign" with the addition of a BP. This is for the suggested classification from Richards et al, not the temperature.

This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub Actions, DN
