### PR TITLE
Use mock HPO terms in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)
 - `has_methylation` field not persisting when a case document is updated (#6375)
-- Missing mock resource resulting in failing `load_disease_terms` test ()
+- Missing mock resource resulting in failing `load_disease_terms` test (#6383)
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)
 - `has_methylation` field not persisting when a case document is updated (#6375)
+- Missing mock resource resulting in failing `load_disease_terms` test ()
 
 ## [4.112]
 ### Added

--- a/tests/load/test_load_diseases.py
+++ b/tests/load/test_load_diseases.py
@@ -2,7 +2,12 @@ from scout.load.disease import load_disease_terms
 
 
 def test_load_disease_terms(
-    gene_database, genemap_handle, orpha_to_hpo_lines, orpha_to_genes_lines, orpha_inheritance_lines
+    gene_database,
+    genemap_handle,
+    orpha_to_hpo_lines,
+    orpha_to_genes_lines,
+    orpha_inheritance_lines,
+    hpo_terms_handle,
 ):
     adapter = gene_database
     alias_genes = adapter.genes_by_alias()
@@ -14,6 +19,7 @@ def test_load_disease_terms(
         adapter=adapter,
         genemap_lines=genemap_handle,
         genes=alias_genes,
+        hpo_annotation_lines=hpo_terms_handle,
         orpha_to_genes_lines=orpha_to_genes_lines,
         orpha_to_hpo_lines=orpha_to_hpo_lines,
         orpha_inheritance_lines=orpha_inheritance_lines,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6381

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by Automatic tests
