### PR TITLE
Fix #6475 - users can only search gene variants in cases they have access to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 ### Fixed
-- Unprivileged users selecting no institute on gene variants page should see only all cases they can access (#6476)
+- Users selecting no institute on gene variants page should still only see cases they have access to (#6476)
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Changed
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
+### Fixed
+- Unprivileged users selecting no institute on gene variants page should see only all cases they can access (#6476)
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 ### Fixed
 - Bug calculating allele read depth in samples genotype module (#6469)
-- Users selecting no institute on gene variants page should still only see cases they have access to (#6476)
+- Users selecting no institute on gene variants page should only see cases they have access to (#6476)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -251,18 +251,14 @@ def gene_variants(institute_id):
                         flash(error, "warning")
             return safe_redirect_back(request)
 
-        institute_ids_granted = authorize_institute_access(form.institute.data, users_institute_ids)
-
         variants_query = store.build_variant_query(
             query=form.data,
-            institute_ids=institute_ids_granted,
+            institute_ids=authorize_institute_access(form.institute.data, users_institute_ids),
             category=category,
             variant_type=variant_type,
-        )  # This is the actual query dictionary, not the cursor with results
+        )
 
-        results = store.variant_collection.find(variants_query).sort(
-            [("rank_score", DESCENDING)]
-        )  # query results
+        results = store.variant_collection.find(variants_query).sort([("rank_score", DESCENDING)])
 
         result_size = store.variant_collection.count_documents(variants_query)
 

--- a/scout/server/blueprints/institutes/views.py
+++ b/scout/server/blueprints/institutes/views.py
@@ -168,6 +168,17 @@ def lock_filter(institute_id, filter_id):
     return safe_redirect_back(request)
 
 
+def authorize_institute_access(institute_ids_requested: list, users_institute_ids: list) -> list:
+    """Check requested institute identifiers against the current user's institute identifiers
+    and return the intersection of the two lists. If the user is admin the request and return lists are allowed to stay empty.
+    Otherwise, it is populated with all the users institute identifiers.
+    """
+    if not institute_ids_requested and current_user.is_admin is False:
+        institute_ids_requested = users_institute_ids
+
+    return [inst for inst in institute_ids_requested if inst in users_institute_ids]
+
+
 @blueprint.route("/<institute_id>/gene_variants", methods=["GET", "POST"])
 @templated("overview/gene_variants.html")
 def gene_variants(institute_id):
@@ -240,9 +251,11 @@ def gene_variants(institute_id):
                         flash(error, "warning")
             return safe_redirect_back(request)
 
+        institute_ids_granted = authorize_institute_access(form.institute.data, users_institute_ids)
+
         variants_query = store.build_variant_query(
             query=form.data,
-            institute_ids=[inst for inst in form.institute.data if inst in users_institute_ids],
+            institute_ids=institute_ids_granted,
             category=category,
             variant_type=variant_type,
         )  # This is the actual query dictionary, not the cursor with results


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6475

Before:
<img width="1468" height="852" alt="Screenshot 2026-08-04 at 11 32 59" src="https://github.com/user-attachments/assets/88db9c85-46ab-44a4-a71f-5e3dbbd945bd" />

After:
<img width="1516" height="764" alt="Screenshot 2026-08-04 at 13 01 55" src="https://github.com/user-attachments/assets/f1e33ff8-f639-4607-b503-db80b5730160" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
