### PR TITLE
Clearer logs with case ID when variants loading fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Contigs on exported variants VCF files (managed and causative variants) (#6310)
 - INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
 - On variant page, matching causatives expandable div, display status and status tags from matching causatives' case (#6315)
+- Clearer logs reporting case ID when variant loading fails ()
 ### Changed
 - Display genome build on managed variants page (#6297)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Contigs on exported variants VCF files (managed and causative variants) (#6310)
 - INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
 - On variant page, matching causatives expandable div, display status and status tags from matching causatives' case (#6315)
-- Clearer logs reporting case ID when variant loading fails ()
+- Clearer logs reporting case ID when variant loading fails (#6329)
 ### Changed
 - Display genome build on managed variants page (#6297)
 ### Fixed

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -100,7 +100,7 @@ class VariantLoader(object):
             try:
                 self.variant_collection.bulk_write(requests, ordered=False)
             except BulkWriteError as err:
-                LOG.warning("Updating variant rank failed")
+                LOG.warning(f"Updating variants rank from {case_obj['_id']} failed")
                 raise err
 
         LOG.info("Updating variant_rank done")
@@ -785,7 +785,9 @@ class VariantLoader(object):
                     genomic_intervals=genomic_intervals,
                 )
             except Exception as error:
-                LOG.exception("unexpected error")
+                LOG.exception(
+                    f"Unexpected error while loading variants from case {case_obj['_id']}"
+                )
                 LOG.warning("Deleting inserted variants")
                 self.delete_variants(case_obj["_id"], variant_type)
                 raise error

--- a/scout/parse/variant/variant.py
+++ b/scout/parse/variant/variant.py
@@ -64,9 +64,11 @@ def parse_variant(
     chrom_match = CHR_PATTERN.match(variant.CHROM)
     chrom = chrom_match.group(2)
 
-    ### We always assume split and normalized vcfs!!!
+    ### We always assume split and normalized VCFs!!!
     if len(variant.ALT) > 1:
-        raise VcfError("Variants are only allowed to have one alternative")
+        raise VcfError(
+            f"Error parsing variants from case {case_id}: variants are only allowed to have one alternative."
+        )
 
     # Builds a dictionary with the different ids that are used
     parsed_variant = {


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6328 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by automated tests
