### PR TITLE
Gens viewer for case opens in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Changed
+- Gens viewer for a case opens in a new tab (#6538)
 ### Fixed
 - Syntax fix rerunner individual select (#6527)
 - Parse ClinGen dosage sensitivity files, add ISCA regions to db (#6515)

--- a/scout/server/blueprints/cases/templates/cases/gens.html
+++ b/scout/server/blueprints/cases/templates/cases/gens.html
@@ -10,8 +10,19 @@
 
 {% macro gens_case_button(case, gens_info=None) %}
   {% if gens_info and gens_info.display and gens_info.version > 3 %}
-    <form action=https://{{gens_info.host}}/viewer/{{case._id}}?genome_build={{case.genome_build}}">
-      <button type="submit" data-bs-toggle="tooltip" title="Gens viewer for full case" class="btn btn-secondary text-white btn-xs form-control" target="_blank" href=><span class="fa fa-binoculars me-1"></span>G<span class="menu-collapsed">ens</span></button>
+    <form
+      action="https://{{ gens_info.host }}/viewer/{{ case._id }}?genome_build={{ case.genome_build }}"
+      target="_blank"
+      method="get"
+    >
+      <button
+        type="submit"
+        data-bs-toggle="tooltip"
+        title="Gens viewer for full case"
+        class="btn btn-secondary text-white btn-xs form-control"
+      >
+        <span class="fa fa-binoculars me-1"></span>G<span class="menu-collapsed">ens</span>
+      </button>
     </form>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.
- Fix #6537 

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
