### PR TITLE
Include MT SVs in mtDNA reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow custom config human reference tracks, e.g. for local emergency copies when UCSC is unreachable (#6479)
 - Option to hide case details on the case specific gene panel extent report (#6485)
 - Pagination on ClinVar germline submissions page (#6491)
+- Include MT SVs on mtDNA report (#)
 ### Changed
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Allow custom config human reference tracks, e.g. for local emergency copies when UCSC is unreachable (#6479)
 - Option to hide case details on the case specific gene panel extent report (#6485)
 - Pagination on ClinVar germline submissions page (#6491)
-- Include MT SVs on mtDNA report (#)
+- Include MT SVs on mtDNA report (#6498)
 ### Changed
 - Changelog enforcement specific to the `unreleased` changelog section (#6216)
 - Decoy GRCh37 build no longer available from igv. Add JP mirror to avoid UCSC fallback and its recent downtime issues (#6479)

--- a/scout/constants/__init__.py
+++ b/scout/constants/__init__.py
@@ -120,6 +120,7 @@ from .variants_export import (
     MITODEL_HEADER,
     MT_COV_STATS_HEADER,
     MT_EXPORT_HEADER,
+    SV_MT_EXPORT_HEADER,
     VCF_HEADER,
     VERIFIED_VARIANTS_HEADER,
 )

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -31,6 +31,7 @@ FUSION_EXPORT_HEADER = EXPORT_HEADER + [
 MT_EXPORT_HEADER = [
     "Position",
     "End",
+    "Change",
     "Position+Change",
     "Category",
     "Sub-category",

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -32,6 +32,7 @@ MT_EXPORT_HEADER = [
     "Position",
     "Change",
     "Position+Change",
+    "Category",
     "Gene",
     "HGVS Description",
     "AD Reference",

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -33,10 +33,15 @@ MT_EXPORT_HEADER = [
     "Change",
     "Position+Change",
     "Category",
-    "Gene",
+    "Sub-category",
+    "Genes",
     "HGVS Description",
     "AD Reference",
     "AD Alternative",
+]
+
+SV_MT_EXPORT_HEADER = [
+    "Size" if header == "HGVS Description" else header for header in MT_EXPORT_HEADER
 ]
 
 MT_COV_STATS_HEADER = [

--- a/scout/constants/variants_export.py
+++ b/scout/constants/variants_export.py
@@ -30,7 +30,7 @@ FUSION_EXPORT_HEADER = EXPORT_HEADER + [
 
 MT_EXPORT_HEADER = [
     "Position",
-    "Change",
+    "End",
     "Position+Change",
     "Category",
     "Sub-category",

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -152,6 +152,18 @@ def _get_genes_and_prot_effect(variant: dict) -> tuple[str, str]:
     return ",".join(genes), ",".join(prot_effect)
 
 
+def _get_sample_allele_depths(variant: dict, sample_id: str) -> tuple[bool, object, object]:
+    """Get allele depths for a sample and whether to skip the variant."""
+    for sample in variant["samples"]:
+        if sample.get("sample_id") == sample_id:
+            if sample["genotype_call"] in GT_NO_ALT_CALL:
+                return True, "", ""
+
+            return False, sample["allele_depths"][0], sample["allele_depths"][1]
+
+    return False, "", ""
+
+
 def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
     """Export mitochondrial variants for a case to create a MT excel report.
     Exclude variants with no cler genotype
@@ -160,18 +172,8 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
 
     for variant in variants:
         line = []
-        skip_variant = False
 
-        ref_ad = ""
-        alt_ad = ""
-        for sample in variant["samples"]:
-            if sample.get("sample_id") == sample_id:
-                if sample["genotype_call"] in GT_NO_ALT_CALL:
-                    skip_variant = True
-                    break
-
-                ref_ad = sample["allele_depths"][0]
-                alt_ad = sample["allele_depths"][1]
+        skip_variant, ref_ad, alt_ad = _get_sample_allele_depths(variant, sample_id)
 
         if skip_variant:
             continue

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -178,14 +178,20 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
 
         position = variant.get("position")
         change = ">".join([variant.get("reference"), variant.get("alternative")])
+        line.append(change)
 
         line.append(position)
-        line.append(change)
-        line.append(f"{position}{change}")
+        line.append(variant.get("end"))
+
         line.append(variant["category"].upper())
+        line.append(variant["sub_category"].upper())
+
         genes, prot_effect = _get_genes_and_prot_effect(variant)
         line.append(genes)
-        line.append(prot_effect)
+        if variant["category"] == "sv":
+            line.append(variant["length"])
+        else:
+            line.append(prot_effect)
 
         line.append(ref_ad)
         line.append(alt_ad)

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -182,7 +182,7 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
         line.append(position)
         line.append(change)
         line.append(f"{position}{change}")
-
+        line.append(variant["category"].upper())
         genes, prot_effect = _get_genes_and_prot_effect(variant)
         line.append(genes)
         line.append(prot_effect)

--- a/scout/export/variant.py
+++ b/scout/export/variant.py
@@ -179,11 +179,12 @@ def export_mt_variants(variants: List[dict], sample_id: str) -> List[str]:
             continue
 
         position = variant.get("position")
-        change = ">".join([variant.get("reference"), variant.get("alternative")])
-        line.append(change)
-
         line.append(position)
         line.append(variant.get("end"))
+
+        change = ">".join([variant.get("reference"), variant.get("alternative")])
+        line.append(change)
+        line.append(f"{position}{change}")
 
         line.append(variant["category"].upper())
         line.append(variant["sub_category"].upper())

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -988,7 +988,12 @@ def _write_mt_variants_lines(
     category: str,
     report_sheet: Worksheet,
 ) -> int:
+    """Write mitochondrial variant data to an Excel worksheet.
 
+    Retrieves the variants matching the query and category, writes the
+    provided header, and exports the variants for the given sample as
+    worksheet rows. Returns the updated row position.
+    """
     mt_variants = list(
         store.variants(
             case_id=case_id,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -977,19 +977,13 @@ def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict
     return data
 
 
-def mt_excel_files(store, case_obj, temp_excel_dir):
+def mt_excel_files(store: MongoAdapter, case_obj: dict, temp_excel_dir: str) -> int:
     """Collect MT variants and format line of a MT variant report
     to be exported in excel format. Create mt excel files, one for each sample,
     in a temporary directory.
 
-    Args:
-        store(adapter.MongoAdapter)
-        case_obj(models.Case)
-        temp_excel_dir(os.Path): folder where the temp excel files are written to
-
     Returns:
         written_files(int): the number of files written to temp_excel_dir
-
     """
 
     def write_coverage(
@@ -1036,7 +1030,13 @@ def mt_excel_files(store, case_obj, temp_excel_dir):
 
     query = {"chrom": get_case_mito_chromosome(case_obj)}
     mt_variants = list(
-        store.variants(case_id=case_obj["_id"], query=query, nr_of_variants=-1, sort_key="position")
+        store.variants(
+            case_id=case_obj["_id"],
+            query=query,
+            nr_of_variants=-1,
+            sort_key="position",
+            category={"$in": ["snv", "sv"]},
+        )
     )
 
     written_files = 0

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -12,6 +12,7 @@ from flask import current_app, flash, redirect, url_for
 from flask_login import current_user
 from requests.auth import HTTPBasicAuth
 from xlsxwriter import Workbook
+from xlsxwriter.worksheet import Worksheet
 
 from scout import __version__
 from scout.adapter import MongoAdapter
@@ -31,6 +32,7 @@ from scout.constants import (
     PHENOTYPE_MAP,
     SAMPLE_SOURCE,
     SEX_MAP,
+    SV_MT_EXPORT_HEADER,
     VERBS_MAP,
 )
 from scout.constants.case_tags import PARAPHRASE_STATUS
@@ -977,6 +979,42 @@ def case_report_content(store: MongoAdapter, institute_obj: dict, case_obj: dict
     return data
 
 
+def _write_mt_variants_lines(
+    row: int,
+    query: dict,
+    header: str,
+    case_id: str,
+    sample_id: str,
+    category: str,
+    report_sheet: Worksheet,
+) -> int:
+
+    mt_variants = list(
+        store.variants(
+            case_id=case_id,
+            query=query,
+            nr_of_variants=-1,
+            sort_key="position",
+            category=category,
+        )
+    )
+    if not mt_variants:
+        return row
+
+    for col, field in enumerate(header):
+        report_sheet.write(row, col, field)
+
+    sample_lines = export_mt_variants(variants=mt_variants, sample_id=sample_id)
+
+    for row, line in enumerate(sample_lines, 1):  # each line becomes a row in the document
+        for col, field in enumerate(line):  # each field in line becomes a cell
+            report_sheet.write(row, col, field)
+
+    if mt_variants:
+        row += 3
+    return row
+
+
 def mt_excel_files(store: MongoAdapter, case_obj: dict, temp_excel_dir: str) -> int:
     """Collect MT variants and format line of a MT variant report
     to be exported in excel format. Create mt excel files, one for each sample,
@@ -1029,39 +1067,37 @@ def mt_excel_files(store: MongoAdapter, case_obj: dict, temp_excel_dir: str) -> 
         )
 
     query = {"chrom": get_case_mito_chromosome(case_obj)}
-    mt_variants = list(
-        store.variants(
-            case_id=case_obj["_id"],
-            query=query,
-            nr_of_variants=-1,
-            sort_key="position",
-            category={"$in": ["snv", "sv"]},
-        )
-    )
 
     written_files = 0
     for sample in samples:
         sample_id = sample["individual_id"]
         display_name = sample["display_name"]
-        sample_lines = export_mt_variants(variants=mt_variants, sample_id=sample_id)
 
         # set up document name
         document_name = ".".join([case_obj["display_name"], display_name, today]) + ".xlsx"
         workbook = Workbook(os.path.join(temp_excel_dir, document_name))
         Report_Sheet = workbook.add_worksheet()
 
-        # Write the column header
         row = 0
+        row = _write_mt_variants_lines(
+            row=row,
+            query=query,
+            header=MT_EXPORT_HEADER,
+            case_id=case_obj["_id"],
+            sample_id=sample_id,
+            category="snv",
+            report_sheet=Report_Sheet,
+        )
 
-        for col, field in enumerate(MT_EXPORT_HEADER):
-            Report_Sheet.write(row, col, field)
-
-        # Write variant lines, after header (start at line 1)
-        for row, line in enumerate(sample_lines, 1):  # each line becomes a row in the document
-            for col, field in enumerate(line):  # each field in line becomes a cell
-                Report_Sheet.write(row, col, field)
-
-        row += 3
+        row = _write_mt_variants_lines(
+            row=row,
+            query=query,
+            header=SV_MT_EXPORT_HEADER,
+            case_id=case_obj["_id"],
+            sample_id=sample_id,
+            category="sv",
+            report_sheet=Report_Sheet,
+        )
 
         row = write_coverage(
             Report_Sheet,

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1011,7 +1011,7 @@ def _write_mt_variants_lines(
 
     sample_lines = export_mt_variants(variants=mt_variants, sample_id=sample_id)
 
-    for row, line in enumerate(sample_lines, 1):  # each line becomes a row in the document
+    for row, line in enumerate(sample_lines, row + 1):  # each line becomes a row in the document
         for col, field in enumerate(line):  # each field in line becomes a cell
             report_sheet.write(row, col, field)
 

--- a/scout/server/blueprints/cases/controllers.py
+++ b/scout/server/blueprints/cases/controllers.py
@@ -1020,7 +1020,7 @@ def _write_mt_variants_lines(
     return row
 
 
-def mt_excel_files(store: MongoAdapter, case_obj: dict, temp_excel_dir: str) -> int:
+def mt_excel_files(case_obj: dict, temp_excel_dir: str) -> int:
     """Collect MT variants and format line of a MT variant report
     to be exported in excel format. Create mt excel files, one for each sample,
     in a temporary directory.

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -349,7 +349,7 @@ def mt_report(institute_id, case_name):
 
     # create a temp folder to write Excel files into
     temp_excel_dir = mkdtemp(suffix="_".join([case_obj["display_name"], "mt_reports"]))
-    if controllers.mt_excel_files(store, case_obj, temp_excel_dir):
+    if controllers.mt_excel_files(case_obj, temp_excel_dir):
         data = zip_dir_to_obj(temp_excel_dir)
 
         shutil.rmtree(temp_excel_dir)

--- a/scout/server/blueprints/cases/views.py
+++ b/scout/server/blueprints/cases/views.py
@@ -347,8 +347,7 @@ def pdf_case_report(institute_id, case_name):
 def mt_report(institute_id, case_name):
     institute_obj, case_obj = institute_and_case(store, institute_id, case_name)
 
-    # create a temp folder to write excel files into
-
+    # create a temp folder to write Excel files into
     temp_excel_dir = mkdtemp(suffix="_".join([case_obj["display_name"], "mt_reports"]))
     if controllers.mt_excel_files(store, case_obj, temp_excel_dir):
         data = zip_dir_to_obj(temp_excel_dir)


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6483 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. Compare case decidingflamingo (cust003) MT report on prod and stage server 38, after deploying this branch on stage 38 server

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by DN
- [ ] tests executed by CR
