### PR TITLE
Revert remove pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Crash when encountering omics gene without inheritance model (#6488)
 - Lint and fix workflow uv use error (#6492)
 - Parsing of `clingen_cgh_benign` and `clingen_cgh_pathogenic` keys (#6494)
+- ClinVar pagination fetches only entries to display (#6496)
+- Fix pagination, e.g. on dismissing variants, (#6496)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -311,7 +311,7 @@ class ClinVarHandler(object):
         if clinvar_id_filter:
             query["clinvar_subm_id"] = {"$regex": clinvar_id_filter, "$options": "i"}
 
-        total_count = self.clinvar_submission_collection.find(query).count()
+        total_count = self.clinvar_submission_collection.count_documents(query)
         results = list(
             self.clinvar_submission_collection.find(query)
             .sort("updated_at", pymongo.DESCENDING)

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -266,15 +266,26 @@ class ClinVarHandler(object):
             "updated_at": result.get("updated_at"),
         }
 
-    def get_clinvar_onc_submissions(self, institute_id: str) -> pymongo.cursor.Cursor:
+    def get_clinvar_onc_submissions(
+        self, institute_id: str, skip: int = 0, limit: int = 15
+    ) -> pymongo.cursor.Cursor:
         """Collect all open and closed ClinVar oncogenocity submissions for an institute."""
         query = {"institute_id": institute_id, "type": "oncogenicity"}
-        return self.clinvar_submission_collection.find(query).sort("updated_at", pymongo.DESCENDING)
+        return (
+            self.clinvar_submission_collection.find(query)
+            .sort("updated_at", pymongo.DESCENDING)
+            .skip(skip)
+            .limit(limit)
+        )
 
     def get_clinvar_germline_submissions(
-        self, institute_id: str, clinvar_id_filter: Optional[str] = None
-    ) -> List[dict]:
-        """Collect all open and closed ClinVar germline submissions for an institute."""
+        self,
+        institute_id: str,
+        clinvar_id_filter: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 15,
+    ) -> tuple[List[dict], int]:
+        """Collect open and closed ClinVar germline submissions for an institute."""
 
         def populate_cases_from_variant_data(variant_data, institute_id):
             cases = {}
@@ -300,8 +311,12 @@ class ClinVarHandler(object):
         if clinvar_id_filter:
             query["clinvar_subm_id"] = {"$regex": clinvar_id_filter, "$options": "i"}
 
+        total_count = self.clinvar_submission_collection.find(query).count()
         results = list(
-            self.clinvar_submission_collection.find(query).sort("updated_at", pymongo.DESCENDING)
+            self.clinvar_submission_collection.find(query)
+            .sort("updated_at", pymongo.DESCENDING)
+            .skip(skip)
+            .limit(limit)
         )
 
         submissions = []
@@ -333,7 +348,7 @@ class ClinVarHandler(object):
 
             submissions.append(submission)
 
-        return submissions
+        return submissions, total_count
 
     def clinvar_assertion_criteria(self, variant_data):
         """Retrieve assertion criteria from the variant data of a submission.

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -54,10 +54,10 @@
   <p>No ClinVar submissions found. You can create one by choosing one or more pinned variants on a case page and clicking the button "Submit to ClinVar".</p>
   {% endif %}
 </div>
-  <form id="pagination-form" method="get" action="{{ url_for('clinvar.clinvar_germline_submissions', institute_id=institute._id) }}">
-  {{ pagination_hidden_div(page, result_size, per_page) }}
-  {{ pagination_footer(page, result_size, per_page) }}
-</form>
+  <form id="pagination-form" method="post" action="{{ url_for('clinvar.clinvar_germline_submissions', institute_id=institute._id) }}">
+    {{ pagination_hidden_div(page, result_size, per_page) }}
+    {{ pagination_footer(page, result_size, per_page) }}
+  </form>
 {% endmacro %}
 
 {% macro submission_panel(subm_obj) %}

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -92,26 +92,26 @@ def clinvar_save(institute_id: str, case_name: str):
     return redirect(url_for("cases.case", institute_id=institute_id, case_name=case_name))
 
 
-@clinvar_bp.route("/<institute_id>/clinvar_germline_submissions", methods=["POST"])
+@clinvar_bp.route("/<institute_id>/clinvar_germline_submissions", methods=["GET", "POST"])
 def clinvar_germline_submissions(institute_id):
     """Handle ClinVar submission objects and files"""
 
     institute_obj = institute_and_case(store, institute_id)
     institute_clinvar_submitters: List[str] = institute_obj.get("clinvar_submitters", [])
     clinvar_id_filter = (
-        request.form.get("clinvar_id_filter").strip()
-        if request.form.get("clinvar_id_filter")
+        request.values.get("clinvar_id_filter").strip()
+        if request.values.get("clinvar_id_filter")
         else None
     )
     per_page = 15
-    page = request.form.get("page", 1, type=int)
+    page = request.values.get("page", 1, type=int)
     start = (page - 1) * per_page
     submissions, total_count = store.get_clinvar_germline_submissions(
         institute_id, clinvar_id_filter=clinvar_id_filter, skip=start, limit=per_page
     )
-    
+
     data = {
-        "submissions": submissions
+        "submissions": submissions,
         "institute": institute_obj,
         "variant_header_fields": CLINVAR_HEADER,
         "casedata_header_fields": CASEDATA_HEADER,

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -92,26 +92,26 @@ def clinvar_save(institute_id: str, case_name: str):
     return redirect(url_for("cases.case", institute_id=institute_id, case_name=case_name))
 
 
-@clinvar_bp.route("/<institute_id>/clinvar_germline_submissions", methods=["GET"])
+@clinvar_bp.route("/<institute_id>/clinvar_germline_submissions", methods=["POST"])
 def clinvar_germline_submissions(institute_id):
-    """Handle clinVar submission objects and files"""
+    """Handle ClinVar submission objects and files"""
 
     institute_obj = institute_and_case(store, institute_id)
     institute_clinvar_submitters: List[str] = institute_obj.get("clinvar_submitters", [])
     clinvar_id_filter = (
-        request.args.get("clinvar_id_filter").strip()
-        if request.args.get("clinvar_id_filter")
+        request.form.get("clinvar_id_filter").strip()
+        if request.form.get("clinvar_id_filter")
         else None
     )
     per_page = 15
-    page = request.args.get("page", 1, type=int)
+    page = request.form.get("page", 1, type=int)
     start = (page - 1) * per_page
-    end = start + per_page
-    all_submissions = store.get_clinvar_germline_submissions(
-        institute_id, clinvar_id_filter=clinvar_id_filter
+    submissions, total_count = store.get_clinvar_germline_submissions(
+        institute_id, clinvar_id_filter=clinvar_id_filter, skip=start, limit=per_page
     )
+    
     data = {
-        "submissions": all_submissions[start:end],
+        "submissions": submissions
         "institute": institute_obj,
         "variant_header_fields": CLINVAR_HEADER,
         "casedata_header_fields": CASEDATA_HEADER,
@@ -119,7 +119,7 @@ def clinvar_germline_submissions(institute_id):
         or not institute_clinvar_submitters,
         "clinvar_id_filter": clinvar_id_filter,
         "page": page,
-        "result_size": len(all_submissions),
+        "result_size": total_count,
         "per_page": per_page,
     }
     return render_template("clinvar/clinvar_submissions.html", **data)

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1258,6 +1258,9 @@
     {% for p in range(1, total_pages + 1) %}
       <input type="submit" name="page" id="paginate-page-{{p}}" value="{{p}}" hidden>
     {% endfor %}
+
+    {# Hidden input for current page - used e.g. when dismissing a variant #}
+    <input type="hidden" id="page" name="page" value="{{ page }}">
   </div>
 {% endmacro %}
 

--- a/uv.lock
+++ b/uv.lock
@@ -656,6 +656,20 @@ wheels = [
 ]
 
 [[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,6 +1244,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1665,6 +1688,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1802,6 +1834,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
 ]
 
 [[package]]
@@ -2267,6 +2308,7 @@ docs = [
 ]
 lint = [
     { name = "black" },
+    { name = "flake8" },
     { name = "isort" },
     { name = "ruff" },
 ]
@@ -2336,6 +2378,7 @@ docs = [
 ]
 lint = [
     { name = "black", specifier = ">=23.3.0" },
+    { name = "flake8" },
     { name = "isort", specifier = ">=5.11.5" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix bug from #6491, and naively try to deal with the fallout 😸 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. test general pagination on variants pages
2. test pagination on clinvar page
3. test that pagination works gracefully with other actions on variants pages
4. test that pagination works gracefully on clinvar page

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [ ] tests executed by
