### PR TITLE
Add 'Has methylation' filter on cases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LitVar2 links: variant link for variants with dbSNP rsID and a gene symbol search link (#6326)
 - Filter variants by OMIM inheritance pattern (#6355)
 - Gene panel filters to the Dark regions page (#6353)
+- `Has Methylation data` filter on cases page (#6375)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)
+- `has_methylation` field not persisting when a case document is updated (#6375)
 
 ## [4.112]
 ### Added

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -565,6 +565,7 @@ class CaseHandler(object):
             # Return the result in order of descending phenotype similarity (the same order or the _ids provided in the query)
             return sorted(list(results), key=lambda res: result_order.index(res["_id"]))
 
+        LOG.warning(query)
         return self.case_collection.find(query, projection).sort("updated_at", -1)
 
     def is_pheno_similarity_query(self, name_query: ImmutableMultiDict) -> bool:

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -374,6 +374,7 @@ class CaseHandler(object):
         finished: bool = False,
         research_requested: bool = False,
         is_research: bool = False,
+        has_methylation: bool = False,
         has_rna_data: bool = False,
         status: Any = None,
         phenotype_terms: bool = False,
@@ -454,6 +455,10 @@ class CaseHandler(object):
             condition=has_causatives,
             set_key="causatives",
             set_value={EXISTS: True, "$ne": []},
+        )
+
+        _conditional_set_query_value(
+            query=query, condition="has_methylation", set_key="has_methylation", set_value=True
         )
 
         _conditional_set_query_value(

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -458,7 +458,7 @@ class CaseHandler(object):
         )
 
         _conditional_set_query_value(
-            query=query, condition="has_methylation", set_key="has_methylation", set_value=True
+            query=query, condition=has_methylation, set_key="has_methylation", set_value=True
         )
 
         _conditional_set_query_value(

--- a/scout/adapter/mongo/case.py
+++ b/scout/adapter/mongo/case.py
@@ -565,7 +565,6 @@ class CaseHandler(object):
             # Return the result in order of descending phenotype similarity (the same order or the _ids provided in the query)
             return sorted(list(results), key=lambda res: result_order.index(res["_id"]))
 
-        LOG.warning(query)
         return self.case_collection.find(query, projection).sort("updated_at", -1)
 
     def is_pheno_similarity_query(self, name_query: ImmutableMultiDict) -> bool:
@@ -1091,6 +1090,7 @@ class CaseHandler(object):
             - gene_fusion_report_research: path to the research gene fusions report
             - genome_build: If there is a new genome build
             - has_meivariants: If there are new mei variants
+            - has_methylation: if methylation data is present
             - has_outliers: If there are new outlier variants
             - has_strvariants: If there are new strvariants
             - has_svvariants: If there are new svvariants
@@ -1164,6 +1164,7 @@ class CaseHandler(object):
                 "gene_fusion_report": case_obj.get("gene_fusion_report"),
                 "gene_fusion_report_research": case_obj.get("gene_fusion_report_research"),
                 "genome_build": case_obj.get("genome_build", "37"),
+                "has_methylation": case_obj.get("has_methylation", False),
                 "has_meivariants": case_obj.get("has_meivariants", False),
                 "has_outliers": case_obj.get("has_outliers", False),
                 "has_strvariants": case_obj.get("has_strvariants", False),

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -633,6 +633,7 @@ def get_cases_by_query(
         name_query=name_query,
         skip_assigned=request.form.get("skip_assigned"),
         is_research=request.form.get("is_research"),
+        has_methylation=request.form.get("has_me"),
         has_rna_data=request.form.get("has_rna"),
         verification_pending=request.form.get("validation_ordered"),
         has_clinvar_submission=request.form.get("clinvar_submitted"),

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -69,6 +69,7 @@ ALL_CASES_PROJECTION = {
     "display_name": 1,
     "genome_build": 1,
     "individuals": 1,
+    "has_methylation": 1,
     "is_rerun": 1,
     "is_research": 1,
     "mme_submission": 1,

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -70,7 +70,6 @@ ALL_CASES_PROJECTION = {
     "genome_build": 1,
     "has_methylation": 1,
     "individuals": 1,
-    "has_methylation": 1,
     "is_rerun": 1,
     "is_research": 1,
     "mme_submission": 1,

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -190,6 +190,7 @@ class CaseFilterForm(FlaskForm):
     is_research = BooleanField("Research only")
     clinvar_submitted = BooleanField("Has ClinVar submissions")
     has_rna = BooleanField("Has RNA-seq data")
+    has_me = BooleanField("Has methylation data")
     validation_ordered = BooleanField("Validation pending")
     search = SubmitField(label="Search")
     export = SubmitField(label="Filter and export")

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -40,11 +40,11 @@
     </div>
     {% if institute %} <!-- The following checkboxes will be displayed when the form is used on institute caseS page only, not on the dashboard -->
     <div class="row">
-        <div class="col-1-5 mb-3 form-check ms-3">
+        <div class="col-2 mb-3 form-check">
             {{ form.skip_assigned(class="form-check-input") }}
             {{ form.skip_assigned.label(class="form-check-label") }}
         </div>
-        <div class="col-1-5 mb-3 form-check">
+        <div class="col-2 mb-3 form-check">
             {{ form.is_research(class="form-check-input") }}
             {{ form.is_research.label(class="form-check-label") }}
         </div>
@@ -52,15 +52,15 @@
             {{ form.clinvar_submitted(class="form-check-input") }}
             {{ form.clinvar_submitted.label(class="form-check-label") }}
         </div>
-        <div class="col-1-5 mb-3 form-check">
+        <div class="col-2 mb-3 form-check">
             {{ form.has_rna(class="form-check-input") }}
             {{ form.has_rna.label(class="form-check-label") }}
         </div>
-        <div class="col-1-5 mb-3 form-check">
+        <div class="col-2 mb-3 form-check">
             {{ form.has_me(class="form-check-input") }}
             {{ form.has_me.label(class="form-check-label") }}
         </div>
-        <div class="col-1-5 mb-3 form-check">
+        <div class="col-2 mb-3 form-check">
             {{ form.validation_ordered(class="form-check-input") }}
             {{ form.validation_ordered.label(class="form-check-label") }}
         </div>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -40,23 +40,27 @@
     </div>
     {% if institute %} <!-- The following checkboxes will be displayed when the form is used on institute caseS page only, not on the dashboard -->
     <div class="row">
-        <div class="col-md-2 mb-3 form-check ms-3">
+        <div class="col-1-5 mb-3 form-check ms-3">
             {{ form.skip_assigned(class="form-check-input") }}
             {{ form.skip_assigned.label(class="form-check-label") }}
         </div>
-        <div class="col-md-2 mb-3 form-check">
+        <div class="col-1-5 mb-3 form-check">
             {{ form.is_research(class="form-check-input") }}
             {{ form.is_research.label(class="form-check-label") }}
         </div>
-        <div class="col-md-2 mb-3 form-check">
+        <div class="col-2 mb-3 form-check">
             {{ form.clinvar_submitted(class="form-check-input") }}
             {{ form.clinvar_submitted.label(class="form-check-label") }}
         </div>
-        <div class="col-md-2 mb-3 form-check">
+        <div class="col-1-5 mb-3 form-check">
             {{ form.has_rna(class="form-check-input") }}
             {{ form.has_rna.label(class="form-check-label") }}
         </div>
-        <div class="col-md-2 mb-3 form-check">
+        <div class="col-1-5 mb-3 form-check">
+            {{ form.has_me(class="form-check-input") }}
+            {{ form.has_me.label(class="form-check-label") }}
+        </div>
+        <div class="col-1-5 mb-3 form-check">
             {{ form.validation_ordered(class="form-check-input") }}
             {{ form.validation_ordered.label(class="form-check-label") }}
         </div>

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -332,23 +332,23 @@
     {{ form.mei_name(class="form-control", data_style="btn-secondary") }}
   {% endif %}
   </div>
-  <div class="col-1-5">
+  <div class="w-12-5-percent">
     {{ form.region_annotations.label(class="control-label") }}
     {{ form.region_annotations(class="selectpicker", data_style="btn-secondary") }}
   </div>
-  <div class="col-1-5">
+  <div class="w-12-5-percent">
     {{ form.functional_annotations.label(class="control-label") }}
     {{ form.functional_annotations(class="selectpicker", data_style="btn-secondary") }}
   </div>
-  <div class="col-1-5">
+  <div class="w-12-5-percent">
     {{ form.genetic_models.label(class="control-label") }}
     {{ form.genetic_models(class="selectpicker", data_style="btn-secondary") }}
   </div>
-  <div class="col-1-5">
+  <div class="w-12-5-percent">
     {{ form.omim_genetic_models.label(class="control-label") }}
     {{ form.omim_genetic_models(class="selectpicker", data_style="btn-secondary") }}
   </div>
-  <div class="col-1-5">
+  <div class="w-12-5-percent">
     {{ form.genotypes.label(class="control-label") }}
     {{ form.genotypes(class="selectpicker", data_style="btn-secondary") }}
   </div>

--- a/scout/server/static/bs_styles.css
+++ b/scout/server/static/bs_styles.css
@@ -422,7 +422,7 @@ tr[data-href] {
   }
 }
 
-.col-1-5 {
+.w-12-5-percent {
     flex: 0 0 12.5%;
     max-width: 12.5%;
 }

--- a/tests/adapter/mongo/test_case_handling.py
+++ b/tests/adapter/mongo/test_case_handling.py
@@ -182,6 +182,14 @@ def test_case_queries(
     assert len(cases) == 1
 
     # -----------------------------
+    # THEN search by methylation data should work
+    # -----------------------------
+    case_obj["has_methylation"] = True
+    adapter.update_case(case_obj)
+    cases = list(adapter.cases(owner=case_obj["owner"], has_methylation=True))
+    assert len(cases) == 1
+
+    # -----------------------------
     # THEN search by phenotype should work
     # -----------------------------
     case_obj["phenotype_terms"] = test_hpo_terms


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR, automatic tests
