### PR TITLE
Revert line on pagination utils and fix accordingly on CLinVar page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - On outliers page, show inheritance patterns badges on genes cell (#6446)
 - Allow custom config human reference tracks, e.g. for local emergency copies when UCSC is unreachable (#6479)
 - Option to hide case details on the case specific gene panel extent report (#6485)
-- Pagination on ClinVar germline submissions page (#6491)
+- Pagination on ClinVar germline submissions page (#6491, #6495)
 ### Changed
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -368,6 +368,10 @@
   {{ super() }}
   <script type="text/javascript">
 
+  document.getElementById("pagination-form").addEventListener("submit", function () {
+      document.getElementById("page").disabled = true;
+  });
+
   $(function () {
       $('.casedata  div').hide();
       $('.vardata  div').hide();

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -54,10 +54,22 @@
   <p>No ClinVar submissions found. You can create one by choosing one or more pinned variants on a case page and clicking the button "Submit to ClinVar".</p>
   {% endif %}
 </div>
-  <form id="pagination-form" method="get" action="{{ url_for('clinvar.clinvar_germline_submissions', institute_id=institute._id) }}">
-  {{ pagination_hidden_div(page, result_size, per_page) }}
-  {{ pagination_footer(page, result_size, per_page) }}
-</form>
+  <form
+    id="pagination-form"
+    method="get"
+    action="{{ url_for('clinvar.clinvar_germline_submissions', institute_id=institute._id) }}"
+    onclick="
+        if (event.target.matches('label.page-link[for^=paginate-]')) {
+            const input = document.getElementById(event.target.htmlFor);
+            document.getElementById('page').value = input.value;
+            event.preventDefault();
+            this.submit();
+        }
+    "
+  >
+      {{ pagination_hidden_div(page, result_size, per_page) }}
+      {{ pagination_footer(page, result_size, per_page) }}
+  </form>
 {% endmacro %}
 
 {% macro submission_panel(subm_obj) %}
@@ -367,10 +379,6 @@
 {% block scripts %}
   {{ super() }}
   <script type="text/javascript">
-
-  document.getElementById("pagination-form").addEventListener("submit", function () {
-      document.getElementById("page").disabled = true;
-  });
 
   $(function () {
       $('.casedata  div').hide();

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1258,6 +1258,7 @@
     {% for p in range(1, total_pages + 1) %}
       <input type="submit" name="page" id="paginate-page-{{p}}" value="{{p}}" hidden>
     {% endfor %}
+    <input type="hidden" id="page" name="page" value="{{ page }}">
   </div>
 {% endmacro %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Revert a line on the variant pagination hidden field, and a necessary fix on ClinVar template

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by CR
