### PR TITLE
Fix exporting causatives from 38 cases without --build param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Comment boxes not editable when reclassifying an existing ACMG classification (#6388)
 - Fix ACMG PDF export to support multi-page output (#6390)
 - Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
+- Exporting causative variants from a case with genome build 38 when the build parameter is omitted from the command (#6399)
 
 ## [4.112]
 ### Added

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -536,7 +536,6 @@ class VariantHandler(VariantLoader):
         }
         if case_id:
             query["case"] = case_id
-
         if within_days:
             days_datetime = datetime.datetime.now() - datetime.timedelta(days=within_days)
             query["created_at"] = {"$gte": days_datetime}
@@ -553,7 +552,7 @@ class VariantHandler(VariantLoader):
         causative_ids = set()
         for case_obj in cases:
 
-            if case_obj is None or build is not None and get_case_genome_build(case_obj) != build:
+            if case_obj is None or build and get_case_genome_build(case_obj) != build:
                 continue
 
             causatives = case_obj.get("causatives", [])

--- a/scout/adapter/mongo/variant.py
+++ b/scout/adapter/mongo/variant.py
@@ -536,6 +536,7 @@ class VariantHandler(VariantLoader):
         }
         if case_id:
             query["case"] = case_id
+
         if within_days:
             days_datetime = datetime.datetime.now() - datetime.timedelta(days=within_days)
             query["created_at"] = {"$gte": days_datetime}
@@ -552,7 +553,7 @@ class VariantHandler(VariantLoader):
         causative_ids = set()
         for case_obj in cases:
 
-            if case_obj is None or build and get_case_genome_build(case_obj) != build:
+            if case_obj is None or build is not None and get_case_genome_build(case_obj) != build:
                 continue
 
             causatives = case_obj.get("causatives", [])

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -162,7 +162,7 @@ def resolve_case(
     """
     if not case_id:
         LOG.info("Use collaborator %s", collaborator)
-        return collaborator, None
+        return collaborator, None, None
 
     case_obj = adapter.case(case_id)
     if not case_obj:

--- a/scout/commands/export/variant.py
+++ b/scout/commands/export/variant.py
@@ -154,7 +154,8 @@ def resolve_case(
     Resolve the effective collaborator and optional case object.
 
     If case_id is provided, the case is fetched and its owner is used
-    as the collaborator. If the case does not exist, the command aborts.
+    as the collaborator. Case genome build is also returned.
+    If the case does not exist, the command aborts.
 
     Returns:
         Tuple of (collaborator, case object or None)
@@ -168,7 +169,7 @@ def resolve_case(
         LOG.info("Case %s does not exist", case_id)
         raise click.Abort
 
-    return case_obj["owner"], case_obj
+    return (case_obj["owner"], case_obj, case_obj["genome_build"])
 
 
 @click.command("causatives", short_help="Export causative variants")
@@ -217,9 +218,9 @@ def causatives(
     LOG.info("Running scout export variants")
     adapter = store
 
-    collaborator, case_obj = resolve_case(adapter, case_id, collaborator)
+    collaborator, case_obj, case_build = resolve_case(adapter, case_id, collaborator)
 
-    build = "38" if build == "GRCh38" else build
+    build = "38" if build == "GRCh38" else (case_build or build)
 
     causatives = adapter.get_causatives(
         document_id=document_id,


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6396 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
