### PR TITLE
Compare LDAP auth response against enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
 - Exporting causative variants from a case with genome build 38 when the build parameter is omitted from the command (#6399)
 - Links in causative variants exported in the managed variants format (#6398)
-- LDAP login accepting failed authentication responses from `flask-ldap3-login` (#)
+- LDAP login accepting failed authentication responses from `flask-ldap3-login` (#6400)
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Re-introduce text wrapping in textareas on ACMG classifications exported to PDF (#6390)
 - Exporting causative variants from a case with genome build 38 when the build parameter is omitted from the command (#6399)
 - Links in causative variants exported in the managed variants format (#6398)
+- LDAP login accepting failed authentication responses from `flask-ldap3-login` (#)
 
 ## [4.112]
 ### Added

--- a/scout/server/extensions/ldap_extension.py
+++ b/scout/server/extensions/ldap_extension.py
@@ -1,6 +1,6 @@
 import logging
 
-from flask_ldap3_login import LDAP3LoginManager
+from flask_ldap3_login import AuthenticationResponseStatus, LDAP3LoginManager
 from ldap3 import ALL, SUBTREE, Connection, Server
 
 LOG = logging.getLogger(__name__)
@@ -41,6 +41,7 @@ class LdapManager:
         """
         Authenticate a user with LDAP, trying direct bind first if configured,
         then falling back to search+bind.
+        The flask-ldap3-login status is an enum, so compare it explicitly.
         """
         try:
             # Attempt direct bind if configured
@@ -53,7 +54,7 @@ class LdapManager:
 
             # Fallback: search+bind via flask-ldap3-login
             result = self.ldap_manager.authenticate(username, password)
-            if not result or not getattr(result, "status", False):
+            if not result or result.status != AuthenticationResponseStatus.success:
                 LOG.warning(f"LDAP search+bind authentication failed for {username}")
                 return False
 

--- a/tests/server/extensions/test_ldap_extension.py
+++ b/tests/server/extensions/test_ldap_extension.py
@@ -1,3 +1,6 @@
+from flask_ldap3_login import AuthenticationResponseStatus
+
+
 def test_ldap_manager_success(ldap_manager_instance):
     """LDAP authentication succeeds for a valid user with correct password."""
     manager = ldap_manager_instance
@@ -64,7 +67,7 @@ def test_ldap_manager_fallback_to_search_bind(ldap_manager_instance):
 
     # Simulate successful search+bind result
     class FakeResult:
-        status = True
+        status = AuthenticationResponseStatus.success
         user_dn = "uid=testuser,ou=people,dc=planetexpress,dc=com"
 
     def mock_authenticate(username, password):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

This update fixes a bug where the LDAP search+bind auth fallback does not correctly check for authentication success. 

The fallback will now correctly reject login attempts that do not return a valid `success` status  

<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [ ] tests executed by
