### PR TITLE
Keep ACMG classification open after submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
+- ACMG evaluation page doesn't close after having submitted the evaluation ()
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
-- ACMG evaluation page doesn't close after having submitted the evaluation ()
+- ACMG evaluation page doesn't close after having submitted the evaluation (#6405)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
 - Comments can be formatted with Markdown, like the synopsis field (#6401)
-- ACMG evaluation page doesn't close after having submitted the evaluation (#6405)
+- Option to keep the ACMG page open after submitting an evaluation (#6405)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -5,7 +5,6 @@ import pymongo
 from bson import ObjectId
 
 from scout.build.acmg import build_evaluation
-from scout.constants import ACMG_MAP
 from scout.utils.acmg import get_acmg
 
 log = logging.getLogger(__name__)
@@ -14,37 +13,15 @@ log = logging.getLogger(__name__)
 class ACMGHandler(object):
     def submit_evaluation(
         self,
-        variant_obj,
-        user_obj,
-        institute_obj,
-        case_obj,
-        link,
-        criteria=None,
-        classification=None,
-    ):
-        """Submit an evaluation to the database
-
-        Get all the relevant information, build an evaluation_obj
-
-        Args:
-            variant_obj(dict)
-            user_obj(dict)
-            institute_obj(dict)
-            case_obj(dict)
-            link(str): variant url
-            criteria(list(dict)):
-                                            [
-                                        {
-                                        'term': str,
-                                        'comment': str,
-                                        'modifier': str,
-                                        'links': list(str)
-                                        },
-                                        .
-                                        .
-                                    ]
-            classification(int)
-        """
+        variant_obj: dict,
+        user_obj: dict,
+        institute_obj: dict,
+        case_obj: dict,
+        link: str,
+        criteria: dict | None = None,
+        classification: tuple | int | None = None,
+    ) -> Tuple(str, str):
+        """Save an ACMG evaluation in the database."""
         criteria = criteria or []
 
         variant_specific = variant_obj["_id"]
@@ -76,16 +53,16 @@ class ACMGHandler(object):
                 criteria=criteria,
             )
 
-            self._load_evaluation(evaluation_obj)
+            classif_id = self._load_evaluation(evaluation_obj)
 
-        # Update the acmg classification for the variant:
+        # Update the ACMG classification for the variant:
         self.update_acmg(institute_obj, case_obj, user_obj, link, variant_obj, classification)
-        return classification
+        return classif_id, classification
 
-    def _load_evaluation(self, evaluation_obj):
+    def _load_evaluation(self, evaluation_obj: dict) -> str:
         """Load a evaluation object into the database"""
         res = self.acmg_collection.insert_one(evaluation_obj)
-        return res
+        return res.inserted_id
 
     def delete_evaluation(self, evaluation_obj):
         """Delete an evaluation from the database

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from typing import Tuple
 
 import pymongo
 from bson import ObjectId

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
-from typing import Tuple
+from typing import List, Tuple
 
 import pymongo
 from bson import ObjectId
 
 from scout.build.acmg import build_evaluation
+from scout.models.acmg_evaluation import criterion
 from scout.utils.acmg import get_acmg
 
 log = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class ACMGHandler(object):
         institute_obj: dict,
         case_obj: dict,
         link: str,
-        criteria: dict | None = None,
+        criteria: List[criterion] | None = None,
         classification: tuple | int | None = None,
     ) -> Tuple(str | None, str):
         """Save an ACMG evaluation in the database."""

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -31,7 +31,7 @@ class ACMGHandler(object):
         user_name = user_obj.get("name", user_obj["_id"])
         institute_id = institute_obj["_id"]
         case_id = case_obj["_id"]
-
+        classif_id = None
         evaluation_terms = []
         for evaluation_info in criteria:
             term = evaluation_info["term"]

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -21,7 +21,7 @@ class ACMGHandler(object):
         link: str,
         criteria: dict | None = None,
         classification: tuple | int | None = None,
-    ) -> Tuple(str, str):
+    ) -> Tuple(str | None, str):
         """Save an ACMG evaluation in the database."""
         criteria = criteria or []
 

--- a/scout/models/acmg_evaluation.py
+++ b/scout/models/acmg_evaluation.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from typing import List
+
 """
 scout.models.acmg_evaluation
 ~~~~~~~~~~~~~~~~~~
@@ -11,6 +12,8 @@ Evaluations are stored in its own collection
 
 from datetime import datetime
 
