### PR TITLE
Fix #6502 - GPT suggestion

### DIFF
--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -25,6 +25,29 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
+      - name: Restore wkhtmltopdf apt cache
+        id: wkhtmltopdf-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/apt/archives
+            ~/.cache/apt/lists
+          key: ${{ runner.os }}-apt-wkhtmltopdf-v1
+
+      - name: Prime wkhtmltopdf apt cache
+        if: steps.wkhtmltopdf-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/apt/archives/partial ~/.cache/apt/lists/partial
+          sudo apt-get \
+            -o dir::cache::archives="$HOME/.cache/apt/archives" \
+            -o dir::state::lists="$HOME/.cache/apt/lists" \
+            update
+          sudo apt-get \
+            -o dir::cache::archives="$HOME/.cache/apt/archives" \
+            -o dir::state::lists="$HOME/.cache/apt/lists" \
+            install -y --no-install-recommends --download-only wkhtmltopdf
+          sudo chown -R "$USER:$USER" ~/.cache/apt
+
       - name: Install the project
         run: uv sync --frozen --all-extras --dev
 
@@ -54,41 +77,35 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Cache apt metadata and packages for wkhtmltopdf
-        id: wkhtmltopdf-cache
-        uses: actions/cache@v6
+      - name: Restore wkhtmltopdf apt cache
+        uses: actions/cache/restore@v6
         with:
           path: |
             ~/.cache/apt/archives
             ~/.cache/apt/lists
           key: ${{ runner.os }}-apt-wkhtmltopdf-v1
 
-      - name: Refresh apt indexes for wkhtmltopdf
-        if: steps.wkhtmltopdf-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.cache/apt/archives/partial ~/.cache/apt/lists/partial
-          sudo apt-get \
-            -o dir::cache::archives="$HOME/.cache/apt/archives" \
-            -o dir::state::lists="$HOME/.cache/apt/lists" \
-            update
-
       - name: Install the HTML 2 PDF renderer
         run: |
           mkdir -p ~/.cache/apt/archives/partial ~/.cache/apt/lists/partial
-          sudo apt-get \
+          if ! sudo apt-get \
             -o dir::cache::archives="$HOME/.cache/apt/archives" \
             -o dir::state::lists="$HOME/.cache/apt/lists" \
-            install -y --no-install-recommends wkhtmltopdf || {
-              echo "Cached apt metadata was stale, refreshing indexes and retrying..."
-              sudo apt-get \
-                -o dir::cache::archives="$HOME/.cache/apt/archives" \
-                -o dir::state::lists="$HOME/.cache/apt/lists" \
-                update
-              sudo apt-get \
-                -o dir::cache::archives="$HOME/.cache/apt/archives" \
-                -o dir::state::lists="$HOME/.cache/apt/lists" \
-                install -y --no-install-recommends wkhtmltopdf
-            }
+            install -y --no-install-recommends --no-download wkhtmltopdf; then
+            echo "wkhtmltopdf apt cache was unavailable or stale, refreshing and retrying..."
+            sudo apt-get \
+              -o dir::cache::archives="$HOME/.cache/apt/archives" \
+              -o dir::state::lists="$HOME/.cache/apt/lists" \
+              update
+            sudo apt-get \
+              -o dir::cache::archives="$HOME/.cache/apt/archives" \
+              -o dir::state::lists="$HOME/.cache/apt/lists" \
+              install -y --no-install-recommends --download-only wkhtmltopdf
+            sudo apt-get \
+              -o dir::cache::archives="$HOME/.cache/apt/archives" \
+              -o dir::state::lists="$HOME/.cache/apt/lists" \
+              install -y --no-install-recommends wkhtmltopdf
+          fi
           sudo chown -R "$USER:$USER" ~/.cache/apt
 
       - name: Run pytest

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  WKHTMLTOPDF_CACHE_VERSION: v0.12.6
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -32,7 +35,7 @@ jobs:
           path: |
             ~/.cache/apt/archives
             ~/.cache/apt/lists
-          key: ${{ runner.os }}-apt-wkhtmltopdf-v1
+          key: ${{ runner.os }}-apt-wkhtmltopdf-${{ env.WKHTMLTOPDF_CACHE_VERSION }}
 
       - name: Prime wkhtmltopdf apt cache
         if: steps.wkhtmltopdf-cache.outputs.cache-hit != 'true'
@@ -83,7 +86,7 @@ jobs:
           path: |
             ~/.cache/apt/archives
             ~/.cache/apt/lists
-          key: ${{ runner.os }}-apt-wkhtmltopdf-v1
+          key: ${{ runner.os }}-apt-wkhtmltopdf-${{ env.WKHTMLTOPDF_CACHE_VERSION }}
 
       - name: Install the HTML 2 PDF renderer
         run: |

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -54,8 +54,42 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Cache apt metadata and packages for wkhtmltopdf
+        id: wkhtmltopdf-cache
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/apt/archives
+            ~/.cache/apt/lists
+          key: ${{ runner.os }}-apt-wkhtmltopdf-v1
+
+      - name: Refresh apt indexes for wkhtmltopdf
+        if: steps.wkhtmltopdf-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/apt/archives/partial ~/.cache/apt/lists/partial
+          sudo apt-get \
+            -o dir::cache::archives="$HOME/.cache/apt/archives" \
+            -o dir::state::lists="$HOME/.cache/apt/lists" \
+            update
+
       - name: Install the HTML 2 PDF renderer
-        run: sudo apt-get update || true && sudo apt-get install -y wkhtmltopdf
+        run: |
+          mkdir -p ~/.cache/apt/archives/partial ~/.cache/apt/lists/partial
+          sudo apt-get \
+            -o dir::cache::archives="$HOME/.cache/apt/archives" \
+            -o dir::state::lists="$HOME/.cache/apt/lists" \
+            install -y --no-install-recommends wkhtmltopdf || {
+              echo "Cached apt metadata was stale, refreshing indexes and retrying..."
+              sudo apt-get \
+                -o dir::cache::archives="$HOME/.cache/apt/archives" \
+                -o dir::state::lists="$HOME/.cache/apt/lists" \
+                update
+              sudo apt-get \
+                -o dir::cache::archives="$HOME/.cache/apt/archives" \
+                -o dir::state::lists="$HOME/.cache/apt/lists" \
+                install -y --no-install-recommends wkhtmltopdf
+            }
+          sudo chown -R "$USER:$USER" ~/.cache/apt
 
       - name: Run pytest
         run: uv run --frozen --dev pytest --cov --test-group-count 8 --test-group=${{ matrix.group }} --test-group-random-seed=12345 --rootdir=/home/runner/work/scout

--- a/.github/workflows/tests_and_cov.yml
+++ b/.github/workflows/tests_and_cov.yml
@@ -51,9 +51,6 @@ jobs:
             install -y --no-install-recommends --download-only wkhtmltopdf
           sudo chown -R "$USER:$USER" ~/.cache/apt
 
-      - name: Install the project
-        run: uv sync --frozen --all-extras --dev
-
   test:
     needs: setup
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6497)
 - ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6497)
 - Keep ClinVar submission accordion open after renaming a sample (#6497)
+- Cache apt wkhtmltopdf package to avoid repeated downloads in GitHub actions (#6503)
 
 ## [4.113.3]
 ### Fixed


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6502 with a cache. Mildly modified GPT suggestion.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions
