### PR TITLE
Hide variants with no GT call on MT reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to keep the ACMG page open after submitting an evaluation (#6405)
 - Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs (#6413)
 - Moved mocked liftover response to tests/confest.py (#6415)
-- MT variants with no GT call are hidden on MT reports ()
+- MT variants with no GT call are not shown on MT reports (#6429)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to keep the ACMG page open after submitting an evaluation (#6405)
 - Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs (#6413)
 - Moved mocked liftover response to tests/confest.py (#6415)
+- MT variants with no GT call are hidden on MT reports ()
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -74,7 +74,7 @@ SECONDARY_CRITERIA = [
     "category_pop_freq",
 ]
 
-GT_NO_CALL = [
+GT_NO_ALT_CALL = [
     "./.",
     ".|.",
     "./0",

--- a/scout/constants/query_terms.py
+++ b/scout/constants/query_terms.py
@@ -73,3 +73,14 @@ SECONDARY_CRITERIA = [
     "methbat_significance",
     "category_pop_freq",
 ]
+
+GT_NO_CALL = [
+    "./.",
+    ".|.",
+    "./0",
+    ".|0",
+    "0/.",
+    "0|.",
+    "0/0",
+    "0|0",
+]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -6,6 +6,7 @@ from typing import List
 from scout.adapter.mongo.base import MongoAdapter
 from scout.constants import CHROMOSOME_INTEGERS
 from scout.constants.managed_variant import MANAGED_CATEGORIES
+from scout.constants.query_terms import GT_NO_CALL
 from scout.models.managed_variant import ManagedVariant
 
 LOG = logging.getLogger(__name__)
@@ -149,16 +150,7 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
         alt_ad = ""
         for sample in variant["samples"]:
             if sample.get("sample_id") == sample_id:
-                if sample["genotype_call"] in [
-                    "./.",
-                    ".|.",
-                    "./0",
-                    ".|0",
-                    "0/.",
-                    "0|.",
-                    "0/0",
-                    "0|0",
-                ]:
+                if sample["genotype_call"] in GT_NO_CALL:
                     skip_variant = True
                     break
                 ref_ad = sample["allele_depths"][0]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -6,7 +6,7 @@ from typing import List
 from scout.adapter.mongo.base import MongoAdapter
 from scout.constants import CHROMOSOME_INTEGERS
 from scout.constants.managed_variant import MANAGED_CATEGORIES
-from scout.constants.query_terms import GT_NO_CALL
+from scout.constants.query_terms import GT_NO_ALT_CALL
 from scout.models.managed_variant import ManagedVariant
 
 LOG = logging.getLogger(__name__)
@@ -150,7 +150,7 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
         alt_ad = ""
         for sample in variant["samples"]:
             if sample.get("sample_id") == sample_id:
-                if sample["genotype_call"] in GT_NO_CALL:
+                if sample["genotype_call"] in GT_NO_ALT_CALL:
                     skip_variant = True
                     break
                 ref_ad = sample["allele_depths"][0]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -137,11 +137,27 @@ def export_verified_variants(aggregate_variants, unique_callers):
     return document_lines
 
 
+def _get_genes_and_prot_effect(variant: dict) -> tuple[str, str]:
+    """Return comma-separated gene symbols and canonical protein sequence names for a variant."""
+    genes = []
+    prot_effect = []
+
+    for gene in variant.get("genes", []):
+        genes.append(gene.get("hgnc_symbol", ""))
+
+        for transcript in gene.get("transcripts", []):
+            if transcript.get("is_canonical") and transcript.get("protein_sequence_name"):
+                prot_effect.append(urllib.parse.unquote(transcript["protein_sequence_name"]))
+
+    return ",".join(genes), ",".join(prot_effect)
+
+
 def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
     """Export mitochondrial variants for a case to create a MT excel report.
     Exclude variants with no cler genotype
     """
     document_lines = []
+
     for variant in variants:
         line = []
         skip_variant = False
@@ -153,30 +169,28 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
                 if sample["genotype_call"] in GT_NO_ALT_CALL:
                     skip_variant = True
                     break
+
                 ref_ad = sample["allele_depths"][0]
                 alt_ad = sample["allele_depths"][1]
 
         if skip_variant:
             continue
+
         position = variant.get("position")
         change = ">".join([variant.get("reference"), variant.get("alternative")])
+
         line.append(position)
         line.append(change)
-        line.append(str(position) + change)
-        genes = []
-        prot_effect = []
-        for gene in variant.get("genes", []):
-            genes.append(gene.get("hgnc_symbol", ""))
-            for transcript in gene.get("transcripts"):
-                if transcript.get("is_canonical") and transcript.get("protein_sequence_name"):
-                    prot_effect.append(
-                        urllib.parse.unquote(transcript.get("protein_sequence_name"))
-                    )
-        line.append(",".join(genes))
-        line.append(",".join(prot_effect))
+        line.append(f"{position}{change}")
+
+        genes, prot_effect = _get_genes_and_prot_effect(variant)
+        line.append(genes)
+        line.append(prot_effect)
+
         line.append(ref_ad)
         line.append(alt_ad)
 
         if alt_ad != 0:
             document_lines.append(line)
+
     return document_lines

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -149,7 +149,7 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
         alt_ad = ""
         for sample in variant["samples"]:
             if sample.get("sample_id") == sample_id:
-                if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/0", "0|0"]:
+                if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/.", "0|.", "0/0", "0|0"]:
                     skip_variant = True
                     break
                 ref_ad = sample["allele_depths"][0]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -149,7 +149,16 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
         alt_ad = ""
         for sample in variant["samples"]:
             if sample.get("sample_id") == sample_id:
-                if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/.", "0|.", "0/0", "0|0"]:
+                if sample["genotype_call"] in [
+                    "./.",
+                    ".|.",
+                    "./0",
+                    ".|0",
+                    "0/.",
+                    "0|.",
+                    "0/0",
+                    "0|0",
+                ]:
                     skip_variant = True
                     break
                 ref_ad = sample["allele_depths"][0]

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import urllib.parse
-from typing import List, Optional
+from typing import List
 
 from scout.adapter.mongo.base import MongoAdapter
 from scout.constants import CHROMOSOME_INTEGERS

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -136,19 +136,23 @@ def export_verified_variants(aggregate_variants, unique_callers):
     return document_lines
 
 
-def export_mt_variants(variants, sample_id):
-    """Export mitochondrial variants for a case to create a MT excel report
-
-    Args:
-        variants(list): all MT variants for a case, sorted by position
-        sample_id(str) : the id of a sample within the case
-
-    Returns:
-        document_lines(list): list of lines to include in the document
+def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
+    """Export mitochondrial variants for a case to create a MT excel report.
+    Exclude variants with no cler genotype
     """
     document_lines = []
     for variant in variants:
         line = []
+
+        ref_ad = ""
+        alt_ad = ""
+        for sample in variant["samples"]:
+            if sample.get("sample_id") == sample_id:
+                if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/0", "0|0"]:
+                    continue
+                ref_ad = sample["allele_depths"][0]
+                alt_ad = sample["allele_depths"][1]
+
         position = variant.get("position")
         change = ">".join([variant.get("reference"), variant.get("alternative")])
         line.append(position)
@@ -165,14 +169,9 @@ def export_mt_variants(variants, sample_id):
                     )
         line.append(",".join(genes))
         line.append(",".join(prot_effect))
-        ref_ad = ""
-        alt_ad = ""
-        for sample in variant["samples"]:
-            if sample.get("sample_id") == sample_id:
-                ref_ad = sample["allele_depths"][0]
-                alt_ad = sample["allele_depths"][1]
         line.append(ref_ad)
         line.append(alt_ad)
+
         if alt_ad != 0:
             document_lines.append(line)
     return document_lines

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -143,16 +143,20 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
     document_lines = []
     for variant in variants:
         line = []
+        skip_variant = False
 
         ref_ad = ""
         alt_ad = ""
         for sample in variant["samples"]:
             if sample.get("sample_id") == sample_id:
                 if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/0", "0|0"]:
-                    continue
+                    skip_variant = True
+                    break
                 ref_ad = sample["allele_depths"][0]
                 alt_ad = sample["allele_depths"][1]
 
+        if skip_variant:
+            continue
         position = variant.get("position")
         change = ">".join([variant.get("reference"), variant.get("alternative")])
         line.append(position)

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -11,7 +11,7 @@ from scout.constants import (
     SO_TERMS,
     VARIANT_FILTERS,
 )
-from scout.constants.query_terms import GT_NO_CALL
+from scout.constants.query_terms import GT_NO_ALT_CALL
 from scout.server.links import add_gene_links, add_tx_links
 from scout.server.utils import get_case_genome_build
 
@@ -689,7 +689,7 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
         return alt_mc
 
     for sample in variant_obj["samples"]:
-        if sample["genotype_call"] in GT_NO_CALL:
+        if sample["genotype_call"] in GT_NO_ALT_CALL:
             continue
         alt_mc = sample.get("alt_mc")
     if alt_mc:

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -11,6 +11,7 @@ from scout.constants import (
     SO_TERMS,
     VARIANT_FILTERS,
 )
+from scout.constants.query_terms import GT_NO_CALL
 from scout.server.links import add_gene_links, add_tx_links
 from scout.server.utils import get_case_genome_build
 
@@ -688,7 +689,7 @@ def get_str_mc(variant_obj: dict) -> Optional[int]:
         return alt_mc
 
     for sample in variant_obj["samples"]:
-        if sample["genotype_call"] in ["./.", ".|.", "./0", ".|0", "0/0", "0|0"]:
+        if sample["genotype_call"] in GT_NO_CALL:
             continue
         alt_mc = sample.get("alt_mc")
     if alt_mc:


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Close #6427

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
