### PR TITLE
Fix error in typing on adapter acmg module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Automatically convert email input to lowercase when logging in using LDAP (#6407)
 - Print N/A for missing variant GQ values (#6420)
 - Sort variant external gene link buttons alphabetically again (#6426)
+- Invalid Tuple type annotation syntax on adapter.mongo.acmg function (#6433)
 
 ## [4.112]
 ### Added

--- a/scout/adapter/mongo/acmg.py
+++ b/scout/adapter/mongo/acmg.py
@@ -22,7 +22,7 @@ class ACMGHandler(object):
         link: str,
         criteria: List[Criterion] | None = None,
         classification: tuple | int | None = None,
-    ) -> Tuple(str | None, str):
+    ) -> Tuple[str | None, str]:
         """Save an ACMG evaluation in the database."""
         criteria = criteria or []
 

--- a/scout/server/blueprints/variant/controllers.py
+++ b/scout/server/blueprints/variant/controllers.py
@@ -831,7 +831,7 @@ def variant_acmg_post(
     variant_id: str,
     user_email: str,
     criteria: list,
-) -> Tuple(str | None, str):
+) -> Tuple[str | None, str]:
     """Calculate an ACMG classification based on a list of criteria."""
     variant_obj = store.variant(variant_id)
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6432 

### After the fix

<img width="1293" height="292" alt="image" src="https://github.com/user-attachments/assets/895f7f54-5086-4a02-b44d-dfac3031459e" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
