### PR TITLE
Fix #6295 - filter dark regions/sma page for gene panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+
+### Added
+- Gene panel filters to the Dark regions page
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
-
 ### Added
 - LitVar2 links: variant link for variants with dbSNP rsID and a gene symbol search link (#6326)
 - Filter variants by OMIM inheritance pattern (#6355)

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -365,16 +365,6 @@ class PanelHandler:
         gene_list = [gene_obj.get(gene_format, "") for gene_obj in panel_obj.get("genes", [])]
         return gene_list
 
-    def case_panels_to_genes(
-        self, panel_names: List[str], gene_format: str = "hgnc_id"
-    ) -> Set[Union[int, str]]:
-        """Return unique genes from selected panel names.
-        For panels present on the case, and other selectable panels (e.g. institute panels),
-        fall back to latest version.
-        """
-
-        return set(self.panels_to_genes(panel_names=panel_names, gene_format=gene_format))
-
     def update_panel(self, panel_obj, version=None, date_obj=None, maintainer=None):
         """Replace a existing gene panel with a new one
 

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -366,19 +366,14 @@ class PanelHandler:
         return gene_list
 
     def case_panels_to_genes(
-        self, case_obj: dict, panel_names: List[str], gene_format: str = "hgnc_id"
+        self, panel_names: List[str], gene_format: str = "hgnc_id"
     ) -> Set[Union[int, str]]:
-        """Return unique genes from selected panel names, preferring case panel versions.
-
-        For panels present on the case, use the version recorded for that case.
-        For other selectable panels (e.g. institute panels), fall back to latest.
+        """Return unique genes from selected panel names.
+        For panels present on the case, and other selectable panels (e.g. institute panels),
+        fall back to latest version.
         """
 
-        case_panel_names = {panel["panel_name"]: panel for panel in case_obj.get("panels", [])}
-
-        panel_genes = self.panels_to_genes(panel_names=case_panel_names, gene_format=gene_format)
-
-        return set(panel_genes)
+        return set(self.panels_to_genes(panel_names=panel_names, gene_format=gene_format))
 
     def update_panel(self, panel_obj, version=None, date_obj=None, maintainer=None):
         """Replace a existing gene panel with a new one

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -4,7 +4,7 @@ import datetime as dt
 import logging
 import math
 from copy import deepcopy
-from typing import Dict, List, Optional, Set, Union
+from typing import Dict, List, Optional, Union
 
 import pymongo
 from bson import ObjectId

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -365,6 +365,21 @@ class PanelHandler:
         gene_list = [gene_obj.get(gene_format, "") for gene_obj in panel_obj.get("genes", [])]
         return gene_list
 
+    def case_panels_to_genes(
+        self, case_obj: dict, panel_names: List[str], gene_format: str = "hgnc_id"
+    ) -> Set[Union[int, str]]:
+        """Return unique genes from selected panel names, preferring case panel versions.
+
+        For panels present on the case, use the version recorded for that case.
+        For other selectable panels (e.g. institute panels), fall back to latest.
+        """
+
+        case_panel_names = {panel["panel_name"]: panel for panel in case_obj.get("panels", [])}
+
+        panel_genes = self.panels_to_genes(panel_names=case_panel_names, gene_format=gene_format)
+
+        return set(panel_genes)
+
     def update_panel(self, panel_obj, version=None, date_obj=None, maintainer=None):
         """Replace a existing gene panel with a new one
 
@@ -545,37 +560,6 @@ class PanelHandler:
             ]
         )
         return set(item["_id"] for item in query_result)
-
-    def case_panels_to_genes(
-        self, case_obj: dict, panel_names: List[str], gene_format: str = "hgnc_id"
-    ) -> Set[Union[int, str]]:
-        """Return unique genes from selected panel names, preferring case panel versions.
-
-        For panels present on the case, use the version recorded for that case.
-        For other selectable panels (e.g. institute panels), fall back to latest.
-        """
-
-        genes: Set[Union[int, str]] = set()
-        case_panels = {panel["panel_name"]: panel for panel in case_obj.get("panels", [])}
-
-        for panel_name in panel_names:
-            panel_obj = None
-            case_panel = case_panels.get(panel_name)
-            if case_panel is not None:
-                panel_obj = self.gene_panel(panel_name, version=case_panel.get("version"))
-            if panel_obj is None:
-                panel_obj = self.gene_panel(panel_name)
-            if panel_obj is None:
-                continue
-
-            panel_genes = {
-                gene.get(gene_format)
-                for gene in panel_obj.get("genes", [])
-                if gene.get(gene_format) is not None
-            }
-            genes.update(panel_genes)
-
-        return genes
 
     def search_panels_hgnc_id(self, hgnc_id: int) -> list[dict]:
         """Return all panels and versions that contain given gene,list is sorted"""

--- a/scout/adapter/mongo/panel.py
+++ b/scout/adapter/mongo/panel.py
@@ -4,7 +4,7 @@ import datetime as dt
 import logging
 import math
 from copy import deepcopy
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Set, Union
 
 import pymongo
 from bson import ObjectId
@@ -545,6 +545,37 @@ class PanelHandler:
             ]
         )
         return set(item["_id"] for item in query_result)
+
+    def case_panels_to_genes(
+        self, case_obj: dict, panel_names: List[str], gene_format: str = "hgnc_id"
+    ) -> Set[Union[int, str]]:
+        """Return unique genes from selected panel names, preferring case panel versions.
+
+        For panels present on the case, use the version recorded for that case.
+        For other selectable panels (e.g. institute panels), fall back to latest.
+        """
+
+        genes: Set[Union[int, str]] = set()
+        case_panels = {panel["panel_name"]: panel for panel in case_obj.get("panels", [])}
+
+        for panel_name in panel_names:
+            panel_obj = None
+            case_panel = case_panels.get(panel_name)
+            if case_panel is not None:
+                panel_obj = self.gene_panel(panel_name, version=case_panel.get("version"))
+            if panel_obj is None:
+                panel_obj = self.gene_panel(panel_name)
+            if panel_obj is None:
+                continue
+
+            panel_genes = {
+                gene.get(gene_format)
+                for gene in panel_obj.get("genes", [])
+                if gene.get(gene_format) is not None
+            }
+            genes.update(panel_genes)
+
+        return genes
 
     def search_panels_hgnc_id(self, hgnc_id: int) -> list[dict]:
         """Return all panels and versions that contain given gene,list is sorted"""

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -89,6 +89,7 @@ COVERAGE_REPORT_TIMEOUT = 20
 
 PANEL_PROJECTION = {"version": 1, "display_name": 1, "genes": 1}
 PANEL_HIDDEN_PROJECTION = {"version": 1, "display_name": 1, "hidden": 1}
