### PR TITLE
Bump IGV.js to 3.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Changed
+- Update igv.js to 3.8.7 (#6539)
 ### Fixed
 - Syntax fix rerunner individual select (#6527)
 - Parse ClinGen dosage sensitivity files, add ISCA regions to db (#6515)

--- a/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
+++ b/scout/server/blueprints/alignviewers/templates/alignviewers/utils.html
@@ -1,7 +1,7 @@
 {% macro igv_script() %}
   <link rel="shortcut icon" href="//igv.org/web/img/favicon.ico">
   <!-- IGV JS-->
-  <script src="https://cdn.jsdelivr.net/npm/igv@3.8.0/dist/igv.min.js" integrity="sha512-6M8ngYCbVOE6FuArECkoMVP9yv5PjU/kZpYwNKQjDqGIIvAVakAKCKyYbGaw0zYW4V4eGUdnM6euong7v7qfKg==" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/igv@3.8.7/dist/igv.min.js" integrity="sha512-LnjF2dkgA168vw5vcoPrdzawUMpXAlJ/E0kfzN6tdjK6Bzhfii2Yq7rpEpv/gMQO73TtM280uMJV+AT+L5BQ3Q==" crossorigin="anonymous"></script>
 {% endmacro %}
 
 {%- macro get_custom_track_url(label, url, institute_id, case_display_name) %}


### PR DESCRIPTION
This PR adds a functionality or fixes a bug.

Update IGV.js to the current v3.8.7, incorporating mostly bugfixes.

<details>
<summary>Testing on `cg-services-stage` (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. Make sure the PR is pushed and available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/scout-server-stage)
1. First book your testing time using the Pax software available at [https://pax.scilifelab.se/](https://pax.scilifelab.se). The resource you are going to call dibs on is `scout-stage` and the server is `cg-vm1`.
1. `ssh <USER.NAME>@cg-services-stage.scilifelab.se`
1. `sudo -iu hiseq.clinical`
1. `ssh localhost`
1. (optional) Find out which Scout branch is currently deployed on `cg-services-stage`: `podman ps`
1. Stop the service with current deployed branch: `systemctl --user stop scout@<name_of_currently_deployed_branch>`
1. Start the scout service with the branch to test: `systemctl --user start scout@<this_branch>`
1. Make sure the branch is deployed: `systemctl --user status scout.target`
1. After testing is done, repeat procedure at [https://pax.scilifelab.se/](https://pax.scilifelab.se), which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing on hasta server (Clinical Genomics Stockholm)</summary>

**Prepare for testing**
1. `ssh <USER.NAME>@hasta.scilifelab.se`
1. Book your testing time using the Pax software. `us; paxa -u <user> -s hasta -r scout-stage`. You can also use the WSGI Pax app available at [https://pax.scilifelab.se/](https://pax.scilifelab.se).
1. (optional) Find out which scout branch is currently deployed on `hasta`: `conda activate S_scout; pip freeze | grep scout-browser`
1. Deploy the branch to test: `bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_scout -t scout -b <this_branch>`
1. Make sure the branch is deployed: `us; scout --version`
1. After testing is done, repeat the `paxa` procedure, which will release the allocated resource (`scout-stage`) to be used for testing by other users.
</details>

<details>
<summary>Testing docs locally with `uv`</summary>
1. Build and serve documents: `uv run --group docs mkdocs serve --strict`
1. Visit [http://127.0.0.1:4000/scout/](http://127.0.0.1:4000/scout/)
</details>

**How to test**:
1. how to test it, possibly with real cases/data

**Expected outcome**:
The functionality should be working
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by DN
