### PR TITLE
Clearer gens buttons on SV variant page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances (#6384)
 - A new search mode for the gene variants page, where users can search for one specific variant, regardless of other filters (#6385)
 - Mitorsaw Mitochondrial variant caller (#6392)
+- An icon to the Gens-to-cases link to distinguish it from Gens-to-individuals links on the SV variant page (#6410)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
+- Enable live search on Bootstrap selectpicker controls (#6377)
+- Comments can be formatted with Markdown, like the synopsis field (#6401)
 - Enable live search on Bootstrap selectpicker controls (#6377)
 - Comments can be formatted with Markdown, like the synopsis field (#6401)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
 - Comments can be formatted with Markdown, like the synopsis field (#6401)
-- Enable live search on Bootstrap selectpicker controls (#6377)
-- Comments can be formatted with Markdown, like the synopsis field (#6401)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/scout/server/blueprints/cases/templates/cases/gens.html
+++ b/scout/server/blueprints/cases/templates/cases/gens.html
@@ -11,7 +11,7 @@
 {% macro gens_case_button(case, gens_info=None) %}
   {% if gens_info and gens_info.display and gens_info.version > 3 %}
     <form action=https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}">
-      <button type="submit" data-bs-toggle="tooltip" title="Gens viewer for full case" class="btn btn-secondary text-white btn-xs form-control" target="_blank" href=><span class="fa fa-solid fa-fw fa-mountain me-1"></span>G<span class="menu-collapsed">ens</span></button>
+      <button type="submit" data-bs-toggle="tooltip" title="Gens viewer for full case" class="btn btn-secondary text-white btn-xs form-control" target="_blank" href=><span class="fa fa-users me-1"></span>G<span class="menu-collapsed">ens</span></button>
     </form>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/cases/templates/cases/gens.html
+++ b/scout/server/blueprints/cases/templates/cases/gens.html
@@ -11,7 +11,7 @@
 {% macro gens_case_button(case, gens_info=None) %}
   {% if gens_info and gens_info.display and gens_info.version > 3 %}
     <form action=https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}">
-      <button type="submit" data-bs-toggle="tooltip" title="Gens viewer for full case" class="btn btn-secondary text-white btn-xs form-control" target="_blank" href=><span class="fa fa-users me-1"></span>G<span class="menu-collapsed">ens</span></button>
+      <button type="submit" data-bs-toggle="tooltip" title="Gens viewer for full case" class="btn btn-secondary text-white btn-xs form-control" target="_blank" href=><span class="fa fa-binoculars me-1"></span>G<span class="menu-collapsed">ens</span></button>
     </form>
   {% endif %}
 {% endmacro %}

--- a/scout/server/blueprints/institutes/templates/overview/cases.html
+++ b/scout/server/blueprints/institutes/templates/overview/cases.html
@@ -67,7 +67,6 @@
 </div>
 {% endmacro %}
 
-
 {% macro case_row(case) %}
   <tr data-target="_blank" data-href="{{ case_link_href(case) }}" class="{% if case.status == 'solved' %}causative{% elif case.dimmed_in_search %}dismiss{% endif %}">
     <td>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -258,16 +258,18 @@
         <li class="list-group-item">
           <span class="d-inline">Gens copy number profile</span>
           <span class="d-inline ms-3">
-            {% if gens_info.version > 3 %}
+            {% if gens_info.version > 3 and variant.samples | length > 1 %}
              <a class="btn btn-secondary text-white" target="_blank"
                href="https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}">
-                <i class="fa fa-users me-1"></i>{{case._id}}
+                <i class="fa fa-binoculars me-1"></i>{{case._id}}
             </a>
             {% endif %}
             {% for sample in variant.samples %}
               <a class="btn btn-secondary" target="_blank"
                 href={% if gens_info.version > 3 %}"https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&sample_ids={{sample.sample_id}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}"{% else %}
-                "http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case._id}}&individual_id={{sample.sample_id}}"{% endif %}>{{ sample.display_name }}</a>
+                "http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case._id}}&individual_id={{sample.sample_id}}"{% endif %}>
+                <i class="fa fa-user me-1"></i>{{ sample.display_name }}
+              </a>
             {% endfor %}
           </span>
         </li>

--- a/scout/server/blueprints/variant/templates/variant/sv-variant.html
+++ b/scout/server/blueprints/variant/templates/variant/sv-variant.html
@@ -256,15 +256,18 @@
 
         {% if gens_info and gens_info.display %}
         <li class="list-group-item">
-          <span class="d-inline">Copy number profile</span>
+          <span class="d-inline">Gens copy number profile</span>
           <span class="d-inline ms-3">
             {% if gens_info.version > 3 %}
-              <a class="btn btn-secondary text-white" target="_blank" href="https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}">Gens {{case._id}}</a>
+             <a class="btn btn-secondary text-white" target="_blank"
+               href="https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}">
+                <i class="fa fa-users me-1"></i>{{case._id}}
+            </a>
             {% endif %}
             {% for sample in variant.samples %}
               <a class="btn btn-secondary" target="_blank"
                 href={% if gens_info.version > 3 %}"https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}&sample_ids={{sample.sample_id}}&region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}"{% else %}
-                "http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case._id}}&individual_id={{sample.sample_id}}"{% endif %}>Gens {{ sample.display_name }}</a>
+                "http://{{gens_info.host}}/{{sample.display_name}}?region={{variant.chromosome}}:{{variant.position - 2000}}-{{variant.end + 2000}}&variant={{variant._id}}&genome_build={{gens_info.genome_build}}&case_id={{case._id}}&individual_id={{sample.sample_id}}"{% endif %}>{{ sample.display_name }}</a>
             {% endfor %}
           </span>
         </li>

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -56,9 +56,9 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # CHANJO2_URL = "http://chanjo2-stage.scilifelab.se"
 
 # Configure gens service
-# GENS_HOST = "127.0.0.1"
-# GENS_PORT = 5000
-# GENS_VERSION = 4
+GENS_HOST = "127.0.0.1"
+GENS_PORT = 5000
+GENS_VERSION = 4
 
 # Connection details for communicating with a rerunner service
 # RERUNNER_API_ENTRYPOINT = "http://rerunner:5001/v1.0/rerun"

--- a/scout/server/config.py
+++ b/scout/server/config.py
@@ -56,9 +56,9 @@ ACCREDITATION_BADGE = "swedac-1926-iso17025.png"
 # CHANJO2_URL = "http://chanjo2-stage.scilifelab.se"
 
 # Configure gens service
-GENS_HOST = "127.0.0.1"
-GENS_PORT = 5000
-GENS_VERSION = 4
+# GENS_HOST = "127.0.0.1"
+# GENS_PORT = 5000
+# GENS_VERSION = 4
 
 # Connection details for communicating with a rerunner service
 # RERUNNER_API_ENTRYPOINT = "http://rerunner:5001/v1.0/rerun"


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6409 

### Before

<img width="374" height="80" alt="image" src="https://github.com/user-attachments/assets/c9b0b5c3-36cd-40f5-b865-3fa43ebad537" />


### After

<img width="462" height="82" alt="image" src="https://github.com/user-attachments/assets/4b78ba22-c61b-45f5-af1d-ff0e22178804" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
