### PR TITLE
Gene vars inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - LitVar2 links: variant link for variants with dbSNP rsID and a gene symbol search link (#6326)
+- Filter options for the gene variants (SNV & SVs search) page: function, inheritance, GT (#6360)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 - LitVar2 links: variant link for variants with dbSNP rsID and a gene symbol search link (#6326)
-- Filter options for the gene variants (SNV & SVs search) page: function, inheritance, GT (#6360)
+- More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6360)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -156,7 +156,7 @@ class QueryHandler(object):
         mongo_variant_query["rank_score"] = {"$gte": rank_score}
 
         secondary_filter = self.secondary_query(query)
-        mongo_variant_query = {"$and": secondary_filter}
+        mongo_variant_query["$and"] = secondary_filter
 
         LOG.debug("Querying %s" % mongo_variant_query)
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -12,6 +12,7 @@ from scout.constants import (
     TRUSTED_REVSTAT_LEVEL,
 )
 from scout.constants.filters import METHBAT_IMPRINT_LABEL, METHBAT_PROMOTER_LABEL
+from scout.constants.query_terms import SECONDARY_VARIANT_CRITERIA
 
 CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
 CLNSIG_ONC_NOT_EXISTS = {"clnsig_onc": {"$exists": False}}
@@ -127,7 +128,6 @@ class QueryHandler(object):
         )
 
         select_cases = None
-        select_case_obj = None
         mongo_case_query = {}
 
         if query.get("phenotype_terms"):
@@ -155,6 +155,27 @@ class QueryHandler(object):
 
         rank_score = query.get("rank_score") or 15
         mongo_variant_query["rank_score"] = {"$gte": rank_score}
+
+        # additional filter options
+        for criterion in SECONDARY_VARIANT_CRITERIA:
+            if not query.get(criterion):
+                continue
+
+            match criterion:
+                case "genetic_models":
+                    criterion_values = query[criterion]
+                    mongo_variant_query[criterion] = {"$in": criterion_values}
+
+                case "functional_annotations" | "region_annotations":
+                    # filter key will be genes.[criterion (minus final char)]
+                    criterion_values = query[criterion]
+                    mongo_variant_query[".".join(["genes", criterion[:-1]])] = {
+                        "$in": criterion_values
+                    }
+
+                case "omim_genetic_models":
+                    criterion_values = query[criterion]
+                    mongo_variant_query["genes.inheritance"] = {"$in": criterion_values}
 
         LOG.debug("Querying %s" % mongo_variant_query)
 

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -12,7 +12,6 @@ from scout.constants import (
     TRUSTED_REVSTAT_LEVEL,
 )
 from scout.constants.filters import METHBAT_IMPRINT_LABEL, METHBAT_PROMOTER_LABEL
-from scout.constants.query_terms import SECONDARY_VARIANT_CRITERIA
 
 CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
 CLNSIG_ONC_NOT_EXISTS = {"clnsig_onc": {"$exists": False}}
@@ -156,26 +155,8 @@ class QueryHandler(object):
         rank_score = query.get("rank_score") or 15
         mongo_variant_query["rank_score"] = {"$gte": rank_score}
 
-        # additional filter options
-        for criterion in SECONDARY_VARIANT_CRITERIA:
-            if not query.get(criterion):
-                continue
-
-            match criterion:
-                case "genetic_models":
-                    criterion_values = query[criterion]
-                    mongo_variant_query[criterion] = {"$in": criterion_values}
-
-                case "functional_annotations" | "region_annotations":
-                    # filter key will be genes.[criterion (minus final char)]
-                    criterion_values = query[criterion]
-                    mongo_variant_query[".".join(["genes", criterion[:-1]])] = {
-                        "$in": criterion_values
-                    }
-
-                case "omim_genetic_models":
-                    criterion_values = query[criterion]
-                    mongo_variant_query["genes.inheritance"] = {"$in": criterion_values}
+        secondary_filter = self.secondary_query(query)
+        mongo_variant_query = {"$and": secondary_filter}
 
         LOG.debug("Querying %s" % mongo_variant_query)
 

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -72,10 +72,3 @@ SECONDARY_CRITERIA = [
     "methbat_significance",
     "category_pop_freq",
 ]
-
-SECONDARY_VARIANT_CRITERIA = [
-    "genetic_models",
-    "omim_genetic_models",
-    "functional_annotations",
-    "region_annotations",
-]

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -72,3 +72,10 @@ SECONDARY_CRITERIA = [
     "methbat_significance",
     "category_pop_freq",
 ]
+
+SECONDARY_VARIANT_CRITERIA = [
+    "genetic_models",
+    "omim_genetic_models",
+    "functional_annotations",
+    "region_annotations",
+]

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -159,8 +159,10 @@ class TagListField(Field):
 class GeneVariantFiltersForm(FlaskForm):
     """Base FiltersForm for SNVs"""
 
+    # conflict with VariantFiltersForm: make polymorphic
     variant_type = SelectMultipleField(choices=[("clinical", "clinical"), ("research", "research")])
-    category = SelectMultipleField(choices=CATEGORY_CHOICES)
+
+    # shared with VariantFiltersForm
     hgnc_symbols = TagListField(
         "HGNC Symbols (comma-separated, case sensitive)",
         validators=[validators.InputRequired()],
@@ -174,28 +176,57 @@ class GeneVariantFiltersForm(FlaskForm):
         choices=[(code, term) for term, code in DISEASE_INHERITANCE_TERMS_MAPPER.items()],
     )
 
+    cadd_score = BetterDecimalField("CADD", validators=[validators.Optional()])
+    cadd_inclusive = BooleanField("CADD inclusive")
+    revel = BetterDecimalField("REVEL", validators=[validators.Optional()])
+
     gnomad_frequency = BetterDecimalField("gnomadAF", validators=[validators.Optional()])
     local_obs_old = IntegerField("Local obs. (archive)", validators=[validators.Optional()])
+
+    # shared with CancerFiltersForm
     local_obs_cancer_somatic_old = IntegerField(
         "Local somatic obs. (archive)", validators=[validators.Optional()]
     )
+
     local_obs_cancer_somatic_panel_old = IntegerField(
         "Local somatic panel obs. (archive)", validators=[validators.Optional()]
     )
     local_obs_cancer_germline_old = IntegerField(
         "Local germline obs. (archive)", validators=[validators.Optional()]
     )
-    cadd_score = BetterDecimalField("CADD", validators=[validators.Optional()])
-    cadd_inclusive = BooleanField("CADD inclusive")
-    revel = BetterDecimalField("REVEL", validators=[validators.Optional()])
+    local_obs_cancer_germline_panel_old = IntegerField(
+        "Local germline panel obs. (archive)", validators=[validators.Optional()]
+    )
+
+    # shared with FiltersForm
     spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
+    # shared with CaseFiltersForm
     institute = SelectMultipleField(choices=[])
-    rank_score = IntegerField(default=15)
     phenotype_terms = TagListField("HPO terms (comma-separated)")
     phenotype_groups = TagListField("Phenotype groups")
     similar_case = TagListField("Phenotypically similar case")
     cohorts = TagListField("Cohorts")
+
+    # shared with CaseFiltersForm
+    institute = SelectMultipleField(choices=[])
+    phenotype_terms = TagListField("HPO terms (comma-separated)")
+    phenotype_groups = TagListField("Phenotype groups")
+    similar_case = TagListField("Phenotypically similar case")
+    cohorts = TagListField("Cohorts")
+
+    # specific to GeneVariants
+    category = SelectMultipleField(choices=CATEGORY_CHOICES)
+    rank_score = IntegerField(
+        default=15,
+        validators=[
+            validators.Optional(),
+            validators.NumberRange(
+                min=5, message="Searching for rank score <5 is prohibitively slow."
+            ),
+        ],
+    )
+    # actions (partly shared)
     filter_variants = SubmitField(label="Filter variants")
     filter_export_variants = SubmitField(label="Filter and export variants")
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -19,14 +19,17 @@ from scout.constants import (
     GENETIC_MODELS,
     PHENOTYPE_GROUPS,
     SO_TERMS,
+    SPIDEX_LEVELS,
 )
 from scout.constants.disease_parsing import DISEASE_INHERITANCE_TERMS_MAPPER
 from scout.models.case import STATUS
+from scout.server.blueprints.variants.forms import BetterDecimalField
 
 ANALYSIS_CHOICES = [(t, t.upper()) for t in ANALYSIS_TYPES]
 CATEGORY_CHOICES = [("snv", "SNV"), ("sv", "SV")]
 FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
 REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
+SPIDEX_CHOICES = [(term, term.replace("_", " ")) for term in SPIDEX_LEVELS]
 
 
 class NonValidatingSelectField(SelectField):
@@ -185,6 +188,7 @@ class GeneVariantFiltersForm(FlaskForm):
     cadd_score = BetterDecimalField("CADD", validators=[validators.Optional()])
     cadd_inclusive = BooleanField("CADD inclusive")
     revel = BetterDecimalField("REVEL", validators=[validators.Optional()])
+    spidex_human = SelectMultipleField("SPIDEX", choices=SPIDEX_CHOICES)
 
     institute = SelectMultipleField(choices=[])
     rank_score = IntegerField(default=15)

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -13,11 +13,20 @@ from wtforms import (
 )
 from wtforms.widgets import PasswordInput, TextInput
 
-from scout.constants import ANALYSIS_TYPES, PHENOTYPE_GROUPS
+from scout.constants import (
+    ANALYSIS_TYPES,
+    FEATURE_TYPES,
+    GENETIC_MODELS,
+    PHENOTYPE_GROUPS,
+    SO_TERMS,
+)
+from scout.constants.disease_parsing import DISEASE_INHERITANCE_TERMS_MAPPER
 from scout.models.case import STATUS
 
 ANALYSIS_CHOICES = [(t, t.upper()) for t in ANALYSIS_TYPES]
 CATEGORY_CHOICES = [("snv", "SNV"), ("sv", "SV")]
+FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
+REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
 
 
 class NonValidatingSelectField(SelectField):
@@ -153,6 +162,15 @@ class GeneVariantFiltersForm(FlaskForm):
         "HGNC Symbols (comma-separated, case sensitive)",
         validators=[validators.InputRequired()],
     )
