### PR TITLE
Fix #6487 - crash on loading omics gene without inheritance model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Typo in MT coverage report (#6481)
 - SonarCloud security issue about pip without binary-only install in automation (#6477)
 - SonarCloud security issue about uv and pip without frozen dependencies in automation (#6477)
+- Crash when encountering omics gene without inheritance model (#6488)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/adapter/mongo/omics_variant.py
+++ b/scout/adapter/mongo/omics_variant.py
@@ -120,9 +120,9 @@ class OmicsVariantHandler:
         """Connect the gene to the omics model using its HGNC ID and build.
         If the gene is found, its inheritance models are added to the gene.
         """
-        hgnc_gene = self.hgnc_gene(omics_model["hgnc_ids"][0], omics_model["build"])
-        if hgnc_gene:
-            hgnc_gene["inheritance"] = hgnc_gene["inheritance_models"]
+        if hgnc_gene := self.hgnc_gene(omics_model["hgnc_ids"][0], omics_model["build"]):
+            if hgnc_gene.get("inheritance_models"):
+                hgnc_gene["inheritance"] = hgnc_gene.get("inheritance_models")
             omics_model["genes"] = [hgnc_gene]
 
     def load_omics_variants(self, case_obj: dict, file_type: str, build: Optional[str] = "37"):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6487 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN
