### PR TITLE
Chr prefix mitochondrial load exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
-- Load all mitochondrial variants, even if there is a `chr` prefix (#6553)
--
+- Load all mitochondrial variants, even if there is a `chr` prefix (#6454)
+
 ## [4.113.1]
 ### Fixed
 - Live loqusdbapi observation counts were not shown on the variant page (#6449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Load all mitochondrial variants, even if there is a `chr` prefix (#6553)
+-
 ## [4.113.1]
 ### Fixed
 - Live loqusdbapi observation counts were not shown on the variant page (#6449)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [4.113.2]
 ### Fixed
-- Load all mitochondrial variants, even if there is a `chr` prefix (#6454)
+- Load all mitochondrial variants, even if there is a `chr` chromosome name prefix (#6454)
 
 ## [4.113.1]
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scout-browser"
-version = "4.113.1"
+version = "4.113.2"
 description = "Clinical DNA variant visualizer and browser"
 authors = [{name="Chiara Rasi", email="chiara.rasi@scilifelab.se"}, {name="Daniel Nilsson", email="daniel.nilsson@ki.se"}, {name="Robin Andeer", email="robin.andeer@gmail.com"}, {name="Måns Magnusson", email="monsunas@gmail.com"}]
 license = {text = "MIT License"}

--- a/scout/adapter/mongo/variant_loader.py
+++ b/scout/adapter/mongo/variant_loader.py
@@ -411,7 +411,7 @@ class VariantLoader(object):
                 if (
                     (rank_score is None)
                     or (rank_score > rank_threshold)
-                    or variant.CHROM in ["M", "MT"]
+                    or "M" in variant.CHROM
                     or category in ["str"]
                     or is_pathogenic(variant)
                     or self._is_managed(

--- a/uv.lock
+++ b/uv.lock
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "scout-browser"
-version = "4.113.1"
+version = "4.113.2"
 source = { editable = "." }
 dependencies = [
     { name = "anytree" },


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6453 

Yes. 

Compare https://scout38-stage.sys.scilifelab.se/cust003/26224/variants before and after patch.

MT filter (show unaffected) on prod before patch:
<img width="237" height="46" alt="Screenshot 2026-06-30 at 14 24 37" src="https://github.com/user-attachments/assets/aeba9b49-c2d0-4e49-a3b3-63eb6573f0e8" />

Same filter, after (also note the additional vars now loaded to the total, but there are different managed vars etc on prod, so not exactly comparable).
<img width="202" height="61" alt="Screenshot 2026-06-30 at 14 24 30" src="https://github.com/user-attachments/assets/dcfcc18e-fa3a-4456-95b0-1b57906881b8" />

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by AJ
- [x] tests executed by DN
