### PR TITLE
Customise displayed variant dismiss tags in institute settings - as an admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances (#6384)
 - A new search mode for the gene variants page, where users can search for one specific variant, regardless of other filters (#6385)
 - Mitorsaw Mitochondrial variant caller (#6392)
+- Variant dismiss tags shown on pages can be customised in the institute settings page by admin users ()
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On variant page, Local observations panel, a tooltip showing an optional description for the LoqusDB instances (#6384)
 - A new search mode for the gene variants page, where users can search for one specific variant, regardless of other filters (#6385)
 - Mitorsaw Mitochondrial variant caller (#6392)
-- Variant dismiss tags shown on pages can be customised in the institute settings page by admin users ()
+- Variant dismiss tags shown on pages can be customised in the institute settings page by admin users (#6416)
 ### Changed
 - Replaced Ensembl rest liftover service with liftover API from the Broad Institute (#6293)
 - Avoid fetching genes and panels multiple times when loading variants (#6350)

--- a/scout/adapter/mongo/institute.py
+++ b/scout/adapter/mongo/institute.py
@@ -59,6 +59,7 @@ class InstituteHandler(object):
         clinvar_key: Optional[str] = None,
         clinvar_submitters: Optional[List[str]] = None,
         soft_filters: Optional[dict] = None,
+        variant_dismiss_tags: Optional[List[int]] = None,
     ) -> Union[dict, str]:
         """Update the information for an institute."""
 
@@ -119,6 +120,7 @@ class InstituteHandler(object):
             "sanger_recipients": sanger_recipients,
             "show_all_cases_status": show_all_cases_status,
             "soft_filters": soft_filters,  # Admin setting
+            "variant_dismiss_tags": variant_dismiss_tags,  # Admin setting
         }
         for key, value in UPDATE_SETTINGS.items():
             if value is None:

--- a/scout/server/blueprints/institutes/controllers.py
+++ b/scout/server/blueprints/institutes/controllers.py
@@ -516,6 +516,7 @@ def update_institute_settings(store: MongoAdapter, institute_obj: Dict, form: Mu
         clinvar_key=form.get("clinvar_key"),
         clinvar_submitters=get_clinvar_submitters(form),
         soft_filters=get_admin_setting_list(field_name="soft_filters", form=form),
+        variant_dismiss_tags=get_admin_setting_list(field_name="variant_dismiss_tags", form=form),
     )
     return updated_institute
 

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -33,7 +33,9 @@ CATEGORY_CHOICES = [("snv", "SNV"), ("sv", "SV")]
 FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
 REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
 SPIDEX_CHOICES = [(term, term.replace("_", " ")) for term in SPIDEX_LEVELS]
-DISMISS_VARIANT_CHOICES = [(key, value["label"]) for key, value in DISMISS_VARIANT_OPTIONS.items()]
+DISMISS_VARIANT_CHOICES = [
+    (str(key), value["label"]) for key, value in DISMISS_VARIANT_OPTIONS.items()
+]
 
 
 class NonValidatingSelectField(SelectField):

--- a/scout/server/blueprints/institutes/forms.py
+++ b/scout/server/blueprints/institutes/forms.py
@@ -17,6 +17,7 @@ from wtforms.widgets import PasswordInput, TextInput
 
 from scout.constants import (
     ANALYSIS_TYPES,
+    DISMISS_VARIANT_OPTIONS,
     FEATURE_TYPES,
     GENETIC_MODELS,
     PHENOTYPE_GROUPS,
@@ -32,6 +33,7 @@ CATEGORY_CHOICES = [("snv", "SNV"), ("sv", "SV")]
 FUNC_ANNOTATIONS = [(term, term.replace("_", " ")) for term in SO_TERMS]
 REGION_ANNOTATIONS = [(term, term.replace("_", " ")) for term in FEATURE_TYPES]
 SPIDEX_CHOICES = [(term, term.replace("_", " ")) for term in SPIDEX_LEVELS]
+DISMISS_VARIANT_CHOICES = [(key, value["label"]) for key, value in DISMISS_VARIANT_OPTIONS.items()]
 
 
 class NonValidatingSelectField(SelectField):
@@ -105,6 +107,12 @@ class InstituteForm(FlaskForm):
     institutes = NonValidatingSelectMultipleField("Institutes to share cases with", choices=[])
 
     loqusdb_id = NonValidatingSelectField("LoqusDB id", choices=[])
+
+    variant_dismiss_tags = NonValidatingSelectMultipleField(
+        "Dismiss variant tags present on pages",
+        choices=DISMISS_VARIANT_CHOICES,
+        validators=[validators.Optional()],
+    )
 
     alamut_key = StringField("Alamut API key", validators=[validators.Optional()])
 

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -341,7 +341,7 @@
                   {{ form.variant_dismiss_tags.label(class="control-label") }}
                   <select multiple="multiple" name="variant_dismiss_tags" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.variant_dismiss_tags.choices or [] %}
-                        <option value="{{choice[0]}}" {% if institute.phenotype_groups and choice[0].split(' ,')[0] in institute.phenotype_groups  %} selected {% endif %}>{{choice[1]}}</option>
+                        <option value="{{choice[0]}}" {% if choice[0] in institute.variant_dismiss_tags  %} selected {% endif %}>{{choice[1]}}</option>
                       {% endfor %}
                     </select>
                 </div>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -202,7 +202,7 @@
                     </div>
                     <div class="col-4">
                       {{form.sanger_emails.label(for_="sanger_emails", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
-                      <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
+                      <select class="select2" id="sanger_emails" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>
                         {% endfor %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -201,7 +201,7 @@
                       {% endfor %}
                     </div>
                     <div class="col-4">
-                      {{form.sanger_emails.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
+                      {{form.sanger_emails.label(class="control-label",data_bs_toggle="tooltip", for=sanger_tags, data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
                       <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>
@@ -237,16 +237,16 @@
                 <legend>Cases display and sharing settings</legend>
                 <div class="row">
                   <div class="col-5">
-                    {{ form.show_all_cases_status.label(class="control-label") }}
-                    <select multiple="multiple" name="show_all_cases_status" class="selectpicker" data-live-search="true" data-style="btn-secondary">
+                    {{ form.show_all_cases_status.label(class="control-label", for="show_all_cases_status") }}
+                    <select multiple="multiple" id="show_all_cases_status", name="show_all_cases_status" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.show_all_cases_status.choices or [] %}
                          <option value="{{choice[0]}}" {% if institute.show_all_cases_status and choice[0] in institute.show_all_cases_status  %} selected {% endif %} >{{choice[1]}}</option>
                       {% endfor %}
                     </select>
                   </div>
                   <div class="col-5">
-                    {{ form.institutes.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Allow case sharing only with preselected institutes.") }}
-                    <select multiple="multiple" class="selectpicker" data-live-search="true" name="institutes" data-style="btn-secondary">
+                    {{ form.institutes.label(for="institutes", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Allow case sharing only with preselected institutes.") }}
+                    <select multiple="multiple" class="selectpicker" data-live-search="true" id="institutes", name="institutes" data-style="btn-secondary">
                       {% for choice in form.institutes.choices %}
                         <option value="{{choice[0]}}" {% if choice[0] in institute.get("collaborators", []) %} selected {% endif %}>{{choice[1]}}</option>
                       {% endfor %}
@@ -264,19 +264,19 @@
                 <legend>Phenotype groups</legend>
                 <div class="row">
                   <div class="col-2">
-                    {{ form.pheno_group.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Add a new phenotype group item to the list of phenotype shortcuts below.") }}
+                    {{ form.pheno_group.label(for="pheno_group", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Add a new phenotype group item to the list of phenotype shortcuts below.") }}
                     <input name="hpo_term" class="typeahead_hpo form-control" id="pheno_group" data-provide="typeahead" autocomplete="off" placeholder="Search HPO..">
                   </div>
                    <div class="col-2">
-                    {{ form.pheno_abbrev.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="A short name for this phenotype group.") }}
+                    {{ form.pheno_abbrev.label(for="pheno_abbrev", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="A short name for this phenotype group.") }}
                     <input name="pheno_abbrev" class="form-control" name="pheno_abbrev" id="pheno_abbrev" placeholder="e.g.: NEUR" pattern=".{2,10}">
                   </div>
                   <div class="col-3 mt-2">
                     <button type="button" class="btn btn-secondary mt-3" onclick="validate_pheno()">Add custom phenotype group</button>
                   </div>
                   <div class="col-3">
-                    {{ form.pheno_groups.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Phenotype groups are used to quickly assign a certain phenotype to a case, on the case page.") }}
-                    <select multiple="multiple" name="pheno_groups" class="selectpicker" data-live-search="true" data-style="btn-secondary">
+                    {{ form.pheno_groups.label(for="pheno_groups", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Phenotype groups are used to quickly assign a certain phenotype to a case, on the case page.") }}
+                    <select multiple="multiple" id="pheno_groups" name="pheno_groups" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.pheno_groups.choices or [] %}
                         <option value="{{choice[0]}}" {% if institute.phenotype_groups and choice[0].split(' ,')[0] in institute.phenotype_groups  %} selected {% endif %}>{{choice[1]}}</option>
                       {% endfor %}
@@ -293,7 +293,7 @@
                 <legend>Cohorts</legend>
                 <div class="row">
                   <div class="col-3">
-                   {{form.cohorts.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Categories used to subdivide patients")}}
+                   {{form.cohorts.label(for="cohort_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Categories used to subdivide patients")}}
                   </div>
                   <div class="col-9">
                     <select class="form-control" id="cohort_tags" name="cohorts" multiple="true" style="width:100%;">
@@ -314,8 +314,8 @@
               <div class="row">
 
                 <div class="col-3">
-                  {{ form.gene_panels.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Select gene panels that will be available for variants filtering.") }}
-                  <select multiple="multiple" name="gene_panels" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
+                  {{ form.gene_panels.label(for="gene_panels", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Select gene panels that will be available for variants filtering.") }}
+                  <select multiple="multiple" id="gene_panels" name="gene_panels" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
                     {% for choice in form.gene_panels.choices or [] %}
                       <option value="{{choice[0]}}" {% if institute.gene_panels and choice[0] in institute.gene_panels.keys() %} selected {% endif %}>{{choice[1]}}</option>
                     {% endfor %}
@@ -323,8 +323,8 @@
                 </div>
 
                 <div class="col-4">
-                  {{ form.gene_panels_matching.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Limit incidental findings by looking for matching managed and causatives variants only in these panels") }}
-                  <select multiple="multiple" name="gene_panels_matching" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
+                  {{ form.gene_panels_matching.label(for="gene_panels_matching", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Limit incidental findings by looking for matching managed and causatives variants only in these panels") }}
+                  <select multiple="multiple" id="gene_panels_matching" name="gene_panels_matching" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
                     {% for choice in form.gene_panels_matching.choices or [] %}
                       <option value="{{choice[0]}}" {% if institute.gene_panels_matching and choice[0] in institute.gene_panels_matching.keys() %} selected {% endif %}>{{choice[1]}}</option>
                     {% endfor %}
@@ -332,14 +332,14 @@
                 </div>
 
                 <div class="col-2">
-                  <input type="checkbox" name="check_show_all_vars" {% if institute.check_show_all_vars %} checked {%endif%}>
-                  {{ form.check_show_all_vars.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Check this box if you want all variants (and not just those occurring in the affected individuals) to be shown by default on variants page") }}
+                  <input type="checkbox" id="check_show_all_vars" name="check_show_all_vars" {% if institute.check_show_all_vars %} checked {%endif%}>
+                  {{ form.check_show_all_vars.label(for="check_show_all_vars", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Check this box if you want all variants (and not just those occurring in the affected individuals) to be shown by default on variants page") }}
                 </div>
 
                 {% if "admin" in current_user.roles %}
                 <div class="col-3">
-                  {{ form.variant_dismiss_tags.label(class="control-label") }}
-                  <select multiple="multiple" name="variant_dismiss_tags" class="selectpicker" data-live-search="true" data-style="btn-secondary">
+                  {{ form.variant_dismiss_tags.label(for="variant_dismiss_tags", class="control-label") }}
+                  <select multiple="multiple" id="variant_dismiss_tags" name="variant_dismiss_tags" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.variant_dismiss_tags.choices or [] %}
                         <option value="{{choice[0]}}" {% if choice[0] in institute.variant_dismiss_tags  %} selected {% endif %}>{{choice[1]}}</option>
                       {% endfor %}
@@ -362,7 +362,7 @@
                       {{ form.clinvar_key(class='form-control', value=institute.clinvar_key if institute.clinvar_key) }}
                     </div>
                     <div class="col-6">
-                      {{form.clinvar_emails.label(class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Scout users who should be able to submit for you institute using this key. Only accepts current Scout user emails.")}}
+                      {{form.clinvar_emails.label(for="clinvar_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Scout users who should be able to submit for you institute using this key. Only accepts current Scout user emails.")}}
                       <select class="selectpicker" data-live-search="true" id="clinvar_tags" name="clinvar_emails" style="width:100%;" multiple="true">
                         {% for user in form.clinvar_emails.choices %}
                           <option value="{{ user[1] }}" {% if institute.clinvar_submitters and user[1] in institute.clinvar_submitters %} selected {% endif %}>{{ user[0] }}</option>
@@ -382,10 +382,10 @@
                   <legend>LoqusDB</legend>
                   <div class="row">
                     <div class="col-2">
-                      {{ form.loqusdb_id.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="LoqudDB id" ) }}
+                      {{ form.loqusdb_id.label(for="loqusdb_id", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="LoqudDB id" ) }}
                     </div>
                     <div class="col-3">
-                      <select multiple="multiple" class="selectpicker" data-live-search="true" name="loqusdb_id" data-style="btn-secondary">
+                      <select multiple="multiple" class="selectpicker" data-live-search="true" id="loqusdb_id" name="loqusdb_id" data-style="btn-secondary">
                         {% for instance in loqus_instances %}
                           <option value="{{instance}}" {% if instance in institute.loqusdb_id %} selected {% endif %}>{{instance}}</option>
                         {% endfor %}
@@ -402,8 +402,8 @@
                   <legend>Variants custom soft filters</legend>
                   <div class="row">
                     <div class="col-sm-6 col-lg-4">
-                      {{form.soft_filters.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Values to filter variant documents with by default. For example germline_risk or in_normal.")}}
-                      <select class="select2" id="soft_filters" name="soft_filters" multiple="true" style="width:100%;">
+                      {{form.soft_filters.label(for="soft_filters", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Values to filter variant documents with by default. For example germline_risk or in_normal.")}}
+                      <select class="select2" id="soft_filters" id="soft_filters" name="soft_filters" multiple="true" style="width:100%;">
                         {% if institute.soft_filters %}
                           {% for filter in institute.soft_filters %}
                             <option value="{{filter}}" selected>{{filter}}</option>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -310,7 +310,7 @@
              <!-- Variants and panels searching -->
             <div class="row mt-5 d-flex align-items-center">
             <fieldset>
-              <legend>Variants and gene panels searching</legend>
+              <legend>Variants and gene panels settings</legend>
               <div class="row">
 
                 <div class="col-3">
@@ -335,6 +335,17 @@
                   <input type="checkbox" name="check_show_all_vars" {% if institute.check_show_all_vars %} checked {%endif%}>
                   {{ form.check_show_all_vars.label(class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Check this box if you want all variants (and not just those occurring in the affected individuals) to be shown by default on variants page") }}
                 </div>
+
+                {% if "admin" in current_user.roles %}
+                <div class="col-3">
+                  {{ form.variant_dismiss_tags.label(class="control-label") }}
+                  <select multiple="multiple" name="variant_dismiss_tags" class="selectpicker" data-live-search="true" data-style="btn-secondary">
+                      {% for choice in form.variant_dismiss_tags.choices or [] %}
+                        <option value="{{choice[0]}}" {% if institute.phenotype_groups and choice[0].split(' ,')[0] in institute.phenotype_groups  %} selected {% endif %}>{{choice[1]}}</option>
+                      {% endfor %}
+                    </select>
+                </div>
+                {% endif %}
 
               </div>
 

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -201,7 +201,7 @@
                       {% endfor %}
                     </div>
                     <div class="col-4">
-                      {{form.sanger_emails.label(class="control-label",data_bs_toggle="tooltip", for=sanger_tags, data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
+                      {{form.sanger_emails.label(for_=sanger_tags, class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
                       <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>
@@ -237,7 +237,7 @@
                 <legend>Cases display and sharing settings</legend>
                 <div class="row">
                   <div class="col-5">
-                    {{ form.show_all_cases_status.label(class="control-label", for="show_all_cases_status") }}
+                    {{ form.show_all_cases_status.label(for_="show_all_cases_status", class="control-label") }}
                     <select multiple="multiple" id="show_all_cases_status", name="show_all_cases_status" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.show_all_cases_status.choices or [] %}
                          <option value="{{choice[0]}}" {% if institute.show_all_cases_status and choice[0] in institute.show_all_cases_status  %} selected {% endif %} >{{choice[1]}}</option>
@@ -245,7 +245,7 @@
                     </select>
                   </div>
                   <div class="col-5">
-                    {{ form.institutes.label(for="institutes", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Allow case sharing only with preselected institutes.") }}
+                    {{ form.institutes.label(for_="institutes", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Allow case sharing only with preselected institutes.") }}
                     <select multiple="multiple" class="selectpicker" data-live-search="true" id="institutes", name="institutes" data-style="btn-secondary">
                       {% for choice in form.institutes.choices %}
                         <option value="{{choice[0]}}" {% if choice[0] in institute.get("collaborators", []) %} selected {% endif %}>{{choice[1]}}</option>
@@ -264,18 +264,18 @@
                 <legend>Phenotype groups</legend>
                 <div class="row">
                   <div class="col-2">
-                    {{ form.pheno_group.label(for="pheno_group", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Add a new phenotype group item to the list of phenotype shortcuts below.") }}
+                    {{ form.pheno_group.label(for_="pheno_group", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Add a new phenotype group item to the list of phenotype shortcuts below.") }}
                     <input name="hpo_term" class="typeahead_hpo form-control" id="pheno_group" data-provide="typeahead" autocomplete="off" placeholder="Search HPO..">
                   </div>
                    <div class="col-2">
-                    {{ form.pheno_abbrev.label(for="pheno_abbrev", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="A short name for this phenotype group.") }}
+                    {{ form.pheno_abbrev.label(for_="pheno_abbrev", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="A short name for this phenotype group.") }}
                     <input name="pheno_abbrev" class="form-control" name="pheno_abbrev" id="pheno_abbrev" placeholder="e.g.: NEUR" pattern=".{2,10}">
                   </div>
                   <div class="col-3 mt-2">
                     <button type="button" class="btn btn-secondary mt-3" onclick="validate_pheno()">Add custom phenotype group</button>
                   </div>
                   <div class="col-3">
-                    {{ form.pheno_groups.label(for="pheno_groups", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Phenotype groups are used to quickly assign a certain phenotype to a case, on the case page.") }}
+                    {{ form.pheno_groups.label(for_="pheno_groups", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Phenotype groups are used to quickly assign a certain phenotype to a case, on the case page.") }}
                     <select multiple="multiple" id="pheno_groups" name="pheno_groups" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.pheno_groups.choices or [] %}
                         <option value="{{choice[0]}}" {% if institute.phenotype_groups and choice[0].split(' ,')[0] in institute.phenotype_groups  %} selected {% endif %}>{{choice[1]}}</option>
@@ -293,7 +293,7 @@
                 <legend>Cohorts</legend>
                 <div class="row">
                   <div class="col-3">
-                   {{form.cohorts.label(for="cohort_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Categories used to subdivide patients")}}
+                   {{form.cohorts.label(for_="cohort_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Categories used to subdivide patients")}}
                   </div>
                   <div class="col-9">
                     <select class="form-control" id="cohort_tags" name="cohorts" multiple="true" style="width:100%;">
@@ -314,7 +314,7 @@
               <div class="row">
 
                 <div class="col-3">
-                  {{ form.gene_panels.label(for="gene_panels", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Select gene panels that will be available for variants filtering.") }}
+                  {{ form.gene_panels.label(for_="gene_panels", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Select gene panels that will be available for variants filtering.") }}
                   <select multiple="multiple" id="gene_panels" name="gene_panels" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
                     {% for choice in form.gene_panels.choices or [] %}
                       <option value="{{choice[0]}}" {% if institute.gene_panels and choice[0] in institute.gene_panels.keys() %} selected {% endif %}>{{choice[1]}}</option>
@@ -323,7 +323,7 @@
                 </div>
 
                 <div class="col-4">
-                  {{ form.gene_panels_matching.label(for="gene_panels_matching", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Limit incidental findings by looking for matching managed and causatives variants only in these panels") }}
+                  {{ form.gene_panels_matching.label(for_="gene_panels_matching", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Limit incidental findings by looking for matching managed and causatives variants only in these panels") }}
                   <select multiple="multiple" id="gene_panels_matching" name="gene_panels_matching" data-live-search="true" class="selectpicker ml-3" data-style="btn-secondary">
                     {% for choice in form.gene_panels_matching.choices or [] %}
                       <option value="{{choice[0]}}" {% if institute.gene_panels_matching and choice[0] in institute.gene_panels_matching.keys() %} selected {% endif %}>{{choice[1]}}</option>
@@ -333,12 +333,12 @@
 
                 <div class="col-2">
                   <input type="checkbox" id="check_show_all_vars" name="check_show_all_vars" {% if institute.check_show_all_vars %} checked {%endif%}>
-                  {{ form.check_show_all_vars.label(for="check_show_all_vars", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Check this box if you want all variants (and not just those occurring in the affected individuals) to be shown by default on variants page") }}
+                  {{ form.check_show_all_vars.label(for_="check_show_all_vars", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Check this box if you want all variants (and not just those occurring in the affected individuals) to be shown by default on variants page") }}
                 </div>
 
                 {% if "admin" in current_user.roles %}
                 <div class="col-3">
-                  {{ form.variant_dismiss_tags.label(for="variant_dismiss_tags", class="control-label") }}
+                  {{ form.variant_dismiss_tags.label(for_="variant_dismiss_tags", class="control-label") }}
                   <select multiple="multiple" id="variant_dismiss_tags" name="variant_dismiss_tags" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.variant_dismiss_tags.choices or [] %}
                         <option value="{{choice[0]}}" {% if choice[0] in institute.variant_dismiss_tags  %} selected {% endif %}>{{choice[1]}}</option>
@@ -362,7 +362,7 @@
                       {{ form.clinvar_key(class='form-control', value=institute.clinvar_key if institute.clinvar_key) }}
                     </div>
                     <div class="col-6">
-                      {{form.clinvar_emails.label(for="clinvar_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Scout users who should be able to submit for you institute using this key. Only accepts current Scout user emails.")}}
+                      {{form.clinvar_emails.label(for_="clinvar_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Scout users who should be able to submit for you institute using this key. Only accepts current Scout user emails.")}}
                       <select class="selectpicker" data-live-search="true" id="clinvar_tags" name="clinvar_emails" style="width:100%;" multiple="true">
                         {% for user in form.clinvar_emails.choices %}
                           <option value="{{ user[1] }}" {% if institute.clinvar_submitters and user[1] in institute.clinvar_submitters %} selected {% endif %}>{{ user[0] }}</option>
@@ -382,7 +382,7 @@
                   <legend>LoqusDB</legend>
                   <div class="row">
                     <div class="col-2">
-                      {{ form.loqusdb_id.label(for="loqusdb_id", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="LoqudDB id" ) }}
+                      {{ form.loqusdb_id.label(for_="loqusdb_id", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="LoqudDB id" ) }}
                     </div>
                     <div class="col-3">
                       <select multiple="multiple" class="selectpicker" data-live-search="true" id="loqusdb_id" name="loqusdb_id" data-style="btn-secondary">
@@ -402,7 +402,7 @@
                   <legend>Variants custom soft filters</legend>
                   <div class="row">
                     <div class="col-sm-6 col-lg-4">
-                      {{form.soft_filters.label(for="soft_filters", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Values to filter variant documents with by default. For example germline_risk or in_normal.")}}
+                      {{form.soft_filters.label(for_="soft_filters", class="control-label", data_bs_toggle="tooltip", data_bs_placement="top", title="Values to filter variant documents with by default. For example germline_risk or in_normal.")}}
                       <select class="select2" id="soft_filters" id="soft_filters" name="soft_filters" multiple="true" style="width:100%;">
                         {% if institute.soft_filters %}
                           {% for filter in institute.soft_filters %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -201,8 +201,8 @@
                       {% endfor %}
                     </div>
                     <div class="col-4">
-                      {{form.sanger_emails.label(for_="sanger_emails", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
-                      <select class="select2" id="sanger_emails" name="sanger_emails" multiple="true" style="width:100%;">
+                      {{form.sanger_emails.label(for_="sanger_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
+                      <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>
                         {% endfor %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -238,7 +238,7 @@
                 <div class="row">
                   <div class="col-5">
                     {{ form.show_all_cases_status.label(for_="show_all_cases_status", class="control-label") }}
-                    <select multiple="multiple" id="show_all_cases_status", name="show_all_cases_status" class="selectpicker" data-live-search="true" data-style="btn-secondary">
+                    <select multiple="multiple" id="show_all_cases_status" name="show_all_cases_status" class="selectpicker" data-live-search="true" data-style="btn-secondary">
                       {% for choice in form.show_all_cases_status.choices or [] %}
                          <option value="{{choice[0]}}" {% if institute.show_all_cases_status and choice[0] in institute.show_all_cases_status  %} selected {% endif %} >{{choice[1]}}</option>
                       {% endfor %}
@@ -246,7 +246,7 @@
                   </div>
                   <div class="col-5">
                     {{ form.institutes.label(for_="institutes", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Allow case sharing only with preselected institutes.") }}
-                    <select multiple="multiple" class="selectpicker" data-live-search="true" id="institutes", name="institutes" data-style="btn-secondary">
+                    <select multiple="multiple" class="selectpicker" data-live-search="true" id="institutes" name="institutes" data-style="btn-secondary">
                       {% for choice in form.institutes.choices %}
                         <option value="{{choice[0]}}" {% if choice[0] in institute.get("collaborators", []) %} selected {% endif %}>{{choice[1]}}</option>
                       {% endfor %}

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -201,7 +201,7 @@
                       {% endfor %}
                     </div>
                     <div class="col-4">
-                      {{form.sanger_emails.label(for_="sanger_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
+                      {{form.sanger_emails.label(for_="sanger_emails", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
                       <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>

--- a/scout/server/blueprints/institutes/templates/overview/utils.html
+++ b/scout/server/blueprints/institutes/templates/overview/utils.html
@@ -201,7 +201,7 @@
                       {% endfor %}
                     </div>
                     <div class="col-4">
-                      {{form.sanger_emails.label(for_=sanger_tags, class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
+                      {{form.sanger_emails.label(for_="sanger_tags", class="control-label",data_bs_toggle="tooltip", data_bs_placement="top", title="Email addresses to send variant verification email to. Only accepts current Scout user emails: exceptions to this can be made by a db admin. Please ask for support!")}}
                       <select class="select2" id="sanger_tags" name="sanger_emails" multiple="true" style="width:100%;">
                         {% for email in institute.sanger_recipients %}
                           <option value="{{ email }}" selected>{{ email }}</option>

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -20,7 +20,6 @@ from scout.constants import (
     CCV_CRITERIA,
     CCV_MAP,
     CCV_OPTIONS,
-    DISMISS_VARIANT_OPTIONS,
     ESCAT_TIER_OPTIONS,
     IGV_TRACKS,
     INHERITANCE_PALETTE,
@@ -62,6 +61,7 @@ from .utils import (
     get_filters,
     get_variant_genome_build,
     is_affected,
+    populate_dismiss_variant_choices,
     predictions,
 )
 
@@ -203,7 +203,7 @@ def variant(
             'manual_rank_options': MANUAL_RANK_OPTIONS,
             'cancer_tier_options': CANCER_TIER_OPTIONS,
             'escat_tier_options': ESCAT_TIER_OPTIONS
-            'dismiss_variant_options': DISMISS_VARIANT_OPTIONS,
+            'dismiss_variant_options': populate_dismiss_variant_choices(institute),
             'ACMG_OPTIONS': ACMG_OPTIONS,
             'CCV_OPTIONS': CCV_OPTIONS,
             'igv_tracks': IGV_TRACKS,
@@ -389,10 +389,10 @@ def variant(
 
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])
 
-    dismiss_options = DISMISS_VARIANT_OPTIONS
+    dismiss_options = populate_dismiss_variant_choices(institute_obj=institute_obj)
     if case_obj.get("track") == "cancer":
         dismiss_options = {
-            **DISMISS_VARIANT_OPTIONS,
+            **dismiss_options,
             **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
         }
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -203,7 +203,7 @@ def variant(
             'manual_rank_options': MANUAL_RANK_OPTIONS,
             'cancer_tier_options': CANCER_TIER_OPTIONS,
             'escat_tier_options': ESCAT_TIER_OPTIONS
-            'dismiss_variant_options': populate_dismiss_variant_choices(institute),
+            'dismiss_variant_options': populate_dismiss_variant_choices(institute, variant),
             'ACMG_OPTIONS': ACMG_OPTIONS,
             'CCV_OPTIONS': CCV_OPTIONS,
             'igv_tracks': IGV_TRACKS,
@@ -389,7 +389,9 @@ def variant(
 
     variant_obj["end_chrom"] = variant_obj.get("end_chrom", variant_obj["chromosome"])
 
-    dismiss_options = populate_dismiss_variant_choices(institute_obj=institute_obj)
+    dismiss_options = populate_dismiss_variant_choices(
+        institute_obj=institute_obj, variant_obj=variant_obj
+    )
     if case_obj.get("track") == "cancer":
         dismiss_options = {
             **dismiss_options,

--- a/scout/server/blueprints/variant/templates/variant/buttons.html
+++ b/scout/server/blueprints/variant/templates/variant/buttons.html
@@ -124,7 +124,13 @@
 
 {% macro dismiss_variant_button(variant, institute, case, dismiss_variant_options) %}
   <form action="{{ url_for('variant.variant_update', institute_id=institute._id, case_name=case.display_name, variant_id=variant._id) }}" method="POST">
-    <label class="mt-3">Dismiss variant</label>
+    <label class="mt-3"
+      {% if institute.variant_dismiss_tags %}
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="If a dismiss reason is marked with an asterisk, it indicates that the tag is no longer available in the current institute settings."
+      {% endif %}
+    >Dismiss variant</label>
     <div class="row">
       <div class="col-8">
         <select multiple="multiple" name="dismiss_variant" id="dismiss_variant" class="selectpicker" data-live-search="true" data-width="100%" data-style="btn-secondary">

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -709,11 +709,15 @@ def get_variant_genome_build(variant_obj: dict, case_obj: dict) -> str:
     return variant_obj.get("build", get_case_genome_build(case_obj))
 
 
-def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
+def populate_dismiss_variant_choices(
+    institute_obj: dict, variant_obj: Optional[dict] = None
+) -> dict[int, dict]:
     """Return variant dismiss options configured for an institute.
     If the institute defines a non-empty `variant_dismiss_tags` list,
     only the corresponding entries from `DISMISS_VARIANT_OPTIONS` are
     returned. Otherwise, all dismiss options are returned.
+    Some variants might have been dismissed with criteria no longer available in institute settings.
+    These criteria will also be shown on variant page.
     """
     dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
 
@@ -721,6 +725,19 @@ def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
         return DISMISS_VARIANT_OPTIONS
 
     dismiss_tags = set(dismiss_tags)
-    return {
-        key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if str(key) in dismiss_tags
-    }
+    previously_dismissed_tags = set(variant_obj.get("dismiss_variant", []) if variant_obj else [])
+
+    available_tags = {}
+
+    for key, value in DISMISS_VARIANT_OPTIONS.items():
+        key_str = str(key)
+
+        if key_str in dismiss_tags or key_str in previously_dismissed_tags:
+            value_copy = dict(value)
+
+            if key_str not in dismiss_tags and key_str in previously_dismissed_tags:
+                value_copy["label"] = f"{value_copy['label']} *"
+
+            available_tags[key] = value_copy
+
+    return available_tags

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -8,6 +8,7 @@ from scout.constants import (
     CALLERS,
     CCV_COMPLETE_MAP,
     CLINSIG_MAP,
+    DISMISS_VARIANT_OPTIONS,
     SO_TERMS,
     VARIANT_FILTERS,
 )
@@ -703,3 +704,20 @@ def get_variant_genome_build(variant_obj: dict, case_obj: dict) -> str:
     """
 
     return variant_obj.get("build", get_case_genome_build(case_obj))
+
+
+def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
+    """Return variant dismiss options configured for an institute.
+    If the institute defines a non-empty `variant_dismiss_tags` list,
+    only the corresponding entries from `DISMISS_VARIANT_OPTIONS` are
+    returned. Otherwise, all dismiss options are returned.
+    """
+    dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
+
+    if not dismiss_tags:
+        return DISMISS_VARIANT_OPTIONS
+
+    dismiss_tags = set(dismiss_tags)
+    return {
+        key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if str(key) in dismiss_tags
+    }

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -136,8 +136,6 @@ def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
     returned. Otherwise, all dismiss options are returned.
     """
     dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
-    LOG.warning(dismiss_tags)
-    LOG.error(DISMISS_VARIANT_OPTIONS)
 
     if not dismiss_tags:
         return DISMISS_VARIANT_OPTIONS

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -129,6 +129,21 @@ def populate_persistent_filters_choices(
     return available_filters
 
 
+def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
+    """Return variant dismiss options configured for an institute.
+    If the institute defines a non-empty `variant_dismiss_tags` list,
+    only the corresponding entries from `DISMISS_VARIANT_OPTIONS` are
+    returned. Otherwise, all dismiss options are returned.
+    """
+    dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
+
+    if not dismiss_tags:
+        return DISMISS_VARIANT_OPTIONS
+
+    dismiss_tags = set(dismiss_tags)
+    return {key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if key in dismiss_tags}
+
+
 def populate_chrom_choices(form, case_obj):
     """Populate the option of the chromosome select according to the case genome build"""
     # Populate chromosome choices
@@ -314,9 +329,12 @@ def render_variants_page(
     data = decorator(*args)
 
     dismiss_variant_options = (
-        {**DISMISS_VARIANT_OPTIONS, **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS}
+        {
+            **populate_dismiss_variant_choices(institute_obj=institute_obj),
+            **CANCER_SPECIFIC_VARIANT_DISMISS_OPTIONS,
+        }
         if category in ["cancer_sv", "cancer"]
-        else DISMISS_VARIANT_OPTIONS
+        else populate_dismiss_variant_choices(institute_obj=institute_obj)
     )
 
     return dict(

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -136,12 +136,16 @@ def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
     returned. Otherwise, all dismiss options are returned.
     """
     dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
+    LOG.warning(dismiss_tags)
+    LOG.error(DISMISS_VARIANT_OPTIONS)
 
     if not dismiss_tags:
         return DISMISS_VARIANT_OPTIONS
 
     dismiss_tags = set(dismiss_tags)
-    return {key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if key in dismiss_tags}
+    return {
+        key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if str(key) in dismiss_tags
+    }
 
 
 def populate_chrom_choices(form, case_obj):

--- a/scout/server/blueprints/variants/controllers.py
+++ b/scout/server/blueprints/variants/controllers.py
@@ -45,6 +45,7 @@ from scout.server.blueprints.variant.utils import (
     get_callers,
     get_filters,
     get_str_mc,
+    populate_dismiss_variant_choices,
     predictions,
     update_representative_gene,
     update_variant_case_panels,
@@ -127,23 +128,6 @@ def populate_persistent_filters_choices(
         for filter in sorted(available_filters, key=lambda f: f.get("display_name", "").lower())
     ]
     return available_filters
-
-
-def populate_dismiss_variant_choices(institute_obj: dict) -> dict[int, dict]:
-    """Return variant dismiss options configured for an institute.
-    If the institute defines a non-empty `variant_dismiss_tags` list,
-    only the corresponding entries from `DISMISS_VARIANT_OPTIONS` are
-    returned. Otherwise, all dismiss options are returned.
-    """
-    dismiss_tags = institute_obj.get("variant_dismiss_tags") if institute_obj else None
-
-    if not dismiss_tags:
-        return DISMISS_VARIANT_OPTIONS
-
-    dismiss_tags = set(dismiss_tags)
-    return {
-        key: value for key, value in DISMISS_VARIANT_OPTIONS.items() if str(key) in dismiss_tags
-    }
 
 
 def populate_chrom_choices(form, case_obj):

--- a/tests/server/blueprints/variant/test_variant_utils.py
+++ b/tests/server/blueprints/variant/test_variant_utils.py
@@ -1,3 +1,4 @@
+from scout.constants import DISMISS_VARIANT_OPTIONS
 from scout.server.blueprints.variant.utils import (
     add_panel_specific_gene_info,
     ccv_evaluation,
@@ -7,6 +8,7 @@ from scout.server.blueprints.variant.utils import (
     frequencies,
     frequency,
     is_affected,
+    populate_dismiss_variant_choices,
     predictions,
     transcript_str,
     update_transcripts_information,
@@ -461,3 +463,22 @@ def test_sv_frequencies_all():
     assert len(freq) == 8
     for annotation in freq:
         assert annotation[1] == 0.02
+
+
+def test_populate_dismiss_variant_choices(institute_obj):
+    """Test the function that populates the dismissed variant tags according to the available institute settings."""
+
+    # GIVEN an institute with no "variant_dismiss_tags" key/values
+    assert "variant_dismiss_tags" not in institute_obj
+    # THEN the dismiss tags should be equal to DISMISS_VARIANT_OPTIONS
+    dismiss_tag_choices = populate_dismiss_variant_choices(institute_obj=institute_obj)
+    assert len(dismiss_tag_choices) == len(DISMISS_VARIANT_OPTIONS)
+
+    # GIVEN an institute with a few dismissed tags saved in settings
+    INSTITUTE_DISMISSED_TAGS = ["2", "3", "5", "7"]
+    institute_obj["variant_dismiss_tags"] = INSTITUTE_DISMISSED_TAGS
+
+    # THEN the dismiss tags should be equal to the tags saved in institute settings
+    assert len(populate_dismiss_variant_choices(institute_obj=institute_obj)) == len(
+        INSTITUTE_DISMISSED_TAGS
+    )


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Customise displayed variant dismiss tags in institute settings - as an admin (fix #6364 )

### Tags saved in settigs

<img width="298" height="499" alt="image" src="https://github.com/user-attachments/assets/8e8ac6b0-c8b8-4680-8df0-e6460584b8a9" />

### Get used on variants page

<img width="1018" height="175" alt="image" src="https://github.com/user-attachments/assets/66d4a784-b83d-4e83-a288-795aa6380349" />

### And on variant page

<img width="366" height="339" alt="image" src="https://github.com/user-attachments/assets/5c885810-88ba-4525-9046-cac59d5658da" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