+
+    region_annotations = SelectMultipleField(choices=REGION_ANNOTATIONS)
+    functional_annotations = SelectMultipleField(choices=FUNC_ANNOTATIONS)
+    genetic_models = SelectMultipleField(choices=GENETIC_MODELS)
+    omim_genetic_models = SelectMultipleField(
+        label="OMIM Genetic Models",
+        choices=[(code, term) for term, code in DISEASE_INHERITANCE_TERMS_MAPPER.items()],
+    )
+
     institute = SelectMultipleField(choices=[])
     rank_score = IntegerField(default=15)
     phenotype_terms = TagListField("HPO terms (comma-separated)")

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -171,6 +171,21 @@ class GeneVariantFiltersForm(FlaskForm):
         choices=[(code, term) for term, code in DISEASE_INHERITANCE_TERMS_MAPPER.items()],
     )
 
+    gnomad_frequency = BetterDecimalField("gnomadAF", validators=[validators.Optional()])
+    local_obs_old = IntegerField("Local obs. (archive)", validators=[validators.Optional()])
+    local_obs_cancer_somatic_old = IntegerField(
+        "Local somatic obs. (archive)", validators=[validators.Optional()]
+    )
+    local_obs_cancer_somatic_panel_old = IntegerField(
+        "Local somatic panel obs. (archive)", validators=[validators.Optional()]
+    )
+    local_obs_cancer_germline_old = IntegerField(
+        "Local germline obs. (archive)", validators=[validators.Optional()]
+    )
+    cadd_score = BetterDecimalField("CADD", validators=[validators.Optional()])
+    cadd_inclusive = BooleanField("CADD inclusive")
+    revel = BetterDecimalField("REVEL", validators=[validators.Optional()])
+
     institute = SelectMultipleField(choices=[])
     rank_score = IntegerField(default=15)
     phenotype_terms = TagListField("HPO terms (comma-separated)")

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -208,13 +208,6 @@ class GeneVariantFiltersForm(FlaskForm):
     similar_case = TagListField("Phenotypically similar case")
     cohorts = TagListField("Cohorts")
 
