### PR TITLE
Do not default to build 37 when loading variants from a case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Paraphase region names alphabetically sorted on SMN/Dark regions page (#6301)
 - Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 (#6322)
 - "likely benign" classification overwrites "benign" for ACMG (#6325)
+- Loading of variants within genomic regions or genes always attempted using genome build 37, even if case is analysed using build 38 ()
 
 ## [4.111.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 (#6322)
 - "likely benign" classification overwrites "benign" for ACMG (#6325)
 - Show pending comments for gene panels (#6327)
-- Loading of variants defaulting to build 37 whenever genomic build was not passed to the loader function (#6331)
+- Loading of variants defaulting to build 37 whenever genomic build is not passed to the loader function (#6331)
 
 ## [4.111.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Paraphase region names alphabetically sorted on SMN/Dark regions page (#6301)
 - Research variants only loaded when they overlap genes present in build 37, even if the case is analyzed using build 38 (#6322)
 - "likely benign" classification overwrites "benign" for ACMG (#6325)
-- Loading of variants within genomic regions or genes always attempted using genome build 37, even if case is analysed using build 38 ()
+- Loading of variants defaulting to build 37 whenever genomic build was not passed to the loader function (#6331)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# stdlib modules
 import logging
 import sys
 from datetime import datetime
@@ -29,6 +28,7 @@ from scout.parse.variant.headers import (
 )
 from scout.parse.variant.ids import parse_simple_id
 from scout.parse.variant.rank_score import parse_rank_score
+from scout.server.utils import get_case_genome_build
 from scout.utils.md5 import generate_md5_key
 
 LOG = logging.getLogger(__name__)
@@ -376,7 +376,7 @@ class VariantLoader(object):
         individual_positions refers to the order of samples in the VCF file. sample_info contains info about samples. It is used for instance to define tumor samples in cancer cases.
         local_archive_info contains info about the local archive used for annotation.
         """
-        build = build or "37"
+        build = build or get_case_genome_build(case_obj)
 
         start_insertion = datetime.now()
         start_five_thousand = datetime.now()


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6330

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by automatic tests
