### PR TITLE
Fix #6342 - load region check chromosome prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Show pending comments for gene panels (#6327)
 - Loading of variants defaulting to build 37 whenever genomic build is not passed to the loader function (#6331)
 - Removed unused imports on `commands/export/variant` module (#6334)
+- Region load command to auto-detect VCF chromosome prefix (#6343)
 
 ## [4.111.3]
 ### Fixed

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -30,6 +30,7 @@ from scout.parse.variant.ids import parse_simple_id
 from scout.parse.variant.rank_score import parse_rank_score
 from scout.server.utils import get_case_genome_build
 from scout.utils.md5 import generate_md5_key
+from scout.utils.vcf import get_vcf_chr_prefix
 
 LOG = logging.getLogger(__name__)
 
@@ -757,7 +758,8 @@ class VariantLoader(object):
                 rank_threshold = rank_threshold or -1000
                 if not (start and end):
                     raise SyntaxError("Specify chrom start and end")
-                region = "{0}:{1}-{2}".format(chrom, start, end)
+                chr_prefix = get_vcf_chr_prefix(vcf_obj)
+                region = f"{chr_prefix}{chrom}:{start}-{end}"
             else:
                 rank_threshold = rank_threshold or 0
 

--- a/scout/utils/vcf.py
+++ b/scout/utils/vcf.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import click
+from cyvcf2 import VCF
 from flask import current_app
 
 from scout.constants.variants_export import CONTIG_LENGTHS, VCF_HEADER
@@ -358,3 +359,9 @@ def get_vcf_entry(
 
     if validate_vcf_line(var_type=var_type, line=variant_string)[0]:
         return variant_string
+
+
+def get_vcf_chr_prefix(vcf_obj: VCF) -> str:
+    """Return "chr" if VCF contigs start with "chr"."""
+    contig_names = vcf_obj.seqnames
+    return "chr" if contig_names[0].startswith("chr") else ""


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6342 

✅ Tested on stage:
```
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Loading vcf_sv_research variants
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Number of variants present on the VCF file:4
Loading variants  [------------------------------------]    0%2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 49602
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5562
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5631
Loading variants  [#########---------------------------]   25%2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 49602
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5562
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5631
Loading variants  [##################------------------]   50%2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 49601
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 49602
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5562
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5631
Loading variants  [###########################---------]   75%2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 49602
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5562
2026-05-26 11:41:35 hasta.scilifelab.se scout.build.variant.variant[253732] WARNING missing HGNC symbol for: 5631
Loading variants  [####################################]  100%
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] WARNING Bulk insertion failed - attempting separate variant upsert for this bulk
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] WARNING Variant a99c9e764c1a5a71bdc834649b1f7c77 already exists in database - modifying
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] WARNING Variant c46af1b5483cccb300d1b243d63727ee already exists in database - modifying
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] WARNING Variant 4a8204e95cf289626afdff9c289b8d8a already exists in database - modifying
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] WARNING Variant eca4e887d6556c0dff1c26b2bbba9776 already exists in database - modifying
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO All variants inserted, time to insert variants: 0:00:00.056382
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Nr variants parsed: 4
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Nr variants inserted: 4
2026-05-26 11:41:35 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Updating variant_rank for all variants
2026-05-26 11:41:36 hasta.scilifelab.se scout.adapter.mongo.variant_loader[253732] INFO Updating variant_rank done
```

 
<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