-    # shared with CaseFiltersForm
-    institute = SelectMultipleField(choices=[])
-    phenotype_terms = TagListField("HPO terms (comma-separated)")
-    phenotype_groups = TagListField("Phenotype groups")
-    similar_case = TagListField("Phenotypically similar case")
-    cohorts = TagListField("Cohorts")
-
     # specific to GeneVariants
     category = SelectMultipleField(choices=CATEGORY_CHOICES)
     rank_score = IntegerField(

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -132,7 +132,7 @@
         </div>
         <div class="col col-md-1">
           <label class="control-label" for="rank_score">Rank Score</label>
-          <input type="number" class="form-control" id="rank_score" name="rank_score" min="5" value={{form.rank_score.data}}>
+          <input type="number" class="form-control" id="rank_score" name="rank_score" data_bs_toggle="tooltip" title="Searching for rank score < 5 is prohibitively slow." min="5" value={{form.rank_score.data}}>
         </div>
         <div class="col col-md-2">
           {{ form.variant_type.label(class="control-label") }}

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -67,7 +67,7 @@
         {% endfor %}
         {% if form.hgnc_symbols.data == [] %}
         <tr>
-          <td colspan=6>
+          <td colspan=7>
             No variants to display
           </td>
         </tr>

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -2,7 +2,7 @@
 {% from "utils.html" import clickable_table_row_script, comments_table %}
 {% from "overview/institute_sidebar.html" import institute_actionbar %}
 {% from "variants/components.html" import cell_cadd, frequency_cell_general, variant_funct_anno_cell, variant_gene_symbols_cell %}
-{% from "variants/utils.html" import gene_variant_link_href, pagination_footer, pagination_hidden_div, variant_rank_score, zygosity_badges %}
+{% from "variants/utils.html" import archived_observations_cancer_filters, archived_observations_filter, gene_variant_link_href, pagination_footer, pagination_hidden_div, variant_rank_score, zygosity_badges %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }} - All SNVs and INDELs
@@ -161,7 +161,7 @@
           {{ form.similar_case(class="form-control") }}
         </div>
       </div>
