### PR TITLE
Fix time limit in export causatives CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
 - On variant page, matching causatives expandable div, display status and status tags from matching causatives' case (#6315)
 - Clearer logs reporting case ID when variant loading fails (#6329)
-- Export causatives to managed variants infile via CLI, filtering variants by date (#6290)
+- Export causatives to managed variants infile via CLI, filtering variants by date (#6290, #)
 - MitoSAlt/SAltShaker SV caller for MT SV variants (#6333)
 ### Changed
 - Display genome build on managed variants page (#6297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - INFO tags for exported variant category `EXPORT_CATEGORY` on exported variants VCF files (#6324)
 - On variant page, matching causatives expandable div, display status and status tags from matching causatives' case (#6315)
 - Clearer logs reporting case ID when variant loading fails (#6329)
-- Export causatives to managed variants infile via CLI, filtering variants by date (#6290, #)
+- Export causatives to managed variants infile via CLI, filtering variants by date (#6290, #6338)
 - MitoSAlt/SAltShaker SV caller for MT SV variants (#6333)
 ### Changed
 - Display genome build on managed variants page (#6297)

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -542,11 +542,7 @@ class VariantHandler(VariantLoader):
 
         case_ids = self.event_collection.distinct(
             "case",
-            {
-                "institute": institute_obj["_id"],
-                "verb": {"$in": ["mark_causative", "mark_partial_causative"]},
-                "category": "case",
-            },
+            query,
         )
         cases = self.case_collection.find(
             {"_id": {"$in": case_ids}}, projection=CASE_CAUSATIVES_PROJECTION


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6337 

### Test with variants marked causatives last week:

`uv run scout --demo export causatives  --within-days 10`:

<img width="984" height="211" alt="image" src="https://github.com/user-attachments/assets/158759f2-02ae-40a7-9065-85388f5f8842" />

`uv run scout --demo export causatives  --within-days 1`:

<img width="435" height="207" alt="image" src="https://github.com/user-attachments/assets/e8b9275f-2547-47de-a998-6a368986b5b2" />



<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [ ] tests executed by
