### PR TITLE
MedGen as default option on ClinVar germline form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)
 - Bump automation GitHub action version (#6477)
+- Condition ID type: MedGen is now the default instead of HPO in the ClinVar submission form ()
 ### Fixed
 - Bug calculating allele read depth in samples genotype module (#6469)
 - Users selecting no institute on gene variants page should only see cases they have access to (#6476)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)
 - Bump automation GitHub action version (#6477)
-- Condition ID type: MedGen is now the default instead of HPO in the ClinVar submission form (#6486)
+- Condition ID type MedGen is now the default instead of HPO in the ClinVar submission form (#6486)
 ### Fixed
 - Bug calculating allele read depth in samples genotype module (#6469)
 - Users selecting no institute on gene variants page should only see cases they have access to (#6476)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)
 - Bump automation GitHub action version (#6477)
-- Condition ID type: MedGen is now the default instead of HPO in the ClinVar submission form ()
+- Condition ID type: MedGen is now the default instead of HPO in the ClinVar submission form (#6486)
 ### Fixed
 - Bug calculating allele read depth in samples genotype module (#6469)
 - Users selecting no institute on gene variants page should only see cases they have access to (#6476)

--- a/scout/constants/clinvar.py
+++ b/scout/constants/clinvar.py
@@ -186,15 +186,15 @@ COLLECTION_METHOD = [
 
 # Database that describe a condition with associated eventual prefix
 CONDITION_PREFIX = {
-    "HPO": "HP:",
     "MedGen": "",
+    "HPO": "HP:",
     "MeSH": "",
     "MONDO": "MONDO:",
     "OMIM": "",
     "Orphanet": "ORPHA",
 }
 
-CONDITION_DBS_API = ["HP", "MedGen", "MeSH", "MONDO", "OMIM", "Orphanet"]
+CONDITION_DBS_API = ["MedGen", "HP", "MeSH", "MONDO", "OMIM", "Orphanet"]
 
 CLINVAR_ASSERTION_METHOD_CIT_DB_OPTIONS = {"DOI", "pmc", "PMID"}
 CITATION_DBS_API = ["PubMed", "BookShelf", "DOI", "pmc"]

--- a/scout/server/blueprints/clinvar/templates/clinvar/components.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/components.html
@@ -91,20 +91,7 @@
 
     <br><br>
     {{ var_form.conditions.label(class="fw-bold, text-dark")}} <span class="text-danger" data-bs-toggle='tooltip' title="Required field. Include data from ONE DATABASE TYPE ONLY (i.e. only OMIM terms, only HPO terms etc). If multiple conditions are submitted for a variant, this indicates that the variant was interpreted for the combination of conditions in the same individual(s).  i.e. this variant causes both condition A and condition B in the same individual. This scenario is most common for a new disease or syndrome that does not yet have a name and is described by several clinical features. If you want to indicate that the variant has been interpreted for more than one condition, please submit these as separate records."><strong>*?</strong></span>
-    <select class="select2" id="condition_tags" name="conditions" multiple="true" style="width:100%;">
-      {% if var_form.omim_terms.choices %}
-        {% for term, _ in var_form.omim_terms.choices %}
-          <option value="{{term}}" selected>{{term}}</option>
-        {% endfor %}
-      {% elif var_form.orpha_terms.choices %}
-        {% for term, _ in var_form.orpha_terms.choices %}
-          <option value="{{term}}" selected>{{term}}</option>
-        {% endfor %}
-      {% elif var_form.hpo_terms.choices %}
-        {% for term, _ in var_form.hpo_terms.choices %}
-          <option value="{{term}}" selected>{{term}}</option>
-        {% endfor %}
-      {% endif %}
+    <select class="select2" id="condition_tags" name="conditions" multiple="true" style="width:100%;" data-placeholder="e.g. C0001080, ..">
     </select>
 
     <div class="mt-3">

--- a/scout/server/blueprints/clinvar/templates/clinvar/scripts.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/scripts.html
@@ -104,21 +104,9 @@ $(".previous").click(function(){
 	});
 });
 
-// Conditions-asociated code
+// Conditions-associated code
 
 var conditionsPlaceHolders = {"OMIM": "e.g. 100800, ..", "HPO": "e.g. 0002839, ..", "HP": "e.g. 0002839, .." , "MedGen": "e.g. C0001080, ..", "MeSh": "e.g. D000130, ..", "MONDO": "e.g. 0007947, ..", "Orphanet": "e.g. 155, .."};
-
-// Set selected condition type on page load
-window.onload = function() {
-  const selectedCondId = document.getElementById('condition_type');
-  {% if variant_data.var_form.omim_terms.choices %}
-    selectedCondId.options.selectedIndex = 4;
-  {% elif variant_data.var_form.orpha_terms.choices %}
-    selectedCondId.options.selectedIndex = 5;
-  {% elif variant_data.var_form.hpo_terms.choices %}
-    selectedCondId.options.selectedIndex = 0;
-  {% endif %}
-};
 
 // Populate condition list
 $('#condition_tags').select2({


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Partial fix for #6468 

### Before

<img width="678" height="363" alt="image" src="https://github.com/user-attachments/assets/9269e4f6-1e69-4b52-a5c2-ac0df0bc20ea" />


### After

<img width="647" height="352" alt="image" src="https://github.com/user-attachments/assets/e13bafdc-6569-4eb3-9046-b3172a1f85e3" />


<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
