### PR TITLE
Fix #6376 - add an activate case button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - A `Me` badge to designate cases with methylation data available, on cases page (#6373)
 - `Has Methylation data` filter on cases page (#6375)
 - More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6357)
-- Activate/inactivate buttons on case page (#6380)
+- Activate/inactivate button on case page (#6379)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - A `Me` badge to designate cases with methylation data available, on cases page (#6373)
 - `Has Methylation data` filter on cases page (#6375)
 - More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6357)
+- Activate/inactivate buttons on case page (#6380)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -108,7 +108,7 @@
 
                   <!-- active/inactive -->
                   <button name="status" value="{{ 'active' if case.status == 'inactive' else 'inactive' }}" type="submit" class="btn btn-dark btn-sm">
-                    {{ 'Activate' if case.status == 'inactive' else 'Inactivate' }}
+                    {{ 'Active' if case.status == 'inactive' else 'Inactive' }}
                   </button>
 
                     <!-- unused/inactive -->

--- a/scout/server/blueprints/cases/templates/cases/case.html
+++ b/scout/server/blueprints/cases/templates/cases/case.html
@@ -106,10 +106,16 @@
                     {{ 'De-prioritized' if case.status == 'prioritized' else 'Prioritized' }}
                   </button>
 
+                  <!-- active/inactive -->
+                  <button name="status" value="{{ 'active' if case.status == 'inactive' else 'inactive' }}" type="submit" class="btn btn-dark btn-sm">
+                    {{ 'Activate' if case.status == 'inactive' else 'Inactivate' }}
+                  </button>
+
                     <!-- unused/inactive -->
                   <button name="status" value="{{ 'inactive' if case.status == 'ignored' else 'ignored' }}" type="submit" class="btn btn-light btn-sm">
                     {{ 'Inactive' if case.status == 'ignored' else 'Ignored' }}
                   </button>
+
                 </div>
                 <div class="btn-group ms-2" role="group">
                   <select name="tags" id="status_tags_case" multiple class="selectpicker" data-style="btn btn-secondary">


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6376 - activate case button

All the infrastructure for the status change is already there, including sanity checks. It is already possible to affect inactivation as a regular user by toggling `ignored` status, and activation by e.g. toggling `prioritized` status. This change makes the user intention clear in the audit trail.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