+SMN_HGNC_IDS = {11117, 11118}
 
 
 def phenomizer_diseases(hpo_ids, case_obj, p_value_treshold=1):
@@ -302,12 +303,39 @@ def bionano_case(store, institute_obj, case_obj) -> Dict:
     return data
 
 
-def sma_case(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:
-    """Preprocess a case for tabular view, SMA."""
+def sma_case(
+    store: MongoAdapter,
+    institute_obj: dict,
+    case_obj: dict,
+    selected_gene_panels: List[str] | None = None,
+) -> dict:
+    """Preprocess a case for tabular view, SMA.
+
+    Prepare lists of genes in the case panels and in the dynamic HPO gene list for filtering on the SMA/dark regions page.
+    """
 
     _populate_case_individuals(case_obj)
 
     case_has_alignments(case_obj)
+
+    selected_gene_panels = selected_gene_panels or []
+    panel_hgnc_ids = {
+        hgnc_id
+        for hgnc_id in store.case_panels_to_genes(
+            case_obj=case_obj,
+            panel_names=selected_gene_panels,
+            gene_format="hgnc_id",
+        )
+        if isinstance(hgnc_id, int)
+    }
+    if "hpo" in selected_gene_panels:
+        panel_hgnc_ids.update(
+            gene.get("hgnc_id")
+            for gene in case_obj.get("dynamic_gene_list", [])
+            if isinstance(gene.get("hgnc_id"), int)
+        )
+
+    show_smn_section = (not selected_gene_panels) or bool(SMN_HGNC_IDS.intersection(panel_hgnc_ids))
 
     data = {
         "institute": institute_obj,
@@ -315,8 +343,10 @@ def sma_case(store: MongoAdapter, institute_obj: dict, case_obj: dict) -> dict:
         "comments": store.events(institute_obj, case=case_obj, comments=True),
         "events": _get_events(store, institute_obj, case_obj),
         "region": GENOME_REGION[get_case_genome_build(case_obj)],
-        "paraphrase_regions": _get_paraphrase_regions(case_obj),
+        "paraphrase_regions": _get_paraphrase_regions(case_obj, panel_hgnc_ids),
         "inherit_palette": INHERITANCE_PALETTE,
+        "selected_gene_panels": selected_gene_panels,
+        "show_smn_section": show_smn_section,
     }
     return data
 
@@ -390,11 +420,15 @@ def _update_case_region(case_region: dict, region: dict, individual_is_affected:
                 )
 
 
-def _get_paraphrase_regions(case_obj: dict) -> dict:
+def _get_paraphrase_regions(case_obj: dict, panel_hgnc_ids: Set[int] | None = None) -> dict:
     """Check all case individuals for paraphrase region information.
     Move fixed global attributes (genes_in_region, phase_region) for display up from the individual level to case region
     level, which is returned.
+
     Set the status of the region to the highest status on any affected individual.
+
+    If given a set of panel hgnc ids, match genes in regions with this gene selection, and return a dict with regions left
+    after filtering.
     """
 
     case_regions = {}
@@ -409,7 +443,27 @@ def _get_paraphrase_regions(case_obj: dict) -> dict:
             case_region = case_regions.setdefault(region_name, {})
             _update_case_region(case_region, region, individual_is_affected)
 
-    return case_regions
+    if not panel_hgnc_ids:
+        return case_regions
+
+    filtered_regions = {}
+    for region_name, region in case_regions.items():
+        region_genes = region.get("genes_in_region", [])
+        if not region_genes:
+            continue
+
+        matched_genes = [
+            gene
+            for gene in region_genes
+            if gene.get("hgnc_id") is not None and gene["hgnc_id"] in panel_hgnc_ids
+        ]
+        if not matched_genes:
+            continue
+
+        region["genes_in_region"] = matched_genes
+        filtered_regions[region_name] = region
+
+    return filtered_regions
 
 
 def _get_suspects_or_causatives(

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -312,6 +312,9 @@ def sma_case(
     """Preprocess a case for tabular view, SMA.
 
     Prepare lists of genes in the case panels and in the dynamic HPO gene list for filtering on the SMA/dark regions page.
+
+    For panels present on the case, and other selectable panels (e.g. institute panels),
+        fall back to latest panel version.
     """
 
     _populate_case_individuals(case_obj)
@@ -321,10 +324,8 @@ def sma_case(
     selected_gene_panels = selected_gene_panels or []
     panel_hgnc_ids = {
         hgnc_id
-        for hgnc_id in store.case_panels_to_genes(
-            case_obj=case_obj,
-            panel_names=selected_gene_panels,
-            gene_format="hgnc_id",
+        for hgnc_id in store.panels_to_genes(
+            panel_names=selected_gene_panels, gene_format="hgnc_id"
         )
         if isinstance(hgnc_id, int)
     }

--- a/scout/server/blueprints/cases/forms.py
+++ b/scout/server/blueprints/cases/forms.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from flask_wtf import FlaskForm
+from wtforms import HiddenField, SelectMultipleField
+
+
+class NonValidatingSelectMultipleField(SelectMultipleField):
+    """Skip strict choice validation for dynamic multi-selects."""
+
+    def pre_validate(self, _form):
+        # Choices are populated at runtime from case/institute panels.
+        pass
+
+
+class SmaPanelFilterForm(FlaskForm):
+    """Panel filter form used on the SMA/dark regions page."""
+
+    panel_filter_applied = HiddenField()
+    gene_panels = NonValidatingSelectMultipleField(choices=[])

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -271,7 +271,7 @@
 {% macro smn_case_page() %}
 <div class="container_spaced col-12">
   <div class="card">
-    <div class="card-title"><a href="https://github.com/Illumina/SMNCopyNumberCaller" target="_blank" rel="noopener">SMN Copy Number</a> status - Individuals</div>
+    <div class="card-title"><a href="https://github.com/Illumina/SMNCopyNumberCaller" target="_blank" rel="noopener">SMN Copy Number</a> status</div>
     <div class="card-body">
       <div class="row">
         <div class="col-xs-12 col-md-12">{{ smn_individuals_table(case, institute, tissue_types) }}</div>

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -55,6 +55,10 @@
   <div class="row" id="body-row">
     {{ panel_filter_card() }}
 
+    {% if case.paraphrase %}
+      {{ paraphrase_case_page() }}
+    {% endif %}
+
     {% if case.smn_tsv %}
       {% if show_smn_section %}
         {{ smn_case_page() }}
@@ -64,11 +68,7 @@
         </div>
       {% endif %}
     {% endif %}
-
-    {% if case.paraphrase %}
-      {{ paraphrase_case_page() }}
-    {% endif %}
-
+  
     <div class="container_spaced">
       <div class="row">
         <div class="col-4">

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -128,7 +128,7 @@
             <div class="row mt-2">
               <div class="col-4 d-flex  align-items-end">
                 <button type="submit" class="btn btn-primary btn-sm me-2">Apply filter</button>
-                <a class="btn btn-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
+                <a class="btn btn-secondary text-white btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
               </div>
             </div>
           </div>

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -46,7 +46,13 @@
 <div class="container-float">
   <div class="row" id="body-row">
     {% if case.smn_tsv %}
-      {{ smn_case_page() }}
+      {% if show_smn_section %}
+        {{ smn_case_page() }}
+      {% elif selected_gene_panels %}
+        <div class="container_spaced col-12">
+          <div class="alert alert-info mb-0">SMN Copy Number section is hidden by the selected gene panel filter.</div>
+        </div>
+      {% endif %}
     {% endif %}
 
     {% if case.paraphrase %}
@@ -83,7 +89,36 @@
   <div class="card">
     <div class="card-body">
       <div class="card-title"> Dark regions - <a href="https://github.com/Clinical-Genomics/paraphrase" target="_blank" rel="noopener">Paraphrase</a> annotation of <a href="https://github.com/PacificBiosciences/paraphase" target="_blank" rel="noopener">Paraphase</a> - Individuals</div>
+      {% if sma_filter_form.gene_panels.choices %}
+        <form class="row g-2 mb-3" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
+          {{ sma_filter_form.panel_filter_applied(value="1") }}
+          <div class="col-md-8">
+            <label class="form-label mb-1" for="gene-panel-filter">Gene panels</label>
+            {{ sma_filter_form.gene_panels(
+              id="gene-panel-filter",
+              class="selectpicker",
+              data_style="btn-secondary",
+              data_width="100%",
+              data_live_search="true",
+              title="Select gene panel(s)"
+            ) }}
+          </div>
+          <div class="col-md-4 d-flex align-items-end">
+            <button type="submit" class="btn btn-secondary btn-sm me-2">Apply filter</button>
+            <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
+          </div>
+        </form>
+      {% endif %}
       <div class="accordion accordion-flush" id="paraphrase">
+      {% if paraphrase_regions|length == 0 %}
+        <div class="alert alert-info mb-0">
+          {% if selected_gene_panels %}
+            No dark regions match the selected gene panel filter.
+          {% else %}
+            No dark regions available for this case.
+          {% endif %}
+        </div>
+      {% endif %}
       {% for region_name, region in paraphrase_regions|dictsort(case_sensitive=False, by='key') %}
         <div class="accordion-item">
           <div class="accordion-header" data-bs-toggle="tooltip" title="Status {{ region.status }} - {{ region.status_matches }}">
@@ -141,21 +176,26 @@
             </table>
 
             <span class="d-flex mt-2">
+              {% set region_gene_symbols = region.get("genes_in_region", []) | map(attribute="hgnc_symbol") | list %}
               {% if case.vcf_files.vcf_snv %}
                 <span class="me-3">
                   <form target="_blank" rel="noopener" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
-                    <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{{ case.individuals[0].paraphrase[region_name].genes_in_region }}"></input>
-                    <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
-                    <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes {{ case.individuals[0].paraphrase[region_name].genes_in_region }}">SNVs</button>
+                    <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{{ region_gene_symbols | join(', ') }}"></input>
+                    {% for panel_name in selected_gene_panels %}
+                      <input type="hidden" name="gene_panels" value="{{ panel_name }}"></input>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes {{ region_gene_symbols | join(', ') }}">SNVs</button>
                   </form>
                 </span>
               {% endif %}
               {% if case.vcf_files.vcf_sv %}
                 <span class="me-3">
                   <form target="_blank" rel="noopener" action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
-                    <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{{ case.individuals[0].paraphrase[region_name].genes_in_region }}"></input>
-                    <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
-                    <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="Structural variants view filtered for the genes {{ case.individuals[0].paraphrase[region_name].genes_in_region }}">SVs</button>
+                    <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="{{ region_gene_symbols | join(', ') }}"></input>
+                    {% for panel_name in selected_gene_panels %}
+                      <input type="hidden" name="gene_panels" value="{{ panel_name }}"></input>
+                    {% endfor %}
+                    <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="Structural variants view filtered for the genes {{ region_gene_symbols | join(', ') }}">SVs</button>
                   </form>
                 </span>
               {% endif %}
@@ -230,7 +270,9 @@
         <span class="me-3">
           <form target="_blank" rel="noopener" action="{{url_for('variants.variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
             <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
-            <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
+            {% for panel_name in selected_gene_panels %}
+              <input type="hidden" name="gene_panels" value="{{ panel_name }}"></input>
+            {% endfor %}
             <span><button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="SNV and INDEL variants view filtered for the genes SMN1 and SMN2">SNVs</button></span>
           </form>
         </span>
@@ -239,7 +281,9 @@
           <span class="me-3">
             <form target="_blank" rel="noopener" action="{{url_for('variants.sv_variants', institute_id=institute._id, case_name=case.display_name, variant_type='clinical') }}">
               <input type="hidden" id="hgnc_symbols" name="hgnc_symbols" value="SMN1, SMN2"></input>
-              <input type="hidden" id="gene_panels" name="gene_panels" value=""></input>
+              {% for panel_name in selected_gene_panels %}
+                <input type="hidden" name="gene_panels" value="{{ panel_name }}"></input>
+              {% endfor %}
               <button type="submit" class="btn btn-secondary btn-sm"  data-bs-toggle="tooltip" title="Structural variants view filtered for the genes SMN1 and SMN2">SVs</button>
             </form>
           </span>

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -32,6 +32,14 @@
     line-height: 1.25;
     vertical-align: top;
   }
+
+  /* Keep chevron direction synced with collapse open/closed state */
+  .chevron-icon {
+    transition: transform 0.3s ease;
+  }
+  button[aria-expanded="true"] .chevron-icon {
+    transform: rotate(90deg);
+  }
 </style>
 {% endblock %}
 
@@ -89,10 +97,20 @@
 {% macro panel_filter_card() %}
   {% if sma_filter_form.gene_panels.choices %}
     <div class="container_spaced col-12">
-      <div class="card">
-        <div class="card-title">Filter SMN - Dark regions</div>
-        <div class="card-body">
-          <form class="row g-2" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
+      <div class="card panel-default" id="filter-accordion">
+        <div class="card-header">
+          <button class="d-flex align-items-center btn btn-link p-0 text-decoration-none {{ 'collapsed' if not expand_search }}"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#collapseFilters"
+            aria-expanded="{{ 'true' if expand_search else 'false' }}"
+            aria-controls="collapseFilters">
+            <strong class="me-2">Filters SMN - Dark regions</strong>
+            <i class="fa fa-chevron-right chevron-icon"></i>
+          </button>
+        </div>
+        <form class="row g-2" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
+          <div class="card-body panel-collapse collapse{{ ' show' if expand_search }}" id="collapseFilters">
             {{ sma_filter_form.panel_filter_applied(value="1") }}
             <div class="col-md-8">
               <label class="form-label mb-1" for="gene-panel-filter">Gene panels</label>
@@ -109,17 +127,18 @@
               <button type="submit" class="btn btn-secondary btn-sm me-2">Apply filter</button>
               <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
             </div>
-          </form>
-        </div>
+          </div>
+        </form>
       </div>
     </div>
   {% endif %}
 {% endmacro %}
 
 {% macro paraphrase_case_page() %}
+
 <div class="container_spaced col-12">
   <div class="card">
-    <div class="card-title"> Dark regions - <a href="https://github.com/Clinical-Genomics/paraphrase" target="_blank" rel="noopener">Paraphrase</a> annotation of <a href="https://github.com/PacificBiosciences/paraphase" target="_blank" rel="noopener">Paraphase</a> - Individuals</div>
+    <div class="card-title"> Dark regions - <a href="https://github.com/Clinical-Genomics/paraphrase" target="_blank" rel="noopener">Paraphrase</a> annotation of <a href="https://github.com/PacificBiosciences/paraphase" target="_blank" rel="noopener">Paraphase</a></div>
     <div class="card-body">
       <div class="accordion accordion-flush" id="paraphrase">
       {% if paraphrase_regions|length == 0 %}

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -68,7 +68,7 @@
         </div>
       {% endif %}
     {% endif %}
-  
+
     <div class="container_spaced">
       <div class="row">
         <div class="col-4">
@@ -109,10 +109,11 @@
             <i class="fa fa-chevron-right chevron-icon"></i>
           </button>
         </div>
-        <form class="row g-2" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
+        <form method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
           <div class="card-body panel-collapse collapse{{ ' show' if expand_search }}" id="collapseFilters">
+            <div class="row">
             {{ sma_filter_form.panel_filter_applied(value="1") }}
-            <div class="col-md-8">
+            <div class="col-6">
               <label class="form-label mb-1" for="gene-panel-filter">Gene panels</label>
               {{ sma_filter_form.gene_panels(
                 id="gene-panel-filter",
@@ -123,9 +124,12 @@
                 title="Select gene panel(s)"
               ) }}
             </div>
-            <div class="col-md-4 d-flex align-items-end">
-              <button type="submit" class="btn btn-secondary btn-sm me-2">Apply filter</button>
-              <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
+            </div>
+            <div class="row mt-2">
+              <div class="col-4 d-flex  align-items-end">
+                <button type="submit" class="btn btn-primary btn-sm me-2">Apply filter</button>
+                <a class="btn btn-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
+              </div>
             </div>
           </div>
         </form>

--- a/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
+++ b/scout/server/blueprints/cases/templates/cases/case_sma_dark.html
@@ -45,6 +45,8 @@
 {% block content_main %}
 <div class="container-float">
   <div class="row" id="body-row">
+    {{ panel_filter_card() }}
+
     {% if case.smn_tsv %}
       {% if show_smn_section %}
         {{ smn_case_page() }}
@@ -84,31 +86,41 @@
 </div>
 {% endblock %}
 
+{% macro panel_filter_card() %}
+  {% if sma_filter_form.gene_panels.choices %}
+    <div class="container_spaced col-12">
+      <div class="card">
+        <div class="card-title">Filter SMN - Dark regions</div>
+        <div class="card-body">
+          <form class="row g-2" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
+            {{ sma_filter_form.panel_filter_applied(value="1") }}
+            <div class="col-md-8">
+              <label class="form-label mb-1" for="gene-panel-filter">Gene panels</label>
+              {{ sma_filter_form.gene_panels(
+                id="gene-panel-filter",
+                class="selectpicker",
+                data_style="btn-secondary",
+                data_width="100%",
+                data_live_search="true",
+                title="Select gene panel(s)"
+              ) }}
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+              <button type="submit" class="btn btn-secondary btn-sm me-2">Apply filter</button>
+              <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% macro paraphrase_case_page() %}
 <div class="container_spaced col-12">
   <div class="card">
+    <div class="card-title"> Dark regions - <a href="https://github.com/Clinical-Genomics/paraphrase" target="_blank" rel="noopener">Paraphrase</a> annotation of <a href="https://github.com/PacificBiosciences/paraphase" target="_blank" rel="noopener">Paraphase</a> - Individuals</div>
     <div class="card-body">
-      <div class="card-title"> Dark regions - <a href="https://github.com/Clinical-Genomics/paraphrase" target="_blank" rel="noopener">Paraphrase</a> annotation of <a href="https://github.com/PacificBiosciences/paraphase" target="_blank" rel="noopener">Paraphase</a> - Individuals</div>
-      {% if sma_filter_form.gene_panels.choices %}
-        <form class="row g-2 mb-3" method="get" action="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">
-          {{ sma_filter_form.panel_filter_applied(value="1") }}
-          <div class="col-md-8">
-            <label class="form-label mb-1" for="gene-panel-filter">Gene panels</label>
-            {{ sma_filter_form.gene_panels(
-              id="gene-panel-filter",
-              class="selectpicker",
-              data_style="btn-secondary",
-              data_width="100%",
-              data_live_search="true",
-              title="Select gene panel(s)"
-            ) }}
-          </div>
-          <div class="col-md-4 d-flex align-items-end">
-            <button type="submit" class="btn btn-secondary btn-sm me-2">Apply filter</button>
-            <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('cases.sma', institute_id=institute._id, case_name=case.display_name) }}">Reset</a>
-          </div>
-        </form>
-      {% endif %}
       <div class="accordion accordion-flush" id="paraphrase">
       {% if paraphrase_regions|length == 0 %}
         <div class="alert alert-info mb-0">
@@ -259,8 +271,8 @@
 {% macro smn_case_page() %}
 <div class="container_spaced col-12">
   <div class="card">
+    <div class="card-title"><a href="https://github.com/Illumina/SMNCopyNumberCaller" target="_blank" rel="noopener">SMN Copy Number</a> status - Individuals</div>
     <div class="card-body">
-      <div class="card-title"><a href="https://github.com/Illumina/SMNCopyNumberCaller" target="_blank" rel="noopener">SMN Copy Number</a> status - Individuals</div>
       <div class="row">
         <div class="col-xs-12 col-md-12">{{ smn_individuals_table(case, institute, tissue_types) }}</div>
       </div> <!-- end of div class row -->

--- a/scout/server/blueprints/cases/templates/cases/case_tabular_view.html
+++ b/scout/server/blueprints/cases/templates/cases/case_tabular_view.html
@@ -7,6 +7,7 @@
 
 {% block css %}
 {{ super() }}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/css/bootstrap-select.min.css" integrity="sha512-g2SduJKxa4Lbn3GW+Q7rNz+pKP9AWMR++Ta8fgwsZRCUsawjPvF/BxSMkGS61VsR9yinGoEgrHPGPn2mrj8+4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {% endblock %}
 
 {% block top_nav %}
@@ -85,9 +86,9 @@
 {{ super() }}
 <script src="{{ url_for('cases.static', filename='madeline.js') }}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js" integrity="sha384-EEbPKCLAcxVCiXCi8k9bdeuayzAxVSmBzP/wLpmpd0LVW+Lvh2mjS1W02kdYm5z1" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.13/js/bootstrap-multiselect.min.js" integrity="sha384-2q+7Pk3OSOseTKfNi/t8mZzYRIovdg+nfXYeKmmnivkyD+nxosintmGKX7SWcrOG" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.14.0-beta3/js/bootstrap-select.min.js" integrity="sha512-yrOmjPdp8qH8hgLfWpSFhC/+R9Cj9USL8uJxYIveJZGAiedxyIxwNw4RsLDlcjNlIRR4kkHaDHSmNHAkxFTmgg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdn.datatables.net/1.12.0/js/jquery.dataTables.min.js" integrity="sha512-fu0WiDG5xqtX2iWk7cp17Q9so54SC+5lk/z/glzwlKFdEOwGG6piUseP2Sik9hlvlmyOJ0lKXRSuv1ltdVk9Jg==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
-<script src="https://cdn.datatables.net/1.12.0/js/dataTables.bootstrap5.min.js" integrity="sha512-nfoMMJ2SPcUdaoGdaRVA1XZpBVyDGhKQ/DCedW2k93MTRphPVXgaDoYV1M/AJQLCiw/cl2Nbf9pbISGqIEQRmQ==" referrerpolicy="no-referrer" crossorigin="anonymous"></script>
+<script src="https://cdn.datatables.net/1.12.0/js/dataTables.bootstrap5.min.js" integrity="sha512-nfoMMJ2SPcUdaoGdaRVA1XZpBVyDGhKQ/DCedW2k93MTRphPVXgaDoYV1M/AJQLCiw/cl2Nbf9pbISGqIEQRmQ==" crossorigin="anonymous"></script>
 
 <script>
   $('#panel-table').DataTable({
@@ -107,8 +108,8 @@
     });
 
     $(function () {
-      $('select[multiple]').multiselect({
-        buttonWidth: '100%'
+      $('select[multiple]').selectpicker({
+        width: '100%'
       });
   });
 </script>

--- a/scout/server/blueprints/cases/templates/cases/gene_panel.html
+++ b/scout/server/blueprints/cases/templates/cases/gene_panel.html
@@ -181,6 +181,14 @@
                Clinical HPO MEIs
              </a>
             {% endif %}
+            {% if case.smn_tsv or case.paraphrase %}
+              <a class="btn btn-secondary btn-sm text-white"
+                href="{{ url_for('cases.sma', institute_id=institute._id,
+                                 case_name=case.display_name, gene_panels=['hpo'],
+                                 panel_filter_applied='1') }}" target="_blank" rel="noopener">
+                 Clinical HPO Dark
+              </a>
+            {% endif %}
             {% if case.has_outliers %}
               <a class="btn btn-secondary btn-sm text-white" href="{{ url_for('omics_variants.outliers',
                 institute_id=institute._id, case_name=case.display_name, variant_type='clinical',

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -149,7 +149,9 @@ def sma(institute_id, case_name):
 
     activate_case(store, institute_obj, case_obj, current_user)
 
