### PR TITLE
Fix #6363 - comments accept markdown syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
+- Comments retain formatting, like the synopsis field (#6400)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
-- Comments retain formatting, like the synopsis field (#6401)
+- Comments can be formatted with Markdown, like the synopsis field (#6401)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
-- Comments retain formatting, like the synopsis field (#6400)
+- Comments retain formatting, like the synopsis field (#6401)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/docs/user-guide/cases.md
+++ b/docs/user-guide/cases.md
@@ -89,3 +89,4 @@ Matches will be ordered by date and each single match object will display matchi
 
 ----------
 [rhocall]: https://github.com/dnil/rhocall
+[markdown]: https://help.github.com/articles/markdown-basics/

--- a/docs/user-guide/variants.md
+++ b/docs/user-guide/variants.md
@@ -170,7 +170,6 @@ Example:
 
 > **Note:** Adding the same variant more than once (same chromosome, position, reference, alternative, and category) will result in a single managed variant entry. The `institutes` and `description` fields will be merged.
 [clinvar]: https://www.ncbi.nlm.nih.gov/clinvar/
-[markdown]: https://help.github.com/articles/markdown-basics/
 [expansion-hunter]: https://github.com/Illumina/ExpansionHunter
 [stranger]: https://github.com/moonso/stranger
 [rhocall]: https://github.com/dnil/rhocall

--- a/scout/server/blueprints/cases/templates/cases/case_report.html
+++ b/scout/server/blueprints/cases/templates/cases/case_report.html
@@ -253,7 +253,7 @@
 	                    {% for comment in comments %}
 	                      <tr>
 	                        <td style="width:50%;">{{comment.created_at.strftime('%Y-%m-%d')}} {{comment.user_name}}</td>
-	                        <td class="text-break"><strong>{{ comment.content }}</strong></td>
+	                        <td class="text-break"><strong>{{ comment.content|markdown }}</strong></td>
 	                      </tr>
 	                    {% endfor %}
 	                    </table>

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -25,7 +25,7 @@
       	  </small>
       	</td>
       	<td>
-      	  {{ comment.content }}
+      	  {{ comment.content|markdown }}
       	</td>
       </tr>
       {% endfor %}
@@ -55,7 +55,7 @@
                   <span class='badge bg-secondary text-white'>edited</span>
                 {% endif %}
               </td>
-              <td class="text-break"><strong>{{ comment.content }}</strong></td>
+              <td class="text-break"><strong>{{ comment.content|markdown }}</strong></td>
             </tr>
           {% endfor %}
         </tbody>
@@ -104,7 +104,7 @@
             <input type="hidden" name="link" value="{{ url_for('variant.variant', institute_id=institute._id, case_name=case.display_name, variant_id=variant_id) if variant_id else url_for('cases.case', institute_id=institute._id, case_name=case.display_name) }}">
             <div class="row">
               <div class="col">
-                <textarea class="form-control" name="content" placeholder="Leave a comment"></textarea>
+                <textarea class="form-control" name="content" data-bs-toggle="tooltip" title="Comments can be formatted with Markdown." placeholder="Leave a comment" ></textarea>
               </div>
             </div>
             <div class="row mt-3">
@@ -129,7 +129,7 @@
 
 {% macro single_comment(institute, case, current_user, comment, index) %}
       <div class="row mx-0 p-3 mb-0 {% if index % 2 %}even{% else %}odd{% endif %}">
-          <div class="col-7 text-break">{{ comment.content }}</div>
+          <div class="col-7 text-break">{{ comment.content|markdown }}</div>
           <div class="col-5 text-end">
             <form method="POST" action="{{ url_for('cases.events', institute_id=institute._id, case_name=case.display_name, event_id=comment._id,_anchor='comments') }}">
               <small>
@@ -169,6 +169,7 @@
     </div>
     <div class="modal-body">
       <div class="row">
+        <small>Comments can be formatted with <a href="https://www.markdownguide.org/basic-syntax/">Markdown</a>.</small>
         <label for="commentContent">Comment content</label>
         <textarea class="form-control" name="updatedContent" id="commentContent" required="required">{{comment.content}}</textarea>
       </div>


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6363 

<img width="694" height="387" alt="Screenshot 2026-06-12 at 15 11 15" src="https://github.com/user-attachments/assets/78d012b3-e3c8-4b8f-8afb-fab7b6709024" />

<img width="546" height="326" alt="Screenshot 2026-06-12 at 15 59 01" src="https://github.com/user-attachments/assets/0f479552-af4c-47c7-ab4b-8de8ed3ba884" />

<img width="638" height="437" alt="Screenshot 2026-06-12 at 15 57 47" src="https://github.com/user-attachments/assets/682af4c5-a5f5-4b9e-abfd-68593bfb932e" />

<img width="1273" height="188" alt="Screenshot 2026-06-12 at 15 22 53" src="https://github.com/user-attachments/assets/31c360e2-c751-44ce-b94c-48cb2d21efbb" />

<img width="1182" height="233" alt="Screenshot 2026-06-12 at 15 22 44" src="https://github.com/user-attachments/assets/7e79e7ff-33f9-47ff-950a-a6d92198e7c8" />

There will be a larger possibility for html injection and between user exposure with this, especially for global comments, but the possibility already exists with e.g. links in managed variants, or synopsis for a shared case.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
