### PR TITLE
Fix setting of rank_score in fusion variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6497)
 - ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6497)
 - Keep ClinVar submission accordion open after renaming a sample (#6497)
+- Set the same value for `rank_score` and `fusion_score` for fusion variants ()
 
 ## [4.113.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Fix pagination, e.g. on dismissing variants. Also on ClinVar submission pages (#6496, #6497)
 - ClinVar submissions page always shows open submissions first, even if not updated for a long time (#6497)
 - Keep ClinVar submission accordion open after renaming a sample (#6497)
-- Set the same value for `rank_score` and `fusion_score` for fusion variants ()
+- Set the same value for `rank_score` and `fusion_score` for fusion variants (#6504)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/build/variant/variant.py
+++ b/scout/build/variant/variant.py
@@ -186,7 +186,7 @@ def build_variant(
 
     ## Fusion variant specific
     if variant_obj["category"] == "fusion":
-        variant_obj["rank_score"] = variant_obj.get("fusion_score")
+        variant_obj["rank_score"] = variant.get("fusion_score")
 
         FUSION_KEYS = [
             "tool_hits",


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6501 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