-      <div class="row">
+        <div class="row">
         <div class="col-2">
           {{ form.region_annotations.label(class="control-label") }}
           {{ form.region_annotations(class="selectpicker", data_style="btn-secondary") }}
@@ -178,6 +178,32 @@
           {{ form.omim_genetic_models.label(class="control-label") }}
           {{ form.omim_genetic_models(class="selectpicker", data_style="btn-secondary") }}
         </div>
+      </div>
+      <div class="row">
+        <div class="col-1">
+          {{ form.cadd_score.label(class="control-label") }}
+          {{ form.cadd_score(class="form-control") }}
+        </div>
+        <div class="col-2 d-flex align-items-end">
+          <div class="form-check mb-2">
+          {{ form.cadd_inclusive.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include empty CADD") }}
+          {{ form.cadd_inclusive(class="form-check-input", type="checkbox") }}</div>
+        </div>
+        <div class="col-1">
+          {{ form.revel.label(class="control-label") }}
+          {{ form.revel(class="form-control") }}
+        </div>
+        <div class="col-2">
+          {{ form.spidex_human.label(class="control-label") }}
+          {{ form.spidex_human(class="selectpicker", data_style="btn-secondary") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-2">
+          {{ form.gnomad_frequency.label(class="control-label") }}
+          {{ form.gnomad_frequency(class="form-control") }}
+        </div>
+        {{ archived_observations_cancer_filters(form) }}
       </div>
       <div class="row justify-content-center mt-3">
         <div class="col col-md-6">

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -132,7 +132,7 @@
         </div>
         <div class="col col-md-1">
           <label class="control-label" for="rank_score">Rank Score</label>
-          <input type="number" class="form-control" id="rank_score" name="rank_score" data_bs_toggle="tooltip" title="Searching for rank score < 5 is prohibitively slow." min="5" value={{form.rank_score.data}}>
+          <input type="number" class="form-control" id="rank_score" name="rank_score" data-bs-toggle="tooltip" data-bs-placement="top" title="Searching for rank score < 5 is prohibitively slow." min="5" value={{form.rank_score.data}}>
         </div>
         <div class="col col-md-2">
           {{ form.variant_type.label(class="control-label") }}

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -144,21 +144,39 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-md-6">
+        <div class="col-6">
           {{ form.phenotype_terms.label(class="control-label") }}
           {{ form.phenotype_terms(class="form-control") }}
         </div>
-        <div class="col-md-2">
+        <div class="col-2">
           {{ form.phenotype_groups.label(class="control-label") }}
           {{ form.phenotype_groups(class="form-control") }}
         </div>
-        <div class="col-md-2">
+        <div class="col-2">
           {{ form.cohorts.label(class="control-label") }}
           {{ form.cohorts(class="form-control") }}
         </div>
-        <div class="col-md-2">
+        <div class="col-2">
           {{ form.similar_case.label(class="control-label") }}
           {{ form.similar_case(class="form-control") }}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-2">
+          {{ form.region_annotations.label(class="control-label") }}
+          {{ form.region_annotations(class="selectpicker", data_style="btn-secondary") }}
+        </div>
+        <div class="col-2">
+          {{ form.functional_annotations.label(class="control-label") }}
+          {{ form.functional_annotations(class="selectpicker", data_style="btn-secondary") }}
+        </div>
+        <div class="col-2">
+          {{ form.genetic_models.label(class="control-label") }}
+          {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
+        </div>
+        <div class="col-2">
+          {{ form.omim_genetic_models.label(class="control-label") }}
+          {{ form.omim_genetic_models(class="selectpicker", data_style="btn-secondary") }}
         </div>
       </div>
       <div class="row justify-content-center mt-3">

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -144,9 +144,13 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-6">
+        <div class="col-4">
           {{ form.phenotype_terms.label(class="control-label") }}
           {{ form.phenotype_terms(class="form-control") }}
+        </div>
+        <div class="col-2">
+          {{ form.omim_genetic_models.label(class="control-label") }}
+          {{ form.omim_genetic_models(class="selectpicker", data_style="btn-secondary") }}
         </div>
         <div class="col-2">
           {{ form.phenotype_groups.label(class="control-label") }}
@@ -161,7 +165,7 @@
           {{ form.similar_case(class="form-control") }}
         </div>
       </div>
-        <div class="row">
+      <div class="row">
         <div class="col-2">
           {{ form.region_annotations.label(class="control-label") }}
           {{ form.region_annotations(class="selectpicker", data_style="btn-secondary") }}
@@ -175,27 +179,22 @@
           {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
         </div>
         <div class="col-2">
-          {{ form.omim_genetic_models.label(class="control-label") }}
-          {{ form.omim_genetic_models(class="selectpicker", data_style="btn-secondary") }}
+          {{ form.spidex_human.label(class="control-label") }}
+          {{ form.spidex_human(class="selectpicker", data_style="btn-secondary") }}
         </div>
-      </div>
-      <div class="row">
+        <div class="col-1">
+          {{ form.revel.label(class="control-label") }}
+          {{ form.revel(class="form-control") }}
+        </div>
         <div class="col-1">
           {{ form.cadd_score.label(class="control-label") }}
           {{ form.cadd_score(class="form-control") }}
         </div>
         <div class="col-2 d-flex align-items-end">
           <div class="form-check mb-2">
-          {{ form.cadd_inclusive.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include empty CADD") }}
-          {{ form.cadd_inclusive(class="form-check-input", type="checkbox") }}</div>
-        </div>
-        <div class="col-1">
-          {{ form.revel.label(class="control-label") }}
-          {{ form.revel(class="form-control") }}
-        </div>
-        <div class="col-2">
-          {{ form.spidex_human.label(class="control-label") }}
-          {{ form.spidex_human(class="selectpicker", data_style="btn-secondary") }}
+            {{ form.cadd_inclusive.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include empty CADD") }}
+            {{ form.cadd_inclusive(class="form-check-input", type="checkbox") }}
+          </div>
         </div>
       </div>
       <div class="row">

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -389,7 +389,7 @@
 {% endmacro %}
 
 {% macro snv_filters(form, institute, case, filters)%}
-<input type="hidden" name="variant_type" value="{{ form.variant_type.data }}">
+  <input type="hidden" name="variant_type" value="{{ form.variant_type.data }}">
   {{ variants_common_filters(form, "snv") }}
   <div class="row mb-2">
     <div class="col-3">
@@ -427,27 +427,28 @@
     </div>
     <div class="col-2">
       <div class="row">
-        <div class="class="form-check">
+        <div class="form-check">
           {{ form.clinvar_trusted_revstat(class="form-check-input") }}
           {{ form.clinvar_trusted_revstat.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Limit search to variants with trusted ClinVar revision status levels: mult, multiple_submitters, single, single_submitter, exp, reviewed_by_expert_panel, guideline, practice_guideline.") }}
         </div>
       </div>
       <div class="row">
-        <div class="class="form-check">
-        {{ form.clinvar_tag(class="form-check-input") }}
-        {{ form.clinvar_tag.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Return only variants with annotated ClinVar significance.") }}
+        <div class="form-check">
+          {{ form.clinvar_tag(class="form-check-input") }}
+          {{ form.clinvar_tag.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Return only variants with annotated ClinVar significance.") }}
         </div>
       </div>
       <div class="row">
-        <div class="class="form-check">
-        {{ form.prioritise_clinvar(class="form-check-input") }}
-        {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded using ClinVar tags will still be returned when found using the other search criteria.") }}
+        <div class="form-check">
+          {{ form.prioritise_clinvar(class="form-check-input") }}
+          {{ form.prioritise_clinvar.label(class="form-check-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Include variants matching the selected ClinVar conditions, in addition to those found using the other search criteria (broadens the search). Note that variants excluded using ClinVar tags will still be returned when found using the other search criteria.") }}
+        </div>
       </div>
     </div>
   </div>
   <div class="row mb-2">
     <div class="col-4">
-      <div class ="row">
+      <div class="row">
         <div class="col-4">
           {{ form.gnomad_frequency.label(class="control-label") }}
           {{ form.gnomad_frequency(class="form-control") }}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #3946
- Fix #5005 

<img width="1487" height="445" alt="Screenshot 2026-06-02 at 11 42 39" src="https://github.com/user-attachments/assets/544b3234-6781-4175-8db5-1d5afa49ad39" />

Does seem fast enough, at least on stage. Prod will be the final test I guess, but much as you said for the OMIM inheritance query the other day, the heavy lifting is done by the partial index, and the rest is filtering. A direct search with only the new options would fail sorely, naturally.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, CR