-    return dict(format="html", sma_filter_form=sma_filter_form, **data)
+    return dict(
+        format="html", sma_filter_form=sma_filter_form, expand_search=panel_filter_applied, **data
+    )
 
 
 @cases_bp.route("/<institute_id>/<case_name>/bionano", methods=["GET"])

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -29,7 +29,11 @@ from pymongo.errors import OperationFailure
 from werkzeug.datastructures import ImmutableMultiDict
 
 from scout.constants import DATE_DAY_FORMATTER
-from scout.server.blueprints.variants.controllers import activate_case
+from scout.server.blueprints.variants.controllers import (
+    activate_case,
+    case_default_panels,
+    gene_panel_choices,
+)
 from scout.server.extensions import beacon, phenopacketapi, store
 from scout.server.utils import (
     html_to_pdf_file,
@@ -44,6 +48,7 @@ from scout.server.utils import (
 from scout.utils.gene import parse_raw_gene_ids, parse_raw_gene_symbols
 
 from . import controllers
+from .forms import SmaPanelFilterForm
 
 LOG = logging.getLogger(__name__)
 
@@ -122,11 +127,29 @@ def case(
 def sma(institute_id, case_name):
     """Visualize case SMA and other dark region data - SMN CN calls, Paraphrase/Paraphase calls"""
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
-    data = controllers.sma_case(store, institute_obj, case_obj)
+    sma_filter_form = SmaPanelFilterForm(request.args)
+    sma_filter_form.gene_panels.choices = gene_panel_choices(store, institute_obj, case_obj)
+
+    selected_gene_panels = sma_filter_form.gene_panels.data or []
+    panel_filter_applied = request.args.get("panel_filter_applied") == "1"
+    if (
+        request.method == "GET"
+        and not panel_filter_applied
+        and not request.args.getlist("gene_panels")
+    ):
+        selected_gene_panels = case_default_panels(case_obj)
+        sma_filter_form.gene_panels.data = selected_gene_panels
+
+    data = controllers.sma_case(
+        store,
+        institute_obj,
+        case_obj,
+        selected_gene_panels=selected_gene_panels,
+    )
 
     activate_case(store, institute_obj, case_obj, current_user)
 
-    return dict(format="html", **data)
+    return dict(format="html", sma_filter_form=sma_filter_form, **data)
 
 
 @cases_bp.route("/<institute_id>/<case_name>/bionano", methods=["GET"])

--- a/tests/adapter/mongo/test_panel_handler.py
+++ b/tests/adapter/mongo/test_panel_handler.py
@@ -405,13 +405,12 @@ def test_case_panels_to_genes_latest_fallback(adapter, testpanel_obj):
     panel_obj = adapter.panel_collection.find_one()
     assert panel_obj["genes"]
 
-    # WHEN selecting genes from the panel
+    # WHEN selecting genes from the panel alone, using the panels_to_genes function
     selected_genes_from_panels = adapter.panels_to_genes(
         panel_names=[testpanel_obj["panel_name"]],
         gene_format="hgnc_id",
     )
 
-    # THEN genes selected from the panels
+    # THEN this should equate to genes selected from the panel itself
     selected_genes_single = adapter.panel_to_genes(panel_id=panel_obj["_id"], gene_format="hgnc_id")
-
     assert selected_genes_from_panels == selected_genes_single

--- a/tests/adapter/mongo/test_panel_handler.py
+++ b/tests/adapter/mongo/test_panel_handler.py
@@ -394,3 +394,42 @@ def test_panel_to_genes(adapter, testpanel_obj):
     panel_name = testpanel_obj["panel_name"]
     gene_symbols = adapter.panel_to_genes(panel_name=panel_name)
     assert sorted(gene_symbols) == ["AAA", "BBB"]
+
+
+def test_case_panels_to_genes_case_version_preferred(adapter, testpanel_obj):
+    """Selected genes should come from the version recorded on the case."""
+
+    panel_v1 = dict(testpanel_obj)
+    panel_v1["version"] = 1.0
+    panel_v1["genes"] = [{"hgnc_id": 101, "symbol": "GENE1"}]
+    panel_v2 = dict(testpanel_obj)
+    panel_v2["_id"] = ObjectId()
+    panel_v2["version"] = 2.0
+    panel_v2["genes"] = [{"hgnc_id": 202, "symbol": "GENE2"}]
+    adapter.panel_collection.insert_many([panel_v1, panel_v2])
+
+    case_obj = {
+        "panels": [{"panel_name": panel_v1["panel_name"], "version": 1.0, "is_default": True}]
+    }
+
+    selected_hgnc_ids = adapter.case_panels_to_genes(
+        case_obj=case_obj,
+        panel_names=[panel_v1["panel_name"]],
+        gene_format="hgnc_id",
+    )
+    assert selected_hgnc_ids == {101}
+
+
+def test_case_panels_to_genes_latest_fallback(adapter, testpanel_obj):
+    """When panel is not present on case, latest panel version should be used."""
+
+    panel_obj = dict(testpanel_obj)
+    panel_obj["genes"] = [{"hgnc_id": 303, "symbol": "GENE3"}]
+    adapter.panel_collection.insert_one(panel_obj)
+
+    selected_symbols = adapter.case_panels_to_genes(
+        case_obj={"panels": []},
+        panel_names=[panel_obj["panel_name"]],
+        gene_format="symbol",
+    )
+    assert selected_symbols == {"GENE3"}

--- a/tests/adapter/mongo/test_panel_handler.py
+++ b/tests/adapter/mongo/test_panel_handler.py
@@ -396,40 +396,22 @@ def test_panel_to_genes(adapter, testpanel_obj):
     assert sorted(gene_symbols) == ["AAA", "BBB"]
 
 
-def test_case_panels_to_genes_case_version_preferred(adapter, testpanel_obj):
-    """Selected genes should come from the version recorded on the case."""
-
-    panel_v1 = dict(testpanel_obj)
-    panel_v1["version"] = 1.0
-    panel_v1["genes"] = [{"hgnc_id": 101, "symbol": "GENE1"}]
-    panel_v2 = dict(testpanel_obj)
-    panel_v2["_id"] = ObjectId()
-    panel_v2["version"] = 2.0
-    panel_v2["genes"] = [{"hgnc_id": 202, "symbol": "GENE2"}]
-    adapter.panel_collection.insert_many([panel_v1, panel_v2])
-
-    case_obj = {
-        "panels": [{"panel_name": panel_v1["panel_name"], "version": 1.0, "is_default": True}]
-    }
-
-    selected_hgnc_ids = adapter.case_panels_to_genes(
-        case_obj=case_obj,
-        panel_names=[panel_v1["panel_name"]],
-        gene_format="hgnc_id",
-    )
-    assert selected_hgnc_ids == {101}
-
-
 def test_case_panels_to_genes_latest_fallback(adapter, testpanel_obj):
     """When panel is not present on case, latest panel version should be used."""
 
-    panel_obj = dict(testpanel_obj)
-    panel_obj["genes"] = [{"hgnc_id": 303, "symbol": "GENE3"}]
-    adapter.panel_collection.insert_one(panel_obj)
+    adapter.panel_collection.insert_one(testpanel_obj)
 
-    selected_symbols = adapter.case_panels_to_genes(
-        case_obj={"panels": []},
-        panel_names=[panel_obj["panel_name"]],
-        gene_format="symbol",
+    # GIVEN a adapter with a gene panel
+    panel_obj = adapter.panel_collection.find_one()
+    assert panel_obj["genes"]
+
+    # WHEN selecting genes from the panel
+    selected_genes_from_panels = adapter.panels_to_genes(
+        panel_names=[testpanel_obj["panel_name"]],
+        gene_format="hgnc_id",
     )
-    assert selected_symbols == {"GENE3"}
+
+    # THEN genes selected from the panels
+    selected_genes_single = adapter.panel_to_genes(panel_id=panel_obj["_id"], gene_format="hgnc_id")
+
+    assert selected_genes_from_panels == selected_genes_single

--- a/tests/server/blueprints/cases/test_cases_controllers.py
+++ b/tests/server/blueprints/cases/test_cases_controllers.py
@@ -1,13 +1,17 @@
 """Tests for the cases controllers"""
 
+import datetime
+
 import responses
 from flask import Flask, url_for
 
 from scout.server.blueprints.cases.controllers import (
+    SMN_HGNC_IDS,
     _get_paraphrase_regions,
     case,
     coverage_report_contents,
     phenotypes_genes,
+    sma_case,
 )
 from scout.server.extensions import store
 
@@ -241,3 +245,137 @@ def test_get_paraphrase(real_populated_database, app):
 
     assert "rccx" in regions
     assert "6" in regions["rccx"]["phase_region"]["chrom"]
+
+
+def test_sma_case_panel_filtered_paraphrase_regions(real_populated_database, app):
+    """Only dark regions with genes on selected panel should be shown."""
+
+    case_obj = real_populated_database.case_collection.find_one({"_id": "internal_id"})
+    institute_obj = real_populated_database.institute(case_obj["owner"])
+    all_regions = _get_paraphrase_regions(case_obj=case_obj)
+
+    region_with_genes = next(
+        (
+            region
+            for region in all_regions.values()
+            if region.get("genes_in_region") and len(region["genes_in_region"]) > 0
+        ),
+        None,
+    )
+    assert region_with_genes is not None
+
+    target_gene = region_with_genes["genes_in_region"][0]
+    panel_name = "sma-dark-test-panel"
+    real_populated_database.panel_collection.insert_one(
+        {
+            "panel_name": panel_name,
+            "display_name": "SMA Dark Test Panel",
+            "version": 1.0,
+            "institute": case_obj["owner"],
+            "date": datetime.datetime.now(),
+            "genes": [{"hgnc_id": target_gene["hgnc_id"], "symbol": target_gene["hgnc_symbol"]}],
+        }
+    )
+    case_obj["panels"] = [
+        {
+            "panel_name": panel_name,
+            "display_name": "SMA Dark Test Panel",
+            "version": 1.0,
+            "is_default": True,
+        }
+    ]
+
+    with app.app_context():
+        data = sma_case(
+            store=real_populated_database,
+            institute_obj=institute_obj,
+            case_obj=case_obj,
+            selected_gene_panels=[panel_name],
+        )
+
+    assert data["selected_gene_panels"] == [panel_name]
+    assert data["paraphrase_regions"]
+    for region in data["paraphrase_regions"].values():
+        for gene in region.get("genes_in_region", []):
+            assert gene["hgnc_id"] == target_gene["hgnc_id"]
+    assert "show_smn_section" in data
+
+
+def test_sma_case_smn_visibility_by_selected_panel_genes(real_populated_database, app):
+    """SMN section visibility should follow selected panel HGNC IDs."""
+
+    case_obj = real_populated_database.case_collection.find_one({"_id": "internal_id"})
+    institute_obj = real_populated_database.institute(case_obj["owner"])
+
+    non_smn_panel_name = "sma-dark-non-smn-panel"
+    real_populated_database.panel_collection.insert_one(
+        {
+            "panel_name": non_smn_panel_name,
+            "display_name": "SMA Dark Non-SMN Panel",
+            "version": 1.0,
+            "institute": case_obj["owner"],
+            "date": datetime.datetime.now(),
+            "genes": [{"hgnc_id": 123456, "symbol": "NONSMN"}],
+        }
+    )
+    case_obj["panels"] = [
+        {
+            "panel_name": non_smn_panel_name,
+            "display_name": "SMA Dark Non-SMN Panel",
+            "version": 1.0,
+            "is_default": True,
+        }
+    ]
+
+    with app.app_context():
+        filtered_data = sma_case(
+            store=real_populated_database,
+            institute_obj=institute_obj,
+            case_obj=case_obj,
+            selected_gene_panels=[non_smn_panel_name],
+        )
+        unfiltered_data = sma_case(
+            store=real_populated_database,
+            institute_obj=institute_obj,
+            case_obj=case_obj,
+            selected_gene_panels=[],
+        )
+
+    assert filtered_data["show_smn_section"] is False
+    assert unfiltered_data["show_smn_section"] is True
+
+
+def test_sma_case_hpo_panel_uses_dynamic_gene_list(real_populated_database, app):
+    """Selecting the virtual HPO panel should filter by case dynamic HPO genes."""
+
+    case_obj = real_populated_database.case_collection.find_one({"_id": "internal_id"})
+    institute_obj = real_populated_database.institute(case_obj["owner"])
+    all_regions = _get_paraphrase_regions(case_obj=case_obj)
+
+    region_with_genes = next(
+        (
+            region
+            for region in all_regions.values()
+            if region.get("genes_in_region") and len(region["genes_in_region"]) > 0
+        ),
+        None,
+    )
+    assert region_with_genes is not None
+
+    target_hgnc_id = region_with_genes["genes_in_region"][0]["hgnc_id"]
+    case_obj["dynamic_gene_list"] = [{"hgnc_id": target_hgnc_id}]
+
+    with app.app_context():
+        data = sma_case(
+            store=real_populated_database,
+            institute_obj=institute_obj,
+            case_obj=case_obj,
+            selected_gene_panels=["hpo"],
+        )
+
+    assert data["selected_gene_panels"] == ["hpo"]
+    assert data["paraphrase_regions"]
+    for region in data["paraphrase_regions"].values():
+        for gene in region.get("genes_in_region", []):
+            assert gene["hgnc_id"] == target_hgnc_id
+    assert data["show_smn_section"] == (target_hgnc_id in SMN_HGNC_IDS)

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -530,6 +530,10 @@ def test_case_sma_dark_explicit_empty_filter_shows_all(app, case_obj, institute_
         )
 
         assert resp.status_code == 200
+        assert b'aria-controls="collapseFilters"' in resp.data
+        assert b'aria-expanded="true"' in resp.data
+        assert b'id="collapseFilters"' in resp.data
+        assert b"card-body panel-collapse collapse show" in resp.data
         selected_option_snippets = [
             f'value="{selected_panel}" selected',
             f'selected value="{selected_panel}"',

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -422,6 +422,8 @@ def test_case_outdated_panel(app, institute_obj, case_obj):
 
 
 def test_case_sma_dark(app, case_obj, institute_obj):
+    """Test SMA dark page loading."""
+
     # GIVEN an initialized app
     # GIVEN a valid user, case and institute
 
@@ -441,6 +443,9 @@ def test_case_sma_dark(app, case_obj, institute_obj):
 
         # THEN it should return a page
         assert resp.status_code == 200
+
+        # THEN SMA panel filter should include the virtual HPO panel option.
+        assert b'value="hpo"' in resp.data
 
 
 def test_case_sma_dark_gene_panel_filter(app, case_obj, institute_obj):
@@ -462,46 +467,10 @@ def test_case_sma_dark_gene_panel_filter(app, case_obj, institute_obj):
         )
 
         assert resp.status_code == 200
+        # THEN the selected panel should be present in the returned data
         assert bytes(selected_panel, "utf-8") in resp.data
 
-
-def test_case_sma_dark_hpo_panel_available(app, case_obj, institute_obj):
-    """SMA panel filter should include the virtual HPO panel option."""
-
-    with app.test_client() as client:
-        resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
-
-        resp = client.get(
-            url_for(
-                "cases.sma",
-                institute_id=institute_obj["internal_id"],
-                case_name=case_obj["display_name"],
-            )
-        )
-
-        assert resp.status_code == 200
-        assert b'value="hpo"' in resp.data
-
-
-def test_case_sma_dark_default_panels_selected(app, case_obj, institute_obj):
-    """SMA panel filter should default to case default panel(s) on initial page load."""
-
-    selected_panel = case_obj["panels"][0]["panel_name"]
-
-    with app.test_client() as client:
-        resp = client.get(url_for("auto_login"))
-        assert resp.status_code == 200
-
-        resp = client.get(
-            url_for(
-                "cases.sma",
-                institute_id=institute_obj["internal_id"],
-                case_name=case_obj["display_name"],
-            )
-        )
-
-        assert resp.status_code == 200
+        # THEN the SMA panel filter should default to case default panel(s) on initial page load
         selected_option_snippets = [
             f'value="{selected_panel}" selected',
             f'selected value="{selected_panel}"',

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -539,6 +539,37 @@ def test_case_sma_dark_explicit_empty_filter_shows_all(app, case_obj, institute_
         assert not any(bytes(snippet, "utf-8") in resp.data for snippet in selected_option_snippets)
 
 
+def test_case_page_clinical_hpo_dark_link(app, case_obj, institute_obj):
+    """Case page should render a direct HPO-filtered dark regions link when dark data exists."""
+
+    store.case_collection.find_one_and_update(
+        {"_id": case_obj["_id"]},
+        {
+            "$set": {
+                "dynamic_gene_list": [{"hgnc_symbol": "ACTA2", "hgnc_id": 130}],
+                "paraphrase": {"rccx": {}},
+            }
+        },
+    )
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.get(
+            url_for(
+                "cases.case",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+            )
+        )
+
+        assert resp.status_code == 200
+        assert b"Clinical HPO Dark" in resp.data
+        assert b"gene_panels=hpo" in resp.data
+        assert b"panel_filter_applied=1" in resp.data
+
+
 def test_case_fusion(app, fusion_case_obj, institute_obj):
     """Test the RNA fusion case page."""
 

--- a/tests/server/blueprints/cases/test_cases_views.py
+++ b/tests/server/blueprints/cases/test_cases_views.py
@@ -443,6 +443,102 @@ def test_case_sma_dark(app, case_obj, institute_obj):
         assert resp.status_code == 200
 
 
+def test_case_sma_dark_gene_panel_filter(app, case_obj, institute_obj):
+    """Test SMA dark page loading with a selected gene panel filter."""
+
+    selected_panel = case_obj["panels"][0]["panel_name"]
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.get(
+            url_for(
+                "cases.sma",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+                gene_panels=[selected_panel],
+            )
+        )
+
+        assert resp.status_code == 200
+        assert bytes(selected_panel, "utf-8") in resp.data
+
+
+def test_case_sma_dark_hpo_panel_available(app, case_obj, institute_obj):
+    """SMA panel filter should include the virtual HPO panel option."""
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.get(
+            url_for(
+                "cases.sma",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+            )
+        )
+
+        assert resp.status_code == 200
+        assert b'value="hpo"' in resp.data
+
+
+def test_case_sma_dark_default_panels_selected(app, case_obj, institute_obj):
+    """SMA panel filter should default to case default panel(s) on initial page load."""
+
+    selected_panel = case_obj["panels"][0]["panel_name"]
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.get(
+            url_for(
+                "cases.sma",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+            )
+        )
+
+        assert resp.status_code == 200
+        selected_option_snippets = [
+            f'value="{selected_panel}" selected',
+            f'selected value="{selected_panel}"',
+            f'value="{selected_panel}" selected="selected"',
+            f'selected="selected" value="{selected_panel}"',
+        ]
+        assert any(bytes(snippet, "utf-8") in resp.data for snippet in selected_option_snippets)
+
+
+def test_case_sma_dark_explicit_empty_filter_shows_all(app, case_obj, institute_obj):
+    """Explicit empty panel filter should not be replaced by default case panel selection."""
+
+    selected_panel = case_obj["panels"][0]["panel_name"]
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.get(
+            url_for(
+                "cases.sma",
+                institute_id=institute_obj["internal_id"],
+                case_name=case_obj["display_name"],
+                panel_filter_applied="1",
+            )
+        )
+
+        assert resp.status_code == 200
+        selected_option_snippets = [
+            f'value="{selected_panel}" selected',
+            f'selected value="{selected_panel}"',
+            f'value="{selected_panel}" selected="selected"',
+            f'selected="selected" value="{selected_panel}"',
+        ]
+        assert not any(bytes(snippet, "utf-8") in resp.data for snippet in selected_option_snippets)
+
+
 def test_case_fusion(app, fusion_case_obj, institute_obj):
     """Test the RNA fusion case page."""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6295. Case gene panels, with clinical default, dynamic HPO, and institute always-available panels.
Make the match on hgnc_id, though the Paraphrase regions are still only with gene symbols, mostly for future safety. 
Hides or shows the SMA table as well, depending on if SMN1/SMN2 are on the panel.
Add a shortcut to the HPO/dynamic list from the case page as well.

<img width="1625" height="698" alt="Screenshot 2026-06-01 at 21 21 58" src="https://github.com/user-attachments/assets/284b9e4b-6921-4f50-a766-15c99ce8964d" />

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
