### PR TITLE
Fix search variants by gene with 38-only genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show pending comments for gene panels (#6327)
 - Loading of variants defaulting to build 37 whenever genomic build is not passed to the loader function (#6331)
 - Removed unused imports on `commands/export/variant` module (#6334)
+- Search SNVs & SVs by gene when gene is only present on build 38 (#6340)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from flask import Response, flash, request, session, url_for
 from flask_login import current_user
+from flask_wtf import FlaskForm
 from markupsafe import Markup
 from pymongo import ASCENDING
 from pymongo.cursor import Cursor
@@ -2068,24 +2069,18 @@ def check_form_gene_symbols(
     return updated_hgnc_symbols
 
 
-def update_form_hgnc_symbols(store, case_obj, form):
+def update_form_hgnc_symbols(
+    store: MongoAdapter, case_obj: Optional[dict], form: FlaskForm
+) -> FlaskForm:
     """Update variants filter form with HGNC symbols from HPO, and check if any non-clinical genes for the case were
     requested. If so, flash a warning to the user.
-
-    Accepts:
-        store(adapter.MongoAdapter)
-        case_obj(dict)
-        form(FiltersForm)
-
-    Returns:
-        form(FiltersForm)
     """
 
     hgnc_symbols = []
     not_found_ids = []
     case_obj = case_obj or {}
 
-    genome_build = get_case_genome_build(case_obj)
+    genome_build = get_case_genome_build(case_obj) if case_obj else None
 
     # retrieve current symbols from form
     if form.hgnc_symbols.data:

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -2083,7 +2083,6 @@ def update_form_hgnc_symbols(store, case_obj, form):
 
     hgnc_symbols = []
     not_found_ids = []
-    genome_build = None
     case_obj = case_obj or {}
 
     genome_build = get_case_genome_build(case_obj)

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -298,7 +298,7 @@ def get_case_genome_build(case_obj: Optional[dict] = None) -> str | None:
     """returns the genome build of a case, as a string."""
     if not case_obj:
         return None
-    return "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
+    return "38" if "38" in str(case_obj.get("genome_build")) else "37"
 
 
 def get_case_mito_chromosome(case_obj: dict) -> str:

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -294,11 +294,9 @@ def refresh_token() -> None:
         LOG.exception(f"Unexpected error while refreshing token: {e}")
 
 
-def get_case_genome_build(case_obj: Optional[dict] = None) -> str | None:
+def get_case_genome_build(case_obj: dict) -> str:
     """returns the genome build of a case, as a string."""
-    if not case_obj:
-        return None
-    return "38" if "38" in str(case_obj.get("genome_build")) else "37"
+    return "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
 
 
 def get_case_mito_chromosome(case_obj: dict) -> str:

--- a/scout/server/utils.py
+++ b/scout/server/utils.py
@@ -294,8 +294,10 @@ def refresh_token() -> None:
         LOG.exception(f"Unexpected error while refreshing token: {e}")
 
 
-def get_case_genome_build(case_obj: dict) -> str:
+def get_case_genome_build(case_obj: Optional[dict] = None) -> str | None:
     """returns the genome build of a case, as a string."""
+    if not case_obj:
+        return None
     return "38" if "38" in str(case_obj.get("genome_build", "37")) else "37"
 
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6339 

### After the fix:

<img width="781" height="291" alt="image" src="https://github.com/user-attachments/assets/7b64a881-c184-473f-8bd5-28e9194c4b7b" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
