### PR TITLE
Associate genes to panels once during variant loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display genome build on managed variants page (#6297)
 - Improve causatives page performance by removing duplicate case query (#6312)
 - Display case tags (provisional, diagnostic, incidental, etc) on causatives and verified variants pages (#6312)
+- Associate genes to relative panels only once when loading variants ()
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display genome build on managed variants page (#6297)
 - Improve causatives page performance by removing duplicate case query (#6312)
 - Display case tags (provisional, diagnostic, incidental, etc) on causatives and verified variants pages (#6312)
-- Associate genes to relative panels only once when loading variants ()
+- Fetch genes  and gene panel associations only once when loading variants (#6345)
 ### Fixed
 - Compress demo case rnafusion VCF and add an index (#6292)
 - Adding single managed variants with build 38 (#6300)

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -21,6 +21,7 @@ from scout.constants import (
 )
 from scout.exceptions import ConfigError, IntegrityError
 from scout.parse.variant.ids import parse_document_id
+from scout.server.utils import get_case_genome_build
 from scout.utils.algorithms import ui_score
 
 LOG = logging.getLogger(__name__)
@@ -1031,11 +1032,11 @@ class CaseHandler(object):
             case_obj, existing_case, institute_obj, update, keep_actions
         )
 
-        gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
-        build = build or get_case_genome_build(case_obj)
-        genes = list(adapter.all_genes(build=build))
-        hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
-        genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)
+        gene_to_panels = (self.gene_to_panels(case_obj=case_obj),)
+        build = get_case_genome_build(case_obj)
+        genes = list(self.all_genes(build=build))
+        hgncid_to_gene = self.hgncid_to_gene(genes=genes, build=build)
+        genomic_intervals = self.get_coding_intervals(genes=genes, build=build)
 
         if existing_case and keep_actions:
             # collect all variants with user actions for this case

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -975,6 +975,7 @@ class CaseHandler(object):
                 custom_images=self._get_variants_custom_images(
                     variant_category=category, case=case_obj
                 ),
+                gene_to_panels=self.gene_to_panels(case_obj=case_obj),
             )
 
     def load_case(self, config_data: dict, update: bool = False, keep_actions: bool = True) -> dict:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import pymongo
 from bson import ObjectId
+from intervaltree import IntervalTree
 from werkzeug.datastructures import ImmutableMultiDict
 
 from scout.build.case import build_case
@@ -956,7 +957,15 @@ class CaseHandler(object):
                 load_type_cat.append(pair)
         return load_type_cat
 
-    def _load_clinical_variants(self, case_obj: dict, build: str, update: bool = False):
+    def _load_clinical_variants(
+        self,
+        case_obj: dict,
+        build: str,
+        gene_to_panels: Optional[Dict[str, set]],
+        hgncid_to_gene: Optional[Dict[int, dict]],
+        genomic_intervals: Optional[Dict[str, IntervalTree]],
+        update: bool = False,
+    ):
         """Load variants in the order specified by CLINICAL_ORDERED_FILE_TYPE_MAP."""
 
         for variant_type, category in self.get_load_type_categories(case_obj):
@@ -975,7 +984,7 @@ class CaseHandler(object):
                 custom_images=self._get_variants_custom_images(
                     variant_category=category, case=case_obj
                 ),
-                gene_to_panels=self.gene_to_panels(case_obj=case_obj),
+                gene_to_panels=gene_to_panels,
             )
 
     def load_case(self, config_data: dict, update: bool = False, keep_actions: bool = True) -> dict:
@@ -1022,12 +1031,25 @@ class CaseHandler(object):
             case_obj, existing_case, institute_obj, update, keep_actions
         )
 
+        gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
+        build = build or get_case_genome_build(case_obj)
+        genes = list(adapter.all_genes(build=build))
+        hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
+        genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)
+
         if existing_case and keep_actions:
             # collect all variants with user actions for this case
             eval_vars, _ = self.evaluated_variants(case_obj["_id"], case_obj["owner"])
             old_evaluated_variants = list(eval_vars)
         try:
-            self._load_clinical_variants(case_obj, build=genome_build, update=update)
+            self._load_clinical_variants(
+                case_obj,
+                build=genome_build,
+                update=update,
+                gene_to_panels=gene_to_panels,
+                hgncid_to_gene=hgncid_to_gene,
+                genomic_intervals=genomic_intervals,
+            )
             self._load_clinical_omics_variants(case_obj, build=genome_build, update=update)
 
         except (IntegrityError, ValueError, ConfigError, KeyError) as error:

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -672,7 +672,8 @@ class VariantLoader(object):
         gene_obj: dict = None,
         custom_images: list = None,
         build: str = "37",
-    ):
+        gene_to_panels: Optional[Dict[str, set]] = None,
+    ) -> int:
         """Load variants for a case into scout.
 
         Load the variants for a specific analysis type and category into scout.
@@ -680,24 +681,10 @@ class VariantLoader(object):
         If region or gene is specified, load all variants from that region
         disregarding variant rank(if not specified)
 
-        Args:
-            case_obj(dict): A case from the scout database
-            variant_type(str): 'clinical' or 'research'. Default: 'clinical'
-            category(str): 'snv', 'str' or 'sv'. Default: 'snv'
-            rank_threshold(float): Only load variants above this score. Default: 0
-            chrom(str): Load variants from a certain chromosome
-            start(int): Specify the start position
-            end(int): Specify the end position
-            gene_obj(dict): A gene object from the database
-
-        Returns:
-            nr_inserted(int)
         """
         institute_id = case_obj["owner"]
 
         nr_inserted = 0
-
-        gene_to_panels = self.gene_to_panels(case_obj)
         genes = list(self.all_genes(build=build))
         hgncid_to_gene = self.hgncid_to_gene(genes=genes, build=build)
         genomic_intervals = self.get_coding_intervals(genes=genes, build=build)

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -665,6 +665,9 @@ class VariantLoader(object):
         case_obj: dict,
         variant_type: str = "clinical",
         category: str = "snv",
+        gene_to_panels: Optional[Dict[str, set]],
+        hgncid_to_gene: Optional[Dict[int, dict]],
+        genomic_intervals: Optional[Dict[str, IntervalTree]],
         rank_threshold: float = None,
         chrom: str = None,
         start: int = None,
@@ -672,7 +675,6 @@ class VariantLoader(object):
         gene_obj: dict = None,
         custom_images: list = None,
         build: str = "37",
-        gene_to_panels: Optional[Dict[str, set]] = None,
     ) -> int:
         """Load variants for a case into scout.
 
@@ -685,9 +687,6 @@ class VariantLoader(object):
         institute_id = case_obj["owner"]
 
         nr_inserted = 0
-        genes = list(self.all_genes(build=build))
-        hgncid_to_gene = self.hgncid_to_gene(genes=genes, build=build)
-        genomic_intervals = self.get_coding_intervals(genes=genes, build=build)
 
         for vcf_file_key, vcf_dict in ORDERED_FILE_TYPE_MAP.items():
             if vcf_dict["variant_type"] != variant_type:

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -663,11 +663,11 @@ class VariantLoader(object):
     def load_variants(
         self,
         case_obj: dict,
-        variant_type: str = "clinical",
-        category: str = "snv",
         gene_to_panels: Optional[Dict[str, set]],
         hgncid_to_gene: Optional[Dict[int, dict]],
         genomic_intervals: Optional[Dict[str, IntervalTree]],
+        variant_type: str = "clinical",
+        category: str = "snv",
         rank_threshold: float = None,
         chrom: str = None,
         start: int = None,

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
 from os import path
-from typing import Optional
+from typing import Dict, Optional
 
 import click
 from flask.cli import with_appcontext
+from intervaltree import IntervalTree
 
 from scout.adapter import MongoAdapter
 from scout.constants import ORDERED_FILE_TYPE_MAP
@@ -20,6 +21,9 @@ def upload_research_variants(
     variant_type: str,
     category: str,
     rank_treshold: int,
+    gene_to_panels: Optional[Dict[str, set]],
+    hgncid_to_gene: Optional[Dict[int, dict]],
+    genomic_intervals: Optional[Dict[str, IntervalTree]],
 ):
     """Delete existing variants and upload new variants"""
     adapter.delete_variants(case_id=case_obj["_id"], variant_type=variant_type, category=category)
@@ -30,7 +34,6 @@ def upload_research_variants(
         category=category,
         rank_threshold=rank_treshold,
         build=case_obj["genome_build"],
-        gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
         gene_to_panels=gene_to_panels,
         hgncid_to_gene=hgncid_to_gene,
         genomic_intervals=genomic_intervals,
@@ -99,6 +102,12 @@ def research(case_id, institute, force):
 
         files = False
 
+        gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
+        build = build or get_case_genome_build(case_obj)
+        genes = list(adapter.all_genes(build=build))
+        hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
+        genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)
+
         for file_type in ORDERED_FILE_TYPE_MAP:
             if ORDERED_FILE_TYPE_MAP[file_type]["variant_type"] != "research":
                 continue
@@ -118,6 +127,9 @@ def research(case_id, institute, force):
                     variant_type="research",
                     category=ORDERED_FILE_TYPE_MAP[file_type]["category"],
                     rank_treshold=case_obj.get("rank_score_threshold", DEFAULT_RANK_THRESHOLD),
+                    gene_to_panels=gene_to_panels,
+                    hgncid_to_gene=hgncid_to_gene,
+                    genomic_intervals=genomic_intervals,
                 )
 
         if not files:

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -31,6 +31,9 @@ def upload_research_variants(
         rank_threshold=rank_treshold,
         build=case_obj["genome_build"],
         gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
+        gene_to_panels=gene_to_panels,
+        hgncid_to_gene=hgncid_to_gene,
+        genomic_intervals=genomic_intervals,
     )
 
 

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -30,6 +30,7 @@ def upload_research_variants(
         category=category,
         rank_threshold=rank_treshold,
         build=case_obj["genome_build"],
+        gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
     )
 
 

--- a/scout/commands/load/research.py
+++ b/scout/commands/load/research.py
@@ -10,6 +10,7 @@ from intervaltree import IntervalTree
 from scout.adapter import MongoAdapter
 from scout.constants import ORDERED_FILE_TYPE_MAP
 from scout.server.extensions import store
+from scout.server.utils import get_case_genome_build
 
 DEFAULT_RANK_THRESHOLD = 8
 LOG = logging.getLogger(__name__)
@@ -103,7 +104,7 @@ def research(case_id, institute, force):
         files = False
 
         gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
-        build = build or get_case_genome_build(case_obj)
+        build = get_case_genome_build(case_obj)
         genes = list(adapter.all_genes(build=build))
         hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
         genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)

--- a/scout/commands/load/variants.py
+++ b/scout/commands/load/variants.py
@@ -200,6 +200,7 @@ def variants(
                     end=end,
                     gene_obj=gene_obj,
                     build=case_obj["genome_build"],
+                    gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
                 )
                 # Update case variants count
                 adapter.case_variants_count(case_obj["_id"], institute_id, force_update_case=True)

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -5,6 +5,7 @@ from typing import Optional
 from scout.adapter.mongo import MongoAdapter
 from scout.constants import ORDERED_FILE_TYPE_MAP
 from scout.exceptions.config import ConfigError
+from scout.server.utils import get_case_genome_build
 
 LOG = logging.getLogger(__name__)
 
@@ -55,6 +56,12 @@ def load_region(
         start = gene_caption["start"]
         end = gene_caption["end"]
 
+    gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
+    build = build or get_case_genome_build(case_obj)
+    genes = list(adapter.all_genes(build=build))
+    hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
+    genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)
+
     for file_type, vcf_dict in ORDERED_FILE_TYPE_MAP.items():
         if not case_obj.get("vcf_files", {}).get(file_type):
             continue
@@ -75,7 +82,9 @@ def load_region(
             chrom=chrom,
             start=start,
             end=end,
-            gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
+            gene_to_panels=gene_to_panels,
+            hgncid_to_gene=hgncid_to_gene,
+            genomic_intervals=genomic_intervals,
         )
 
     # Update case variants count

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -75,6 +75,7 @@ def load_region(
             chrom=chrom,
             start=start,
             end=end,
+            gene_to_panels=adapter.gene_to_panels(case_obj=case_obj),
         )
 
     # Update case variants count

--- a/scout/load/all.py
+++ b/scout/load/all.py
@@ -57,7 +57,7 @@ def load_region(
         end = gene_caption["end"]
 
     gene_to_panels = (adapter.gene_to_panels(case_obj=case_obj),)
-    build = build or get_case_genome_build(case_obj)
+    build = get_case_genome_build(case_obj)
     genes = list(adapter.all_genes(build=build))
     hgncid_to_gene = adapter.hgncid_to_gene(genes=genes, build=build)
     genomic_intervals = adapter.get_coding_intervals(genes=genes, build=build)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
