### PR TITLE
Make comments editable/removable by LDAP users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Print N/A for missing variant GQ values (#6420)
 - Sort variant external gene link buttons alphabetically again (#6426)
 - Invalid Tuple type annotation syntax on adapter.mongo.acmg function (#6433)
+- Made comments editable and removable for users authenticated via LDAP (#6439)
 
 ## [4.112]
 ### Added

--- a/scout/server/templates/utils.html
+++ b/scout/server/templates/utils.html
@@ -144,7 +144,7 @@
                 {% if comment.created_at < comment.updated_at %}
                   <span class='badge bg-secondary'>edited</span>
                 {% endif %}
-                {% if comment.user_id == current_user.email %}
+                {% if comment.user_id == current_user._id %}
                   <button class="btn btn-link btn-sm" type="submit" name="remove"><i class="fa fa-times"></i></button>
                   <button class="btn btn-link btn-sm" type="button" data-bs-toggle="modal" data-bs-target="#editComment_{{index}}"><i class="fa fa-edit"></i></button>
                 {% endif %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6434

### Tested with LDAP login

<img width="622" height="189" alt="image" src="https://github.com/user-attachments/assets/cee9399a-5301-4f87-b919-2f573d736177" />


### Tested with demo login

<img width="620" height="180" alt="image" src="https://github.com/user-attachments/assets/474cb061-f314-4aec-a08d-2f18bb23a1c6" />






<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
