### PR TITLE
Tooltip with LoqusDB instances description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `Has Methylation data` filter on cases page (#6375)
 - More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6357)
 - Activate/inactivate button on case page (#6379)
-- On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances ()
+- On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances (#6384)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `Has Methylation data` filter on cases page (#6375)
 - More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6357)
 - Activate/inactivate button on case page (#6379)
+- On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances ()
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -647,7 +647,7 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
-        instance_description = loqusdb.loqusdb_settings[loqus_id].get("description")
+        instance_description = loqusdb.loqusdb_settings.get(loqus_id, {}).get("description")
         if instance_description:
             obs_data[loqus_id]["instance_description"] = instance_description
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -647,10 +647,9 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
-        if loqusdb.loqusdb_settings[loqus_id].get("description"):
-            obs_data[loqus_id]["instance_description"] = loqusdb.loqusdb_settings[loqus_id].get(
-                "description"
-            )
+        instance_description = loqusdb.loqusdb_settings[loqus_id].get("description")
+        if instance_description:
+            obs_data[loqus_id]["instance_description"] = instance_description
 
         if obs_data[loqus_id] is None:
             flash(

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -647,6 +647,10 @@ def observations(store: MongoAdapter, loqusdb: LoqusDB, variant_obj: dict) -> Di
     for loqus_id in inst_loqus_ids:  # Loop over all loqusdb instances of an institute
         # collect observation on that loqusdb instance
         obs_data[loqus_id] = loqusdb.get_variant(loqus_query, loqusdb_id=loqus_id)
+        if loqusdb.loqusdb_settings[loqus_id].get("description"):
+            obs_data[loqus_id]["instance_description"] = loqusdb.loqusdb_settings[loqus_id].get(
+                "description"
+            )
 
         if obs_data[loqus_id] is None:
             flash(

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -240,12 +240,19 @@
         </thead>
         <tbody>
           {% for loqusid, obs in observations.items() %}
-              {% set obs_count = obs.observations %}
               <tr>
-                <td>{{ loqusid }}</td>
-               <td>{{ render_obs(obs_count) }}</td>
-               <td>{{ render_obs(0 if obs_count == 0 else obs.homozygote) }}</td>
-               <td>{{ render_obs(obs.total) }}</td>
+                <td
+                  {% if obs.instance_description %}
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="{{ obs.instance_description }}"
+                  {% endif %}
+                >
+                  {{ loqusid }}
+                </td>
+                <td>{{ render_obs(obs_count) }}</td>
+                <td>{{ render_obs(0 if obs_count == 0 else obs.homozygote) }}</td>
+                <td>{{ render_obs(obs.total) }}</td>
              </tr>
             {% if obs.cases or obs.observations == 1 %}
               <tr>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -85,8 +85,15 @@ CLINVAR_API_URL = "https://submit.ncbi.nlm.nih.gov/apitest/v1/submissions/"
 # Example with 2 instances of LoqusDB, one using a binary file and one instance connected via REST API
 # When multiple instances are available, admin users can modify which one is in use for a given institute from the admin settings page
 # LOQUSDB_SETTINGS = {
-#    "default" : {"binary_path": "/miniconda3/envs/loqus2.5/bin/loqusdb", "config_path": "/home/user/settings/loqus_default.yaml"},
-#    "loqus_api" : {"api_url": "http://127.0.0.1:9000"},
+#    "default": {
+#        "binary_path": "/opt/homebrew/Caskroom/miniconda/base/envs/loqusdb/bin/loqusdb",
+#        "config_path": "/home/user/settings/loqus_default.yaml",
+#        "description": "This is a CLI LoqusDB instance",
+#    },
+#    "loqus_api": {
+#        "api_url": "http://127.0.0.1:9000",
+#        "description": "This is an API LoqusDB instance",
+#    },
 # }
 
 # Connection details for Scout REViewer service

--- a/scout/server/extensions/loqus_extension.py
+++ b/scout/server/extensions/loqus_extension.py
@@ -96,6 +96,7 @@ class LoqusDB:
         for key, setting in self.loqusdb_settings.items():
             # Scout might connect to Loqus via an API or an executable, define which one for every instance
             setting["instance_type"] = "api" if setting.get(API_URL) else "exec"
+            setting["instance_description"] = setting.get("description")
             setting["id"] = key
             if app.config["TESTING"] is True:
                 setting["version"] = "2.5"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #6361 

<img width="182" height="184" alt="image" src="https://github.com/user-attachments/assets/0b44bbbb-a6ba-4883-bdf1-6bc23becf913" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
