### PR TITLE
Fix links in causatives exported to managed variants format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
 - Fix ACMG PDF export to support multi-page output (#6390)
 - Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
+- Links in causative variants exported in the managed variants format ()
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
 - Fix ACMG PDF export to support multi-page output (#6390)
 - Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
-- Links in causative variants exported in the managed variants format ()
+- Links in causative variants exported in the managed variants format (#6398)
 
 ## [4.112]
 ### Added

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -181,16 +181,16 @@ def variants_to_managed_variants(
         alt = variant.get("alternative")
         sub_category = variant.get("sub_category")
         build = variant.get("case_obj", {}).get("genome_build", "37")
-        institute_id = variant.get("institute")
+        institute = institute_id or variant.get("institute")
 
         if base_url:
             variant_href = (
-                f"{base_url}/{institute_id}/{variant['case_obj']['display_name']}/{variant['_id']}"
+                f"{base_url}/{institute}/{variant['case_obj']['display_name']}/{variant['_id']}"
             )
         else:
             variant_href = url_for(
                 valid_categories[category],
-                institute_id=institute_id,
+                institute_id=institute,
                 case_name=variant["case_obj"]["display_name"],
                 variant_id=variant["_id"],
                 _external=True,
@@ -204,7 +204,7 @@ def variants_to_managed_variants(
 
         managed_lines.append(
             f"{chromosome};{position};{end};{ref};{alt};"
-            f"{category};{sub_category};{build};{description};;{institute_id}"
+            f"{category};{sub_category};{build};{description};;{institute}"
         )
 
     return managed_lines

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -181,8 +181,6 @@ def variants_to_managed_variants(
         alt = variant.get("alternative")
         sub_category = variant.get("sub_category")
         build = variant.get("case_obj", {}).get("genome_build", "37")
-        LOG.warning(institute_id)
-        LOG.warning(variant.get("institute"))
         institute_id = variant.get("institute")
 
         if base_url:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -197,7 +197,7 @@ def variants_to_managed_variants(
             )
         pretty_variant_name = current_app.custom_filters.pretty_variant(variant)
         link = f'<a target="blank" rel="noopener noreferrer" href="{variant_href}">{pretty_variant_name}</a>'
-        description = f"{link} ({type},{institute_id},build{build})"
+        description = f"{link} ({type},{institute},build{build})"
 
         if category == "cancer":
             category = "cancer_snv"

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -181,7 +181,9 @@ def variants_to_managed_variants(
         alt = variant.get("alternative")
         sub_category = variant.get("sub_category")
         build = variant.get("case_obj", {}).get("genome_build", "37")
-        institute_id = institute_id or variant.get("institute")
+        LOG.warning(institute_id)
+        LOG.warning(variant.get("institute"))
+        institute_id = variant.get("institute")
 
         if base_url:
             variant_href = (


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
OR
This PR marks a new Scout release. We apply semantic versioning. This is a major/minor/patch release for reasons.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
