### PR TITLE
Search specific var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - A `Me` badge to designate cases with methylation data available, on cases page (#6373)
 - `Has Methylation data` filter on cases page (#6375)
 - More filter options for the gene variants page: function, inheritance pattern, predictors, frequency (#6357)
+- A new search mode for the gene variants page, where users can search for one specific variant, regardless of other filters (#6385)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -84,7 +84,11 @@ class QueryHandler(object):
     ) -> dict:
         """Build a query to find a variant by its simple id."""
 
-        chrom, pos, ref, alt = simple_id.split("-")
+        delimiter = "-"
+        if "_" in simple_id:
+            delimiter = "_"
+
+        chrom, pos, ref, alt = simple_id.split(delimiter)
 
         variant_id_query = [
             parse_variant_id(chrom, pos, ref, alt, variant_type_element)

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -12,6 +12,7 @@ from scout.constants import (
     TRUSTED_REVSTAT_LEVEL,
 )
 from scout.constants.filters import METHBAT_IMPRINT_LABEL, METHBAT_PROMOTER_LABEL
+from scout.parse.variant.ids import parse_variant_id
 
 CLNSIG_NOT_EXISTS = {"clnsig": {"$exists": False}}
 CLNSIG_ONC_NOT_EXISTS = {"clnsig_onc": {"$exists": False}}
@@ -78,12 +79,30 @@ class QueryHandler(object):
 
         return query
 
+    def build_simple_id_query(
+        self, simple_id: str, variant_type: list, institute_ids: Optional[list]
+    ) -> dict:
+        """Build a query to find a variant by its simple id."""
+
+        chrom, pos, ref, alt = simple_id.split("-")
+
+        variant_id_query = [
+            parse_variant_id(chrom, pos, ref, alt, variant_type_element)
+            for variant_type_element in variant_type
+        ]
+
+        mongo_variant_query = {"variant_id": {"$in": variant_id_query}}
+        if institute_ids:
+            mongo_variant_query["institute"] = {"$in": institute_ids}
+
+        return mongo_variant_query
+
     def build_variant_query(
         self,
         query: Optional[dict] = None,
         institute_ids: Optional[list] = [],
         category: Optional[Union[str, list]] = "snv",
-        variant_type: Optional[list] = ["clinical"],
+        variant_type: list = ["clinical"],
     ):
         """Build a mongo query across multiple cases.
         Translate query options from a form into a complete mongo query dictionary.
@@ -113,18 +132,14 @@ class QueryHandler(object):
         """
 
         query = query or {}
-        mongo_variant_query = {}
-
         LOG.debug("Building a mongo query for %s" % query)
 
-        mongo_variant_query["hgnc_symbols"] = {"$in": query["hgnc_symbols"]}
-        mongo_variant_query["variant_type"] = {"$in": variant_type}
-
-        if not category:
-            category = "snv"
-        mongo_variant_query["category"] = (
-            {"$in": category} if isinstance(category, list) else category
-        )
+        if query["simple_id"]:
+            return self.build_simple_id_query(
+                simple_id=query["simple_id"],
+                variant_type=variant_type,
+                institute_ids=institute_ids,
+            )
 
         select_cases = None
         mongo_case_query = {}
@@ -146,6 +161,15 @@ class QueryHandler(object):
 
         if query.get("similar_case"):
             select_cases = self._get_similar_cases(query, institute_ids)
+
+        if not category:
+            category = "snv"
+
+        mongo_variant_query = {
+            "hgnc_symbols": {"$in": query["hgnc_symbols"]},
+            "variant_type": {"$in": variant_type},
+            "category": ({"$in": category} if isinstance(category, list) else category),
+        }
 
         if (
             select_cases is not None

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -155,7 +155,7 @@ class QueryHandler(object):
         if query.get("similar_case"):
             select_cases = self._get_similar_cases(query, institute_ids)
 
-        if query["simple_id"]:
+        if "simple_id" in query and query["simple_id"]:
             mongo_variant_query = self.build_simple_id_query(
                 simple_id=query["simple_id"],
                 variant_type=variant_type,
@@ -176,7 +176,7 @@ class QueryHandler(object):
         ):  # Could be an empty list, and in that case the search would not return variants
             mongo_variant_query["case_id"] = {"$in": select_cases}
 
-        if query["simple_id"]:
+        if "simple_id" in query and query["simple_id"]:
             return mongo_variant_query
 
         rank_score = query.get("rank_score") or 15

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -134,13 +134,6 @@ class QueryHandler(object):
         query = query or {}
         LOG.debug("Building a mongo query for %s" % query)
 
-        if query["simple_id"]:
-            return self.build_simple_id_query(
-                simple_id=query["simple_id"],
-                variant_type=variant_type,
-                institute_ids=institute_ids,
-            )
-
         select_cases = None
         mongo_case_query = {}
 
@@ -162,19 +155,29 @@ class QueryHandler(object):
         if query.get("similar_case"):
             select_cases = self._get_similar_cases(query, institute_ids)
 
-        if not category:
-            category = "snv"
+        if query["simple_id"]:
+            mongo_variant_query = self.build_simple_id_query(
+                simple_id=query["simple_id"],
+                variant_type=variant_type,
+                institute_ids=institute_ids,
+            )
+        else:
+            if not category:
+                category = "snv"
 
-        mongo_variant_query = {
-            "hgnc_symbols": {"$in": query["hgnc_symbols"]},
-            "variant_type": {"$in": variant_type},
-            "category": ({"$in": category} if isinstance(category, list) else category),
-        }
+            mongo_variant_query = {
+                "hgnc_symbols": {"$in": query["hgnc_symbols"]},
+                "variant_type": {"$in": variant_type},
+                "category": ({"$in": category} if isinstance(category, list) else category),
+            }
 
         if (
             select_cases is not None
         ):  # Could be an empty list, and in that case the search would not return variants
             mongo_variant_query["case_id"] = {"$in": select_cases}
+
+        if query["simple_id"]:
+            return mongo_variant_query
 
         rank_score = query.get("rank_score") or 15
         mongo_variant_query["rank_score"] = {"$gte": rank_score}

--- a/scout/adapter/mongo/query.py
+++ b/scout/adapter/mongo/query.py
@@ -85,8 +85,7 @@ class QueryHandler(object):
         """Build a query to find a variant by its simple id."""
 
         delimiter = "-"
-        if "_" in simple_id:
-            delimiter = "_"
+        simple_id = simple_id.replace("_", delimiter)
 
         chrom, pos, ref, alt = simple_id.split(delimiter)
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from re import IGNORECASE
+
 from flask_wtf import FlaskForm
 from wtforms import (
     BooleanField,
@@ -156,6 +158,13 @@ class TagListField(Field):
             self.data = []
 
 
+def hgnc_symbol_or_simple_id(form, field):
+    if not form.hgnc_symbols.data and not form.simple_id.data:
+        raise validators.ValidationError(
+            "Either HGNC gene symbols or a simple variant ID is required"
+        )
+
+
 class GeneVariantFiltersForm(FlaskForm):
     """Base FiltersForm for SNVs"""
 
@@ -165,7 +174,7 @@ class GeneVariantFiltersForm(FlaskForm):
     # shared with VariantFiltersForm
     hgnc_symbols = TagListField(
         "HGNC Symbols (comma-separated, case sensitive)",
-        validators=[validators.InputRequired()],
+        validators=[validators.Optional(), hgnc_symbol_or_simple_id],
     )
 
     region_annotations = SelectMultipleField(choices=REGION_ANNOTATIONS)
@@ -209,6 +218,19 @@ class GeneVariantFiltersForm(FlaskForm):
     cohorts = TagListField("Cohorts")
 
     # specific to GeneVariants
+    simple_id = StringField(
+        "Simple ID",
+        [
+            validators.Optional(),
+            hgnc_symbol_or_simple_id,
+            validators.Length(min=8),
+            validators.Regexp(
+                r"^(?:[1-9]|1[0-9]|2[0-2]|X|Y|MT)-[0-9]+-[ATGCN]+-[ATGCN]+$",
+                IGNORECASE,
+                message="Use format CHR-POS-REF-ALT, e.g. 1-2345-A-C",
+            ),
+        ],
+    )
     category = SelectMultipleField(choices=CATEGORY_CHOICES)
     rank_score = IntegerField(
         default=15,

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -225,9 +225,9 @@ class GeneVariantFiltersForm(FlaskForm):
             hgnc_symbol_or_simple_id,
             validators.Length(min=8),
             validators.Regexp(
-                r"^(?:[1-9]|1[0-9]|2[0-2]|X|Y|MT)-[0-9]+-[ATGCN]+-[ATGCN]+$",
+                r"^(?:[1-9]|1[0-9]|2[0-2]|X|Y|MT)[-_][0-9]+[-_][ATGCN]+[-_][ATGCN]+$",
                 IGNORECASE,
-                message="Use format CHR-POS-REF-ALT, e.g. 1-2345-A-C",
+                message="Use format CHR-POS-REF-ALT or CHR_POS_REF_ALT, e.g. 1-2345-A-C",
             ),
         ],
     )

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -204,6 +204,12 @@
         </div>
         {{ archived_observations_cancer_filters(form) }}
       </div>
+      <div class="row">
+        <div class="col">
+          {{ form.simple_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Higly specific query for variant using the form 12-123456-A-C.") }}
+          {{ form.simple_id(class="form-control") }}
+        </div>
+      </div>
       <div class="row justify-content-center mt-3">
         <div class="col col-md-6">
           <div class="row">

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -206,7 +206,7 @@
       </div>
       <div class="row">
         <div class="col">
-          {{ form.simple_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Specific query for variant using the form 12-123456-A-C. You can still filter for case options, but variant search terms like the HGNC gene symbols are not used together with this.") }}
+          {{ form.simple_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Specific query for variant using the form 12-123456-A-C or 12_123456_A_C. You can still filter for institute and case options, but variant search terms like the HGNC gene symbols cannot be used together with a variant id.") }}
           {{ form.simple_id(class="form-control") }}
         </div>
       </div>

--- a/scout/server/blueprints/institutes/templates/overview/gene_variants.html
+++ b/scout/server/blueprints/institutes/templates/overview/gene_variants.html
@@ -206,7 +206,7 @@
       </div>
       <div class="row">
         <div class="col">
-          {{ form.simple_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Higly specific query for variant using the form 12-123456-A-C.") }}
+          {{ form.simple_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Specific query for variant using the form 12-123456-A-C. You can still filter for case options, but variant search terms like the HGNC gene symbols are not used together with this.") }}
           {{ form.simple_id(class="form-control") }}
         </div>
       </div>

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -193,6 +193,11 @@ def gene_variants(institute_id):
     else:  # POST
         form.process(request.form)
 
+        if isinstance(form.variant_type.data, str):
+            form.variant_type.data = [form.variant_type.data]
+        if isinstance(form.category.data, str):
+            form.category.data = [form.category.data]
+
         if form.variant_type.data == []:
             form.variant_type.data = ["clinical"]
         variant_type = form.data.get("variant_type")
@@ -201,9 +206,17 @@ def gene_variants(institute_id):
 
         update_form_hgnc_symbols(store=store, case_obj=None, form=form)
 
-        # If no valid gene is provided, redirect to form
-        if not form.hgnc_symbols.data:
-            flash("Provided gene symbols could not be used in variants' search", "warning")
+        if not form.hgnc_symbols.data and not form.simple_id.data:
+            flash("Either HGNC gene symbols or a simple variant ID is required", "warning")
+            return safe_redirect_back(request)
+
+        if not form.validate():
+            seen = set()
+            for field_errors in form.errors.values():
+                for error in field_errors:
+                    if error not in seen:
+                        seen.add(error)
+                        flash(error, "warning")
             return safe_redirect_back(request)
 
         variants_query = store.build_variant_query(

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -4,7 +4,7 @@ import io
 import json
 import logging
 
-from flask import Blueprint, flash, jsonify, render_template, request, send_file
+from flask import Blueprint, flash, jsonify, redirect, render_template, request, send_file
 from flask_login import current_user
 from pymongo import DESCENDING
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -219,7 +219,7 @@ def gene_variants(institute_id):
             ]
         ):
             flash(
-                "A Variant Simple ID was given. It cannot be used together with other variant filter options, such as gene symbol.",
+                "Search by variant Simple ID cannot be combined with any other variant filter except institute.",
                 "warning",
             )
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -219,7 +219,7 @@ def gene_variants(institute_id):
             ]
         ):
             flash(
-                "Search by variant Simple ID cannot be combined with any other variant filter except institute.",
+                "Search by variant Simple ID cannot be combined with other variant filter options, only institute and case filter options.",
                 "warning",
             )
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -4,7 +4,7 @@ import io
 import json
 import logging
 
-from flask import Blueprint, flash, jsonify, redirect, render_template, request, send_file
+from flask import Blueprint, flash, jsonify, render_template, request, send_file
 from flask_login import current_user
 from pymongo import DESCENDING
 
@@ -16,6 +16,7 @@ from scout.constants import (
     CCV_MAP,
     DATE_DAY_FORMATTER,
     INHERITANCE_PALETTE,
+    SECONDARY_CRITERIA,
     VERBS_ICONS_MAP,
     VERBS_MAP,
 )
@@ -209,6 +210,26 @@ def gene_variants(institute_id):
         if not form.hgnc_symbols.data and not form.simple_id.data:
             flash("Either HGNC gene symbols or a simple variant ID is required", "warning")
             return safe_redirect_back(request)
+
+        if form.simple_id.data and any(
+            [
+                getattr(form, criterium).data
+                for criterium in set(["hgnc_symbols"] + SECONDARY_CRITERIA) - set(["rank_score"])
+                if hasattr(form, criterium)
+            ]
+        ):
+            flash(
+                "A Variant Simple ID was given. It cannot be used together with other variant filter options, such as gene symbol.",
+                "warning",
+            )
+
+            return render_template(
+                "/overview/gene_variants.html",
+                form=form,
+                institute=institute_obj,
+                result_size=result_size,
+                page=page,
+            )
 
         if not form.validate():
             seen = set()

--- a/tests/server/blueprints/institutes/test_institute_views.py
+++ b/tests/server/blueprints/institutes/test_institute_views.py
@@ -63,6 +63,65 @@ def test_gene_variants(app, user_obj, institute_obj):
         assert "POT1" in str(resp.data)
 
 
+def test_gene_variants_requires_gene_symbol_or_simple_id(app, institute_obj):
+    """Empty submission should warn and redirect instead of running an empty query."""
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        variants_url = url_for(
+            OVERVIEW_GENE_VARIANTS_ENDPOINT,
+            institute_id=institute_obj["internal_id"],
+            _external=True,
+        )
+        resp = client.post(variants_url, data={}, headers={"Referer": variants_url})
+
+        assert resp.status_code == 302
+        assert (
+            url_for(
+                OVERVIEW_GENE_VARIANTS_ENDPOINT,
+                institute_id=institute_obj["internal_id"],
+                _external=False,
+            )
+            in resp.location
+        )
+
+        with client.session_transaction() as session:
+            assert (
+                "warning",
+                "Either HGNC gene symbols or a simple variant ID is required",
+            ) in session.get("_flashes", [])
+
+
+def test_gene_variants_with_simple_id(app, institute_obj):
+    """Test gene variants search using a valid simple_id query."""
+
+    variant_obj = store.variant(document_id=VARIANT_ID)
+    assert variant_obj
+    simple_id = (
+        f"{variant_obj['chromosome']}-{variant_obj['position']}-"
+        f"{variant_obj['reference']}-{variant_obj['alternative']}"
+    )
+
+    with app.test_client() as client:
+        resp = client.get(url_for("auto_login"))
+        assert resp.status_code == 200
+
+        resp = client.post(
+            url_for(OVERVIEW_GENE_VARIANTS_ENDPOINT, institute_id=institute_obj["internal_id"]),
+            data={
+                "simple_id": simple_id,
+                "variant_type": ["clinical"],
+                "category": "snv",
+                "institute": ["cust000"],
+            },
+        )
+
+        assert resp.status_code == 200
+        assert variant_obj["_id"] in str(resp.data)
+
+
 def test_gene_variants_export(app, user_obj, institute_obj):
     """Test that the SNPs and INDELs page exports data given a gene provided by user"""
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6263 - specifically allow searching for variant ids

We already have an index for `variant_id` (with an optional `institute`). That is a complete one, not like the sparse index. It should allow pretty quick access. The other variant search terms become irrelevant given this, though additional filtering at the case level is still possible.

See what you think. It is pretty convenient to have this on the same page, and hopefully it is intuitive enough not to cause confusion.

<img width="1001" height="351" alt="Screenshot 2026-06-08 at 16 25 31" src="https://github.com/user-attachments/assets/3457eb0c-1900-4447-9b1e-35a5e81056de" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
