### PR TITLE
Fix #6436 - `CN=.` call parsing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Print N/A for missing variant GQ values (#6420)
 - Sort variant external gene link buttons alphabetically again (#6426)
 - Invalid Tuple type annotation syntax on adapter.mongo.acmg function (#6433)
+- SV CN FORMAT field `.` parsing issue (#6437)
 
 ## [4.112]
 ### Added

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -20,6 +20,7 @@ Uses 'DV' to describe number of paired ends that supports the event and
 
 import ast
 import logging
+import math
 from typing import Dict, List, Optional, Tuple, Union
 
 import cyvcf2
@@ -267,16 +268,23 @@ def get_paired_ends(variant: cyvcf2.Variant, pos: int) -> tuple:
 
 def get_copy_number(variant: cyvcf2.Variant, sample_index: int) -> Optional[float]:
     """Return the copy number for a SV variant."""
+
+    def is_nan_like(value) -> bool:
+        try:
+            return math.isnan(float(value))
+        except (TypeError, ValueError):
+            return False
+
     if "CN" not in variant.FORMAT:
         return None
+
+    cn_value = variant.format("CN")[sample_index][0]
+
+    if cn_value in [None, -1] or is_nan_like(cn_value):
+        return None
+
     try:
-        cn_value = variant.format("CN")[sample_index][0]
-
-        if cn_value in [None, -1, ".", "nan"]:
-            return None
-
         return int(cn_value)
-
     except (ValueError, IndexError) as e:
         LOG.error(f"Error extracting CN {type(cn_value)} {cn_value} for sample {sample_index}: {e}")
 

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -278,7 +278,7 @@ def get_copy_number(variant: cyvcf2.Variant, sample_index: int) -> Optional[floa
         return int(cn_value)
 
     except (ValueError, IndexError) as e:
-        LOG.error(f"Error extracting CN for sample {sample_index}: {e}")
+        LOG.error(f"Error extracting CN {cn_value} for sample {sample_index}: {e}")
 
 
 def get_split_reads(variant, pos):

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -272,13 +272,13 @@ def get_copy_number(variant: cyvcf2.Variant, sample_index: int) -> Optional[floa
     try:
         cn_value = variant.format("CN")[sample_index][0]
 
-        if cn_value in [None, -1, "."]:
+        if cn_value in [None, -1, ".", "nan"]:
             return None
 
         return int(cn_value)
 
     except (ValueError, IndexError) as e:
-        LOG.error(f"Error extracting CN {cn_value} for sample {sample_index}: {e}")
+        LOG.error(f"Error extracting CN {type(cn_value)} {cn_value} for sample {sample_index}: {e}")
 
 
 def get_split_reads(variant, pos):

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -270,6 +270,10 @@ def get_copy_number(variant: cyvcf2.Variant, sample_index: int) -> Optional[floa
     """Return the copy number for a SV variant."""
 
     def is_nan_like(value) -> bool:
+        """Determine if a value should be treated as a NaN-like value.
+        This helper converts the input to float and checks for IEEE NaN semantics, returning False if conversion fails.
+        """
+
         try:
             return math.isnan(float(value))
         except (TypeError, ValueError):

--- a/scout/parse/variant/genotype.py
+++ b/scout/parse/variant/genotype.py
@@ -272,7 +272,7 @@ def get_copy_number(variant: cyvcf2.Variant, sample_index: int) -> Optional[floa
     try:
         cn_value = variant.format("CN")[sample_index][0]
 
-        if cn_value in [None, -1]:
+        if cn_value in [None, -1, "."]:
             return None
 
         return int(cn_value)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6436 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
