### PR TITLE
Improve ClinVar pagniation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Lint and fix workflow uv use error (#6492)
 - Parsing of `clingen_cgh_benign` and `clingen_cgh_pathogenic` keys (#6494)
 - ClinVar pagination fetches only entries to display (#6496)
-- Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6498)
-- ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6498)
-- Keep ClinVar submission accordion open after renaming a sample (#6498)
+- Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6497)
+- ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6497)
+- Keep ClinVar submission accordion open after renaming a sample (#6497)
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - ClinVar pagination fetches only entries to display (#6496)
 - Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6498)
 - ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6498)
+- Keep ClinVar submission accordion open after renaming a sample (#6498)
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Lint and fix workflow uv use error (#6492)
 - Parsing of `clingen_cgh_benign` and `clingen_cgh_pathogenic` keys (#6494)
 - ClinVar pagination fetches only entries to display (#6496)
-- Fix pagination, e.g. on dismissing variants, (#6496)
+- Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6498)
+- ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6498)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/adapter/mongo/clinvar.py
+++ b/scout/adapter/mongo/clinvar.py
@@ -312,12 +312,16 @@ class ClinVarHandler(object):
             query["clinvar_subm_id"] = {"$regex": clinvar_id_filter, "$options": "i"}
 
         total_count = self.clinvar_submission_collection.count_documents(query)
-        results = list(
-            self.clinvar_submission_collection.find(query)
-            .sort("updated_at", pymongo.DESCENDING)
-            .skip(skip)
-            .limit(limit)
-        )
+
+        sort_pipeline = [
+            {"$match": query},
+            {"$addFields": {"statusOrder": {"$cond": [{"$eq": ["$status", "open"]}, 0, 1]}}},
+            {"$sort": {"statusOrder": pymongo.ASCENDING, "updated_at": pymongo.DESCENDING}},
+            {"$skip": skip},
+            {"$limit": limit},
+            {"$project": {"statusOrder": 0}},
+        ]
+        results = self.clinvar_submission_collection.aggregate(sort_pipeline)
 
         submissions = []
         for result in results:

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -64,8 +64,9 @@
 <div class="accordion accordion-flush" id="accordionFlushSubmissions">
   <div class="accordion-item">
     <h2 class="accordion-header" id="header-{{subm_obj._id}}">
+      {% set is_open = (open_submission and subm_obj._id|string == open_submission|string) %}
       <a
-        class="accordion-button collapsed {% if subm_obj.status == 'open' %}link-primary{% elif subm_obj.status == 'submitted' %}link-success{% else %}link-secondary{% endif %}"
+        class="accordion-button {% if not is_open %}collapsed{% endif %} {% if subm_obj.status == 'open' %}link-primary{% elif subm_obj.status == 'submitted' %}link-success{% else %}link-secondary{% endif %}"
         data-bs-toggle="collapse"
         data-bs-target="#flush-{{ subm_obj._id }}"
         aria-expanded="false"
@@ -98,7 +99,7 @@
         </div>
       </a>
     </h2>
-    <div id="flush-{{subm_obj._id}}" class="accordion-collapse collapse" aria-labelledby="header-{{subm_obj._id}}" data-bs-parent="#accordionFlushSubmissions">
+    <div id="flush-{{subm_obj._id}}" class="accordion-collapse collapse {% if is_open %}show{% endif %}" aria-labelledby="header-{{subm_obj._id}}" data-bs-parent="#accordionFlushSubmissions">
       <div class="accordion-body">
         <div class="row">
           <form id="updateStatus_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">

--- a/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
+++ b/scout/server/blueprints/clinvar/templates/clinvar/clinvar_submissions.html
@@ -2,7 +2,7 @@
 {% from "overview/institute_sidebar.html" import institute_actionbar %}
 {% from "clinvar/clinvar_howto.html" import clinvar_howto_modal %}
 {% from "clinvar/components.html" import update_submission_status_form %}
-{% from "variants/utils.html" import pagination_hidden_div, pagination_footer %}
+{% from "variants/utils.html" import pagination_hidden_div, pagination_footer, current_page_anchor %}
 
 {% block title %}
   {{ super() }} - {{ institute.display_name }}
@@ -101,25 +101,26 @@
     <div id="flush-{{subm_obj._id}}" class="accordion-collapse collapse" aria-labelledby="header-{{subm_obj._id}}" data-bs-parent="#accordionFlushSubmissions">
       <div class="accordion-body">
         <div class="row">
-        <form id="updateStatus_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
-          <nav aria-label="breadcrumb">
-            <ol class="breadcrumb align-items-center">
-              <li class="breadcrumb-item">
-                <a id="download_clinvar_json" href="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
-                  Download submission json file
-                </a>
-              </li>
-              {% if subm_obj.status=='open'%}
-                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="closed" class="btn btn-warning btn-xs">Close submission</button></li>
-              {% else %}
-                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="open" class="btn btn-primary btn-xs">Re-open submission</button></li>
-              {% endif %}
-              {% if subm_obj.status != 'submitted' %}
-                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="submitted" class="btn btn-success btn-xs">Mark as submitted</button></li>
-              {% endif %}
-                <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission from Scout</button></li>
-            </ol>
-          </nav>
+          <form id="updateStatus_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
+            <nav aria-label="breadcrumb">
+              <ol class="breadcrumb align-items-center">
+                <li class="breadcrumb-item">
+                  <a id="download_clinvar_json" href="{{ url_for('clinvar.clinvar_download_json', submission=subm_obj._id, clinvar_id=subm_obj.clinvar_subm_id or 'None') }}" class="btn btn-primary btn-xs text-white" target="_blank" rel="noopener">
+                    Download submission json file
+                  </a>
+                </li>
+                {% if subm_obj.status=='open'%}
+                  <li class="breadcrumb-item"><button type="submit" name="update_submission" value="closed" class="btn btn-warning btn-xs">Close submission</button></li>
+                {% else %}
+                  <li class="breadcrumb-item"><button type="submit" name="update_submission" value="open" class="btn btn-primary btn-xs">Re-open submission</button></li>
+                {% endif %}
+                {% if subm_obj.status != 'submitted' %}
+                  <li class="breadcrumb-item"><button type="submit" name="update_submission" value="submitted" class="btn btn-success btn-xs">Mark as submitted</button></li>
+                {% endif %}
+                  <li class="breadcrumb-item"><button type="submit" name="update_submission" value="delete" class="btn btn-danger btn-xs">Delete submission from Scout</button></li>
+              </ol>
+            </nav>
+            {{ current_page_anchor(page) }}
           </form>
         </div>
         <div class="row">
@@ -128,25 +129,29 @@
             <tr><th></th></tr>
             <tr>
               <form id="updateName_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
-              <td style="width: 10%"><label for="clinvar_id">Submission ID</label></td>
-              <td style="width: 25%"> <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id or ""}}"></td>
-              <td style="width: 20%"><button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button></td>
+                <td style="width: 10%"><label for="clinvar_id">Submission ID</label></td>
+                <td style="width: 25%"> <input type="text" class="form-control" name="clinvar_id" pattern="SUB[0-9]+" placeholder="ex: SUB1234567" value="{{ subm_obj.clinvar_subm_id or ""}}"></td>
+                <td style="width: 20%"><button type="submit" class="btn btn-sm btn-primary form-control" name="update_submission" value="register_id">Update ID manually</button></td>
+                {{ current_page_anchor(page) }}
               </form>
               {% if subm_obj.status == 'open' and show_submit  %}
                 <form id="useApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_update_submission', institute_id=institute._id, submission=subm_obj._id) }}" method="POST">
-                {{ submit_modal() }}
+                  {{ submit_modal() }}
                   <td style="width: 20%"><button type="button" class="btn btn-sm btn-success form-control" name="update_submission" value="api_submit" data-bs-toggle="modal" data-bs-target="#submitModal">Submit to ClinVar</button></td>
+                  {{ current_page_anchor(page) }}
                 </form>
               {% endif %}
               {% if subm_obj.status == 'submitted' %} <!--Submission status query -->
-                 <form id="statusApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_submission_status', submission_id=subm_obj.clinvar_subm_id) }}" method="POST">
-                   {{ action_modal("status", subm_obj._id) }}
-                   <td style="width: 20%"><button type="button" class="btn btn-sm btn-secondary form-control" name="status_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#statusModal_{{subm_obj._id}}">Submission status enquiry</button></td>
-                 </form>
+                <form id="statusApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_submission_status', submission_id=subm_obj.clinvar_subm_id) }}" method="POST">
+                  {{ action_modal("status", subm_obj._id) }}
+                  <td style="width: 20%"><button type="button" class="btn btn-sm btn-secondary form-control" name="status_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#statusModal_{{subm_obj._id}}">Submission status enquiry</button></td>
+                  {{ current_page_anchor(page) }}
+                </form>
                 <form id="deleteApi_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_submission_delete', submission_id=subm_obj.clinvar_subm_id) }}" method="POST">
-                   {{ action_modal("remove", subm_obj._id) }}
-                   <td style="width: 20%"><button type="button" class="btn btn-sm btn-danger form-control" name="_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#removeModal_{{subm_obj._id}}">Delete submission from ClinVar</button></td>
-                 </form>
+                  {{ action_modal("remove", subm_obj._id) }}
+                  <td style="width: 20%"><button type="button" class="btn btn-sm btn-danger form-control" name="_enquiry" value="api_status" data-bs-toggle="modal" data-bs-target="#removeModal_{{subm_obj._id}}">Delete submission from ClinVar</button></td>
+                  {{ current_page_anchor(page) }}
+                </form>
               {% endif %}
             </tr>
           </table>
@@ -215,6 +220,7 @@
                   <td>
                     <form id="delete_variant_{{subm_variant._id}}" action="{{ url_for('clinvar.clinvar_delete_object', submission=subm_obj._id, object_type='variant_data') }}" method="POST">
                       <button type="submit" name="delete_object" value="{{subm_variant._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash" aria-hidden="true"></span></button>
+                      {{ current_page_anchor(page) }}
                     </form>
                   </td>
                 </tr>
@@ -263,9 +269,10 @@
                   <tr>
                     <td>{{loop.index}}</td>
                     <form id="rename_cd_{{subm_obj._id}}" action="{{ url_for('clinvar.clinvar_rename_casedata', submission=subm_obj._id, case=case.case_id, old_name=case.individual_id) }}" method="POST">
-                    <td>
-                      <input type="text" name="new_name" value="{{case.individual_id}}"><button name="rename_sample" type="submit" class="btn btn-primary btn-xs mb-1 mr-3"><span class="fa fa-pen-square" aria-hidden="true"></span></button>
-                    </td>
+                      <td>
+                        <input type="text" name="new_name" value="{{case.individual_id}}"><button name="rename_sample" type="submit" class="btn btn-primary btn-xs mb-1 mr-3"><span class="fa fa-pen-square" aria-hidden="true"></span></button>
+                      </td>
+                      {{ current_page_anchor(page) }}
                     </form>
                     <td><button id="{{case._id}}" type="button" class="btn btn-primary btn-xs cd_btn"><span class="fa fa-search-plus" aria-hidden="true"></span></button></td>
                     <td>{{ case_link(institute_id=institute._id, case_name=subm_obj.cases[case.case_id]) }}</td>
@@ -274,6 +281,7 @@
                     <td>
                       <form id="delete_casedata_{{case._id}}" action="{{ url_for('clinvar.clinvar_delete_object', submission=subm_obj._id, object_type='case_data') }}" method="POST">
                         <button type="submit" name="delete_object" value="{{case._id}}" class="btn btn-danger btn-xs"><span class="fa fa-trash" aria-hidden="true"></span></button>
+                        {{ current_page_anchor(page) }}
                       </form>
                     </td>
                   </tr>

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -2,6 +2,7 @@ import logging
 from json import dumps
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from flask import (
     Blueprint,
@@ -131,7 +132,15 @@ def clinvar_rename_casedata(submission, case, old_name):
 
     new_name = request.form.get("new_name")
     controllers.update_clinvar_sample_names(submission, case, old_name, new_name)
-    return safe_redirect_back(request, request.referrer + f"#cdata_{submission}")
+    page = request.values.get("page", 1, type=int)
+    referrer = request.referrer or ""
+
+    parsed = urlparse(referrer)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["page"] = str(page)
+
+    link = urlunparse(parsed._replace(query=urlencode(query), fragment=f"cdata_{submission}"))
+    return safe_redirect_back(request, link)
 
 
 @clinvar_bp.route("/<submission>/<object_type>", methods=["POST"])

--- a/scout/server/blueprints/clinvar/views.py
+++ b/scout/server/blueprints/clinvar/views.py
@@ -110,7 +110,6 @@ def clinvar_germline_submissions(institute_id):
     submissions, total_count = store.get_clinvar_germline_submissions(
         institute_id, clinvar_id_filter=clinvar_id_filter, skip=start, limit=per_page
     )
-
     data = {
         "submissions": submissions,
         "institute": institute_obj,
@@ -122,13 +121,16 @@ def clinvar_germline_submissions(institute_id):
         "page": page,
         "result_size": total_count,
         "per_page": per_page,
+        "open_submission": request.values.get("open_submission"),
     }
     return render_template("clinvar/clinvar_submissions.html", **data)
 
 
 @clinvar_bp.route("/<submission>/<case>/rename/<old_name>", methods=["POST"])
 def clinvar_rename_casedata(submission, case, old_name):
-    """Rename one or more casedata individuals belonging to the same clinvar submission, same case"""
+    """Rename one or more casedata individuals belonging to the same clinvar submission, same case.
+    When redirecting to the page, we want to end up on the same page, with the same entry as before in view, with
+    the same entry open."""
 
     new_name = request.form.get("new_name")
     controllers.update_clinvar_sample_names(submission, case, old_name, new_name)
@@ -138,6 +140,7 @@ def clinvar_rename_casedata(submission, case, old_name):
     parsed = urlparse(referrer)
     query = dict(parse_qsl(parsed.query, keep_blank_values=True))
     query["page"] = str(page)
+    query["open_submission"] = submission
 
     link = urlunparse(parsed._replace(query=urlencode(query), fragment=f"cdata_{submission}"))
     return safe_redirect_back(request, link)

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1260,8 +1260,12 @@
     {% endfor %}
 
     {# Hidden input for current page - used e.g. when dismissing a variant #}
-    <input type="hidden" id="page" name="page" value="{{ page }}">
+    {{ current_page_anchor(page) }}
   </div>
+{% endmacro %}
+
+{% macro current_page_anchor(page) %}
+  <input type="hidden" id="page" name="page" value="{{ page }}">
 {% endmacro %}
 
 {% macro pagination_footer(page, result_size, per_page=50) %}

--- a/scout/server/blueprints/variants/templates/variants/utils.html
+++ b/scout/server/blueprints/variants/templates/variants/utils.html
@@ -1259,12 +1259,12 @@
       <input type="submit" name="page" id="paginate-page-{{p}}" value="{{p}}" hidden>
     {% endfor %}
 
-    {# Hidden input for current page - used e.g. when dismissing a variant #}
     {{ current_page_anchor(page) }}
   </div>
 {% endmacro %}
 
 {% macro current_page_anchor(page) %}
+  {# Hidden input for current page - used e.g. when dismissing a variant #}
   <input type="hidden" id="page" name="page" value="{{ page }}">
 {% endmacro %}
 


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Some more fixes towards #6468 

- Open submissions are now always found first in the list, regardless of updated_at time
- Add a page number to all clinvar submissions subforms to allow requesting a return to the current page
- Use this new page in particular for clinvar_rename_casedata which before had a goto div anchor upon redirect
- Also keep the accordion tab with the renamed case open upon redirect

<img width="823" height="944" alt="Screenshot 2026-08-13 at 13 55 14" src="https://github.com/user-attachments/assets/0a8e93b3-b533-46d7-95dc-a9de301d137f" />

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by CR
- [x] tests executed by DN, CR
