### PR TITLE
Skip loading omics entry on parsing failure rather than crashing case loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LDAP login accepting failed authentication responses from `flask-ldap3-login` (#6400)
 - Normalize email addresses to lowercase when users are created through the GUI (#6406)
 - Automatically convert email input to lowercase when logging in using LDAP (#6407)
+- Skip malformed omics variant rows during case loading instead of aborting the whole load.
 
 ## [4.112]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - LDAP login accepting failed authentication responses from `flask-ldap3-login` (#6400)
 - Normalize email addresses to lowercase when users are created through the GUI (#6406)
 - Automatically convert email input to lowercase when logging in using LDAP (#6407)
-- Skip malformed omics variant rows during case loading instead of aborting the whole load.
+- Skip malformed omics variant rows during case loading instead of aborting the whole load. (#6414)
 
 ## [4.112]
 ### Added

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -3,6 +3,7 @@ import os
 from typing import Dict, Iterable, List, Optional
 
 from pymongo import ASCENDING, DESCENDING
+from pymongo.collections import Collection 
 
 from scout.constants import ORDERED_OMICS_FILE_TYPE_MAP
 from scout.models.omics_variant import OmicsVariantLoader
@@ -13,6 +14,8 @@ SORT_ORDER = {"asc": ASCENDING, "desc": DESCENDING}
 
 
 class OmicsVariantHandler:
+
+    omics_variant_collection : Collection
 
     def delete_omics_variants_by_category(
         self, case_id: str, variant_type: str, category: str = None

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Dict, Iterable, List, Optional
 
+from pydantic import ValidationError
 from pymongo import ASCENDING, DESCENDING
 from pymongo.collections import Collection 
 
@@ -146,6 +147,7 @@ class OmicsVariantHandler:
 
         file_handle = open(case_obj["omics_files"].get(file_type), "r")
 
+        nr_skipped = 0
         for omics_info in parse_omics_file(file_handle, omics_file_type=omics_file_type):
             omics_info["case_id"] = case_obj["_id"]
             omics_info["build"] = "37" if "37" in build else "38"
@@ -154,12 +156,27 @@ class OmicsVariantHandler:
             for key in ["category", "sub_category", "variant_type", "analysis_type"]:
                 omics_info[key] = omics_file_type[key]
 
-            omics_model = OmicsVariantLoader(**omics_info).model_dump(
-                by_alias=True, exclude_none=True
-            )
-
-            self.set_genes(omics_model)
-            self.set_samples(case_obj, omics_model)
+            try:
+                omics_model = OmicsVariantLoader(**omics_info).model_dump(
+                    by_alias=True, exclude_none=True
+                )
+                self.set_genes(omics_model)
+                self.set_samples(case_obj, omics_model)
+            except (KeyError, TypeError, ValueError, ValidationError) as error:
+                nr_skipped += 1
+                LOG.error(
+                    "Skipping malformed %s OMICS variant for case %s: sample=%s, chrom=%s, start=%s, end=%s, cpg_label=%s, hgncId=%s. Error: %s",
+                    file_type,
+                    case_obj["_id"],
+                    omics_info.get("sample_id") or omics_info.get("sampleID"),
+                    omics_info.get("chrom") or omics_info.get("seqnames"),
+                    omics_info.get("start"),
+                    omics_info.get("end"),
+                    omics_info.get("cpg_label"),
+                    omics_info.get("hgncId") or omics_info.get("hgnc_id"),
+                    error,
+                )
+                continue
 
             # If case has gene panels, only add clinical variants with a matching gene
             variant_genes = [gene["hgnc_id"] for gene in omics_model.get("genes", [])]
@@ -173,6 +190,8 @@ class OmicsVariantHandler:
             self.omics_variant_collection.insert_one(omics_model)
             nr_inserted += 1
 
+        if nr_skipped:
+            LOG.warning("%s malformed OMICS variants skipped", nr_skipped)
         LOG.info("%s variants inserted", nr_inserted)
 
     def omics_variant(self, variant_id: str, projection: Optional[Dict] = None):

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, List, Optional
 
 from pydantic import ValidationError
 from pymongo import ASCENDING, DESCENDING
-from pymongo.collections import Collection 
+from pymongo.collections import Collection
 
 from scout.constants import ORDERED_OMICS_FILE_TYPE_MAP
 from scout.models.omics_variant import OmicsVariantLoader
@@ -16,7 +16,7 @@ SORT_ORDER = {"asc": ASCENDING, "desc": DESCENDING}
 
 class OmicsVariantHandler:
 
-    omics_variant_collection : Collection
+    omics_variant_collection: Collection
 
     def delete_omics_variants_by_category(
         self, case_id: str, variant_type: str, category: str = None

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, List, Optional
 
 from pydantic import ValidationError
 from pymongo import ASCENDING, DESCENDING
-from pymongo.collection import Collection 
+from pymongo.collection import Collection
 
 from scout.constants import ORDERED_OMICS_FILE_TYPE_MAP
 from scout.models.omics_variant import OmicsVariantLoader

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, List, Optional
 
 from pydantic import ValidationError
 from pymongo import ASCENDING, DESCENDING
-from pymongo.collections import Collection
+from pymongo.collection import Collection 
 
 from scout.constants import ORDERED_OMICS_FILE_TYPE_MAP
 from scout.models.omics_variant import OmicsVariantLoader


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

This update alters case loading to skip omics variants that cannot be parsed and log it as an error.

Currently the entire case load will crash on parsing errors.

Discovered when scout tried to convert a malformed HGNC id to an int when loading a methbat TSV.

## TODO:

- [ ] Test on actual data


<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
