### PR TITLE
Fix #6516 - exception on storing existing rank model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Keep ClinVar submission accordion open after renaming a sample (#6497)
 - Cache apt wkhtmltopdf package to avoid repeated downloads in GitHub actions (#6503)
 - Set the same value for `rank_score` and `fusion_score` for fusion variants (#6504)
+- Avoid trying to store the same rank model multiple times (#6517)
 
 ## [4.113.3]
 ### Fixed

--- a/scout/adapter/mongo/rank_model.py
+++ b/scout/adapter/mongo/rank_model.py
@@ -82,9 +82,9 @@ class RankModelHandler(object):
         Otherwise fetch it with HTTP request and save it to database.
         """
 
-        rank_model = self.rank_model_collection.find_one(rank_model_url) or self.add_rank_model(
-            rank_model_url
-        )
+        rank_model = self.rank_model_collection.find_one(
+            {"_id": rank_model_url}
+        ) or self.add_rank_model(rank_model_url)
 
         return rank_model
 

--- a/scout/adapter/mongo/rank_model.py
+++ b/scout/adapter/mongo/rank_model.py
@@ -57,7 +57,7 @@ class RankModelHandler(object):
         if config := self.parse_rank_model(rank_model_lines):
             config.update({"_id": rank_model_url})
             config_id = self.rank_model_collection.insert_one(config).inserted_id
-            return self.rank_model_collection.find_one(config_id)
+            return self.rank_model_collection.find_one({"_id": config_id})
 
         return {}
 

--- a/scout/server/blueprints/variant/views.py
+++ b/scout/server/blueprints/variant/views.py
@@ -37,13 +37,9 @@ from scout.server.blueprints.variant.controllers import (
 )
 from scout.server.blueprints.variant.controllers import variant as variant_controller
 from scout.server.blueprints.variant.controllers import variant_acmg as acmg_controller
-from scout.server.blueprints.variant.controllers import (
-    variant_acmg_post,
-)
+from scout.server.blueprints.variant.controllers import variant_acmg_post
 from scout.server.blueprints.variant.controllers import variant_ccv as ccv_controller
-from scout.server.blueprints.variant.controllers import (
-    variant_ccv_post,
-)
+from scout.server.blueprints.variant.controllers import variant_ccv_post
 from scout.server.blueprints.variant.verification_controllers import (
     MissingVerificationRecipientError,
     variant_verification,

--- a/tests/adapter/mongo/test_rank_model.py
+++ b/tests/adapter/mongo/test_rank_model.py
@@ -48,7 +48,7 @@ def test_rank_model_from_url_sv(adapter, case_obj):
     assert isinstance(rank_model_dict, dict)
 
     # And should also be saved to database
-    assert adapter.rank_model_collection.find_one()
+    assert adapter.rank_model_collection.find_one({"_id": sv_rank_model_url})
 
 
 def test_rank_model_from_file(adapter):

--- a/tests/adapter/mongo/test_rank_model.py
+++ b/tests/adapter/mongo/test_rank_model.py
@@ -23,7 +23,7 @@ def test_rank_model_from_url_snv(adapter, case_obj):
     assert isinstance(rank_model_dict, dict)
 
     # And should also be saved to database
-    assert adapter.rank_model_collection.find_one()
+    assert adapter.rank_model_collection.find_one({"_id": rank_model_url})
 
 
 def test_rank_model_from_url_sv(adapter, case_obj):


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

- Fix #6516 

Checking and storing tested on stage with
- [x] a case with previously loaded rank model 
- [x] a case with a defined, but unloaded rank model:
✅ Display is ok. 
Before visiting a variant page:
<img width="901" height="396" alt="Screenshot 2026-08-28 at 16 48 23" src="https://github.com/user-attachments/assets/f88da350-67ee-4d57-8467-12f3ad330e07" />
✅ After visiting the page:
<img width="786" height="553" alt="Screenshot 2026-08-28 at 16 48 38" src="https://github.com/user-attachments/assets/7e560e02-1139-46ab-95e3-950543003017" />

NOTE that this does not fully support the claim to "fix" the exception. It does fix a bug with the current implementation, that would allow the situation to occur. We now identify stored models better. But simply visiting a variant from a case that has the model unset - or set - does not trigger an exception. Perhaps visiting multiple variants, deleting the model while visiting a variant, or some such is needed. This change should at the very least make the situation where writes are called for more rare, allowing fewer opportunities for such conditions to appear. 

The attempt to store an existing model is in itself benign, so I'll just close this for now, and we can revisit if it should still happen again.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
