### PR TITLE
Fix #6428 - GnomAD MT link out from empty r2 to r3/r4 build with variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs (#6413)
 - Moved mocked liftover response to tests/confest.py (#6415)
 - MT variants with no GT call are not shown on MT reports (#6429)
-- Link out to gnomAD v4 for MT variants (#6430)
+- Link out to gnomAD v4 for MT variants, and only once (#6430)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Option to keep the ACMG page open after submitting an evaluation (#6405)
 - Display both GnomAD and GnomAD non-UK-Biobank links on variants and gene pages for build 38 SNVs (#6413)
 - Moved mocked liftover response to tests/confest.py (#6415)
+- Link out to gnomAD v4 for MT variants (#6430)
 ### Fixed
 - Enable link to previous ACMG classifications for SVs and cancer SVs (#6365)
 - Fixes bug where CCV classification ignores modifiers when submitting to db (#6369)

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -368,7 +368,7 @@ def frequencies(variant_obj: dict) -> list[Tuple]:
         "snv": {
             "gnomad_frequency": (
                 "GnomAD",
-                [variant_obj.get("gnomad_link"), variant_obj.get("gnomad_non_ukb_link")],
+                list(set([variant_obj.get("gnomad_link"), variant_obj.get("gnomad_non_ukb_link")])),
             ),
             "thousand_genomes_frequency": ("1000G", variant_obj.get("thousandg_link")),
             "max_thousand_genomes_frequency": ("1000G(max)", variant_obj.get("thousandg_link")),

--- a/scout/server/blueprints/variant/utils.py
+++ b/scout/server/blueprints/variant/utils.py
@@ -368,7 +368,11 @@ def frequencies(variant_obj: dict) -> list[Tuple]:
         "snv": {
             "gnomad_frequency": (
                 "GnomAD",
-                list(set([variant_obj.get("gnomad_link"), variant_obj.get("gnomad_non_ukb_link")])),
+                list(
+                    dict.fromkeys(
+                        [variant_obj.get("gnomad_link"), variant_obj.get("gnomad_non_ukb_link")]
+                    )
+                ),
             ),
             "thousand_genomes_frequency": ("1000G", variant_obj.get("thousandg_link")),
             "max_thousand_genomes_frequency": ("1000G(max)", variant_obj.get("thousandg_link")),

--- a/scout/server/links.py
+++ b/scout/server/links.py
@@ -614,23 +614,23 @@ def exac_link(variant_obj):
 
 
 def gnomad_link(variant_obj, build=37, non_ukb=False):
-    """Compose link to gnomAD website for a variant."""
+    """Compose link to the gnomAD website for a variant."""
     url_template = (
         "https://gnomad.broadinstitute.org/variant/{this[chromosome]}-"
         "{this[position]}-{this[reference]}-{this[alternative]}"
     ).format(this=variant_obj)
 
-    if build == 37:
-        url_template += "?dataset=gnomad_r2_1"
-        return url_template
-
     if variant_obj["chromosome"] in ["M", "MT"]:
         url_template += "?dataset=gnomad_r4"
         return url_template
 
-    if build == 38 and non_ukb:
+    if build == 37:
+        url_template += "?dataset=gnomad_r2_1"
+        return url_template
+
+    if non_ukb:
         url_template += "?dataset=gnomad_r4_non_ukb"
-    elif build == 38:
+    else:
         url_template += "?dataset=gnomad_r4"
 
     return url_template


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6428 

As far as I know, v3 and v4 have the same gnomAD MT content: the wgs samples, so also no uk-biobank split. Slightly easier to go with the latter.

<img width="737" height="869" alt="Screenshot 2026-06-22 at 14 54 06" src="https://github.com/user-attachments/assets/59edcef1-b583-41c5-a843-9d8fa420342d" />

<img width="1162" height="798" alt="Screenshot 2026-06-22 at 14 54 47" src="https://github.com/user-attachments/assets/2df6d81b-2e5f-496b-9c92-1f8b99b9ba0c" />

<img width="945" height="506" alt="Screenshot 2026-06-22 at 14 57 35" src="https://github.com/user-attachments/assets/c655e8f0-aca4-4dcd-a99e-17b3b031c35c" />

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
