### PR TITLE
Fix ACMG PDF export to support multi-page output and multi-line textareas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `has_methylation` field not persisting when a case document is updated (#6375)
 - Missing mock resource resulting in failing `load_disease_terms` test (#6383)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
-- Fix ACMG PDF export to support multi-page output ()
+- Fix ACMG PDF export to support multi-page output (#6390)
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - `has_methylation` field not persisting when a case document is updated (#6375)
 - Missing mock resource resulting in failing `load_disease_terms` test (#6383)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
+- Fix ACMG PDF export to support multi-page output ()
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Missing mock resource resulting in failing `load_disease_terms` test (#6383)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
 - Fix ACMG PDF export to support multi-page output (#6390)
+- Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
 
 ## [4.112]
 ### Added

--- a/scout/server/blueprints/variant/templates/variant/acmg_base.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg_base.html
@@ -15,15 +15,6 @@
     width: 100%;
     box-sizing: border-box;
   }
-
-  .comment-box {
-    width: 90%;
-    padding: 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    white-space: normal;
-    word-break: break-word;
-    overflow-wrap: anywhere;
   </style>
 {% endblock %}
 
@@ -39,7 +30,7 @@
           {% if evaluation %}
              <h4>
               {{ evaluation.classification.label }}
-              <span class="badge bg-info">{{ evaluation.classification.short|safe }}</span>
+              <span class="badge bg-info ms-3">{{ evaluation.classification.short|safe }}</span>
             </h4>
             On case {{ case.display_name }}. Variant {{ pretty_link_variant(variant, case) }}.<br>
             By {{ evaluation.user_name }} on {{ evaluation.created_at.date() }}
@@ -260,10 +251,35 @@
       }
     });
 
+    // Fix textarea style for text wrapping on multiple lines
+    const textareaClones = [];
+    container.querySelectorAll("textarea").forEach(el => {
+      const div = document.createElement("div");
+      // IMPORTANT: preserve line breaks exactly
+      div.innerText = el.value;
+      const style = getComputedStyle(el);
+      div.style.whiteSpace = "pre-wrap";
+      div.style.wordBreak = "break-word";
+      div.style.overflowWrap = "break-word";
+      div.style.font = style.font;
+      div.style.padding = style.padding;
+      div.style.border = style.border;
+      div.style.minHeight = style.height;
+      div.style.background = "white";
+      el.style.display = "none";
+      el.parentNode.insertBefore(div, el);
+      textareaClones.push({ el, div });
+    });
+
     // Capture PDF
       const canvas = await html2canvas(container, { scale: 1, useCORS: true, backgroundColor: '#ffffff' });
 
       // Restore original styles
+      textareaClones.forEach(({ el, div }) => {
+        div.remove();
+        el.style.display = "";
+      });
+
       allElements.forEach(el => {
         if (el.dataset.originalBg !== undefined) {
           el.style.backgroundColor = el.dataset.originalBg;

--- a/scout/server/blueprints/variant/templates/variant/acmg_base.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg_base.html
@@ -292,10 +292,30 @@
       // Generate PDF
       const imgData = canvas.toDataURL('image/jpeg', 0.75);
       const { jsPDF } = globalThis.jspdf;
+
       const pdf = new jsPDF('p', 'mm', 'a4');
+
       const pdfWidth = pdf.internal.pageSize.getWidth();
-      const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
-      pdf.addImage(imgData, 'JPEG', 0, 0, pdfWidth, pdfHeight);
+      const pdfHeight = pdf.internal.pageSize.getHeight();
+
+      const imgWidth = pdfWidth;
+      const imgHeight = (canvas.height * pdfWidth) / canvas.width;
+
+      let heightLeft = imgHeight;
+      let position = 0;
+
+      // first page
+      pdf.addImage(imgData, 'JPEG', 0, position, imgWidth, imgHeight);
+      heightLeft -= pdfHeight;
+
+      // additional pages
+      while (heightLeft > 0) {
+        position -= pdfHeight;
+        pdf.addPage();
+        pdf.addImage(imgData, 'JPEG', 0, position, imgWidth, imgHeight);
+        heightLeft -= pdfHeight;
+      }
+
       {% if case %}
         pdf.save('{{ case.display_name }}{{ "_" + variant.display_name }}_acmg.pdf');
       {% else %}
@@ -304,6 +324,8 @@
         const formatted = iso.slice(0,16).replace('T','_').replace(':','-');
         pdf.save(`sandbox_${formatted}.pdf`);
       {% endif %}
+
     });
+
   </script>
 {% endblock %}

--- a/scout/server/blueprints/variant/templates/variant/acmg_base.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg_base.html
@@ -292,22 +292,16 @@
       // Generate PDF
       const imgData = canvas.toDataURL('image/jpeg', 0.75);
       const { jsPDF } = globalThis.jspdf;
-
       const pdf = new jsPDF('p', 'mm', 'a4');
-
       const pdfWidth = pdf.internal.pageSize.getWidth();
       const pdfHeight = pdf.internal.pageSize.getHeight();
-
       const imgWidth = pdfWidth;
       const imgHeight = (canvas.height * pdfWidth) / canvas.width;
-
       let heightLeft = imgHeight;
       let position = 0;
-
       // first page
       pdf.addImage(imgData, 'JPEG', 0, position, imgWidth, imgHeight);
       heightLeft -= pdfHeight;
-
       // additional pages
       while (heightLeft > 0) {
         position -= pdfHeight;
@@ -315,7 +309,6 @@
         pdf.addImage(imgData, 'JPEG', 0, position, imgWidth, imgHeight);
         heightLeft -= pdfHeight;
       }
-
       {% if case %}
         pdf.save('{{ case.display_name }}{{ "_" + variant.display_name }}_acmg.pdf');
       {% else %}
@@ -324,8 +317,6 @@
         const formatted = iso.slice(0,16).replace('T','_').replace(':','-');
         pdf.save(`sandbox_${formatted}.pdf`);
       {% endif %}
-
     });
-
   </script>
 {% endblock %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6389
- Fix #6085

### Main branch
- One page only, last part cut
- Comments on one line, unreadable

<img width="645" height="435" alt="image" src="https://github.com/user-attachments/assets/be025f22-db2a-4f6b-922c-04f3f1b35240" />


### This branch
- Multipage PDFs
- Comments wrapped and readable

<img width="854" height="555" alt="image" src="https://github.com/user-attachments/assets/524441d8-6f44-403c-a280-6bd854d85e06" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