+criterion = dict(term=str, comment=str, links=List[str], modifier=str)
+
 evaluation = dict(
     variant_specific=str,  # md5 document id
     variant_id=str,  # md5 variant id
@@ -20,7 +23,7 @@ evaluation = dict(
     # All evaluations will have an author
     user_id=str,  # user email, required
     user_name=str,  # user name
-    criteria=list,  # List of dictionaries with criterias
+    criteria=List[criterion],  # List of dictionaries with criteria
     # timestamps
     created_at=datetime,
 )

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 import requests
 from flask import abort, current_app, flash, url_for

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -831,21 +831,8 @@ def variant_acmg_post(
     variant_id: str,
     user_email: str,
     criteria: list,
-) -> dict:
-    """Calculate an ACMG classification based on a list of criteria.
-
-    Args:
-        store(scout.adapter.MongoAdapter)
-        institute_id(str): institute_obj['_id']
-        case_name(str): case_obj['display_name']
-        variant_id(str): variant_obj['document_id']
-        user_mail(str)
-        criteria()
-
-    Returns:
-        data(dict): Things for the template
-
-    """
+) -> Tuple(str, str):
+    """Calculate an ACMG classification based on a list of criteria."""
     variant_obj = store.variant(variant_id)
 
     if not variant_obj:
@@ -862,7 +849,7 @@ def variant_acmg_post(
         case_name=case_name,
         variant_id=variant_id,
     )
-    classification = store.submit_evaluation(
+    classification_id, classification = store.submit_evaluation(
         institute_obj=institute_obj,
         case_obj=case_obj,
         variant_obj=variant_obj,
@@ -870,7 +857,7 @@ def variant_acmg_post(
         link=variant_link,
         criteria=criteria,
     )
-    return classification
+    return classification_id, classification
 
 
 def variant_ccv(store: MongoAdapter, institute_id: str, case_name: str, variant_id: str):

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -831,7 +831,7 @@ def variant_acmg_post(
     variant_id: str,
     user_email: str,
     criteria: list,
-) -> Tuple(str, str):
+) -> Tuple(str | None, str):
     """Calculate an ACMG classification based on a list of criteria."""
     variant_obj = store.variant(variant_id)
 

--- a/scout/server/blueprints/variant/templates/variant/acmg_base.html
+++ b/scout/server/blueprints/variant/templates/variant/acmg_base.html
@@ -120,7 +120,10 @@
       </div>
 
     {% if not evaluation and institute %}
-      <button class="btn btn-primary form-control mt-3">Submit</button>
+      <div class="d-flex gap-2 mt-2">
+        <button type="submit" name="action" value="stay" class="btn btn-primary btn-lg flex-fill" style="width: 200px;">Save</button>
+        <button type="submit" name="action" value="return" class="btn btn-primary btn-lg flex-fill" style="width: 200px;">Save and return</button>
+      </div>
     {% elif edit %}
       <button class="btn btn-primary form-control mt-3" data-bs-toggle="tooltip" title="Editing this classification will result in a new classification">Reclassify</button>
     {%endif %}

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -241,7 +241,18 @@ def variant_acmg(institute_id, case_name, variant_id):
     else:
         flash("Empty ACMG criteria, redirecting", "info")
 
-    return redirect(url_for(".evaluation", evaluation_id=acmg_id))
+    action = request.form.get("action")
+    if action == "stay":
+        return redirect(url_for(".evaluation", evaluation_id=acmg_id))
+    variant_obj = store.variant(variant_id)
+    return redirect(
+        url_for(
+            ".variant" if variant_obj.get("category") == "snv" else ".sv_variant",
+            institute_id=institute_id,
+            case_name=case_name,
+            variant_id=variant_id,
+        )
+    )
 
 
 @variant_bp.route("/<institute_id>/<case_name>/<variant_id>/ccv", methods=["GET", "POST"])

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -234,22 +234,14 @@ def variant_acmg(institute_id, case_name, variant_id):
                     modifier=request.form.get("modifier-{}".format(term)),
                 )
             )
-        acmg = variant_acmg_post(
+        acmg_id, acmg = variant_acmg_post(
             store, institute_id, case_name, variant_id, current_user.email, criteria
         )
         flash("classified as: {}".format(acmg), "info")
     else:
         flash("Empty ACMG criteria, redirecting", "info")
 
-    variant_obj = store.variant(variant_id)
-    return redirect(
-        url_for(
-            ".variant" if variant_obj.get("category") == "snv" else ".sv_variant",
-            institute_id=institute_id,
-            case_name=case_name,
-            variant_id=variant_id,
-        )
-    )
+    return redirect(url_for(".evaluation", evaluation_id=acmg_id))
 
 
 @variant_bp.route("/<institute_id>/<case_name>/<variant_id>/ccv", methods=["GET", "POST"])

--- a/tests/server/blueprints/variant/test_variant_controllers.py
+++ b/tests/server/blueprints/variant/test_variant_controllers.py
@@ -41,7 +41,7 @@ def test_check_reset_variant_classification(app, case_obj, variant_obj):
 
         # WHEN retrieving the variant again,
         current_variant = store.variant(variant_obj["_id"])
-        # THEN the classification was acutally set
+        # THEN the classification should be set
         assert current_variant.get("acmg_classification") is not None
 
         # GIVEN that there are no separate evaluations stored for the variant


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Closes #6386

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
