### PR TITLE
Remove unused imports on commands/export/variants module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - "likely benign" classification overwrites "benign" for ACMG (#6325)
 - Show pending comments for gene panels (#6327)
 - Loading of variants defaulting to build 37 whenever genomic build is not passed to the loader function (#6331)
+- Removed unused imports on `commands/export/variant` module ()
 
 ## [4.111.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - "likely benign" classification overwrites "benign" for ACMG (#6325)
 - Show pending comments for gene panels (#6327)
 - Loading of variants defaulting to build 37 whenever genomic build is not passed to the loader function (#6331)
-- Removed unused imports on `commands/export/variant` module ()
+- Removed unused imports on `commands/export/variant` module (#6334)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -2,12 +2,9 @@ import datetime
 import json as json_lib
 import logging
 import os
-import sys
-from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import click
-from flask import current_app
 from flask.cli import with_appcontext
 from xlsxwriter import Workbook
 
@@ -20,7 +17,7 @@ from scout.export.variant import (
 )
 from scout.server.blueprints.institutes.controllers import variants_to_managed_variants
 from scout.server.extensions import store
-from scout.utils.vcf import build_vcf_header, print_vcf, validate_vcf_line
+from scout.utils.vcf import print_vcf
 
 from .export_handler import bson_handler
 from .utils import build_option, category_option, collaborator_option, json_option


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Remove unused imports, I think they were left there by mistake after a conflict merging or something

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by GitHub actions
