### PR TITLE
Fix parsing of 2 Clingen keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - SonarCloud security issue about uv and pip without frozen dependencies in automation (#6477)
 - Crash when encountering omics gene without inheritance model (#6488)
 - Lint and fix workflow uv use error (#6492)
+- Parsing of clingen_cgh_benign and clingen_cgh_pathogenic keys (#6494)
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - SonarCloud security issue about uv and pip without frozen dependencies in automation (#6477)
 - Crash when encountering omics gene without inheritance model (#6488)
 - Lint and fix workflow uv use error (#6492)
-- Parsing of clingen_cgh_benign and clingen_cgh_pathogenic keys (#6494)
+- Parsing of `clingen_cgh_benign` and `clingen_cgh_pathogenic` keys (#6494)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -446,8 +446,8 @@ def add_frequencies(variant_obj, frequencies):
     variant_obj["colorsdb_af"] = call_safe(float, frequencies.get("colorsdb_af"))
 
     # Add the sv counts:
-    variant_obj["clingen_cgh_benign"] = frequencies.get("clingen_benign")
-    variant_obj["clingen_cgh_pathogenic"] = frequencies.get("clingen_pathogenic")
+    variant_obj["clingen_cgh_benign"] = frequencies.get("clingen_cgh_benign")
+    variant_obj["clingen_cgh_pathogenic"] = frequencies.get("clingen_cgh_pathogenic")
     variant_obj["clingen_mip"] = frequencies.get("clingen_mip")
     variant_obj["clingen_ngi"] = frequencies.get("clingen_ngi")
     variant_obj["swegen"] = frequencies.get("swegen")


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6493 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
