### PR TITLE
Display 2 GnomAD frequency links on SNV and Gene pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
 - Comments can be formatted with Markdown, like the synopsis field (#6401)
+- Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs ()
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Only admin users can edit the list of institutes available to share cases with (#6370)
 - Enable live search on Bootstrap selectpicker controls (#6377)
 - Comments can be formatted with Markdown, like the synopsis field (#6401)
-- Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs ()
+- Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs (#6413)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -14,11 +14,6 @@
   </li>
 {% endblock %}
 
-{% macro gnomad_links() %}
-<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">v.4</a>
-<a class="sm-3" href={{ builds["38"].gnomad_non_ukb_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">v.4 (non-UKB)</a>
-{% endmacro %}
-
 {% block content_main %}
   {{ super() }}
 
@@ -98,7 +93,7 @@
                   <li class="list-group-item">
                     GnomAD
                     <span class="float-end">
-                      {{ gnomad_links() }}
+                      <a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">v.4</a>
                     </span>
                   </li>
                   {% if pli_score %}

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -19,7 +19,6 @@
 <a href={{ builds["38"].gnomad_non_ukb_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD non-UKB</a>
 {% endmacro %}
 
-
 {% block content_main %}
   {{ super() }}
 

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -14,6 +14,12 @@
   </li>
 {% endblock %}
 
+{% macro gnomad_links() %}
+<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>
+<a href={{ builds["38"].gnomad_non_ukb_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD non-UKB</a>
+{% endmacro %}
+
+
 {% block content_main %}
   {{ super() }}
 
@@ -92,7 +98,7 @@
                   </li>
                   {% if pli_score %}
                   <li class="list-group-item">
-                    pLi Score (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    pLi Score ({{gnomad_links()}})
                     <span class="float-end">
                       {{ pli_score|round(2) }}
                     </span>
@@ -100,7 +106,7 @@
                   {% endif %}
                   {% if constraint_lof_oe %}
                   <li class="list-group-item">
-                    LoF o/e (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    LoF o/e ({{gnomad_links()}})
                     <span class="float-end">
                       {{ constraint_lof_oe|round(2) }}({{ constraint_lof_oe_ci_lower|round(2) }} - <mark><span data-bs-toggle="tooltip" title="LOEUF {{ constraint_lof_oe_ci_upper}}">{{ constraint_lof_oe_ci_upper|round(2) }}</span></mark>)
                     </span>
@@ -108,7 +114,7 @@
                 {% endif %}
                 {% if constraint_mis_z %}
                   <li class="list-group-item">
-                    Missense Z (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    Missense Z ({{gnomad_links()}})
                     <span class="float-end">
                       {{ constraint_mis_z|round(2) }}
                     </span>
@@ -116,7 +122,7 @@
                 {% endif %}
                   {% if constraint_mis_oe %}
                   <li class="list-group-item">
-                    Missense o/e (<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>)
+                    Missense o/e ({{gnomad_links()}})
                     <span class="float-end">
                       {{ constraint_mis_oe|round(2) }}({{ constraint_mis_oe_ci_lower|round(2) }} - {{ constraint_mis_oe_ci_upper|round(2) }})
                     </span>

--- a/scout/server/blueprints/genes/templates/genes/gene.html
+++ b/scout/server/blueprints/genes/templates/genes/gene.html
@@ -15,8 +15,8 @@
 {% endblock %}
 
 {% macro gnomad_links() %}
-<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD</a>
-<a href={{ builds["38"].gnomad_non_ukb_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">GnomAD non-UKB</a>
+<a href={{ builds["38"].gnomad_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">v.4</a>
+<a class="sm-3" href={{ builds["38"].gnomad_non_ukb_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank">v.4 (non-UKB)</a>
 {% endmacro %}
 
 {% block content_main %}
@@ -95,9 +95,15 @@
                       <a target="_blank" href={{ record.panelapp_link }} referrerpolicy="no-referrer" rel="noopener" target="_blank"> {{ symbol }} </a>
                     </span>
                   </li>
+                  <li class="list-group-item">
+                    GnomAD
+                    <span class="float-end">
+                      {{ gnomad_links() }}
+                    </span>
+                  </li>
                   {% if pli_score %}
                   <li class="list-group-item">
-                    pLi Score ({{gnomad_links()}})
+                    pLi Score
                     <span class="float-end">
                       {{ pli_score|round(2) }}
                     </span>
@@ -105,7 +111,7 @@
                   {% endif %}
                   {% if constraint_lof_oe %}
                   <li class="list-group-item">
-                    LoF o/e ({{gnomad_links()}})
+                    LoF o/e
                     <span class="float-end">
                       {{ constraint_lof_oe|round(2) }}({{ constraint_lof_oe_ci_lower|round(2) }} - <mark><span data-bs-toggle="tooltip" title="LOEUF {{ constraint_lof_oe_ci_upper}}">{{ constraint_lof_oe_ci_upper|round(2) }}</span></mark>)
                     </span>
@@ -113,7 +119,7 @@
                 {% endif %}
                 {% if constraint_mis_z %}
                   <li class="list-group-item">
-                    Missense Z ({{gnomad_links()}})
+                    Missense Z
                     <span class="float-end">
                       {{ constraint_mis_z|round(2) }}
                     </span>
@@ -121,7 +127,7 @@
                 {% endif %}
                   {% if constraint_mis_oe %}
                   <li class="list-group-item">
-                    Missense o/e ({{gnomad_links()}})
+                    Missense o/e
                     <span class="float-end">
                       {{ constraint_mis_oe|round(2) }}({{ constraint_mis_oe_ci_lower|round(2) }} - {{ constraint_mis_oe_ci_upper|round(2) }})
                     </span>

--- a/scout/server/blueprints/variant/templates/variant/variant_details.html
+++ b/scout/server/blueprints/variant/templates/variant/variant_details.html
@@ -180,15 +180,26 @@
     {% for freq_name, value, link in variant.frequencies %}
       <tr>
         <td class="py-1 px-2">
+          {{ freq_name }}
+
           {% if link %}
-            <a href="{{ link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">{{ freq_name }}</a>
-          {% else %}
-            {{ freq_name }}
+            {% set links = link if link is iterable and link is not string else [link] %}
+
+            {% for link in links %}
+              {% if link %}
+                <a href="{{ link }}" target="_blank" rel="noopener" referrerpolicy="no-referrer">
+                  <i class="fa fa-external-link ms-1"></i>
+                </a>
+              {% endif %}
+            {% endfor %}
           {% endif %}
         </td>
+
         <td class="py-1 px-2">
           {% if value %}
-            <span class="badge bg-secondary" style="font-size: 0.75rem;">{{ value|human_decimal }}</span>
+            <span class="badge bg-secondary" style="font-size: 0.75rem;">
+              {{ value|human_decimal }}
+            </span>
           {% else %}
             -
           {% endif %}

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -365,7 +365,10 @@ def frequencies(variant_obj: dict) -> list[Tuple]:
             "swegen_mei_max": ("SweGen MEI(max)", None),
         },
         "snv": {
-            "gnomad_frequency": ("GnomAD", variant_obj.get("gnomad_link")),
+            "gnomad_frequency": (
+                "GnomAD",
+                [variant_obj.get("gnomad_link"), variant_obj.get("gnomad_non_ukb_link")],
+            ),
             "thousand_genomes_frequency": ("1000G", variant_obj.get("thousandg_link")),
             "max_thousand_genomes_frequency": ("1000G(max)", variant_obj.get("thousandg_link")),
             "exac_frequency": ("ExAC", variant_obj.get("exac_link")),

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -51,9 +51,6 @@ def add_gene_links(
     gene_obj["gnomad_link"] = gnomad(ensembl_id, build)
     if build == 38:
         gene_obj["ensembl_link"] = ensembl_38_link
-        gene_obj["gnomad_non_ukb_link"] = (
-            "".join([gene_obj["gnomad_link"], "_non_ukb"]) if gene_obj["gnomad_link"] else None
-        )
     gene_obj["hpa_link"] = hpa(ensembl_id)
     gene_obj["string_link"] = string(ensembl_id)
     gene_obj["reactome_link"] = reactome(ensembl_id)

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -48,8 +48,10 @@ def add_gene_links(
     gene_obj["ensembl_37_link"] = ensembl_37_link
     gene_obj["ensembl_38_link"] = ensembl_38_link
     gene_obj["ensembl_link"] = ensembl_37_link
+    gene_obj["gnomad_link"] = gnomad(ensembl_id, build)
     if build == 38:
         gene_obj["ensembl_link"] = ensembl_38_link
+        gene_obj["gnomad_non_ukb_link"] = "".join([gene_obj["gnomad_link"], "_non_ukb"])
     gene_obj["hpa_link"] = hpa(ensembl_id)
     gene_obj["string_link"] = string(ensembl_id)
     gene_obj["reactome_link"] = reactome(ensembl_id)
@@ -59,7 +61,6 @@ def add_gene_links(
     gene_obj["expression_atlas_link"] = expression_atlas(ensembl_id)
     gene_obj["gtex_link"] = gtex(ensembl_id)
     gene_obj["exac_link"] = exac(ensembl_id)
-    gene_obj["gnomad_link"] = gnomad(ensembl_id, build)
     # Add links that use entrez_id
     entrez_id = gene_obj.get("common", {}).get("entrez_id")
     gene_obj["entrez_link"] = entrez(entrez_id)
@@ -218,7 +219,7 @@ def gnomad(ensembl_id, build=37):
     if build == 37:
         link += "gnomad_r2_1"
     if build == 38:
-        link += "gnomad_r4_non_ukb"
+        link += "gnomad_r4"
 
     return link.format(ensembl_id)
 
@@ -515,7 +516,8 @@ def get_variant_links(institute_obj: dict, variant_obj: dict, build: int = None)
     links = dict(
         thousandg_link=thousandg_link(variant_obj, build),
         exac_link=exac_link(variant_obj),
-        gnomad_link=gnomad_link(variant_obj, build),
+        gnomad_link=gnomad_link(variant_obj=variant_obj, build=build, non_ukb=False),
+        gnomad_non_ukb_link=gnomad_link(variant_obj=variant_obj, build=build, non_ukb=True),
         gnomad_sv_link=gnomad_sv_link(variant_obj, build),
         swegen_link=swegen_link(variant_obj),
         cosmic_links=cosmic_links(variant_obj),
@@ -532,6 +534,7 @@ def get_variant_links(institute_obj: dict, variant_obj: dict, build: int = None)
         litvar_snp_links=litvar_snp_links(variant_obj),
         alamut_link=alamut_variant_link(institute_obj, variant_obj, build),
     )
+
     return links
 
 
@@ -611,7 +614,7 @@ def exac_link(variant_obj):
     return url_template.format(this=variant_obj)
 
 
-def gnomad_link(variant_obj, build=37):
+def gnomad_link(variant_obj, build=37, non_ukb=False):
     """Compose link to gnomAD website for a variant."""
     url_template = (
         "https://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
@@ -626,8 +629,10 @@ def gnomad_link(variant_obj, build=37):
         url_template += "?dataset=gnomad_r4"
         return url_template
 
-    if build == 38:
+    if build == 38 and non_ukb:
         url_template += "?dataset=gnomad_r4_non_ukb"
+    elif build == 38:
+        url_template += "?dataset=gnomad_r4"
 
     return url_template
 

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -51,7 +51,9 @@ def add_gene_links(
     gene_obj["gnomad_link"] = gnomad(ensembl_id, build)
     if build == 38:
         gene_obj["ensembl_link"] = ensembl_38_link
-        gene_obj["gnomad_non_ukb_link"] = "".join([gene_obj["gnomad_link"], "_non_ukb"])
+        gene_obj["gnomad_non_ukb_link"] = (
+            "".join([gene_obj["gnomad_link"], "_non_ukb"]) if gene_obj["gnomad_link"] else None
+        )
     gene_obj["hpa_link"] = hpa(ensembl_id)
     gene_obj["string_link"] = string(ensembl_id)
     gene_obj["reactome_link"] = reactome(ensembl_id)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6408 

### Main branch
- Variant page
<img width="350" height="186" alt="image" src="https://github.com/user-attachments/assets/6ec2acf3-c609-4f1c-8872-b8cbaeb24800" />

- Gene page
<img width="480" height="298" alt="image" src="https://github.com/user-attachments/assets/cf776213-526e-4ca3-9d11-d1822beca6e0" />


### This branch

- Variant page:
<img width="403" height="177" alt="image" src="https://github.com/user-attachments/assets/039af5da-fa27-449c-a541-0e34f1aeb2c7" />

- Gene page
<img width="491" height="298" alt="image" src="https://github.com/user-attachments/assets/a5a6a2e3-8284-473e-a68a-1c07682cc086" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
